### PR TITLE
Add failure details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,9 +467,9 @@ The following are special parameters that are only supported by ElasticPress.
 
 The following commands are supported by ElasticPress:
 
-* `wp elasticpress index [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset]`
+* `wp elasticpress index [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset] [--show-bulk-errors]`
 
-  Index all posts in the current blog. `--network-wide` will force indexing on all the blogs in the network. `--network-wide` takes an optional argument to limit the number of blogs to be indexed across where 0 is no limit. For example, `--network-wide=5` would limit indexing to only 5 blogs on the network. `--setup` will clear the index first and re-send the put mapping. `--posts-per-page` let's you determine the amount of posts to be indexed per bulk index (or cycle). `--no-bulk` let's you disable bulk indexing. `--offset` let's you skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
+  Index all posts in the current blog. `--network-wide` will force indexing on all the blogs in the network. `--network-wide` takes an optional argument to limit the number of blogs to be indexed across where 0 is no limit. For example, `--network-wide=5` would limit indexing to only 5 blogs on the network. `--setup` will clear the index first and re-send the put mapping. `--posts-per-page` let's you determine the amount of posts to be indexed per bulk index (or cycle). `--no-bulk` let's you disable bulk indexing. `--offset` let's you skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again). `--show-bulk-errors` displays the error message returned from Elasticsearch when a post fails to index (as opposed to just the title and ID of the post).
 
 * `wp elasticpress activate`
 

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -24,6 +24,13 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	private $failed_posts = array();
 
 	/**
+	 * Holds error messages for individual posts that failed to index (assuming they're available).
+	 *
+	 * @since 1.7
+	 */
+	private $failed_posts_message = array();
+
+	/**
 	 * Add the document mapping
 	 *
 	 * @synopsis [--network-wide]
@@ -174,7 +181,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Index all posts for a site or network wide
 	 *
-	 * @synopsis [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset]
+	 * @synopsis [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset] [--show-bulk-errors]
 	 * @param array $args
 	 *
 	 * @since 0.1.2
@@ -230,7 +237,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site['blog_id'] );
 
-				$result = $this->_index_helper( isset( $assoc_args['no-bulk'] ), $assoc_args['posts-per-page'], $assoc_args['offset'] );
+				$result = $this->_index_helper( isset( $assoc_args['no-bulk'] ), $assoc_args['posts-per-page'], $assoc_args['offset'], isset( $assoc_args['show-bulk-errors'] ) );
 
 				$total_indexed += $result['synced'];
 
@@ -253,7 +260,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 			WP_CLI::log( __( 'Indexing posts...', 'elasticpress' ) );
 
-			$result = $this->_index_helper( isset( $assoc_args['no-bulk'] ), $assoc_args['posts-per-page'], $assoc_args['offset'] );
+			$result = $this->_index_helper( isset( $assoc_args['no-bulk'] ), $assoc_args['posts-per-page'], $assoc_args['offset'], isset( $assoc_args['show-bulk-errors'] ) );
 
 			WP_CLI::log( sprintf( __( 'Number of posts synced on site %d: %d', 'elasticpress' ), get_current_blog_id(), $result['synced'] ) );
 
@@ -276,11 +283,12 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	 * @param bool $no_bulk disable bulk indexing
 	 * @param int $posts_per_page
 	 * @param int $offset
+	 * @param bool $show_bulk_errors whether or not to show bulk error messages.
 	 *
 	 * @since 0.9
 	 * @return array
 	 */
-	private function _index_helper( $no_bulk = false, $posts_per_page, $offset = 0) {
+	private function _index_helper( $no_bulk = false, $posts_per_page, $offset = 0, $show_bulk_errors = false ) {
 		global $wpdb, $wp_object_cache;
 		$synced = 0;
 		$errors = array();
@@ -306,7 +314,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 						// index the posts one-by-one. not sure why someone may want to do this.
 						$result = ep_sync_post( get_the_ID() );
 					} else {
-						$result = $this->queue_post( get_the_ID(), $query->post_count );
+						$result = $this->queue_post( get_the_ID(), $query->post_count, $show_bulk_errors );
 					}
 
 					if ( ! $result ) {
@@ -356,10 +364,11 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	 *
 	 * @param $post_id
 	 * @param $bulk_trigger
+	 * @param bool $show_bulk_errors true to show individual post error messages for bulk errors
 	 *
 	 * @return bool
 	 */
-	private function queue_post( $post_id, $bulk_trigger ) {
+	private function queue_post( $post_id, $bulk_trigger, $show_bulk_errors = false ) {
 		static $post_count = 0;
 
 		$post_args = ep_prepare_post( $post_id );
@@ -379,7 +388,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 		// if we have hit the trigger, initiate the bulk request
 		if ( $post_count === absint( $bulk_trigger ) ) {
-			$this->bulk_index();
+			$this->bulk_index( $show_bulk_errors );
 
 			// reset the post count
 			$post_count = 0;
@@ -394,9 +403,11 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Perform the bulk index operation
 	 *
+	 * @param bool $show_bulk_errors true to show individual post error messages for bulk errors
+	 *
 	 * @since 0.9.2
 	 */
-	private function bulk_index() {
+	private function bulk_index( $show_bulk_errors = false ) {
 		// monitor how many times we attempt to add this particular bulk request
 		static $attempts = 0;
 
@@ -438,11 +449,14 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 						unset( $this->posts[$item['index']['_id']] );
 					}
 				}
-				$this->bulk_index();
+				$this->bulk_index( $show_bulk_errors );
 			} else {
 				foreach ( $response['items'] as $item ) {
 					if ( ! empty( $item['index']['_id'] ) ) {
 						$this->failed_posts[] = $item['index']['_id'];
+						if ( $show_bulk_errors ) {
+							$this->failed_posts_message[$item['index']['_id']] = $item['index']['error'];
+						}
 					}
 				}
 				$attempts = 0;
@@ -465,6 +479,9 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				$failed_post = get_post( $failed );
 				if ( $failed_post ) {
 					$error_text .= "- {$failed}: " . $failed_post->post_title . "\r\n";
+					if ( array_key_exists( $failed, $this->failed_posts_message ) ) {
+						$error_text .= "\t" . $this->failed_posts_message[ $failed ] . PHP_EOL;
+					}
 				}
 			}
 
@@ -472,6 +489,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 			// clear failed posts after printing to the screen
 			$this->failed_posts = array();
+			$this->failed_posts_message = array();
 		}
 	}
 


### PR DESCRIPTION
When running a bulk index troubleshoot the individual errors in posts that fail to index can be problematic. This makes it a bit easier by adding a --show-bulk-errors param to display the error message along with the post that failed to index.