### PR TITLE
Filter the _source post array from Elasticsearch

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -140,7 +140,7 @@ class EP_API {
 			foreach ( $hits as $hit ) {
 				$post = $hit['_source'];
 				$post['site_id'] = $this->parse_site_id( $hit['_index'] );
-				$posts[] = $post;
+				$posts[] = apply_filters( 'ep_retrieve_the_post', $post, $hit );
 			}
 
 			return array( 'found_posts' => $response['hits']['total'], 'posts' => $posts );


### PR DESCRIPTION
By filtering the _source array when building the posts in the API class, this provides the ability to pass data from the Elasticsearch hit to the view. Our use case is to pass the `_score` and `highlight` for rendering in search results. 

**Example usage:**

```php
add_filter( 'ep_retrieve_the_post', function ( $post, $hit ) {

    $post['score'] = $hit['_score'];

    return $post;

}, 10, 2 );
```

Currently, the best way to handle this is to leverage the `ep_retrieve_raw_response` action, but that necessitates rewriting functionality from the `EP_WP_Query_Integration` class (maintaining the `$query_stack`, preparing the posts, filtering `the_posts`, etc.). This new filter would provide an easier way to accomplish this.

We’ve also submitted [a PR](https://github.com/wpengine/wpe-search/pull/31) on the WP Engine fork.