### PR TITLE
Meta Formatting Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
 
 * ```meta_query``` (*array*)
 
-    Filter posts by post meta conditions. Takes an array of form:
+    Filter posts by post meta conditions. Meta arrays and objects are serialized due to limitations of Elasticsearch. Takes an array of form:
 
     ```php
     new WP_Query( array(

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -615,7 +615,19 @@ class EP_API {
 
 		foreach ( $meta as $key => $value ) {
 			if ( ! is_protected_meta( $key ) ) {
-				$prepared_meta[$key] = maybe_unserialize( $value );
+				$formatted_value_array = array();
+
+				if ( is_array( $value_array ) ) {
+					foreach ( $value_array as $single_value ) {
+						if ( is_object( $single_value ) || is_array( $single_value ) ) {
+							$formatted_value_array[] = serialize( $single_value ); // Sorry no complex meta values :(
+						} else {
+							$formatted_value_array[] = $single_value;
+						}
+					}
+				}
+
+				$prepared_meta[$key] = $formatted_value_array;
 			}
 		}
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -613,7 +613,7 @@ class EP_API {
 
 		$prepared_meta = array();
 
-		foreach ( $meta as $key => $value ) {
+		foreach ( $meta as $key => $value_array ) {
 			if ( ! is_protected_meta( $key ) ) {
 				$formatted_value_array = array();
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -915,28 +915,6 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
-	 * Test meta mapping for simple integer
-	 *
-	 * @since 1.7
-	 */
-	public function testSearchMetaMappingInteger() {
-		ep_create_and_sync_post( array( 'post_content' => 'post content' ), array( 'test_key' => 5 ) );
-
-		ep_refresh_index();
-		$args = array(
-			'ep_integrate' => true,
-		);
-
-		$query = new WP_Query( $args );
-
-		$this->assertEquals( 1, $query->post_count );
-
-		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
-
-		$this->assertTrue( ( 5 === $query->posts[0]->post_meta['test_key'][0] ) );
-	}
-
-	/**
 	 * Test a query that fuzzy searches meta
 	 *
 	 * @since 1.0

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -846,6 +846,119 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test meta mapping for complex arrays. All complex arrays are serialized
+	 *
+	 * @since 1.7
+	 */
+	public function testSearchMetaMappingComplexArray() {
+		ep_create_and_sync_post( array( 'post_content' => 'post content' ), array( 'test_key' => array( 'test' ) ) );
+
+		ep_refresh_index();
+		$args = array(
+			'ep_integrate' => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
+
+		$this->assertTrue( is_array( unserialize( $query->posts[0]->post_meta['test_key'][0] ) ) ); // Make sure value is properly serialized
+	}
+
+	/**
+	 * Test meta mapping for complex objects. All complex objects are serialized
+	 *
+	 * @since 1.7
+	 */
+	public function testSearchMetaMappingComplexObject() {
+		$object = new stdClass();
+		$object->test = 'hello';
+
+		ep_create_and_sync_post( array( 'post_content' => 'post content' ), array( 'test_key' => $object ) );
+
+		ep_refresh_index();
+		$args = array(
+			'ep_integrate' => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
+
+		$this->assertEquals( 'hello', unserialize( $query->posts[0]->post_meta['test_key'][0] )->test ); // Make sure value is properly serialized
+	}
+
+	/**
+	 * Test meta mapping for simple string
+	 *
+	 * @since 1.7
+	 */
+	public function testSearchMetaMappingString() {
+		ep_create_and_sync_post( array( 'post_content' => 'post content' ), array( 'test_key' => 'test' ) );
+
+		ep_refresh_index();
+		$args = array(
+			'ep_integrate' => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
+
+		$this->assertEquals( 'test', $query->posts[0]->post_meta['test_key'][0] );
+	}
+
+	/**
+	 * Test meta mapping for simple integer
+	 *
+	 * @since 1.7
+	 */
+	public function testSearchMetaMappingInteger() {
+		ep_create_and_sync_post( array( 'post_content' => 'post content' ), array( 'test_key' => 5 ) );
+
+		ep_refresh_index();
+		$args = array(
+			'ep_integrate' => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
+
+		$this->assertEquals( 5, $query->posts[0]->post_meta['test_key'][0] );
+	}
+
+	/**
+	 * Test meta mapping for simple boolean
+	 *
+	 * @since 1.7
+	 */
+	public function testSearchMetaMappingBoolean() {
+		ep_create_and_sync_post( array( 'post_content' => 'post content' ), array( 'test_key' => true ) );
+
+		ep_refresh_index();
+		$args = array(
+			'ep_integrate' => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
+
+		$this->assertEquals( true, $query->posts[0]->post_meta['test_key'][0] );
+	}
+
+	/**
 	 * Test a query that fuzzy searches meta
 	 *
 	 * @since 1.0

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -933,29 +933,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
 
-		$this->assertEquals( 5, $query->posts[0]->post_meta['test_key'][0] );
-	}
-
-	/**
-	 * Test meta mapping for simple boolean
-	 *
-	 * @since 1.7
-	 */
-	public function testSearchMetaMappingBoolean() {
-		ep_create_and_sync_post( array( 'post_content' => 'post content' ), array( 'test_key' => true ) );
-
-		ep_refresh_index();
-		$args = array(
-			'ep_integrate' => true,
-		);
-
-		$query = new WP_Query( $args );
-
-		$this->assertEquals( 1, $query->post_count );
-
-		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
-
-		$this->assertEquals( true, $query->posts[0]->post_meta['test_key'][0] );
+		$this->assertTrue( ( 5 === $query->posts[0]->post_meta['test_key'][0] ) )
 	}
 
 	/**

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -933,7 +933,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 1, count( $query->posts[0]->post_meta['test_key'] ) ); // Make sure there is only one value
 
-		$this->assertTrue( ( 5 === $query->posts[0]->post_meta['test_key'][0] ) )
+		$this->assertTrue( ( 5 === $query->posts[0]->post_meta['test_key'][0] ) );
 	}
 
 	/**


### PR DESCRIPTION
This ticket is in response to #338.

Unfortunately, due to limitations of Elasticsearch we cannot store unserialized meta objects and arrays. We can however serialize them in case anyone needs that information. Right now our mapping is limited to storing boolean, integer, long, double, and string (possibly float not sure).

This PR fixes a line of useless code that was unserializing an array every time. It also does a check on each meta value. If it's an array or object, it serializes. If not, it simply indexes the value. A slew of tests have been added to test this code and the general meta mapping.

Down the road I can see us improving the mapping a bit, but this PR maintains backwards compatibility.

@ChrisWiegman @allan23 can you review?