### PR TITLE
Issue-190

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -264,7 +264,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			$args = apply_filters( 'ep_index_posts_args', array(
 				'posts_per_page'      => $posts_per_page,
 				'post_type'           => ep_get_indexable_post_types(),
-				'post_status'         => 'publish',
+				'post_status'         => ep_get_indexable_post_status(),
 				'offset'              => $offset,
 				'ignore_sticky_posts' => true
 			) );

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -447,7 +447,7 @@ class EP_API {
 						),
 						'post_status' => array(
 							'type' => 'string',
-							'index' => 'no'
+							'index' => 'not_analyzed'
 						),
 						'post_name' => array(
 							'type' => 'multi_field',
@@ -583,7 +583,7 @@ class EP_API {
 			'post_title'        => get_the_title( $post_id ),
 			'post_excerpt'      => $post->post_excerpt,
 			'post_content'      => apply_filters( 'the_content', $post->post_content ),
-			'post_status'       => 'publish',
+			'post_status'       => $post->post_status,
 			'post_name'         => $post->post_name,
 			'post_modified'     => $post_modified,
 			'post_modified_gmt' => $post_modified_gmt,

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -72,6 +72,16 @@ class EP_Config {
 	}
 
 	/**
+	 * Return indexable post_status for the current site
+	 *
+	 * @since 1.3
+	 * @return array
+	 */
+	public function get_indexable_post_status() {
+		return apply_filters( 'ep_indexable_post_status', array( 'publish' ) );
+	}
+
+	/**
 	 * Generate network index name for alias
 	 *
 	 * @since 0.9
@@ -104,6 +114,10 @@ function ep_get_index_name( $blog_id = null ) {
 
 function ep_get_indexable_post_types() {
 	return EP_Config::factory()->get_indexable_post_types();
+}
+
+function ep_get_indexable_post_status() {
+	return EP_Config::factory()->get_indexable_post_status();
 }
 
 function ep_get_network_alias() {

--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -52,7 +52,9 @@ class EP_Sync_Manager {
 			return;
 		}
 
-		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+		$indexable_post_statuses = ep_get_indexable_post_status();
+
+		if ( ! in_array( $new_status, $indexable_post_statuses ) && ! in_array( $old_status, $indexable_post_statuses ) ) {
 			return;
 		}
 
@@ -61,7 +63,7 @@ class EP_Sync_Manager {
 		}
 
 		// Our post was published, but is no longer, so let's remove it from the Elasticsearch index
-		if ( 'publish' !== $new_status ) {
+		if ( ! in_array( $new_status, $indexable_post_statuses ) ) {
 			$this->action_delete_post( $post->ID );
 		} else {
 			$post_type = get_post_type( $post->ID );

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -222,6 +222,7 @@ class EP_WP_Query_Integration {
 				$post->site_id = $post_array['site_id'];
 			}
 
+			$post->post_type = $post_array['post_type'];
 			$post->post_name = $post_array['post_name'];
 			$post->post_status = $post_array['post_status'];
 			$post->post_title = $post_array['post_title'];


### PR DESCRIPTION
This should fix #190.

Here's what I've done:
- Provided a filter for post statuses which default to publish
- Change the sync mecanism to make sure it takes all the post statuses into account
- Change Elasticsearch mapping of post_status to "not_analyzed" so we are able to filter the search query (require re-indexing for people to start using this in queries)

By implementing those changes, we are able to implement those filters to make the admin search work:

```php
public static function filter_ep_indexable_post_status( post_statuses ) {
  $post_statuses[] = 'draft';
  $post_statuses[] = 'pending';
  //...
  return $post_statuses;
}
add_filter( 'ep_indexable_post_status', 'filter_ep_indexable_post_status' , 10, 1 );

public static function filter_ep_formatted_args( $formatted_args ) {
  if ( ! is_admin() ) {
      $formatted_args['filter']['and'][] = array(
      'term' => array( 'post_status' => array( 'publish' ) ),
    );
  }

  return $formatted_args;
}
add_filter( 'ep_formatted_args',  'filter_ep_formatted_args' , 10, 1 );
```

@tlovett1 or @AaronHolbrook any feedback to make this better is greatly appreciated!
