### PR TITLE
use post id in get_post to enrich the post object and make it possible for multisite

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -297,7 +297,7 @@ class EP_WP_Query_Integration {
 
 		// if multisite is enabled get post object for each site
 		if( is_multisite() ) {
-			$new_posts = $this->fetch_wp_post_object( $new_posts );
+			$new_posts = $this->fill_post_objects( $new_posts );
 		}
 
 
@@ -317,9 +317,11 @@ class EP_WP_Query_Integration {
 	 * for WP_Post object
 	 *
 	 * @param  array $post_list list of found post objects
+	 *
+	 * @since  1.4
 	 * @return array            list of WP_Post objects
 	 */
-	public function fetch_wp_post_object( $post_list ) {
+	public function fill_post_objects( $post_list ) {
 		$post_objs = array();
 		$posts_ordered = array();
 		$grouped = array();
@@ -329,7 +331,7 @@ class EP_WP_Query_Integration {
 		foreach ( $post_list as $post_data ) {
 			$grouped[$post_data->site_id][] = $post_data;
 			// use this to keep the initial order of posts
-			$order[] = md5( $post_data->ID . ' ' . $post_data->post_date_gmt . ' ' . $post_data->site_id );
+			$order[] = $post_data->ID . '-' . $post_data->site_id;
 		}
 
 		foreach ( $grouped as $site_id => $post_data ) {
@@ -352,7 +354,7 @@ class EP_WP_Query_Integration {
 
 		// retrive initial order of posts
 		foreach ( $post_objs as $current_index => $post_obj ) {
-			$index = array_search ( md5( $post_obj->ID . ' ' . $post_obj->post_date_gmt . ' ' . $post_obj->site_id ), $order );
+			$index = array_search ( $post_obj->ID . '-' . $post_obj->site_id, $order );
 			$posts_ordered[$index] = $post_objs[$current_index];
 		}
 

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -300,6 +300,7 @@ class EP_WP_Query_Integration {
 			$new_posts = $this->fetch_wp_post_object( $new_posts );
 		}
 
+
 		$this->posts_by_query[spl_object_hash( $query )] = $new_posts;
 
 		do_action( 'ep_wp_query_search', $new_posts, $search, $query );
@@ -328,7 +329,7 @@ class EP_WP_Query_Integration {
 		foreach ( $post_list as $post_data ) {
 			$grouped[$post_data->site_id][] = $post_data;
 			// use this to keep the initial order of posts
-			$order[] = md5( $post_data->ID . ' ' . $post_data->post_date_gmt );
+			$order[] = md5( $post_data->ID . ' ' . $post_data->post_date_gmt . ' ' . $post_data->site_id );
 		}
 
 		foreach ( $grouped as $site_id => $post_data ) {
@@ -351,7 +352,7 @@ class EP_WP_Query_Integration {
 
 		// retrive initial order of posts
 		foreach ( $post_objs as $current_index => $post_obj ) {
-			$index = array_search ( md5( $post_obj->ID . ' ' . $post_obj->post_date_gmt ), $order );
+			$index = array_search ( md5( $post_obj->ID . ' ' . $post_obj->post_date_gmt . ' ' . $post_obj->site_id ), $order );
 			$posts_ordered[$index] = $post_objs[$current_index];
 		}
 

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -282,12 +282,24 @@ class EP_WP_Query_Integration {
 			$post->elasticsearch = true; // Super useful for debugging
 
 			// Run through get_post() to add all expected properties (even if they're empty)
-			$post = get_post( $post );
+			// do this if mulstisite is disabled
+			// if mulstisite is enabled then we need to proceed differently
+			if( !is_multisite() ) {
+				$post_obj = get_post( $post->ID );
+				// merge with the initial object values
+				$post = (object) array_merge( (array) $post_obj, (array) $post );
+			}
 
 			if ( $post ) {
 				$new_posts[] = $post;
 			}
 		}
+
+		// if multisite is enabled get post object for each site
+		if( is_multisite() ) {
+			$new_posts = $this->fetch_wp_post_object( $new_posts );
+		}
+
 		$this->posts_by_query[spl_object_hash( $query )] = $new_posts;
 
 		do_action( 'ep_wp_query_search', $new_posts, $search, $query );
@@ -295,6 +307,58 @@ class EP_WP_Query_Integration {
 		global $wpdb;
 
 		return "SELECT * FROM $wpdb->posts WHERE 1=0";
+	}
+
+	/**
+	 * Get post object data in multisite network.
+	 * Using post ID is better as get_post function pupulates all possible fields
+	 * So passing post ID and then merging with inital post object pupulates all expected fields
+	 * for WP_Post object
+	 *
+	 * @param  array $post_list list of found post objects
+	 * @return array            list of WP_Post objects
+	 */
+	public function fetch_wp_post_object( $post_list ) {
+		$post_objs = array();
+		$posts_ordered = array();
+		$grouped = array();
+		$order = array();
+
+		// group by site_id to decrease number of switch_to_blogs
+		foreach ( $post_list as $post_data ) {
+			$grouped[$post_data->site_id][] = $post_data;
+			// use this to keep the initial order of posts
+			$order[] = md5( $post_data->ID . ' ' . $post_data->post_date_gmt );
+		}
+
+		foreach ( $grouped as $site_id => $post_data ) {
+			// switch blog only if needed
+			if ( get_current_blog_id() != $site_id ) {
+				global $switched;
+				switch_to_blog( $site_id );
+				foreach ( $post_data as $single_post_data ) {
+					$post_obj = get_post( $single_post_data->ID );
+					$post_objs[] = (object) array_merge( (array) $post_obj, (array) $single_post_data );
+				}
+				restore_current_blog();
+			} else {
+				foreach ( $post_data as $single_post_data ) {
+					$post_obj = get_post( $single_post_data->ID );
+					$post_objs[] = (object) array_merge( (array) $post_obj, (array) $single_post_data );
+				}
+			}
+		}
+
+		// retrive initial order of posts
+		foreach ( $post_objs as $current_index => $post_obj ) {
+			$index = array_search ( md5( $post_obj->ID . ' ' . $post_obj->post_date_gmt ), $order );
+			$posts_ordered[$index] = $post_objs[$current_index];
+		}
+
+		// sort by indexes/keys
+		ksort( $posts_ordered );
+
+		return $posts_ordered;
 	}
 
 	/**

--- a/tests/test-multisite.php
+++ b/tests/test-multisite.php
@@ -1443,6 +1443,46 @@ class EPTestMultisite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test post object data
+	 *
+	 * @since 1.4
+	 */
+	public function testPostObject() {
+		$sites = ep_get_sites();
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			ep_create_and_sync_post( array( 'post_title' => 'findme', 'post_author' => $site['blog_id'] ) );
+			ep_create_and_sync_post( array( 'post_title' => 'findme', 'post_author' => $site['blog_id'] ) );
+
+			ep_refresh_index();
+
+			restore_current_blog();
+		}
+
+		$args = array(
+			's' => 'findme',
+			'sites' => 'all',
+			'posts_per_page' => 10,
+		);
+
+		$query = new WP_Query( $args );
+
+
+		$this->assertEquals( 6, $query->post_count );
+		$this->assertEquals( 6, $query->found_posts );
+
+		while ( $query->have_posts() ) {
+			$query->the_post();
+			global $post;
+
+			$this->assertEquals( $post->site_id, $post->post_author );
+		}
+		wp_reset_postdata();
+	}
+
+	/**
 	 * Test index_exists helper function
 	 */
 	public function testIndexExists() {


### PR DESCRIPTION
fix for #235 
Just passing post ID as argument to get_post will override some data in the initial post object and will not work on multisite, but it's better to use as it will return all possible fields. Then merging it with the initial object populates all fields and keeps the initial values.
I've added additional function to make this method work for multisite as well.
