### PR TITLE
Added a `destroy()` method

### DIFF
--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -25,6 +25,19 @@ class EP_Sync_Manager {
 		add_action( 'archive_blog', array( $this, 'action_delete_blog_from_index') );
 		add_action( 'deactivate_blog', array( $this, 'action_delete_blog_from_index') );
 	}
+	
+	/**
+	 * Remove actions and filters
+	 *
+	 * @since 1.4
+	 */
+	public function destroy() {
+		remove_action( 'wp_insert_post', array( $this, 'action_sync_on_update' ), 999, 3 );
+		remove_action( 'delete_post', array( $this, 'action_delete_post' ) );
+		remove_action( 'delete_blog', array( $this, 'action_delete_blog_from_index') );
+		remove_action( 'archive_blog', array( $this, 'action_delete_blog_from_index') );
+		remove_action( 'deactivate_blog', array( $this, 'action_delete_blog_from_index') );
+	}
 
 	public function action_delete_blog_from_index( $blog_id ) {
 		if ( ep_index_exists( ep_get_index_name( $blog_id ) ) && ! apply_filters( 'ep_keep_index', false ) ) {


### PR DESCRIPTION
It would be helpful to have a method that does the opposite of `setup()` for removing the sync hooks. The use case being I want local dev instances of sites to use the live Elasticsearch index but I don't want post updates/deletions on my local set-up to propagate to the production index.

Adding a method to this class would simplify things since when new hooks are added to ElasticPress, I wouldn't need to keep up with the changes. I could just call one method and be done with it.