### PR TITLE
adds single site post "fields => ids", and "fields => id=>parent" response

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -309,7 +309,7 @@ class EP_WP_Query_Integration {
 			if ( is_multisite() ) {
 				$sql_query = ( 'id=>parent' == $query->query_vars['fields'] ) ? "SELECT ID, post_parent FROM $wpdb->posts WHERE 1=0" : "SELECT ID FROM $wpdb->posts WHERE 1=0";
 				$this->elasticsearch_fields = $query->query_vars['fields'];
-				unset( $query->query_vars['fields'] );
+				$query->query_vars['fields'] = '';
 			} else {
 				return $query->request;
 			}

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1372,4 +1372,45 @@ class EPTestSingleSite extends EP_Test_Base {
 		// Reset the main $wp_post_types item
 		$GLOBALS['wp_post_types'] = $backup_post_types;
 	}
+
+	/**
+	 * Test for query where `fields` => `ids` should return $query object where $query->posts contains array of post ids
+	 *
+	 */
+	public function testQueryForIDs() {
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+
+		ep_refresh_index();
+
+		$args  = array(
+			'post_type' => 'post',
+			'fields'    => 'ids',
+			's'         => 'findme',
+		);
+		$query = new WP_Query( $args );
+		$this->assertEquals( 2, $query->post_count );
+	}
+
+	/**
+	 * Test for query where `fields` => `id=>parent` should return $query object where $query->posts contains array of
+	 * objects with `ID` and `post_parent` properties
+	 */
+	public function testQueryForParentIDs() {
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+
+		ep_refresh_index();
+
+		$args  = array(
+			'post_type' => 'post',
+			'fields'    => 'id=>parent',
+			's'         => 'findme',
+		);
+		$query = new WP_Query( $args );
+		$this->assertEquals( 2, $query->post_count );
+
+		$this->assertTrue( ! empty( $query->posts[0]->ID ) );
+		$this->assertTrue( 0 === $query->posts[0]->post_parent );
+	}
 }


### PR DESCRIPTION
and a multisite results workaround. Multisite results need to be handled this way because of the nature of WP_Query content sanitization. There are no filters available to allow altering IDs or id=>parent query responses. So I stick those in an ep_posts property on the query object.

Otherwise, single site works exactly as non-ep searches.

Fix #227