### PR TITLE
Remove duplicates filters and allow sync post termination

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -608,6 +608,9 @@ class EP_API {
 			//'site_id'         => get_current_blog_id(),
 		);
 
+		/**
+		 * This filter is named poorly but has to stay to keep backwards compat
+		 */
 		$post_args = apply_filters( 'ep_post_sync_args', $post_args, $post_id );
 
 		return $post_args;

--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -105,7 +105,11 @@ class EP_Sync_Manager {
 	 */
 	public function sync_post( $post_id ) {
 
-		$post_args = apply_filters( 'ep_post_sync_args', ep_prepare_post( $post_id ), $post_id );
+		$post_args = ep_prepare_post( $post_id );
+
+		if ( apply_filters( 'ep_post_sync_kill', false, $post_args, $post_id ) ) {
+			return;
+		}
 
 		$response = ep_index_post( $post_args );
 


### PR DESCRIPTION
Remove duplicate `ep_post_sync_args` filter and add `ep_prepare_post_args` filter. If ep_post_sync_args is empty, don't sync