### PR TITLE
WP-CLI index by post type

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ The following commands are supported by ElasticPress:
     * `--posts-per-page` let's you determine the amount of posts to be indexed per bulk index (or cycle).
     * `--no-bulk` let's you disable bulk indexing.
     * `--offset` let's you skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
-    * `--post-type` let's you specify which post types will be indexed (by default: all indexable post types are indexed). For example, `--post-type="my_custom_post_type"` would limit indexing to only posts from the post type "my_custom_post_type".
+    * `--post-type` let's you specify which post types will be indexed (by default: all indexable post types are indexed). For example, `--post-type="my_custom_post_type"` would limit indexing to only posts from the post type "my_custom_post_type". Accepts multiple post types separated by comma.
 
 * `wp elasticpress activate`
 

--- a/README.md
+++ b/README.md
@@ -467,9 +467,16 @@ The following are special parameters that are only supported by ElasticPress.
 
 The following commands are supported by ElasticPress:
 
-* `wp elasticpress index [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset]`
+* `wp elasticpress index [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset] [--post-type]`
 
-  Index all posts in the current blog. `--network-wide` will force indexing on all the blogs in the network. `--network-wide` takes an optional argument to limit the number of blogs to be indexed across where 0 is no limit. For example, `--network-wide=5` would limit indexing to only 5 blogs on the network. `--setup` will clear the index first and re-send the put mapping. `--posts-per-page` let's you determine the amount of posts to be indexed per bulk index (or cycle). `--no-bulk` let's you disable bulk indexing. `--offset` let's you skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
+    Index all posts in the current blog.
+  
+    * `--network-wide` will force indexing on all the blogs in the network. `--network-wide` takes an optional argument to limit the number of blogs to be indexed across where 0 is no limit. For example, `--network-wide=5` would limit indexing to only 5 blogs on the network.
+    * `--setup` will clear the index first and re-send the put mapping.
+    * `--posts-per-page` let's you determine the amount of posts to be indexed per bulk index (or cycle).
+    * `--no-bulk` let's you disable bulk indexing.
+    * `--offset` let's you skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
+    * `--post-type` let's you specify which post types will be indexed (by default: all indexable post types are indexed). For example, `--post-type="my_custom_post_type"` would limit indexing to only posts from the post type "my_custom_post_type".
 
 * `wp elasticpress activate`
 

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -308,7 +308,8 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		$post_type = ep_get_indexable_post_types();
 
 		if ( ! empty( $args['post-type'] ) ) {
-			$post_type = explode( ',', array_map( 'trim', $args['post-type'] ) );
+			$post_type = explode( ',', $args['post-type'] );
+			$post_type = array_map( 'trim', $post_type );
 		}
 
 		while ( true ) {

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -277,14 +277,12 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Helper method for indexing posts
 	 *
-	 * @param bool $no_bulk disable bulk indexing
-	 * @param int $posts_per_page
-	 * @param int $offset
+	 * @param array $args
 	 *
 	 * @since 0.9
 	 * @return array
 	 */
-	private function _index_helper( $no_bulk = false, $posts_per_page, $offset = 0) {
+	private function _index_helper( $args ) {
 		global $wpdb, $wp_object_cache;
 		$synced = 0;
 		$errors = array();


### PR DESCRIPTION
Also cleans up private _index_helper() method to support more args long term.

Usage:

`wp elasticpress index --post-type="my_cpt1,my_cpt3"`

The example above will only index `my_cpt1` and `my_cpt3`, it will not index `my_cpt2` or `post` or any other indexable post type that may be registered. Super handy for splitting up large indexing jobs into multiple processes.