### PR TITLE
Change sync hook

### DIFF
--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -15,7 +15,7 @@ class EP_Sync_Manager {
 	 * @since 0.1.2
 	 */
 	public function setup() {
-		add_action( 'transition_post_status', array( $this, 'action_sync_on_transition' ), 10, 3 );
+		add_action( 'wp_insert_post', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'delete_post', array( $this, 'action_delete_post' ) );
 		add_action( 'delete_blog', array( $this, 'action_delete_blog_from_index') );
 		add_action( 'archive_blog', array( $this, 'action_delete_blog_from_index') );
@@ -48,12 +48,12 @@ class EP_Sync_Manager {
 	/**
 	 * Sync ES index with what happened to the post being saved
 	 *
-	 * @param string $new_status
-	 * @param string $old_status
+	 * @param $post_ID
 	 * @param object $post
+	 * @param $update
 	 * @since 0.1.0
 	 */
-	public function action_sync_on_transition( $new_status, $old_status, $post ) {
+	public function action_sync_on_update( $post_ID, $post, $update ) {
 		global $importer;
 
 		// If we have an importer we must be doing an import - let's abort
@@ -62,32 +62,28 @@ class EP_Sync_Manager {
 		}
 
 		$indexable_post_statuses = ep_get_indexable_post_status();
+		$post_type               = get_post_type( $post_ID );
 
-		if ( ! in_array( $new_status, $indexable_post_statuses ) && ! in_array( $old_status, $indexable_post_statuses ) ) {
-			return;
-		}
-
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! current_user_can( 'edit_post', $post->ID ) || 'revision' === get_post_type( $post->ID ) ) {
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! current_user_can( 'edit_post', $post_ID ) || 'revision' === $post_type ) {
 			return;
 		}
 
 		// Our post was published, but is no longer, so let's remove it from the Elasticsearch index
-		if ( ! in_array( $new_status, $indexable_post_statuses ) ) {
-			$this->action_delete_post( $post->ID );
+		if ( ! in_array( $post->post_status, $indexable_post_statuses ) ) {
+			$this->action_delete_post( $post_ID );
 		} else {
-			$post_type = get_post_type( $post->ID );
+			$post_type = get_post_type( $post_ID );
 
 			$indexable_post_types = ep_get_indexable_post_types();
 
 			if ( in_array( $post_type, $indexable_post_types ) ) {
 
-				do_action( 'ep_sync_on_transition', $post->ID );
+				do_action( 'ep_sync_on_transition', $post_ID );
 
-				$this->sync_post( $post->ID );
+				$this->sync_post( $post_ID);
 			}
 		}
 	}
-
 	/**
 	 * Return a singleton instance of the current class
 	 *


### PR DESCRIPTION
Hi! 

Right now a post would sync using the `transition_post_status` action which is a little early for other plugin (I'm looking at you ACF!). This would therefore not save all updated information on post metas.

Using the `wp_insert_post` action with a low priority would let all other plugin hook before we actually sync with the ElasticSearch index.

Any feedback greatly accepted!
Cheers!
