### PR TITLE
Add property to integration post object for debugging

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -177,6 +177,7 @@ class EP_WP_Query_Integration {
 			$post->post_date_gmt = $post_array['post_date_gmt'];
 			$post->post_modified = $post_array['post_modified'];
 			$post->post_modified_gmt = $post_array['post_modified_gmt'];
+			$post->elasticsearch = true; // Super useful for debugging
 
 			// Run through get_post() to add all expected properties (even if they're empty)
 			$post = get_post( $post );


### PR DESCRIPTION
Adding the property `elasticsearch` to the post object makes debugging much easier.
