### PR TITLE
Adjust default fuzziness to .75 instead of .5

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -578,7 +578,7 @@ class EP_API {
 					'fuzzy_like_this' => array(
 						'fields' => $search_fields,
 						'like_text' => '',
-						'min_similarity' => 0.5,
+						'min_similarity' => 0.75,
 					),
 				),
 			),


### PR DESCRIPTION
This is a small but important change. `.5` fuzziness is too liberal and is overeager with it's matching.

`.75` is a good default in my opinion.

@tlovett1 @mattonomics #reviewmerge
