### PR TITLE
Support date in orderby - closes #203

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
     
 * ```orderby``` (*string*)
 
-    Order results by field name instead of relevance. Currently only supports: ```title```, ```name```, and ```relevance``` (default).
+    Order results by field name instead of relevance. Currently only supports: ```title```, ```name```, ```date```, and ```relevance``` (default).
 
 * ```order``` (*string*)
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1157,6 +1157,7 @@ class EP_API {
 	 * @access protected
 	 *
 	 * @param string $orderby Alias for the field to order by.
+	 * @param string $order
 	 * @return array|bool Array formatted value to used in the sort DSL. False otherwise.
 	 */
 	protected function parse_orderby( $orderby, $order ) {
@@ -1165,6 +1166,7 @@ class EP_API {
 			'relevance',
 			'name',
 			'title',
+			'date',
 		);
 
 		if ( ! in_array( $orderby, $allowed_keys ) ) {
@@ -1177,6 +1179,15 @@ class EP_API {
 				$sort = array(
 					array(
 						'_score' => array(
+							'order' => $order,
+						),
+					),
+				);
+				break;
+			case 'date':
+				$sort = array(
+					array(
+						'post_date' => array(
 							'order' => $order,
 						),
 					),

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -716,9 +716,9 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
-		$this->assertEquals( 'ordertes 333', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertest 111', $query->posts[1]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[2]->post_title );
+		$this->assertEquals( 'ordertes 333', $query->posts[2]->post_title );
 	}
 
 	/**

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -691,6 +691,33 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test post_date orderby query
+	 *
+	 * @since 1.4
+	 */
+	public function testSearchPostDateOrderbyQuery() {
+		ep_create_and_sync_post( array( 'post_title' => 'ordertes 333' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'ordertest',
+			'orderby' => 'date',
+			'order'   => 'DESC',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+		$this->assertEquals( 'ordertes 333', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest 111', $query->posts[1]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[2]->post_title );
+	}
+
+	/**
 	 * Test relevance orderby query advanced
 	 *
 	 * @since 1.2

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -697,7 +697,11 @@ class EPTestSingleSite extends EP_Test_Base {
 	 */
 	public function testSearchPostDateOrderbyQuery() {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertes 333' ) );
+		sleep( 3 );
+
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ) );
+		sleep( 3 );
+
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ) );
 
 		ep_refresh_index();


### PR DESCRIPTION
PR adds support for `date` in orderby and adds a unit test.