### PR TITLE
Aborts sync when post status is auto-draft. Unit test included.

### DIFF
--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -79,7 +79,7 @@ class EP_Sync_Manager {
 		if ( ! empty( $importer ) ) {
 			return;
 		}
-
+		
 		$indexable_post_statuses = ep_get_indexable_post_status();
 		$post_type               = get_post_type( $post_ID );
 
@@ -88,6 +88,11 @@ class EP_Sync_Manager {
 		}
 
 		$post = get_post( $post_ID );
+
+		// If the post is an auto-draft - let's abort.
+		if ( 'auto-draft' == $post->post_status ) {
+			return;
+		}
 
 		// Our post was published, but is no longer, so let's remove it from the Elasticsearch index
 		if ( ! in_array( $post->post_status, $indexable_post_statuses ) ) {

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1952,6 +1952,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertFalse( $this->is_404, 'auto-draft post status on wp_insert_post action.' );
 
 		// Now let's test inserting a 'publish' post.
+		$this->is_404 = false;
 		add_action( 'http_api_debug', array( $this, '_check_404' ), 10, 5 );
 		$new_post = wp_insert_post( array( 'post_title' => 'Published', 'post_status' => 'publish' ) );
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1,7 +1,12 @@
 <?php
 
 class EPTestSingleSite extends EP_Test_Base {
-
+	/**
+	 * Checking if HTTP request returns 404 status code.
+	 * @var boolean 
+	 */
+	var $is_404=false;
+	
 	/**
 	 * Setup each test.
 	 *
@@ -1931,6 +1936,42 @@ class EPTestSingleSite extends EP_Test_Base {
 		$post_types = ep_get_indexable_post_types();
 		$this->assertArrayNotHasKey( 'ep_test_excluded', $post_types );
 		$this->assertArrayNotHasKey( 'ep_test_not_public', $post_types );
+	}
+	
+	/**
+	 * Test to make sure that brand new posts with 'auto-draft' post status do not fire delete or sync.
+	 * @group 343
+	 * @since 1.6
+	 * @link https://github.com/10up/ElasticPress/issues/343
+	 */
+	public function testAutoDraftPostStatus() {
+		// Let's test inserting an 'auto-draft' post.
+		add_action( 'http_api_debug', array( $this, '_check_404' ), 10, 5 );
+		$new_post = wp_insert_post( array( 'post_title' => 'Auto Draft', 'post_status' => 'auto-draft' ) );
+
+		$this->assertFalse( $this->is_404, 'auto-draft post status on wp_insert_post action.' );
+
+		// Now let's test inserting a 'publish' post.
+		add_action( 'http_api_debug', array( $this, '_check_404' ), 10, 5 );
+		$new_post = wp_insert_post( array( 'post_title' => 'Published', 'post_status' => 'publish' ) );
+
+		$this->assertFalse( $this->is_404, 'publish post status on wp_insert_post action.' );
+	}
+
+	/**
+	 * Runs on http_api_debug action to check for a returned 404 status code.
+	 * @param array|WP_Error $response  HTTP response or WP_Error object.
+	 * @param string $type Context under which the hook is fired.
+	 * @param string $class HTTP transport used.
+	 * @param array $args HTTP request arguments.
+	 * @param string $url The request URL.
+	 */
+	function _check_404( $response, $type, $class, $args, $url ) {
+		$response_code = $response[ 'response' ][ 'code' ];
+		if ( 404 == $response_code ) {
+			$this->is_404 = true;
+		}
+		remove_action( 'http_api_debug', array( $this, '_check_404' ) );
 	}
 
 }


### PR DESCRIPTION
When you hit post-new.php, WP will create a post with the post status of auto-draft. When the wp_insert_post action is fired, EP will try to delete the post from the index and will fail. This PR will prevent the HTTP request from occurring if the post status is auto-draft.