### PR TITLE
Order non-search queries by date if no orderby passed in

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -700,6 +700,11 @@ class EP_API {
 			$order = 'desc';
 		}
 
+		// Default sort for non-searches to date
+		if ( empty( $args['orderby'] ) && ( ! isset( $args['s'] ) || '' === $args['s'] ) ) {
+			$args['orderby'] = 'date';
+		}
+
 		// Set sort type
 		if ( ! empty( $args['orderby'] ) ) {
 			$sort = $this->parse_orderby( $args['orderby'], $order );
@@ -711,7 +716,6 @@ class EP_API {
 
 		// Either nothing was passed or the parse_orderby failed, use default sort
 		if ( empty( $args['orderby'] ) || false === $sort ) {
-
 			// Default sort is to use the score (based on relevance)
 			$default_sort = array(
 				array(
@@ -721,10 +725,10 @@ class EP_API {
 				),
 			);
 
-            $default_sort = apply_filters( 'ep_set_default_sort', $default_sort, $order );
+			$default_sort = apply_filters( 'ep_set_default_sort', $default_sort, $order );
 
-            $formatted_args['sort'] = $default_sort;
-        }
+			$formatted_args['sort'] = $default_sort;
+		}
 
 		$filter = array(
 			'and' => array(),

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -988,6 +988,36 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test post_date default order for ep_integrate query with no search
+	 *
+	 * @since 1.7
+	 */
+	public function testSearchPostDateOrderbyQueryEPIntegrate() {
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ) );
+		sleep( 3 );
+
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest ordertest order test 111' ) );
+		sleep( 3 );
+
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			'ep_integrate' => true,
+			'order'        => 'desc',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+		$this->assertEquals( 'ordertest 222', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest ordertest order test 111', $query->posts[1]->post_title );
+		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
+	}
+
+	/**
 	 * Test relevance orderby query advanced
 	 *
 	 * @since 1.2


### PR DESCRIPTION
Fixes #327