### PR TITLE
Revert "Add WP_Query integration on init, not plugin load"

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -17,10 +17,7 @@ class EP_WP_Query_Integration {
 	public function __construct() { }
 
 	public function setup() {
-		add_action( 'init', array( $this, 'setup_wp_query_integration' ) );
-	}
 
-	public function setup_wp_query_integration() {
 		// Ensure we aren't on the admin (unless overridden)
 		if ( is_admin() && ! apply_filters( 'ep_admin_wp_query_integration', false ) ) {
 			return;

--- a/tests/test-multisite.php
+++ b/tests/test-multisite.php
@@ -37,7 +37,7 @@ class EPTestMultisite extends EP_Test_Base {
 
 		wp_set_current_user( $admin_id );
 
-		EP_WP_Query_Integration::factory()->setup_wp_query_integration();
+		EP_WP_Query_Integration::factory()->setup();
 
 		$this->setup_test_post_type();
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -21,7 +21,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		ep_activate();
 
-		EP_WP_Query_Integration::factory()->setup_wp_query_integration();
+		EP_WP_Query_Integration::factory()->setup();
 
 		$this->setup_test_post_type();
 	}


### PR DESCRIPTION
This should be merged into develop, not master.

Reverting to fix the master branch.
