### PR TITLE
Remove unnessecary global variables when creating objects

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -176,33 +176,24 @@ class EP_API {
 	}
 }
 
-global $ep_api;
-$ep_api = EP_API::factory();
+EP_API::factory();
 
 /**
  * Accessor functions for methods in above class. See doc blocks above for function details.
  */
 
 function ep_index_post( $post, $site_id = null ) {
-	global $ep_api;
-
-	return $ep_api->index_post( $post, $site_id );
+	return EP_API::factory()->index_post( $post, $site_id );
 }
 
 function ep_search( $args, $site_id = null ) {
-	global $ep_api;
-
-	return $ep_api->search( $args, $site_id );
+	return EP_API::factory()->search( $args, $site_id );
 }
 
 function ep_post_indexed( $post_id, $site_id = null, $host_site_id = null ) {
-	global $ep_api;
-
-	return $ep_api->post_indexed( $post_id, $site_id, $host_site_id );
+	return EP_API::factory()->post_indexed( $post_id, $site_id, $host_site_id );
 }
 
 function ep_delete_post( $post_id, $site_id = null, $host_site_id = null ) {
-	global $ep_api;
-
-	return $ep_api->delete_post( $post_id, $site_id, $host_site_id );
+	return EP_API::factory()->delete_post( $post_id, $site_id, $host_site_id );
 }

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -123,8 +123,7 @@ class EP_Config {
 	}
 }
 
-global $ep_config;
-$ep_config = EP_Config::factory();
+EP_Config::factory();
 
 /**
  * Accessor functions for methods in above class. See doc blocks above for function details.
@@ -132,25 +131,17 @@ $ep_config = EP_Config::factory();
 
 
 function ep_get_option( $site_id = null ) {
-	global $ep_config;
-
-	return $ep_config->get_option( $site_id );
+	return EP_Config::factory()->get_option( $site_id );
 }
 
 function ep_update_option( $config, $site_id = null ) {
-	global $ep_config;
-
-	return $ep_config->update_option( $config, $site_id );
+	return EP_Config::factory()->update_option( $config, $site_id );
 }
 
 function ep_get_index_url( $site_id = null ) {
-	global $ep_config;
-
-	return $ep_config->get_index_url( $site_id );
+	return EP_Config::factory()->get_index_url( $site_id );
 }
 
 function ep_is_setup( $site_id = null ) {
-	global $ep_config;
-
-	return $ep_config->is_setup( $site_id );
+	return EP_Config::factory()->is_setup( $site_id );
 }

--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -363,7 +363,6 @@ class EP_Sync_Manager {
 	}
 }
 
-global $ep_sync_manager;
 $ep_sync_manager = EP_Sync_Manager::factory();
 
 /**
@@ -371,13 +370,9 @@ $ep_sync_manager = EP_Sync_Manager::factory();
  */
 
 function ep_schedule_sync( $site_id = null ) {
-	global $ep_sync_manager;
-
-	$ep_sync_manager->schedule_sync( $site_id );
+	EP_Sync_Manager::factory()->schedule_sync( $site_id );
 }
 
 function ep_full_sync() {
-	global $ep_sync_manager;
-
-	$ep_sync_manager->do_scheduled_syncs();
+	EP_Sync_Manager::factory()->do_scheduled_syncs();
 }

--- a/classes/class-ep-sync-statii.php
+++ b/classes/class-ep-sync-statii.php
@@ -130,39 +130,28 @@ class EP_Sync_Statii {
 	}
 }
 
-global $ep_sync_statii;
-$ep_sync_statii = EP_Sync_Statii::factory();
+EP_Sync_Statii::factory();
 
 /**
  * Accessor functions for methods in above class. See doc blocks above for function details.
  */
 
 function ep_get_sync_status( $site_id = null ) {
-	global $ep_sync_statii;
-
-	return $ep_sync_statii->get_status( $site_id );
+	return EP_Sync_Statii::factory()->get_status( $site_id );
 }
 
 function ep_update_sync_status( $status, $site_id = null ) {
-	global $ep_sync_statii;
-
-	return $ep_sync_statii->update_status( $status, $site_id );
+	return EP_Sync_Statii::factory()->update_status( $status, $site_id );
 }
 
 function ep_get_alive_sync_count() {
-	global $ep_sync_statii;
-
-	return $ep_sync_statii->get_alive_sync_count();
+	return EP_Sync_Statii::factory()->get_alive_sync_count();
 }
 
 function ep_reset_sync( $site_id = null ) {
-	global $ep_sync_statii;
-
-	return $ep_sync_statii->reset_sync( $site_id );
+	return EP_Sync_Statii::factory()->reset_sync( $site_id );
 }
 
 function ep_is_sync_alive( $site_id = null ) {
-	global $ep_sync_statii;
-
-	return $ep_sync_statii->is_sync_alive( $site_id );
+	return EP_Sync_Statii::factory()->is_sync_alive( $site_id );
 }


### PR DESCRIPTION
We can just use the factory() method to access the singleton instance of these classes. Much cleaner. @AaronHolbrook #reviewmerge
