### PR TITLE
Add EP_Query class

### DIFF
--- a/classes/class-ep-query.php
+++ b/classes/class-ep-query.php
@@ -89,7 +89,7 @@ class EP_Query implements IteratorAggregate, Countable{
                 if ( empty( $searchable_post_types ) ) {
 
                     // Have to return something or it improperly calculates the found_posts
-                    return "WHERE 0 = 1";
+                    return false;
                 }
 
                 // Conform the post types array to an acceptable format for ES

--- a/classes/class-ep-query.php
+++ b/classes/class-ep-query.php
@@ -59,7 +59,8 @@ class EP_Query implements IteratorAggregate, Countable{
      * @param string $scope Scope to use.
      * @return WP_Query
      */
-    public function __construct($args = array(), $scope = 'current') {
+    public function __construct($args = array(), $scope = 'current')
+    {
         $this->args = $args;
         $this->scope = $scope;
     }
@@ -72,7 +73,6 @@ class EP_Query implements IteratorAggregate, Countable{
      */
     public static function from_wp_query(&$query)
     {
-
         $query_vars = $query->query_vars;
         if ( 'any' === $query_vars['post_type'] ) {
             
@@ -117,7 +117,7 @@ class EP_Query implements IteratorAggregate, Countable{
 
         $formatted_args = ep_format_args( $query_vars );
 
-        $ep_query = new static($formatted_args, $scope);
+        $ep_query = new self($formatted_args, $scope);
         $ep_query->wp_query = $query;
         
         return $ep_query;

--- a/classes/class-ep-query.php
+++ b/classes/class-ep-query.php
@@ -1,0 +1,199 @@
+<?php
+
+class EP_Query implements IteratorAggregate, Countable{
+
+    /**
+     * Arguments used for searching
+     *
+     * @access public
+     * @var array
+     */
+    public $args = array();
+
+    /**
+     * Scope to use for searching
+     *
+     * @access public
+     * @var string
+     */
+    public $scope = 'current';
+
+    /**
+     * WP_Query object if used to create instance
+     *
+     * @access public
+     * @var mixed
+     */
+    public $wp_query = false;
+
+    /**
+     * Result, after parsing
+     *
+     * @access private
+     * @var mixed
+     */
+    private $result = false;
+
+    /**
+     * Posts, after parsing
+     *
+     * @access private
+     * @var array
+     */
+    private $posts = array();
+
+    /**
+     * Number of posts, after parsing
+     *
+     * @access public
+     * @var integer
+     */
+    public $found_posts = 0;
+
+    /**
+     * Constructor.
+     *
+     * Sets up the ElasticPress query
+     *
+     * @param array $args Query arguments.
+     * @param string $scope Scope to use.
+     * @return WP_Query
+     */
+    public function __construct($args = array(), $scope = 'current') {
+        $this->args = $args;
+        $this->scope = $scope;
+    }
+
+    /**
+     * Create an instance of EP_Query using an instance of WP_Query
+     *
+     * @param WP_Query $query Wordpress query object.
+     * @return EP_Query
+     */
+    public static function from_wp_query(&$query)
+    {
+
+        $query_vars = $query->query_vars;
+        if ( 'any' == $query_vars['post_type'] ) {
+            unset( $query_vars['post_type'] );
+        }
+
+        $scope = 'current';
+        if ( ! empty( $query_vars['sites'] ) ) {
+            $scope = $query_vars['sites'];
+        }
+
+        $formatted_args = ep_format_args( $query_vars );
+
+        $ep_query = new static($formatted_args, $scope);
+        $ep_query->wp_query = $query;
+        
+        return $ep_query;
+    }
+
+    /**
+     * Get the ES search result
+     *
+     * @return array
+     */
+    public function get_result()
+    {
+        if ($this->result) {
+            return $this->result;
+        }
+        $this->result = ep_search( $this->args, $this->scope );
+        $this->found_posts = !empty($this->result['found_posts']) ? $this->result['found_posts'] : 0;
+        return $this->result;
+    }
+
+    /**
+     * Reset search results
+     *
+     * @return array
+     */
+    public function reset_result()
+    {
+        $this->result = array();
+        $this->posts = array();
+        $this->found_posts = 0;
+        return $this;
+    }
+
+    /**
+     * Get an array of posts from ES search result
+     *
+     * @return array
+     */
+    public function get_posts()
+    {
+        if ($this->posts) {
+            return $this->posts;
+        }
+
+        do_action( 'ep_before_get_posts', $this);
+
+        $result = $this->get_result();
+
+        if ($wp_query = $this->wp_query) {
+            $wp_query->found_posts = $result['found_posts'];
+            $wp_query->max_num_pages = ceil( $result['found_posts'] / $wp_query->get( 'posts_per_page' ) );
+        }
+
+        $posts = array();
+
+        foreach ( $result['posts'] as $post_array ) {
+            $post = new stdClass();
+
+            $post->ID = $post_array['post_id'];
+            $post->site_id = get_current_blog_id();
+
+            if ( ! empty( $post_array['site_id'] ) ) {
+                $post->site_id = $post_array['site_id'];
+            }
+
+            $post->post_name = $post_array['post_name'];
+            $post->post_status = $post_array['post_status'];
+            $post->post_title = $post_array['post_title'];
+            $post->post_parent = $post_array['post_parent'];
+            $post->post_content = $post_array['post_content'];
+            $post->post_date = $post_array['post_date'];
+            $post->post_date_gmt = $post_array['post_date_gmt'];
+            $post->post_modified = $post_array['post_modified'];
+            $post->post_modified_gmt = $post_array['post_modified_gmt'];
+
+            // Run through get_post() to add all expected properties (even if they're empty)
+            $post = get_post( $post );
+
+            if ( $post ) {
+                $posts[] = $post;
+            }
+        }
+
+        $this->posts = $posts;
+
+        do_action( 'ep_after_get_posts', $this);
+        do_action( 'ep_wp_query_search', $posts, $result, $this->wp_query );
+
+        return $this->posts;
+    }
+
+    /**
+     * Returns an iterator with the posts.
+     *
+     * @return ArrayIterator
+     */
+    public function getIterator() {
+        return new ArrayIterator($this->get_posts());
+    }
+
+    /**
+     * Returns the number of posts found.
+     *
+     * @return integer
+     */
+    public function count() 
+    { 
+        return $this->found_posts; 
+    } 
+
+}

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -139,54 +139,7 @@ class EP_WP_Query_Integration {
 			return $posts;
 		}
 
-		$query_vars = $query->query_vars;
-		if ( 'any' == $query_vars['post_type'] ) {
-			unset( $query_vars['post_type'] );
-		}
-
-		$scope = 'current';
-		if ( ! empty( $query_vars['sites'] ) ) {
-			$scope = $query_vars['sites'];
-		}
-
-		$formatted_args = ep_format_args( $query_vars );
-
-		$search = ep_search( $formatted_args, $scope );
-
-		$query->found_posts = $search['found_posts'];
-		$query->max_num_pages = ceil( $search['found_posts'] / $query->get( 'posts_per_page' ) );
-
-		$posts = array();
-
-		foreach ( $search['posts'] as $post_array ) {
-			$post = new stdClass();
-
-			$post->ID = $post_array['post_id'];
-			$post->site_id = get_current_blog_id();
-
-			if ( ! empty( $post_array['site_id'] ) ) {
-				$post->site_id = $post_array['site_id'];
-			}
-
-			$post->post_name = $post_array['post_name'];
-			$post->post_status = $post_array['post_status'];
-			$post->post_title = $post_array['post_title'];
-			$post->post_parent = $post_array['post_parent'];
-			$post->post_content = $post_array['post_content'];
-			$post->post_date = $post_array['post_date'];
-			$post->post_date_gmt = $post_array['post_date_gmt'];
-			$post->post_modified = $post_array['post_modified'];
-			$post->post_modified_gmt = $post_array['post_modified_gmt'];
-
-			// Run through get_post() to add all expected properties (even if they're empty)
-			$post = get_post( $post );
-
-			if ( $post ) {
-				$posts[] = $post;
-			}
-		}
-
-		do_action( 'ep_wp_query_search', $posts, $search, $query );
+		$posts = EP_Query::from_wp_query($query)->get_posts();
 
 		return $posts;
 	}

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -191,6 +191,10 @@ class EP_WP_Query_Integration {
 
 		$ep_query = EP_Query::from_wp_query($query);
 
+		if ($ep_query === false) {
+			return "WHERE 0 = 1";
+		}
+
 		if ( false === $ep_query->get_result() ) {
 			return $request;
 		}

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -19,6 +19,7 @@ require_once( 'classes/class-ep-config.php' );
 require_once( 'classes/class-ep-api.php' );
 require_once( 'classes/class-ep-sync-manager.php' );
 require_once( 'classes/class-ep-elasticpress.php' );
+require_once( 'classes/class-ep-query.php' );
 require_once( 'classes/class-ep-wp-query-integration.php' );
 
 /**


### PR DESCRIPTION
At the moment, this commit doesn't change anything to how things are executed, with the exeption of adding two new hooks. The idea is to, in a near future, add more functionality to the class to easier manipulate the the ES query arguments.

You can now do cool stuff like

    $posts = EP_Query::from_wp_query($wp_query)->get_posts();
