### PR TITLE
Query is checking for date order to be descending, test was checking for...

### DIFF
--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -716,9 +716,9 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
-		$this->assertEquals( 'ordertes 333', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertest 111', $query->posts[1]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[2]->post_title );
+		$this->assertEquals( 'ordertes 333', $query->posts[2]->post_title );
 	}
 
 	/**


### PR DESCRIPTION
The query in the test was getting results by date in descending order, while the asserts were setup to check for ascending order. This should resolve the CI build errors by allowing unit tests to pass.