### PR TITLE
Fix wrong author ID in post object

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -269,6 +269,7 @@ class EP_WP_Query_Integration {
 				$post->site_id = $post_array['site_id'];
 			}
 
+			$post->post_author = $post_array['post_author']['id'];
 			$post->post_type = $post_array['post_type'];
 			$post->post_name = $post_array['post_name'];
 			$post->post_status = $post_array['post_status'];


### PR DESCRIPTION
When using ElasticPress in the admin section of WP and doing a search, the user ID from get_post is set to zero even when Elastic Search has the ID.

This was tested and resolve the issue I am having.