### PR TITLE
Feature/disable sync import

### DIFF
--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -3,14 +3,6 @@
 class EP_Sync_Manager {
 
 	/**
-	 * Flag to allow us to prevent syncing during an import
-	 *
-	 * @var bool
-	 * @since 0.9.2
-	 */
-	private $importing = false;
-
-	/**
 	 * Placeholder method
 	 *
 	 * @since 0.1.0
@@ -25,9 +17,6 @@ class EP_Sync_Manager {
 	public function setup() {
 		add_action( 'transition_post_status', array( $this, 'action_sync_on_transition' ), 10, 3 );
 		add_action( 'wp_trash_post', array( $this, 'action_trash_post' ) );
-
-		add_action( 'import_start', array( $this, 'import_start' ) );
-		add_action( 'import_end', array( $this, 'import_end' ) );
 	}
 
 	/**
@@ -56,6 +45,13 @@ class EP_Sync_Manager {
 	 * @since 0.1.0
 	 */
 	public function action_sync_on_transition( $new_status, $old_status, $post ) {
+		global $importer;
+
+		// If we have an importer we must be doing an import - let's abort
+		if ( ! empty( $importer ) ) {
+			return;
+		}
+
 		if ( 'publish' !== $new_status ) {
 			return;
 		}
@@ -107,20 +103,6 @@ class EP_Sync_Manager {
 		$response = ep_index_post( $post_args );
 
 		return $response;
-	}
-
-	/**
-	 * Importing of a post has begun, turn on our flag
-	 */
-	public function import_start() {
-		$this->importing = true;
-	}
-
-	/**
-	 * Importing of a post has finished, turn off our flag
-	 */
-	public function import_end() {
-		$this->importing = false;
 	}
 }
 


### PR DESCRIPTION
Checks to see if the global `$importer` is defined and is not empty (it's set anytime an import is done in admin.php on 248: https://github.com/WordPress/WordPress/blob/master/wp-admin/admin.php#L248).

This would fix #115.
# reviewmerge @tlovett1 @mattonomics
