### PR TITLE
cleared failed_posts array after errors email is sent

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -443,6 +443,8 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 					WP_CLI::log( $email_text );
 				}
 			}
+			// clear failed posts after sending emails
+			$this->failed_posts = array();
 		}
 	}
 


### PR DESCRIPTION
cleared failed_posts array after email is sent, to not send it only for one site for #232 