### PR TITLE
Include arguments to the ep_get_sites

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -34,8 +34,11 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	public function put_mapping( $args, $assoc_args ) {
 		$this->_connect_check();
 
-		if ( ! empty( $assoc_args['network-wide'] ) && is_multisite() ) {
-			$sites = ep_get_sites();
+		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
+			if ( ! is_numeric( $assoc_args['network-wide'] ) ){
+				$assoc_args['network-wide'] = 0;
+			}
+			$sites = ep_get_sites( $assoc_args['network-wide'] );
 
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site['blog_id'] );
@@ -85,8 +88,11 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	public function delete_index( $args, $assoc_args ) {
 		$this->_connect_check();
 
-		if ( ! empty( $assoc_args['network-wide'] ) && is_multisite() ) {
-			$sites = ep_get_sites();
+		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
+			if ( ! is_numeric( $assoc_args['network-wide'] ) ){
+				$assoc_args['network-wide'] = 0;
+			}
+			$sites = ep_get_sites( $assoc_args['network-wide'] );
 
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site['blog_id'] );
@@ -181,7 +187,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		} else {
 			$assoc_args['posts-per-page'] = 350;
 		}
-		
+
 		if ( ! empty( $assoc_args['offset'] ) ) {
 			$assoc_args['offset'] = absint( $assoc_args['offset'] );
 		} else {
@@ -193,7 +199,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		/**
 		 * Prior to the index command invoking
 		 * Useful for deregistering filters/actions that occur during a query request
-		 * 
+		 *
 		 * @since 1.4.1
 		 */
 		do_action( 'ep_wp_cli_pre_index', $args, $assoc_args );
@@ -210,11 +216,14 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			$this->put_mapping( $args, $assoc_args );
 		}
 
-		if ( ! empty( $assoc_args['network-wide'] ) && is_multisite() ) {
+		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
+			if ( ! is_numeric( $assoc_args['network-wide'] ) ){
+				$assoc_args['network-wide'] = 0;
+			}
 
 			WP_CLI::log( __( 'Indexing posts network-wide...', 'elasticpress' ) );
 
-			$sites = ep_get_sites();
+			$sites = ep_get_sites( $assoc_args['network-wide'] );
 
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site['blog_id'] );
@@ -313,16 +322,16 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			$offset += $posts_per_page;
 
 			usleep( 500 );
-			
+
 			// Avoid running out of memory
 			$wpdb->queries = array();
-	
+
 			if ( is_object( $wp_object_cache ) ) {
 				$wp_object_cache->group_ops = array();
 				$wp_object_cache->stats = array();
 				$wp_object_cache->memcache_debug = array();
 				$wp_object_cache->cache = array();
-		
+
 				if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
 					call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important
 				}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -835,8 +835,8 @@ class EP_API {
 									),
 								);
 							}
-							
-							break;						
+
+							break;
 						case '<=':
 							if ( isset( $single_meta_query['value'] ) ) {
 								$terms_obj = array(
@@ -1082,10 +1082,16 @@ class EP_API {
 	/**
 	 * Wrapper function for wp_get_sites - allows us to have one central place for the `ep_indexable_sites` filter
 	 *
+	 * @param int $limit The maximum amount of sites retrieved, Use 0 to return all sites
+	 *
 	 * @return mixed|void
 	 */
-	public function get_sites() {
-		return apply_filters( 'ep_indexable_sites', wp_get_sites() );
+	public function get_sites( $limit = 0 ) {
+		$args = apply_filters( 'ep_indexable_sites_args', array(
+			'limit' => $limit,
+		) );
+
+		return apply_filters( 'ep_indexable_sites', wp_get_sites( $args ) );
 	}
 
 	/**
@@ -1313,8 +1319,8 @@ function ep_prepare_post( $post_id ) {
 	return EP_API::factory()->prepare_post( $post_id );
 }
 
-function ep_get_sites() {
-	return EP_API::factory()->get_sites();
+function ep_get_sites( $limit = 0 ) {
+	return EP_API::factory()->get_sites( $limit );
 }
 
 function ep_bulk_index_posts( $body ) {


### PR DESCRIPTION
- New Filter `ep_indexable_sites_args` to allow control over the whole `wp_get_sites`
- Easy usage of --network-wide=INT to change the limit, defaults to 0 where it has no LIMIT

_Resolve:_ #272