### PR TITLE
Run unit tests again.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,5 @@
 <?php
 
- if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
-}
-
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';

--- a/tests/includes/class-ep-test-base.php
+++ b/tests/includes/class-ep-test-base.php
@@ -1,7 +1,5 @@
 <?php
- if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
-}
+
 class EP_Test_Base extends WP_UnitTestCase {
 
 	/**

--- a/tests/includes/functions.php
+++ b/tests/includes/functions.php
@@ -1,9 +1,5 @@
 <?php
 
- if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
-}
-
 /**
  * Recursive version of PHP's in_array
  *

--- a/tests/test-multisite.php
+++ b/tests/test-multisite.php
@@ -1,9 +1,5 @@
 <?php
 
- if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
-}
-
 class EPTestMultisite extends EP_Test_Base {
 
 	/**

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1,9 +1,5 @@
 <?php
 
- if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
-}
-
 class EPTestSingleSite extends EP_Test_Base {
 
 	/**


### PR DESCRIPTION
This reverts parts of e8c82bb3c72617dd4db19513bb3eadc58cb748cd since `ABSPATH` isn't (always) defined for tests, especially not in `tests/bootstrap.php`.