### PR TITLE
Abide by the 'exclude_from_search' flag when running search queries.

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -191,7 +191,30 @@ class EP_WP_Query_Integration {
 
 		$query_vars = $query->query_vars;
 		if ( 'any' == $query_vars['post_type'] ) {
-			unset( $query_vars['post_type'] );
+			
+			if( $query->is_search() ) {
+				
+				/*
+				 * This is a search query
+				 * To follow WordPress conventions,
+				 * make sure we only search 'searchable' post types
+				 */
+				$searchable_post_types = get_post_types( array( 'exclude_from_search' => false ) );
+				
+				// Conform the post types array to an acceptable format for ES
+				$post_types = array();
+				foreach( $searchable_post_types as $type ) {
+					$post_types[] = $type;
+				}
+				$query_vars['post_type'] = $post_types;
+			} else {
+				
+				/*
+				 * This is not a search query
+				 * so unset the post_type query var
+				 */
+				unset( $query_vars['post_type'] );
+			}
 		}
 
 		$scope = 'current';

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -190,7 +190,7 @@ class EP_WP_Query_Integration {
 		}
 
 		$query_vars = $query->query_vars;
-		if ( 'any' == $query_vars['post_type'] ) {
+		if ( 'any' === $query_vars['post_type'] ) {
 			
 			if ( $query->is_search() ) {
 

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -192,23 +192,30 @@ class EP_WP_Query_Integration {
 		$query_vars = $query->query_vars;
 		if ( 'any' == $query_vars['post_type'] ) {
 			
-			if( $query->is_search() ) {
-				
+			if ( $query->is_search() ) {
+
 				/*
 				 * This is a search query
 				 * To follow WordPress conventions,
 				 * make sure we only search 'searchable' post types
 				 */
 				$searchable_post_types = get_post_types( array( 'exclude_from_search' => false ) );
-				
+
+				// If we have no searchable post types, there's no point going any further
+				if ( empty( $searchable_post_types ) ) {
+					return;
+				}
+
 				// Conform the post types array to an acceptable format for ES
 				$post_types = array();
 				foreach( $searchable_post_types as $type ) {
 					$post_types[] = $type;
 				}
+
+				// These are now the only post types we will search
 				$query_vars['post_type'] = $post_types;
 			} else {
-				
+
 				/*
 				 * This is not a search query
 				 * so unset the post_type query var


### PR DESCRIPTION
WordPress core search enforces limiting the post types searched to just those without the 'exclude_from_search' flag turned on when it would otherwise be 'any', but previously ElasticPress didn't enforce this limit at all, and just opened up to any post type if one wasn't specified already.

This PR does the following:
1. If we're doing a search for 'any' post, default to post types not excluded from search.
2. For all other query types (not search), continue to allow querying across all indexed post types.
