### PR TITLE
Extra check for proper host.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1324,6 +1324,15 @@ class EP_API {
 
 		$host = null !== $host ? $host : ep_get_host(); //fallback to EP_HOST if no other host provided
 
+		//If we get a WP_Error try again for backups and return false if we still get an error
+		if ( is_wp_error( $host ) ) {
+			$host = ep_get_host( true );
+		}
+
+		if ( is_wp_error( $host ) ) {
+			return $elasticsearch_alive;
+		}
+
 		$request_args = array( 'headers' => $this->format_request_headers() );
 		$url = $host;
 


### PR DESCRIPTION
After running ep_get_host() the elasticsearch_alive() method will still attempt to reach the host even if a wp_error is returned due to a failure of all available hosts. This fix will force a 2nd host check for backups and then return false instead of the wp_error();