### PR TITLE
Add filter to modify indexed data before object is sent to ElasticSearch

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -36,6 +36,17 @@ class EP_API {
 	 */
 	public function index_post( $post ) {
 
+		/**
+		 * Filter post prior to indexing
+		*
+		* Allows for last minute indexing of post information.
+		*
+		* @since 1.7
+		*
+		* @param         array Array of post information to index.
+		*/
+		$post = apply_filters( 'ep_pre_index_post', $post );
+
 		$index = trailingslashit( ep_get_index_name() );
 
 		$path = $index . 'post/' . $post['post_id'];


### PR DESCRIPTION
When working with some plugins, such as post-to-posts and others, if there is a need to index information not part of the post itself, such as a connection title in the above scenario, it becomes difficult to do so without significantly modifying post meta or other aspects. This, among other uses, allows for the filtering of information sent to ElasticSearch at the last moment before the request is made.