### PR TITLE
Fix ep_search() argument

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1476,8 +1476,8 @@ function ep_index_post( $post ) {
 	return EP_API::factory()->index_post( $post );
 }
 
-function ep_search( $args, $cross_site = false ) {
-	return EP_API::factory()->search( $args, $cross_site );
+function ep_search( $args, $scope = 'current' ) {
+	return EP_API::factory()->search( $args, $scope );
 }
 
 function ep_get_post( $post_id ) {


### PR DESCRIPTION
The search() method takes the parameter $scope which defaults to 'current' but the accessor, ep_search(), was using $cross_site = false as the second parameter. This updates ep_search to be consistent with search().