### PR TITLE
Add WP_Query integration on init, not plugin load

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -17,7 +17,10 @@ class EP_WP_Query_Integration {
 	public function __construct() { }
 
 	public function setup() {
+		add_action( 'init', array( $this, 'setup_wp_query_integration' ) );
+	}
 
+	public function setup_wp_query_integration() {
 		// Ensure we aren't on the admin (unless overridden)
 		if ( is_admin() && ! apply_filters( 'ep_admin_wp_query_integration', false ) ) {
 			return;

--- a/tests/test-multisite.php
+++ b/tests/test-multisite.php
@@ -37,7 +37,7 @@ class EPTestMultisite extends EP_Test_Base {
 
 		wp_set_current_user( $admin_id );
 
-		EP_WP_Query_Integration::factory()->setup();
+		EP_WP_Query_Integration::factory()->setup_wp_query_integration();
 
 		$this->setup_test_post_type();
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -21,7 +21,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		ep_activate();
 
-		EP_WP_Query_Integration::factory()->setup();
+		EP_WP_Query_Integration::factory()->setup_wp_query_integration();
 
 		$this->setup_test_post_type();
 	}


### PR DESCRIPTION
Switches the integration setup to fire on init, once WordPress is loaded and any potential theme filters have a chance to load. Also, updates the unit test factory setup to use the new setup call. All unit tests pass aftert his change.

Corrects an issue where it was not possible to use the ep_admin_wp_query_integration filter to enable admin side ES enhanced queries during an ajax callback (or possibly at all). Because the ep_admin_wp_query_integration filter was applied during class instantiation (at plugin load), the returned value was always false.Switches the integration setup to fire on init, once WordPress is loaded and any potential theme filters have a chance to load.

Corrects an issue where it was not possible to use the ep_admin_wp_query_integration filter to enable admin side ES enhanced queries during an ajax callback (or possibly at all). Because the ep_admin_wp_query_integration filter was applied during class instantiation (at plugin load), the returned value was always false.
