### PR TITLE
Add support for category_name queries

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -706,6 +706,23 @@ class EP_API {
 		}
 
 		/**
+		 * 'category_name' arg support.
+		 *
+		 * @since 1.5
+		 */
+		if ( ! empty( $args[ 'category_name' ] ) ) {
+			$terms_obj = array(
+				'terms.category.slug' => array( $args[ 'category_name' ] ),
+			);
+
+			$filter['and'][]['bool']['must'] = array(
+				'terms' => $terms_obj
+			);
+
+			$use_filters = true;
+		}
+
+		/**
 		 * Author query support
 		 *
 		 * @since 1.0

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -363,6 +363,32 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test a category_name query
+	 *
+	 * @since 1.5
+	 */
+	public function testCategoryNameQuery() {
+		$cat_one = wp_insert_category( array( 'cat_name' => 'one') );
+		$cat_two = wp_insert_category( array( 'cat_name' => 'two') );
+		$cat_three = wp_insert_category( array( 'cat_name' => 'three') );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'post_category' => array( $cat_one, $cat_two ) ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 3', 'post_category' => array( $cat_one, $cat_three) ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'             => 'findme',
+			'category_name' => 'one'
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+	}
+
+	/**
 	 * Test an author ID query
 	 *
 	 * @since 1.0


### PR DESCRIPTION
WordPress supports searches via the `category_name` argument. The arg is set on pages like example.com/category/foo/?s=bar.
I think ElasticPress should support this type of queries too.

Workaround:
```php
add_filter( 'ep_formatted_args', 'ds_category_name_searches', 10, 2 );
function ds_category_name_searches( $formatted_args, $args ) {

	if ( ! empty( $args[ 'category_name' ] ) ) {
		$terms_obj = array(
			'terms.category.slug' => array( $args[ 'category_name' ] ),
		);

		$formatted_args['filter']['and'][]['bool']['must'] = array(
			'terms' => $terms_obj
		);
	}

	return $formatted_args;
}

