### PR TITLE
Use the `ep_post_sync_kill` filter for bulk index

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -362,9 +362,17 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	private function queue_post( $post_id, $bulk_trigger ) {
 		static $post_count = 0;
 
+		$post_args = ep_prepare_post( $post_id );
+
+		// Mimic EP_Sync_Manager::sync_post( $post_id ), otherwise posts can slip
+		// through the kill filter... that would be bad!
+		if ( apply_filters( 'ep_post_sync_kill', false, $post_args, $post_id ) ) {
+			return true;
+		}
+
 		// put the post into the queue
 		$this->posts[$post_id][] = '{ "index": { "_id": "' . absint( $post_id ) . '" } }';
-		$this->posts[$post_id][] = addcslashes( json_encode( ep_prepare_post( $post_id ) ), "\n" );
+		$this->posts[$post_id][] = addcslashes( json_encode( $post_args ), "\n" );
 
 		// augment the counter
 		++$post_count;


### PR DESCRIPTION
Added the `ep_post_sync_kill` filter when queing posts too, otherwise they get indexed anyway.