### PR TITLE
Allow indexing for posts that have "0000-00-00 00:00:00" date value

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -5,6 +5,11 @@
 class EP_API {
 
 	/**
+	 * @var string
+	 */
+	const INVALID_DATETIME = "0000-00-00 00:00:00";
+
+	/**
 	 * Placeholder method
 	 *
 	 * @since 0.1.0
@@ -432,7 +437,7 @@ class EP_API {
 				$post_date = null;
 			}
 
-			if ( ! strtotime( $post_date_gmt ) ) {
+			if ( ! strtotime( $post_date_gmt ) || $post_date_gmt == self::INVALID_DATETIME ) {
 				$post_date_gmt = null;
 			}
 
@@ -440,7 +445,7 @@ class EP_API {
 				$post_modified = null;
 			}
 
-			if ( ! strtotime( $post_modified_gmt ) ) {
+			if ( ! strtotime( $post_modified_gmt ) || $post_modified_gmt == self::INVALID_DATETIME ) {
 				$post_modified_gmt = null;
 			}
 		}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -498,6 +498,7 @@ class EP_API {
 		}
 
 		$terms = array();
+		$allowedHierarchy = apply_filters('ep_sync_term_allow_hierarchy', false);
 
 		foreach ( $selected_taxonomies as $taxonomy ) {
 			$object_terms = get_the_terms( $post->ID, $taxonomy->name );
@@ -506,17 +507,45 @@ class EP_API {
 				continue;
 			}
 
-			foreach ( $object_terms as $term ) {
-				$terms[$term->taxonomy][] = array(
-					'term_id' => $term->term_id,
-					'slug'    => $term->slug,
-					'name'    => $term->name,
-					'parent'  => $term->parent
-				);
-			}
-		}
+			$termsDic = array();
 
-		return $terms;
+			foreach ( $object_terms as $term ) {
+				if( ! isset( $termsDic[ $term->term_id ] ) ) {
+					$termsDic[ $term->term_id ] = array(
+						'term_id' => $term->term_id,
+						'slug'    => $term->slug,
+						'name'    => $term->name,
+						'parent'  => $term->parent
+					);
+				}
+				if( $allowedHierarchy ){
+					$termsDic = $this->getParents( $termsDic, $term, $taxonomy->name );
+				}
+			}
+			$terms[$taxonomy->name] = array_values( $termsDic );
+		}
+	}
+
+	/**
+	 * Recursively get all the ancestor terms of given term
+	 * @param $terms
+	 * @param $term
+	 * @param $taxonomyName
+	 * @return mixed
+	 */
+	private function getParents( $terms, $term, $taxonomyName ) {
+		$parentTerm = get_term( $term->parent, $taxonomyName );
+		if( ! $parentTerm || is_wp_error( $parentTerm ) )
+			return $terms;
+		if( ! isset( $terms[ $parentTerm->term_id ] ) ) {
+			$terms[ $parentTerm->term_id ] = array(
+				'term_id' => $parentTerm->term_id,
+				'slug'    => $parentTerm->slug,
+				'name'    => $parentTerm->name,
+				'parent'  => $parentTerm->parent
+			);
+		}
+		return $this->getParents( $terms, $parentTerm, $taxonomyName );
 	}
 
 	/**

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -12,6 +12,11 @@ class EP_API {
 	public function __construct() { }
 
 	/**
+	 * @var string
+	 */
+	const INVALID_DATETIME = "0000-00-00 00:00:00";
+
+	/**
 	 * Return singleton instance of class
 	 *
 	 * @return EP_API
@@ -432,7 +437,7 @@ class EP_API {
 				$post_date = null;
 			}
 
-			if ( ! strtotime( $post_date_gmt ) ) {
+			if ( ! strtotime( $post_date_gmt ) || $post_date_gmt == self::INVALID_DATETIME ) {
 				$post_date_gmt = null;
 			}
 
@@ -440,7 +445,7 @@ class EP_API {
 				$post_modified = null;
 			}
 
-			if ( ! strtotime( $post_modified_gmt ) ) {
+			if ( ! strtotime( $post_modified_gmt ) || $post_modified_gmt == self::INVALID_DATETIME ) {
 				$post_modified_gmt = null;
 			}
 		}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -5,11 +5,6 @@
 class EP_API {
 
 	/**
-	 * @var string
-	 */
-	const INVALID_DATETIME = "0000-00-00 00:00:00";
-
-	/**
 	 * Placeholder method
 	 *
 	 * @since 0.1.0
@@ -437,7 +432,7 @@ class EP_API {
 				$post_date = null;
 			}
 
-			if ( ! strtotime( $post_date_gmt ) || $post_date_gmt == self::INVALID_DATETIME ) {
+			if ( ! strtotime( $post_date_gmt ) ) {
 				$post_date_gmt = null;
 			}
 
@@ -445,7 +440,7 @@ class EP_API {
 				$post_modified = null;
 			}
 
-			if ( ! strtotime( $post_modified_gmt ) || $post_modified_gmt == self::INVALID_DATETIME ) {
+			if ( ! strtotime( $post_modified_gmt ) ) {
 				$post_modified_gmt = null;
 			}
 		}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -498,7 +498,7 @@ class EP_API {
 		}
 
 		$terms = array();
-		$allowedHierarchy = apply_filters('ep_sync_term_allow_hierarchy', false);
+		$allowedHierarchy = apply_filters('ep_sync_terms_allow_hierarchy', false);
 
 		foreach ( $selected_taxonomies as $taxonomy ) {
 			$object_terms = get_the_terms( $post->ID, $taxonomy->name );
@@ -524,6 +524,8 @@ class EP_API {
 			}
 			$terms[$taxonomy->name] = array_values( $termsDic );
 		}
+
+		return $terms;
 	}
 
 	/**

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -266,8 +266,9 @@ class EPTestSingleSite extends EP_Test_Base {
         $expectedTerms = array( $term3['term_id'] );
 
         $this->assertTrue( count( $indexedTerms ) > 0 );
-        array_walk($indexedTerms, function( $term ) use( $expectedTerms ) {
-           $this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
+		$me = $this;
+        array_walk($indexedTerms, function( $term ) use( $expectedTerms, $me ) {
+           $me->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
         });
 	}
 
@@ -311,8 +312,9 @@ class EPTestSingleSite extends EP_Test_Base {
 		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
 		
 		$this->assertTrue( count( $indexedTerms ) > 0 );
-		array_walk( $indexedTerms, function( $term ) use ($expectedTerms ) {
-			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
+		$me = $this;
+		array_walk( $indexedTerms, function( $term ) use ($expectedTerms, $me ) {
+			$me->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		});
 	}
 
@@ -358,8 +360,9 @@ class EPTestSingleSite extends EP_Test_Base {
 		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
 
 		$this->assertTrue( count( $indexedTerms ) > 0 );
-		array_walk( $indexedTerms, function( $term ) use ($expectedTerms ) {
-			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
+		$me = $this;
+		array_walk( $indexedTerms, function( $term ) use ($expectedTerms, $me ) {
+			$me->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		});
 
 	}
@@ -405,8 +408,9 @@ class EPTestSingleSite extends EP_Test_Base {
 		$expectedTerms = array( $term3['term_id'] );
 
 		$this->assertTrue( count( $indexedTerms ) > 0 );
-		array_walk($indexedTerms, function( $term ) use( $expectedTerms ) {
-			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
+		$me = $this;
+		array_walk($indexedTerms, function( $term ) use( $expectedTerms, $me) {
+			$me->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		});
 	}
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -35,7 +35,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		parent::tearDown();
 
 		//make sure no one attached to this
-		remove_filter('ep_sync_terms_allow_hierarchy', [ $this, 'ep_allow_multiple_level_terms_sync' ], 100);
+		remove_filter('ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100);
 		$this->fired_actions = array();
 	}
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -36,7 +36,6 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		//make sure no one attached to this
 		remove_filter('ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100);
-		remove_filter('ep_indexable_post_status', array( $this, 'mockIndexablePostStatus' ), 10);
 		$this->fired_actions = array();
 	}
 
@@ -1834,35 +1833,5 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertTrue( $request_4 );
 		$this->assertTrue( $request_5 );
 
-	}
-
-	public function mockIndexablePostStatus($post_statuses){
-		$post_statuses = array();
-		$post_statuses[] = "draft";
-		return $post_statuses;
-	}
-
-	public function testPostInvalidDateTime(){
-		add_filter( 'ep_indexable_post_status', array( $this, 'mockIndexablePostStatus' ), 10, 1 );
-		$post_id = ep_create_and_sync_post( array( 'post_status' => 'draft' ) );
-
-		ep_refresh_index();
-
-		ep_sync_post($post_id);
-
-		wp_cache_flush();
-
-		$wp_post = get_post($post_id);
-		$post = ep_get_post($post_id);
-
-		$invalid_datetime = "0000-00-00 00:00:00";
-		if( $wp_post->post_date_gmt == $invalid_datetime ){
-			$this->assertNull( $post[ 'post_date_gmt'] );
-		}
-
-		if( $wp_post->post_modified_gmt == $invalid_datetime ){
-			$this->assertNull( $post[ 'post_modified_gmt' ] );
-		}
-		$this->assertNotNull( $post );
 	}
 }

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -35,7 +35,8 @@ class EPTestSingleSite extends EP_Test_Base {
 		parent::tearDown();
 
 		//make sure no one attached to this
-		remove_filter('ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100);
+		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100);
+		remove_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10);
 		$this->fired_actions = array();
 	}
 
@@ -1833,5 +1834,35 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertTrue( $request_4 );
 		$this->assertTrue( $request_5 );
 
+	}
+
+	public function mock_indexable_post_status($post_statuses){
+		$post_statuses = array();
+		$post_statuses[] = "draft";
+		return $post_statuses;
+	}
+
+	public function testPostInvalidDateTime(){
+		add_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10, 1 );
+		$post_id = ep_create_and_sync_post( array( 'post_status' => 'draft' ) );
+
+		ep_refresh_index();
+
+		ep_sync_post($post_id);
+
+		wp_cache_flush();
+
+		$wp_post = get_post($post_id);
+		$post = ep_get_post($post_id);
+
+		$invalid_datetime = "0000-00-00 00:00:00";
+		if( $wp_post->post_date_gmt == $invalid_datetime ){
+			$this->assertNull( $post[ 'post_date_gmt'] );
+		}
+
+		if( $wp_post->post_modified_gmt == $invalid_datetime ){
+			$this->assertNull( $post[ 'post_modified_gmt' ] );
+		}
+		$this->assertNotNull( $post );
 	}
 }

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -352,7 +352,6 @@ class EPTestSingleSite extends EP_Test_Base {
 		$post = $query->posts[0];
 
 		$terms = $post->terms;
-		error_log(var_export($terms, true));
 		$this->assertTrue( isset( $terms[$taxName] ) );
 		$this->assertTrue( count( $terms[$taxName] ) === 3 );
 		$indexedTerms = $terms[$taxName];

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -241,7 +241,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$post = get_post( $post_id );
 
 		$taxName = rand_str( 32 );
-		register_taxonomy( $taxName, $post->post_type, ["label" => $taxName] );
+		register_taxonomy( $taxName, $post->post_type, array( "label" => $taxName ) );
 		register_taxonomy_for_object_type( $taxName, $post->post_type );
 
 		$term1Name = rand_str( 32 );
@@ -264,6 +264,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
         $indexedTerms = $terms[$taxName];
         $expectedTerms = array( $term3['term_id'] );
+
+        $this->assertTrue( count( $indexedTerms ) > 0 );
         array_walk($indexedTerms, function( $term ) use( $expectedTerms ) {
            $this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
         });
@@ -279,12 +281,12 @@ class EPTestSingleSite extends EP_Test_Base {
 	 */
 	public function testPostTermSyncHierarchyMultipleLevel(){
 
-		add_filter('ep_sync_terms_allow_hierarchy', [$this, 'ep_allow_multiple_level_terms_sync'], 100, 1);
+		add_filter('ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100, 1);
 		$post_id = ep_create_and_sync_post();
 		$post = get_post( $post_id );
 
 		$taxName = rand_str( 32 );
-		register_taxonomy( $taxName, $post->post_type, ["label" => $taxName] );
+		register_taxonomy( $taxName, $post->post_type, array( "label" => $taxName ) );
 		register_taxonomy_for_object_type( $taxName, $post->post_type );
 
 		$term1Name = rand_str( 32 );
@@ -307,7 +309,104 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertTrue( count( $terms[$taxName] ) === 3 );
 		$indexedTerms = $terms[$taxName];
 		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
+		
+		$this->assertTrue( count( $indexedTerms ) > 0 );
 		array_walk( $indexedTerms, function( $term ) use ($expectedTerms ) {
+			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
+		});
+	}
+
+	/**
+	 * @group testPostTermSyncHierarchy
+	 *
+	 */
+	public function testPostTermSyncHierarchyMultipleLevelQuery(){
+
+		add_filter('ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100, 1);
+		$post_id = ep_create_and_sync_post(array("post_title" => "#findme"));
+		$post = get_post( $post_id );
+
+		$taxName = rand_str( 32 );
+		register_taxonomy( $taxName, $post->post_type, array( "label" => $taxName ) );
+		register_taxonomy_for_object_type( $taxName, $post->post_type );
+
+		$term1Name = rand_str( 32 );
+		$term1 = wp_insert_term( $term1Name, $taxName );
+
+		$term2Name = rand_str( 32 );
+		$term2 = wp_insert_term( $term2Name, $taxName, array( 'parent' => $term1['term_id'] ) );
+
+		$term3Name = rand_str( 32 );
+		$term3 = wp_insert_term( $term3Name, $taxName, array( 'parent' => $term2['term_id'] ) );
+
+		wp_set_object_terms( $post_id, array( $term3['term_id'] ), $taxName, true );
+
+		ep_sync_post( $post_id );
+		ep_refresh_index();
+
+		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
+		$query = new WP_Query(array('s' => "#findme"));
+
+		$this->assertNotNull($query->posts[0]);
+		$this->assertNotNull($query->posts[0]->terms);
+		$post = $query->posts[0];
+
+		$terms = $post->terms;
+		error_log(var_export($terms, true));
+		$this->assertTrue( isset( $terms[$taxName] ) );
+		$this->assertTrue( count( $terms[$taxName] ) === 3 );
+		$indexedTerms = $terms[$taxName];
+		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
+
+		$this->assertTrue( count( $indexedTerms ) > 0 );
+		array_walk( $indexedTerms, function( $term ) use ($expectedTerms ) {
+			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
+		});
+
+	}
+
+	/**
+	 * @group testPostTermSyncHierarchy
+	 *
+	 */
+	public function testPostTermSyncSingleLevelQuery(){
+
+		$post_id = ep_create_and_sync_post(array("post_title" => "#findme"));
+		$post = get_post( $post_id );
+
+		$taxName = rand_str( 32 );
+		register_taxonomy( $taxName, $post->post_type, array( "label" => $taxName ) );
+		register_taxonomy_for_object_type( $taxName, $post->post_type );
+
+		$term1Name = rand_str( 32 );
+		$term1 = wp_insert_term( $term1Name, $taxName );
+
+		$term2Name = rand_str( 32 );
+		$term2 = wp_insert_term( $term2Name, $taxName, array( 'parent' => $term1['term_id'] ) );
+
+		$term3Name = rand_str( 32 );
+		$term3 = wp_insert_term( $term3Name, $taxName, array( 'parent' => $term2['term_id'] ) );
+
+		wp_set_object_terms( $post_id, array( $term3['term_id'] ), $taxName, true );
+
+		ep_sync_post( $post_id );
+		ep_refresh_index();
+
+		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
+		$query = new WP_Query(array('s' => "#findme"));
+
+		$this->assertNotNull($query->posts[0]);
+		$this->assertNotNull($query->posts[0]->terms);
+		$post = $query->posts[0];
+
+		$terms = $post->terms;
+		$this->assertTrue( isset( $terms[$taxName] ) );
+
+		$indexedTerms = $terms[$taxName];
+		$expectedTerms = array( $term3['term_id'] );
+
+		$this->assertTrue( count( $indexedTerms ) > 0 );
+		array_walk($indexedTerms, function( $term ) use( $expectedTerms ) {
 			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		});
 	}


### PR DESCRIPTION
- Draft, pending, auto-draft post will have post_date_gmt set to:
“0000-00-00 00:00:00”. This value is not parseable by ElasticSearch,
hence, we will need to set it to null value to get indexing gone
through.
http://cl.ly/image/2J2U0H3u2f3c
- This will also apply for post_modified_gmt