### PR TITLE
Indexable post type check for exclude_from_search. (fixes #321)

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -113,7 +113,7 @@ class EP_Config {
 	 * @return mixed|void
 	 */
 	public function get_indexable_post_types() {
-		$post_types = get_post_types( array( 'public' => true ) );
+		$post_types = get_post_types( array( 'public' => true, 'exclude_from_search' => false ) );
 
 		return apply_filters( 'ep_indexable_post_types', $post_types );
 	}

--- a/tests/includes/class-ep-test-base.php
+++ b/tests/includes/class-ep-test-base.php
@@ -66,7 +66,7 @@ class EP_Test_Base extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Setup a post type for testing
+	 * Setup a few post types for testing
 	 *
 	 * @since 1.0
 	 */
@@ -77,5 +77,14 @@ class EP_Test_Base extends WP_UnitTestCase {
 		);
 
 		register_post_type( 'ep_test', $args );
+		
+		// Post type that is excluded from search.
+		$args = array(
+			'public' => true,
+			'taxonomies' => array( 'post_tag', 'category' ),
+			'exclude_from_search' => true,
+		);
+
+		register_post_type( 'ep_test_excluded', $args );
 	}
 }

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1735,4 +1735,16 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertNotNull( $post );
 		remove_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10);
 	}
+	
+	/**
+	 * Test to verify that a post type that is set to exclude_from_search isn't indexable.
+	 * @group 321
+	 * @since 1.6
+	 * @link https://github.com/10up/ElasticPress/issues/321
+	 */
+	public function testExcludeIndexablePostType() {
+		$post_types = ep_get_indexable_post_types();
+		$this->assertArrayNotHasKey( 'ep_test_excluded', $post_types );
+	}
+
 }


### PR DESCRIPTION
Update to get_indexable_post_types() to only return post types that have exclude_from_search set to false and a unit test to verify.