### PR TITLE
Enhancement for #263 Support like query in metadata, in addition with main query

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -877,6 +877,17 @@ class EP_API {
 							}
 
 							break;
+						case 'like':
+							if ( isset( $single_meta_query['value'] ) ) {
+								$terms_obj = array(
+									'query' => array(
+										"match" => array(
+											'post_meta.' . $single_meta_query['key'] => $single_meta_query['value'],
+										)
+									),
+								);
+							}
+							break;
 						case '=':
 						default:
 							if ( isset( $single_meta_query['value'] ) ) {


### PR DESCRIPTION
- Main query can actually do a like query to meta data. However,
sometimes we need to have both main query and meta data query. They
are, of course, different, hence, it would be great if we can use meta
data query as a filter for main query and this meta data query supports
LIKE rather than normal ‘term’ filter.