### PR TITLE
Fix fields not loaded from elasticsearch query

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -274,7 +274,9 @@ class EP_WP_Query_Integration {
 			$post->post_status = $post_array['post_status'];
 			$post->post_title = $post_array['post_title'];
 			$post->post_parent = $post_array['post_parent'];
+			$post->post_excerpt = $post_array['post_excerpt'];
 			$post->post_content = $post_array['post_content'];
+			$post->post_author = $post_array['post_author']['id'];
 			$post->post_date = $post_array['post_date'];
 			$post->post_date_gmt = $post_array['post_date_gmt'];
 			$post->post_modified = $post_array['post_modified'];

--- a/tests/test-multisite.php
+++ b/tests/test-multisite.php
@@ -1686,8 +1686,8 @@ class EPTestMultisite extends EP_Test_Base {
 		foreach ( $sites as $site ) {
 			switch_to_blog( $site['blog_id'] );
 
-			ep_create_and_sync_post( array( 'post_title' => 'findme', 'post_author' => $site['blog_id'] ) );
-			ep_create_and_sync_post( array( 'post_title' => 'findme', 'post_author' => $site['blog_id'] ) );
+			ep_create_and_sync_post( array( 'post_title' => 'findme', 'post_excerpt' => $site['blog_id'] ) );
+			ep_create_and_sync_post( array( 'post_title' => 'findme', 'post_excerpt' => $site['blog_id'] ) );
 
 			ep_refresh_index();
 
@@ -1702,7 +1702,6 @@ class EPTestMultisite extends EP_Test_Base {
 
 		$query = new WP_Query( $args );
 
-
 		$this->assertEquals( 6, $query->post_count );
 		$this->assertEquals( 6, $query->found_posts );
 
@@ -1710,8 +1709,9 @@ class EPTestMultisite extends EP_Test_Base {
 			$query->the_post();
 			global $post;
 
-			$this->assertEquals( $post->site_id, $post->post_author );
+			$this->assertEquals( $post->site_id, $post->post_excerpt );
 		}
+		
 		wp_reset_postdata();
 	}
 


### PR DESCRIPTION
The `post_excerpt` and `post_author` fields were not set in the query integration causing `the_author()` and related functions to fail and `the_excerpt()` to handle the excerpt like there is none.