### PR TITLE
Fetching the test suite from 4.3 branch instead of trunk.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -42,9 +42,9 @@ install_test_suite() {
 	# set up testing suite
 	mkdir -p $WP_TESTS_DIR
 	cd $WP_TESTS_DIR
-	svn co --quiet --trust-server-cert --non-interactive https://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
-
-	wget -nv -O wp-tests-config.php https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php --no-check-certificate
+        
+        svn co --quiet --trust-server-cert --non-interactive https://develop.svn.wordpress.org/branches/4.3/tests/phpunit/includes/
+        wget -nv -O wp-tests-config.php https://develop.svn.wordpress.org/branches/4.3/wp-tests-config-sample.php --no-check-certificate
 
 	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php


### PR DESCRIPTION
New functionality was recently introduced into WP trunk that will break all unit tests regardless of version. This PR updates the install script to fetch the testing suite from the 4.3 branch instead of trunk.

Definitely open to thoughts on this one.

<img width="604" alt="screen shot 2015-10-05 at 10 36 57 am" src="https://cloud.githubusercontent.com/assets/1326772/10287536/da6441d2-6b50-11e5-8042-8804542b9d30.png">

<img width="873" alt="screen shot 2015-10-05 at 10 37 16 am" src="https://cloud.githubusercontent.com/assets/1326772/10287535/da4234ac-6b50-11e5-847e-e9a56a6a5709.png">


