### PR TITLE
Add filter before args are encoded

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -119,7 +119,7 @@ class EP_API {
 		$path = $index . '/post/_search';
 
 		$request_args = array(
-			'body'    => json_encode( $args ),
+			'body'    => json_encode( apply_filters( 'ep_search_args', $args, $scope ) ),
 			'method'  => 'POST',
 		);
 


### PR DESCRIPTION
The ep_search_request_args is handy but, as it is applied after the args themselves are encoded it is rather innefficient. This allows for the filtering of args as they're encoded.