### PR TITLE
Add filter to search results

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -153,7 +153,18 @@ class EP_API {
 				$posts[] = $post;
 			}
 
-			return array( 'found_posts' => $response['hits']['total'], 'posts' => $posts );
+			/**
+			 * Filter search results.
+			 *
+			 * Allows more complete use of filtering request variables by allowing for filtering of results.
+			 *
+			 * @since 1.6.0
+			 *
+			 * @param array  $results  The unfiltered search results.
+			 * @param object $response The response body retrieved from ElasticSearch.
+			 */
+
+			return apply_filters( 'ep_search_results_array', array( 'found_posts' => $response['hits']['total'], 'posts' => $posts ), $response );
 		}
 
 		return false;


### PR DESCRIPTION
Adds a filter to search results to allow filtering of results after retrieval from ES.

When making use of filtering request_args for the search function many of the return variables (such as search term highlighting) will modify the response in ways that aren't easily accounted without being able to modify the return data. This filter adds in the ability to filter the return data while adding the initial response thereby allowing the developer to better make use of the various modifications that are enabled with the 'ep_search_request_args' filter.