### PR TITLE
Resolves PHP notices post 1.5 upgrade.

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -309,7 +309,7 @@ class EP_WP_Query_Integration {
 			foreach ( $post_return_args as $key ) {
 				if( $key === 'post_author' ) {
 					$post->$key = $post_array[$key]['id'];
-				} else {
+				} elseif ( isset( $post_array[ $key ] ) ) {
 					$post->$key = $post_array[$key];
 				}
 			}

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1513,4 +1513,31 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertTrue( empty( $cache ) );
 	}
+	
+		
+	/**
+	 * Test if $post object values exist after receiving odd values from the 'ep_search_post_return_args' filter.
+	 * @group 306
+	 * @link https://github.com/10up/ElasticPress/issues/306
+	 */
+	public function testPostReturnArgs() {
+		add_filter( 'ep_search_post_return_args', array( $this, 'ep_search_post_return_args_filter' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme' ) );
+		ep_refresh_index();
+		$args	 = array(
+			's' => 'findme'
+		);
+		$query	 = new WP_Query( $args );
+		remove_filter( 'ep_search_post_return_args', array( $this, 'ep_search_post_return_args_filter' ) );
+	}
+
+	/**
+	 * Adds fake_item to post_return_args.
+	 * @param array $args
+	 * @return string
+	 */
+	public function ep_search_post_return_args_filter( $args ) {
+		$args[] = 'fake_item';
+		return $args;
+	}
 }


### PR DESCRIPTION
Issue #306 shows that there are PHP notices due to array keys not existing in the $post_array. To test, I utilized the ep_search_post_return_args filter to add a fake_item to the $post_return_args array. If the item in the array does not exist, the test will error out. 

The resolution for this was to add an isset() conditional to verify that the key exists in the $post_array.