### PR TITLE
Adding ep_search_fields filter for adding custom search fields

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -572,6 +572,8 @@ class EP_API {
 			}
 		}
 
+		$search_fields =  apply_filters( 'ep_search_fields', $search_fields );
+
 		$query = array(
 			'bool' => array(
 				'must' => array(


### PR DESCRIPTION
Currently you can add custom fields with the ep_post_sync_args filter before a post is synced but there is no way to add those fields to the array that is returned from the format_args method. This filter allows you to add any custom fields you might need to the $search_fields array.
