### PR TITLE
Dont use like_text unless we have a non-empty search string; test

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -862,7 +862,7 @@ class EP_API {
 				),
 			),
 		);
-		if ( isset( $args['s'] ) && ! isset( $args['ep_match_all'] ) ) {
+		if ( ! empty( $args['s'] ) && ! isset( $args['ep_match_all'] ) ) {
 			$query['bool']['must']['fuzzy_like_this']['like_text'] = $args['s'];
 			$formatted_args['query'] = $query;
 		} else if ( isset( $args['ep_match_all'] ) && true === $args['ep_match_all'] ) {

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -799,4 +799,25 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->fired_actions = array();
 	}
+
+	/**
+	 * Test that empty search string returns all results
+	 *
+	 * @since 1.2
+	 */
+	public function testEmptySearchString() {
+		ep_create_and_sync_post();
+		ep_create_and_sync_post();
+
+		ep_refresh_index();
+
+		$args = array(
+			's' => '',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+	}
 }


### PR DESCRIPTION
We don't want to add the `like_text` query unless we have a non empty search string. This mimcs the behavior of MySQL or WP which will return everything if `s` is empty.
