### PR TITLE
Feature/fallback hosts

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -477,7 +477,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 		$request_args = array( 'headers' => ep_format_request_headers() );
 
-		$request = wp_remote_get( trailingslashit( EP_HOST ) . '_status/?pretty', $request_args );
+		$request = wp_remote_get( trailingslashit( ep_get_host( true ) ) . '_status/?pretty', $request_args );
 
 		if ( is_wp_error( $request ) ) {
 			WP_CLI::error( implode( "\n", $request->get_error_messages() ) );
@@ -500,7 +500,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 		$request_args = array( 'headers' => ep_format_request_headers() );
 
-		$request = wp_remote_get( trailingslashit( EP_HOST ) . '_stats/', $request_args );
+		$request = wp_remote_get( trailingslashit( ep_get_host( true ) ) . '_stats/', $request_args );
 		if ( is_wp_error( $request ) ) {
 			WP_CLI::error( implode( "\n", $request->get_error_messages() ) );
 		}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -36,13 +36,17 @@ class EP_API {
 	 */
 	public function index_post( $post ) {
 
-		$index_url = ep_get_index_url();
+		$index = trailingslashit( ep_get_index_name() );
 
-		$url = $index_url . '/post/' . $post['post_id'];
+		$path = $index . 'post/' . $post['post_id'];
 
-		$request_args = array( 'body' => json_encode( $post ), 'method' => 'PUT', 'timeout' => 15, 'headers' => $this->format_request_headers() );
+		$request_args = array(
+			'body'    => json_encode( $post ),
+			'method'  => 'PUT',
+			'timeout' => 15,
+		);
 
-		$request = wp_remote_request( $url, apply_filters( 'ep_index_post_request_args', $request_args, $post ) );
+		$request = ep_remote_request( $path, apply_filters( 'ep_index_post_request_args', $request_args, $post ) );
 
 		if ( ! is_wp_error( $request ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
@@ -71,9 +75,10 @@ class EP_API {
 	 * @return bool
 	 */
 	public function refresh_index() {
-		$request_args = array( 'method' => 'POST', 'headers' => $this->format_request_headers() );
 
-		$request = wp_remote_request( ep_get_index_url() . '/_refresh', apply_filters( 'ep_refresh_index_request_args', $request_args ) );
+		$request_args = array( 'method' => 'POST' );
+
+		$request = ep_remote_request( '_refresh', apply_filters( 'ep_refresh_index_request_args', $request_args ) );
 
 		if ( ! is_wp_error( $request ) ) {
 			if ( isset( $request['response']['code'] ) && 200 === $request['response']['code'] ) {
@@ -105,15 +110,20 @@ class EP_API {
 			foreach ( $scope as $site_id ) {
 				$index[] = ep_get_index_name( $site_id );
 			}
+
+			$index = implode( ',', $index );
+		} else {
+			$index = ep_get_index_name();
 		}
 
-		$index_url = ep_get_index_url( $index );
+		$path = $index . '/post/_search';
 
-		$url = $index_url . '/post/_search';
+		$request_args = array(
+			'body'    => json_encode( $args ),
+			'method'  => 'POST',
+		);
 
-		$request_args = array( 'body' => json_encode( $args ), 'method' => 'POST', 'headers' => $this->format_request_headers() );
-
-		$request = wp_remote_request( $url, apply_filters( 'ep_search_request_args', $request_args, $args, $scope ) );
+		$request = ep_remote_request( $path, apply_filters( 'ep_search_request_args', $request_args, $args, $scope ) );
 
 		if ( ! is_wp_error( $request ) ) {
 
@@ -182,13 +192,14 @@ class EP_API {
 	 * @return bool
 	 */
 	public function delete_post( $post_id  ) {
-		$index_url = ep_get_index_url();
 
-		$url = $index_url . '/post/' . $post_id;
+		$index = trailingslashit( ep_get_index_name() );
 
-		$request_args = array( 'method' => 'DELETE', 'timeout' => 15, 'headers' => $this->format_request_headers() );
+		$path = $index . '/post/' . $post_id;
 
-		$request = wp_remote_request( $url, apply_filters( 'ep_delete_post_request_args', $request_args, $post_id ) );
+		$request_args = array( 'method' => 'DELETE', 'timeout' => 15 );
+
+		$request = ep_remote_request( $path, apply_filters( 'ep_delete_post_request_args', $request_args, $post_id ) );
 
 		if ( ! is_wp_error( $request ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
@@ -229,13 +240,14 @@ class EP_API {
 	 * @return bool
 	 */
 	public function get_post( $post_id ) {
-		$index_url = ep_get_index_url();
 
-		$url = $index_url . '/post/' . $post_id;
+		$index = ep_get_index_name();
 
-		$request_args = array( 'method' => 'GET', 'headers' => $this->format_request_headers() );
+		$path = $index . '/post/' . $post_id;
 
-		$request = wp_remote_request( $url, apply_filters( 'ep_get_post_request_args', $request_args, $post_id ) );
+		$request_args = array( 'method' => 'GET' );
+
+		$request = ep_remote_request( $path, apply_filters( 'ep_get_post_request_args', $request_args, $post_id ) );
 
 		if ( ! is_wp_error( $request ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
@@ -257,11 +269,12 @@ class EP_API {
 	 * @return bool|array
 	 */
 	public function delete_network_alias() {
-		$url = untrailingslashit( EP_HOST ) . '/*/_alias/' . ep_get_network_alias();
 
-		$request_args = array( 'method' => 'DELETE', 'headers' => $this->format_request_headers() );
+		$path = '*/_alias/' . ep_get_network_alias();
 
-		$request = wp_remote_request( $url, apply_filters( 'ep_delete_network_alias_request_args', $request_args ) );
+		$request_args = array( 'method' => 'DELETE' );
+
+		$request = ep_remote_request( $path, apply_filters( 'ep_delete_network_alias_request_args', $request_args ) );
 
 		if ( ! is_wp_error( $request ) && ( 200 >= wp_remote_retrieve_response_code( $request ) && 300 > wp_remote_retrieve_response_code( $request ) ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
@@ -280,10 +293,11 @@ class EP_API {
 	 * @return array|bool
 	 */
 	public function create_network_alias( $indexes ) {
-		$url = untrailingslashit( EP_HOST ) . '/_aliases';
+
+		$path = '_aliases';
 
 		$args = array(
-			'actions' => array()
+			'actions' => array(),
 		);
 
 		foreach ( $indexes as $index ) {
@@ -291,13 +305,16 @@ class EP_API {
 				'add' => array(
 					'index' => $index,
 					'alias' => ep_get_network_alias(),
-				)
+				),
 			);
 		}
 
-		$request_args = array( 'body' => json_encode( $args ), 'method' => 'POST', 'headers' => $this->format_request_headers() );
+		$request_args = array(
+			'body'    => json_encode( $args ),
+			'method'  => 'POST',
+		);
 
-		$request = wp_remote_request( $url, apply_filters( 'ep_create_network_alias_request_args', $request_args, $args, $indexes ) );
+		$request = ep_remote_request( $path, apply_filters( 'ep_create_network_alias_request_args', $request_args, $args, $indexes ) );
 
 		if ( ! is_wp_error( $request ) && ( 200 >= wp_remote_retrieve_response_code( $request ) && 300 > wp_remote_retrieve_response_code( $request ) ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
@@ -342,13 +359,16 @@ class EP_API {
 
 		$mapping = apply_filters( 'ep_config_mapping', $mapping );
 
-		$index_url = ep_get_index_url();
+		$index = ep_get_index_name();
 
-		$request_args = array( 'body' => json_encode( $mapping ), 'method' => 'PUT', 'headers' => $this->format_request_headers() );
+		$request_args = array(
+			'body'    => json_encode( $mapping ),
+			'method'  => 'PUT',
+		);
 
-		$request = wp_remote_request( $index_url, apply_filters( 'ep_put_mapping_request_args', $request_args ) );
+		$request = ep_remote_request( $index, apply_filters( 'ep_put_mapping_request_args', $request_args ) );
 
-		$request = apply_filters( 'ep_config_mapping_request', $request, $index_url, $mapping );
+		$request = apply_filters( 'ep_config_mapping_request', $request, $index, $mapping );
 
 		if ( ! is_wp_error( $request ) && 200 === wp_remote_retrieve_response_code( $request ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
@@ -555,11 +575,11 @@ class EP_API {
 	 */
 	public function delete_index( $index_name = null ) {
 
-		$index_url = ep_get_index_url( $index_name );
+		$index = ( null === $index_name ) ? ep_get_index_name() : sanitize_text_field( $index_name );
 
-		$request_args = array( 'method' => 'DELETE', 'headers' => $this->format_request_headers() );
+		$request_args = array( 'method' => 'DELETE' );
 
-		$request = wp_remote_request( $index_url, apply_filters( 'ep_delete_index_request_args', $request_args ) );
+		$request = ep_remote_request( $index, apply_filters( 'ep_delete_index_request_args', $request_args ) );
 
 		// 200 means the delete was successful
 		// 404 means the index was non-existent, but we should still pass this through as we will occasionally want to delete an already deleted index
@@ -580,11 +600,12 @@ class EP_API {
 	 * @return bool
 	 */
 	public function index_exists( $index_name = null ) {
-		$index_url = ep_get_index_url( $index_name );
 
-		$request_args = array( 'headers' => $this->format_request_headers() );
+		$index = ( null === $index_name ) ? ep_get_index_name() : sanitize_text_field( $index_name );
 
-		$request = wp_remote_head( $index_url, apply_filters( 'ep_index_exists_request_args', $request_args, $index_name ) );
+		$request_args = array( 'method' => 'HEAD' );
+
+		$request = ep_remote_request( $index, apply_filters( 'ep_index_exists_request_args', $request_args, $index_name ) );
 
 		// 200 means the index exists
 		// 404 means the index was non-existent
@@ -1122,11 +1143,15 @@ class EP_API {
 	 */
 	public function bulk_index_posts( $body ) {
 		// create the url with index name and type so that we don't have to repeat it over and over in the request (thereby reducing the request size)
-		$url     = trailingslashit( EP_HOST ) . trailingslashit( ep_get_index_name() ) . 'post/_bulk';
+		$path = trailingslashit( ep_get_index_name() ) . 'post/_bulk';
 
-		$request_args = array( 'method' => 'POST', 'body' => $body, 'timeout' => 30, 'headers' => $this->format_request_headers() );
+		$request_args = array(
+			'method'  => 'POST',
+			'body'    => $body,
+			'timeout' => 30,
+		);
 
-		$request = wp_remote_request( $url, apply_filters( 'ep_bulk_index_posts_request_args', $request_args, $body ) );
+		$request = ep_remote_request( $path, apply_filters( 'ep_bulk_index_posts_request_args', $request_args, $body ) );
 
 		if ( is_wp_error( $request ) ) {
 			return $request;
@@ -1277,14 +1302,19 @@ class EP_API {
 	 * server.
 	 *
 	 * @since 1.1.0
+	 *
+	 * @param string $host The host to check
+	 *
 	 * @return bool
 	 */
-	public function elasticsearch_alive() {
+	public function elasticsearch_alive( $host = null ) {
+
 		$elasticsearch_alive = false;
 
-		$url = EP_HOST;
+		$host = null !== $host ? $host : ep_get_host(); //fallback to EP_HOST if no other host provided
 
 		$request_args = array( 'headers' => $this->format_request_headers() );
+		$url = $host;
 
 		$request = wp_remote_request( $url, apply_filters( 'ep_es_alive_request_args', $request_args ) );
 
@@ -1296,6 +1326,61 @@ class EP_API {
 
 		return $elasticsearch_alive;
 	}
+
+	/**
+	 * Wrapper for wp_remote_request
+	 *
+	 * This is a wrapper function for wp_remote_request that will switch to a backup server
+	 * (if present) should the primary EP host fail.
+	 *
+	 * @since 1.6
+	 *
+	 * @param string $path Site URL to retrieve.
+	 * @param array  $args Optional. Request arguments. Default empty array.
+	 *
+	 * @return WP_Error|array The response or WP_Error on failure.
+	 */
+	public function remote_request( $path, $args = array() ) {
+
+		//The allowance of these variables makes testing easier.
+		$force       = false;
+		$use_backups = false;
+
+		//Add the API Header
+		$args['headers'] = $this->format_request_headers();
+
+		if ( defined( 'EP_FORCE_HOST_REFRESH' ) && true === EP_FORCE_HOST_REFRESH ) {
+			$force = true;
+		}
+
+		if ( defined( 'EP_HOST_USE_ONLY_BACKUPS' ) && true === EP_HOST_USE_ONLY_BACKUPS ) {
+			$use_backups = true;
+		}
+
+		$host    = ep_get_host( $force, $use_backups );
+		$request = false;
+
+		if ( ! is_wp_error( $host ) ) { // probably only reachable in testing but just to be safe
+			$request = wp_remote_request( esc_url( trailingslashit( $host ) . $path ), $args ); //try the existing host to avoid unnecessary calls
+		}
+
+		//If we have a failure we'll try it again with a backup host
+		if ( false === $request || is_wp_error( $request ) || ( isset( $request['response']['code'] ) && 200 !== $request['response']['code'] ) ) {
+
+			$host = ep_get_host( true, $use_backups );
+
+			if ( is_wp_error( $host ) ) {
+				return $host;
+			}
+
+			return wp_remote_request( esc_url( trailingslashit( $host ) . $path ), $args );
+
+		}
+
+		return $request;
+
+	}
+
 }
 
 EP_API::factory();
@@ -1372,8 +1457,8 @@ function ep_is_activated() {
 	return EP_API::factory()->is_activated();
 }
 
-function ep_elasticsearch_alive() {
-	return EP_API::factory()->elasticsearch_alive();
+function ep_elasticsearch_alive( $host = null ) {
+	return EP_API::factory()->elasticsearch_alive( $host );
 }
 
 function ep_index_exists( $index_name = null ) {
@@ -1382,4 +1467,8 @@ function ep_index_exists( $index_name = null ) {
 
 function ep_format_request_headers() {
 	return EP_API::factory()->format_request_headers();
+}
+
+function ep_remote_request( $path, $args ) {
+	return EP_API::factory()->remote_request( $path, $args );
 }

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -22,6 +22,67 @@ class EP_Config {
 	}
 
 	/**
+	 * Retrieve the appropriate EP_HOST
+	 *
+	 * Looks at the defined EP_HOST or a backup global should the defined host failed.
+	 * Priority is given to the EP_HOST constand with the backups only used when needed.
+	 *
+	 * @since 1.6
+	 *
+	 * @global array $ep_backup_host   array of backup hosts
+	 *
+	 * @param bool   $force            Whether to force a new lookup or not
+	 * @param bool   $use_only_backups Forces the use of only the backup array, no others
+	 *
+	 * @return string|WP_Error the host to use or an error
+	 */
+	public function get_ep_host( $force = false, $use_only_backups = false ) {
+
+		global $ep_backup_host;
+
+		// Delete the transient if we want to force a new good host lookup
+		if ( true === $force ) {
+			delete_site_transient( 'ep_last_good_host' );
+		}
+
+		$last_good_host = get_site_transient( 'ep_last_good_host' );
+
+		if ( $last_good_host ) {
+			return $last_good_host;
+		}
+
+		// If nothing is defined just return an error
+		if ( ! defined( 'EP_HOST' ) && ! $ep_backup_host ) {
+			return new WP_Error( 'elasticpress', __( 'No running host available.', 'elasticpress' ) );
+		}
+
+		$hosts = array();
+
+		if ( defined( 'EP_HOST' ) && false === $use_only_backups ) {
+			$hosts[] = EP_HOST;
+		}
+
+		// If no backups are defined just return the host
+		if ( $ep_backup_host && is_array( $ep_backup_host ) ) {
+			$hosts = array_merge( $hosts, $ep_backup_host );
+		}
+
+		foreach ( $hosts as $host ) {
+
+			if ( true === ep_elasticsearch_alive( $host ) ) {
+
+				set_site_transient( 'ep_last_good_host', $host, apply_filters( 'ep_last_good_host_timeout', 3600 ) );
+
+				return $host;
+
+			}
+		}
+
+		return new WP_Error( 'elasticpress', __( 'No running host available.', 'elasticpress' ) );
+
+	}
+
+	/**
 	 * Generates the index name for the current site
 	 *
 	 * @param int $blog_id (optional) Blog ID. Defaults to current blog.
@@ -43,23 +104,6 @@ class EP_Config {
 		}
 
 		return apply_filters( 'ep_index_name', $index_name );
-	}
-
-	/**
-	 * Returns the index url given an index name. Defaults to current index
-	 *
-	 * @param string|array $index
-	 * @since 0.9
-	 * @return string
-	 */
-	public function get_index_url( $index = null ) {
-		if ( null === $index ) {
-			$index = $this->get_index_name();
-		} elseif ( is_array( $index ) ) {
-			$index = implode( ',', array_filter( $index ) );
-		}
-
-		return untrailingslashit( EP_HOST ) . '/' . $index;
 	}
 
 	/**
@@ -107,8 +151,8 @@ EP_Config::factory();
  * Accessor functions for methods in above class. See doc blocks above for function details.
  */
 
-function ep_get_index_url( $index = null ) {
-	return EP_Config::factory()->get_index_url( $index );
+function ep_get_host( $force = false, $use_only_backups = false ) {
+	return EP_Config::factory()->get_ep_host( $force, $use_only_backups );
 }
 
 function ep_get_index_name( $blog_id = null ) {

--- a/readme.txt
+++ b/readme.txt
@@ -49,12 +49,14 @@ configuring single site and multi-site cross-site search are slightly different.
 = Single Site =
 1. Activate the plugin.
 2. Define the constant `EP_HOST` in your wp-config.php file with the connection (and port) of your Elasticsearch application.
-3. Using WP-CLI, do an initial sync (with mapping) with your ES server by running: `wp elasticpress index --setup`.
+3. If you would like to define backup servers in case EP_HOST fails enter `global $ep_backup_host` in wp-config.php and then instantiate the variable with an array of backup hosts to use.
+4. Using WP-CLI, do an initial sync (with mapping) with your ES server by running: `wp elasticpress index --setup`.
 
 = Multi-site Cross-site Search =
 1. Network activate the plugin
 2. Define the constant `EP_HOST` in your wp-config.php file with the connection (and port) of your Elasticsearch application.
-3. Using WP-CLI, do an initial sync (with mapping) with your ES server by running: `wp elasticpress index --setup --network-wide`.
+3. If you would like to define backup servers in case EP_HOST fails enter `global $ep_backup_host` in wp-config.php and then instantiate the variable with an array of backup hosts to use.
+4. Using WP-CLI, do an initial sync (with mapping) with your ES server by running: `wp elasticpress index --setup --network-wide`.
 
 == Changelog ==
 


### PR DESCRIPTION
This gives the option to have one or more fallback servers should the primary ES host fail. Fallback servers can be specified in a global array $eb_backup_hosts. Upon failure of the primary host the backup hosts will be checked sequentially until a good host is found or an error will be returned. Good hosts are cached for an hour before the process is checked again.