### PR TITLE
Allow for filtered query integration on admin ajax requests

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -32,7 +32,7 @@ class EP_WP_Query_Integration {
 		$admin_integration = apply_filters( 'ep_admin_wp_query_integration', false );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			if ( apply_filters( 'ep_ajax_wp_query_integration', false ) ) {
+			if ( ! apply_filters( 'ep_ajax_wp_query_integration', false ) ) {
 				return;
 			} else {
 				$admin_integration = true;

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -23,8 +23,23 @@ class EP_WP_Query_Integration {
 	 * @since 0.9
 	 */
 	public function setup() {
-		// Ensure we aren't on the admin (unless overridden)
-		if ( is_admin() && ! apply_filters( 'ep_admin_wp_query_integration', false ) ) {
+
+		/**
+		 * By default EP will not integrate on admin or ajax requests. Since admin-ajax.php is
+		 * technically an admin request, there is some weird logic here. If we are doing ajax
+		 * and ep_ajax_wp_query_integration is filtered true, then we skip the next admin check.
+		 */
+		$admin_integration = apply_filters( 'ep_admin_wp_query_integration', false );
+
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			if ( apply_filters( 'ep_ajax_wp_query_integration', false ) ) {
+				return;
+			} else {
+				$admin_integration = true;
+			}
+		}
+
+		if ( is_admin() && ! $admin_integration ) {
 			return;
 		}
 


### PR DESCRIPTION
By default no integration will happen on admin ajax. This PR add a filter for this.