### PR TITLE
WP_CLI GET Calls missing headers

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -456,7 +456,9 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	public function status() {
 		$this->_connect_check();
 
-		$request = wp_remote_get( trailingslashit( EP_HOST ) . '_status/?pretty' );
+		$request_args = array( 'headers' => ep_format_request_headers() );
+
+		$request = wp_remote_get( trailingslashit( EP_HOST ) . '_status/?pretty', $request_args );
 
 		if ( is_wp_error( $request ) ) {
 			WP_CLI::error( implode( "\n", $request->get_error_messages() ) );
@@ -477,7 +479,9 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	public function stats() {
 		$this->_connect_check();
 
-		$request = wp_remote_get( trailingslashit( EP_HOST ) . '_stats/' );
+		$request_args = array( 'headers' => ep_format_request_headers() );
+
+		$request = wp_remote_get( trailingslashit( EP_HOST ) . '_stats/', $request_args );
 		if ( is_wp_error( $request ) ) {
 			WP_CLI::error( implode( "\n", $request->get_error_messages() ) );
 		}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1344,3 +1344,7 @@ function ep_elasticsearch_alive() {
 function ep_index_exists( $index_name = null ) {
 	return EP_API::factory()->index_exists( $index_name );
 }
+
+function ep_format_request_headers() {
+	return EP_API::factory()->format_request_headers();
+}


### PR DESCRIPTION
In #249 the option for a security header (API key) was added however it does not function on the stats and status calls when called by WP-CLI as these calls don't use the header. This fixes the issue and adds a callable function for getting the headers in future classes.