### PR TITLE
New rules for post_type argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ After running an index, ElasticPress integrates with WP_Query. The end goal is t
 
 * ```post_type``` (*string*/*array*)
 
-    Filter posts by post type. ```any``` wil search all public post types.
+    Filter posts by post type. ```any``` wil search all public post types. `WP_Query` defaults to either `post` or `any` if no `post_type` is provided depending on the context of the query. This is confusing. ElasticPress will ALWAYS default to `any` if no `post_type` is provided. If you want to search for `post` posts, you MUST specify `post` as the `post_type`.
 
 * ```offset``` (*int*)
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -899,20 +899,29 @@ class EP_API {
 			$formatted_args['query']['match_all'] = array();
 		}
 
-		if ( isset( $args['post_type'] ) ) {
-			$post_types = (array) $args['post_type'];
-			$terms_map_name = 'terms';
-			if ( count( $post_types ) < 2 ) {
-				$terms_map_name = 'term';
+		/**
+		 * Like WP_Query in search context, if no post_type is specified we default to "any". To
+		 * be safe you should ALWAYS specify the post_type parameter UNLIKE with WP_Query.
+		 *
+		 * @since 1.3
+		 */
+		if ( ! empty( $args['post_type'] ) ) {
+			// should NEVER be "any" but just in case
+			if ( 'any' !== $args['post_type'] ) {
+				$post_types = (array) $args['post_type'];
+				$terms_map_name = 'terms';
+				if ( count( $post_types ) < 2 ) {
+					$terms_map_name = 'term';
+				}
+
+				$filter['and'][] = array(
+					$terms_map_name => array(
+						'post_type.raw' => $post_types,
+					),
+				);
+
+				$use_filters = true;
 			}
-
-			$filter['and'][] = array(
-				$terms_map_name => array(
-					'post_type.raw' => $post_types,
-				),
-			);
-
-			$use_filters = true;
 		}
 
 		if ( isset( $args['offset'] ) ) {

--- a/tests/test-multisite.php
+++ b/tests/test-multisite.php
@@ -463,11 +463,11 @@ class EPTestMultisite extends EP_Test_Base {
 	}
 
 	/**
-	 * Test a post type query search
+	 * Test a post type query search for pages
 	 *
-	 * @since 1.0
+	 * @since 1.3
 	 */
-	public function testPostTypeQuery() {
+	public function testPostTypeSearchQueryPage() {
 		$sites = ep_get_sites();
 
 		$i = 0;
@@ -498,6 +498,118 @@ class EPTestMultisite extends EP_Test_Base {
 
 		$this->assertEquals( $query->post_count, 2 );
 		$this->assertEquals( $query->found_posts, 2 );
+	}
+
+	/**
+	 * Test a post type query search for posts
+	 *
+	 * @since 1.3
+	 */
+	public function testPostTypeSearchQueryPost() {
+		$sites = ep_get_sites();
+
+		$i = 0;
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			ep_create_and_sync_post( array( 'post_content' => 'findme', 'post_type' => 'page' ) );
+
+			if ( $i > 0 ) {
+				ep_create_and_sync_post( array( 'post_content' => 'findme' ) );
+			}
+
+			ep_refresh_index();
+
+			restore_current_blog();
+
+			$i++;
+		}
+
+		$args = array(
+			's' => 'findme',
+			'sites' => 'all',
+			'post_type' => 'post',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( $query->post_count, 2 );
+		$this->assertEquals( $query->found_posts, 2 );
+	}
+
+	/**
+	 * Test a post type query search where no post type is specified
+	 *
+	 * @since 1.3
+	 */
+	public function testNoPostTypeSearchQuery() {
+		$sites = ep_get_sites();
+
+		$i = 0;
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			ep_create_and_sync_post( array( 'post_content' => 'findme', 'post_type' => 'page' ) );
+
+			if ( $i > 0 ) {
+				ep_create_and_sync_post( array( 'post_content' => 'findme' ) );
+			}
+
+			ep_refresh_index();
+
+			restore_current_blog();
+
+			$i++;
+		}
+
+		$args = array(
+			's' => 'findme',
+			'sites' => 'all',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( $query->post_count, 5 );
+		$this->assertEquals( $query->found_posts, 5 );
+	}
+
+	/**
+	 * Test a post type query non-search where no post type is specified
+	 *
+	 * @since 1.3
+	 */
+	public function testNoPostTypeNoSearchQuery() {
+		$sites = ep_get_sites();
+
+		$i = 0;
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			ep_create_and_sync_post( array( 'post_content' => 'findme', 'post_type' => 'page' ) );
+
+			if ( $i > 0 ) {
+				ep_create_and_sync_post( array( 'post_content' => 'findme' ) );
+			}
+
+			ep_refresh_index();
+
+			restore_current_blog();
+
+			$i++;
+		}
+
+		$args = array(
+			'ep_integrate' => true,
+			'sites' => 'all',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( $query->post_count, 5 );
+		$this->assertEquals( $query->found_posts, 5 );
 	}
 
 	/**

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -409,11 +409,11 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
-	 * Test a post type query
+	 * Test a post type query for pages
 	 *
-	 * @since 1.0
+	 * @since 1.3
 	 */
-	public function testPostTypeQuery() {
+	public function testPostTypeQueryPage() {
 		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'post_type' => 'page' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'findme test 3', 'post_type' => 'page' ) );
@@ -429,6 +429,99 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
+	}
+
+
+	/**
+	 * Test a post type query for posts
+	 *
+	 * @since 1.3
+	 */
+	public function testPostTypeQueryPost() {
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'post_type' => 'page' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 3', 'post_type' => 'page' ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'         => 'findme',
+			'post_type' => 'post',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+	}
+
+	/**
+	 * Test a query with no post type
+	 *
+	 * @since 1.3
+	 */
+	public function testNoPostTypeSearchQuery() {
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'post_type' => 'page' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 3' ) );
+
+		ep_refresh_index();
+
+		// post_type defaults to "any"
+		$args = array(
+			's' => 'findme',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+	}
+
+	/**
+	 * Test a query with no post type on non-search query
+	 *
+	 * @since 1.3
+	 */
+	public function testNoPostTypeNonSearchQuery() {
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'post_type' => 'page' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 3' ) );
+
+		ep_refresh_index();
+
+		// post_type defaults to "any"
+		$args = array(
+			'ep_integrate' => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+	}
+
+	/**
+	 * Test a query with "any" post type
+	 *
+	 * @since 1.3
+	 */
+	public function testAnyPostTypeQuery() {
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'post_type' => 'page' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 3', 'post_type' => 'page' ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'         => 'findme',
+			'post_type' => 'any',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
 	}
 
 	/**


### PR DESCRIPTION
Previously, we were checking of the `post_type` argument existed, then passing that to a filter. WordPress in certain situations passes `post_type` as an empty string which was breaking our query. This PR does the following:

1) If no or empty `post_type` argument, default to `any` post type.
2) If `post_type` argument is present and not empty, use it. This means if you want to query for `post_type` post, you MUST specify it. WP defaults to either post or any depending on the situation. We are NOT mimicking this confusing behavior
