### PR TITLE
Add ep_min_similarity and ep_formatted_args filters

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -626,7 +626,7 @@ class EP_API {
 		}
 
 		if ( isset( $args['paged'] ) ) {
-			$paged = ( $args['paged'] <= 1 ) ? 0 : $ags['paged'] - 1;
+			$paged = ( $args['paged'] <= 1 ) ? 0 : $args['paged'] - 1;
 			$formatted_args['from'] = $args['posts_per_page'] * $paged;
 		}
 


### PR DESCRIPTION
These filters allow the end users to have additional control of their search parameters.  ep_min_similarity allows you to quickly set the min similarity for the search. ep_formatted_args give you complete access to the search parameters returned from the format_args method. 
