### PR TITLE
Adding filter to set default sortorder

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -636,14 +636,18 @@ class EP_API {
 		if ( empty( $args['orderby'] ) || false === $sort ) {
 
 			// Default sort is to use the score (based on relevance)
-			$formatted_args['sort'] = array(
+			$default_sort = array(
 				array(
 					'_score' => array(
 						'order' => $order,
 					),
 				),
 			);
-		}
+
+            $default_sort = apply_filters( 'ep_set_default_sort', $default_sort, $order );
+
+            $formatted_args['sort'] = $default_sort;
+        }
 
 		$filter = array(
 			'and' => array(),


### PR DESCRIPTION
Hi,
I need use the $post->post_modified as the default sortorder and I havn't found a way to do this. It would be great if you add this feature to your plugin.

Thanks for the great work, Hannes