### PR TITLE
Add configuration to choose to index all attachments at index time

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -125,7 +125,12 @@ class EP_Config {
 	 * @return array
 	 */
 	public function get_indexable_post_status() {
-		return apply_filters( 'ep_indexable_post_status', array( 'publish' ) );
+    if ( defined( 'EP_INDEX_ATTACHMENTS' ) ) {
+		  return apply_filters( 'ep_indexable_post_status', array( 'publish', 'inherit' ) );
+    }
+    else {
+		  return apply_filters( 'ep_indexable_post_status', array( 'publish' ) );
+    }
 	}
 
 	/**


### PR DESCRIPTION
Hi, my apologies if this patch should be applied within https://github.com/10up/ElasticPress/pull/319, I wasn't sure as I see that it has already been merged.

Anyway, this patch essentially just adds a new ElasticPress config  (EP_INDEX_ATTACHMENTS) that, if defined in wp-config.php will cause all attachments to indexed on initial ElasticSearch index. I believe something like this was discussed here - https://github.com/10up/ElasticPress/pull/319#commitcomment-12347070

I'm unclear if this is actually the appropriate place to be checking runtime configuration, so suggestions happily accepted.

Thanks,
Sam