### PR TITLE
Remove index exists check

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -138,7 +138,7 @@ class EP_API {
 			return array( 'found_posts' => $response['hits']['total'], 'posts' => $posts );
 		}
 
-		return array( 'found_posts' => 0, 'posts' => array() );
+		return false;
 	}
 
 	/**

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1134,32 +1134,6 @@ class EP_API {
 
 		return $elasticsearch_alive;
 	}
-
-	/**
-	 * Ensures that this index exists
-	 *
-	 * @param null $index
-	 *
-	 * @return bool
-	 * @since 1.1.0
-	 */
-	public function index_exists( $index = null ) {
-		$index_exists = false;
-
-		$index_url = ep_get_index_url( $index );
-
-		$url = $index_url . '/_status';
-
-		$request = wp_remote_request( $url );
-
-		if ( ! is_wp_error( $request ) ) {
-			if ( isset( $request['response']['code'] ) && 200 === $request['response']['code'] ) {
-				$index_exists = true;
-			}
-		}
-
-		return $index_exists;
-	}
 }
 
 EP_API::factory();

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -9,6 +9,8 @@ class EP_WP_Query_Integration {
 	 */
 	private $query_stack = array();
 
+	private $posts_by_query = array();
+
 	/**
 	 * Placeholder method
 	 *
@@ -25,11 +27,6 @@ class EP_WP_Query_Integration {
 
 		// Ensure that we are currently allowing ElasticPress to override the normal WP_Query search
 		if ( ! ep_is_activated() ) {
-			return;
-		}
-
-		// If we can't reach the Elasticsearch service, don't bother with the rest of this
-		if ( ! ep_index_exists() ) {
 			return;
 		}
 
@@ -128,15 +125,50 @@ class EP_WP_Query_Integration {
 	}
 
 	/**
-	 * Filter the posts array to contain ES search results in EP_Post form.
+	 * Filter the posts array to contain ES search results in EP_Post form. Pull previously search posts.
 	 *
 	 * @param array $posts
 	 * @param object &$query
 	 * @return array
 	 */
 	public function filter_the_posts( $posts, &$query ) {
-		if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query )  ) {
+		if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query ) || ! isset( $this->posts_by_query[spl_object_hash( $query )] ) ) {
 			return $posts;
+		}
+
+		$new_posts = $this->posts_by_query[spl_object_hash( $query )];
+
+		return $new_posts;
+	}
+
+	/**
+	 * Remove the found_rows from the SQL Query
+	 *
+	 * @param string $sql
+	 * @param object $query
+	 * @since 0.9
+	 * @return string
+	 */
+	public function filter_found_posts_query( $sql, $query ) {
+		if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query )  ) {
+			return $sql;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Filter query string used for get_posts(). Search for posts and save for later.
+	 * Return a query that will return nothing.
+	 *
+	 * @param string $request
+	 * @param object $query
+	 * @since 0.9
+	 * @return string
+	 */
+	public function filter_posts_request( $request, $query ) {
+		if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query ) ) {
+			return $request;
 		}
 
 		$query_vars = $query->query_vars;
@@ -153,10 +185,14 @@ class EP_WP_Query_Integration {
 
 		$search = ep_search( $formatted_args, $scope );
 
+		if ( false === $search ) {
+			return $request;
+		}
+
 		$query->found_posts = $search['found_posts'];
 		$query->max_num_pages = ceil( $search['found_posts'] / $query->get( 'posts_per_page' ) );
 
-		$posts = array();
+		$new_posts = array();
 
 		foreach ( $search['posts'] as $post_array ) {
 			$post = new stdClass();
@@ -183,43 +219,12 @@ class EP_WP_Query_Integration {
 			$post = get_post( $post );
 
 			if ( $post ) {
-				$posts[] = $post;
+				$new_posts[] = $post;
 			}
 		}
+		$this->posts_by_query[spl_object_hash( $query )] = $new_posts;
 
-		do_action( 'ep_wp_query_search', $posts, $search, $query );
-
-		return $posts;
-	}
-
-	/**
-	 * Remove the found_rows from the SQL Query
-	 *
-	 * @param string $sql
-	 * @param object $query
-	 * @since 0.9
-	 * @return string
-	 */
-	public function filter_found_posts_query( $sql, $query ) {
-		if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query )  ) {
-			return $sql;
-		}
-
-		return '';
-	}
-
-	/**
-	 * Filter query string used for get_posts(). Return a query that will return nothing.
-	 *
-	 * @param string $request
-	 * @param object $query
-	 * @since 0.9
-	 * @return string
-	 */
-	public function filter_posts_request( $request, $query ) {
-		if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query ) ) {
-			return $request;
-		}
+		do_action( 'ep_wp_query_search', $new_posts, $search, $query );
 
 		global $wpdb;
 


### PR DESCRIPTION
Fixes #186. Remove the index exists check by moving the search to an earlier filter in query execution. We then save the search to an associate array using a unique query hash as the key. If search fails, it will return false and we will revert to MySQL. If search is successful but returns 0 results from ES, we will just show 0 results.