### PR TITLE
Remap meta mappings for extensive `type` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
     ) );
     ```
 
-    ```meta_query``` accepts an array of arrays where each inner array *only* supports ```key``` (string), ```value``` (string|array|int), and ```compare``` (string) parameters. ```compare``` supports the following:
+    ```meta_query``` accepts an array of arrays where each inner array *only* supports ```key``` (string), 
+    ```type``` (string), ```value``` (string|array|int), and ```compare``` (string) parameters. ```compare``` supports the following:
 
       * ```=``` - Posts will be returned that have a post meta key corresponding to ```key``` and a value that equals the value passed to ```value```.
       * ```!=``` - Posts will be returned that have a post meta key corresponding to ```key``` and a value that does NOT equal the value passed to ```value```.
@@ -274,6 +275,25 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
     ```
 
     Possible values for ```relation``` are ```OR``` and ```AND```. If ```relation``` is set to ```AND```, all inner queries must be true for a post to be returned. If ```relation``` is set to ```OR```, only one of the inner meta queries must be true for the post to be returned.
+
+    ```type``` supports the following values:  'NUMERIC', 'BINARY', 'CHAR', 'DATE', 'DATETIME', 
+    'DECIMAL', 'SIGNED', 'TIME', and 'UNSIGNED'. By default WordPress casts meta values to these types 
+    in MySQL so some of these don't make sense in the context of Elasticsearch. ElasticPress does no "runtime" 
+    casting but instead compares the value to a different type compiled during indexing
+
+    * `NUMERIC` - Compares query `value` to integer version of stored meta value.
+    * `SIGNED` - Compares query `value` to integer version of stored meta value.
+    * `UNSIGNED` - Compares query `value` to integer version of stored meta value.
+    * `BINARY` - Compares query `value` to raw, unanalyzed version of stored meta value.
+    * `CHAR` - Compares query `value` to raw, unanalyzed version of stored meta value.
+    * `DECIMAL` - Compares query `value` to float version of stored meta value.
+    * `DATE` - Compares query `value` to date version of stored meta value. Query `value` must be formated like `2015-11-14`
+    * `DATETIME` - Compares query `value` to date/time version of stored meta value. Query `value` must be formated like `2012-01-02 05:00:00` or `yyyy:mm:dd hh:mm:ss`.
+    * `TIME` - Compares query `value` to time version of stored meta value. Query `value` must be formated like `17:00:00` or `hh:mm:ss`.
+
+    If no type is specified, ElasticPress will just deduce the type from the comparator used. ```type``` 
+    is very rarely needed to be used.
+
 
 * ```post_type``` (*string*/*array*)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ElasticPress [![Build Status](https://travis-ci.org/10up/ElasticPress.svg?branch
 
 Integrate [Elasticsearch](http://www.elasticsearch.org/) with [WordPress](http://wordpress.org/).
 
-**Please note:** the master branch is the stable branch
+**Please note:** the master branch is the stable 
+**Upgrade Notice:** Versions 1.6.1, 1.6.2, and 1.7 require re-indexing.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
     * `NUMERIC` - Compares query `value` to integer version of stored meta value.
     * `SIGNED` - Compares query `value` to integer version of stored meta value.
     * `UNSIGNED` - Compares query `value` to integer version of stored meta value.
-    * `BINARY` - Compares query `value` to raw, unanalyzed version of stored meta value.
+    * `BINARY` - Compares query `value` to raw, unanalyzed version of stored meta value. For actual attachment searches, check out [this](https://github.com/elastic/elasticsearch-mapper-attachments).
     * `CHAR` - Compares query `value` to raw, unanalyzed version of stored meta value.
     * `DECIMAL` - Compares query `value` to float version of stored meta value.
     * `DATE` - Compares query `value` to date version of stored meta value. Query `value` must be formated like `2015-11-14`

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1057,6 +1057,7 @@ class EP_API {
 						$type = strtolower( $single_meta_query['type'] );
 					}
 
+					// Comparisons need to look at different paths
 					if ( in_array( $compare, array( 'exists', 'not exists' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'];
 					} elseif ( in_array( $compare, array( '>=', '<=', '>', '<' ) ) ) {
@@ -1064,6 +1065,7 @@ class EP_API {
 					} elseif ( in_array( $compare, array( '=', '!=' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.raw';
 					} elseif ( $type && isset( $meta_query_type_mapping[ $type ] ) ) {
+						// Map specific meta field types to different ElasticSearch core types
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.' . $meta_query_type_mapping[ $type ];
 					} else {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.value';

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1030,7 +1030,6 @@ class EP_API {
 		 *
 		 * Relation supports 'AND' and 'OR'. 'AND' is the default. For each individual query, the
 		 * following 'compare' values are supported: =, !=, EXISTS, NOT EXISTS. '=' is the default.
-		 * 'type' is NOT support at this time.
 		 *
 		 * @since 1.3
 		 */
@@ -1072,7 +1071,7 @@ class EP_API {
 					// Comparisons need to look at different paths
 					if ( in_array( $compare, array( 'exists', 'not exists' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'];
-					} elseif ( in_array( $compare, array( '=', '!=' ) ) ) {
+					} elseif ( in_array( $compare, array( '=', '!=' ) ) && ! $type ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.raw';
 					} elseif ( $type && isset( $meta_query_type_mapping[ $type ] ) ) {
 						// Map specific meta field types to different ElasticSearch core types

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1061,6 +1061,8 @@ class EP_API {
 						$meta_key_path = 'meta.' . $single_meta_query['key'];
 					} elseif ( in_array( $compare, array( '>=', '<=', '>', '<' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.double';
+					} elseif ( in_array( $compare, array( '=', '!=' ) ) ) {
+						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.raw';
 					} elseif ( $type && isset( $meta_query_type_mapping[ $type ] ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.' . $meta_query_type_mapping[ $type ];
 					} else {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1060,13 +1060,13 @@ class EP_API {
 					// Comparisons need to look at different paths
 					if ( in_array( $compare, array( 'exists', 'not exists' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'];
-					} elseif ( in_array( $compare, array( '>=', '<=', '>', '<' ) ) ) {
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.double';
 					} elseif ( in_array( $compare, array( '=', '!=' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.raw';
 					} elseif ( $type && isset( $meta_query_type_mapping[ $type ] ) ) {
 						// Map specific meta field types to different ElasticSearch core types
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.' . $meta_query_type_mapping[ $type ];
+					} elseif ( in_array( $compare, array( '>=', '<=', '>', '<' ) ) ) {
+						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.double';
 					} else {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.value';
 					}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -492,6 +492,8 @@ class EP_API {
 
 		$post_args['meta'] = $this->prepare_meta_types( $post_args['post_meta'] );
 
+		$post_args = apply_filters( 'ep_post_sync_args_post_prepare_meta', $post_args, $post_id );
+
 		return $post_args;
 	}
 

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -127,7 +127,7 @@ class EP_WP_Query_Integration {
 			restore_current_blog();
 
 			switch_to_blog( $post->site_id );
-			
+
 			remove_action( 'the_post', array( $this, 'action_the_post' ), 10, 1 );
 			setup_postdata( $post );
 			add_action( 'the_post', array( $this, 'action_the_post' ), 10, 1 );
@@ -218,7 +218,7 @@ class EP_WP_Query_Integration {
 
 		$query_vars = $query->query_vars;
 		if ( 'any' === $query_vars['post_type'] ) {
-			
+
 			if ( $query->is_search() ) {
 
 				/*

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -67,6 +67,54 @@ return array(
 					),
 				),
 				array(
+					'template_meta_long' => array(
+						'path_match' => 'post_meta.*.long',
+						'mapping' => array(
+							'type' => 'long',
+							'include_in_all' => false,
+						),
+					),
+				),
+				array(
+					'template_meta_double' => array(
+						'path_match' => 'post_meta.*.double',
+						'mapping' => array(
+							'type' => 'double',
+							'include_in_all' => false,
+						),
+					),
+				),
+				array(
+					'template_meta_date' => array(
+						'path_match' => 'post_meta.*.date',
+						'mapping' => array(
+							'type' => 'date',
+							'format' => 'yyyy-MM-dd',
+							'include_in_all' => false,
+						),
+					),
+				),
+				array(
+					'template_meta_datetime' => array(
+						'path_match' => 'post_meta.*.datetime',
+						'mapping' => array(
+							'type' => 'datetime',
+							'format' => 'yyyy-MM-dd HH:mm:ss',
+							'include_in_all' => false,
+						),
+					),
+				),
+				array(
+					'template_meta_time' => array(
+						'path_match' => 'post_meta.*.time',
+						'mapping' => array(
+							'type' => 'date',
+							'format' => 'HH:mm:ss',
+							'include_in_all' => false,
+						),
+					),
+				),
+				array(
 					'template_terms' => array(
 						'path_match' => 'terms.*',
 						'mapping' => array(

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -75,7 +75,6 @@ return array(
 							'properties' => array(
 								'value' => array(
 									'type' => 'string',
-									'index' => 'not_analyzed',
 								),
 								'raw' => array(
 									'type' => 'string',

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -67,50 +67,49 @@ return array(
 					),
 				),
 				array(
-					'template_meta_long' => array(
-						'path_match' => 'post_meta.*.long',
+					'template_meta_types' => array(
+						'path_match' => 'meta.*',
 						'mapping' => array(
-							'type' => 'long',
-							'include_in_all' => false,
-						),
-					),
-				),
-				array(
-					'template_meta_double' => array(
-						'path_match' => 'post_meta.*.double',
-						'mapping' => array(
-							'type' => 'double',
-							'include_in_all' => false,
-						),
-					),
-				),
-				array(
-					'template_meta_date' => array(
-						'path_match' => 'post_meta.*.date',
-						'mapping' => array(
-							'type' => 'date',
-							'format' => 'yyyy-MM-dd',
-							'include_in_all' => false,
-						),
-					),
-				),
-				array(
-					'template_meta_datetime' => array(
-						'path_match' => 'post_meta.*.datetime',
-						'mapping' => array(
-							'type' => 'datetime',
-							'format' => 'yyyy-MM-dd HH:mm:ss',
-							'include_in_all' => false,
-						),
-					),
-				),
-				array(
-					'template_meta_time' => array(
-						'path_match' => 'post_meta.*.time',
-						'mapping' => array(
-							'type' => 'date',
-							'format' => 'HH:mm:ss',
-							'include_in_all' => false,
+							'type' => 'object',
+							'path' => 'full',
+							'properties' => array(
+								'value' => array(
+									'type' => 'string',
+									'index' => 'not_analyzed',
+								),
+								'raw' => array(
+									'type' => 'string',
+									'index' => 'not_analyzed',
+									'include_in_all' => false,
+								),
+								'long' => array(
+									'type' => 'long',
+									'index' => 'not_analyzed',
+								),
+								'double' => array(
+									'type' => 'double',
+									'index' => 'not_analyzed',
+								),
+								'boolean' => array(
+									'type' => 'boolean',
+									'index' => 'not_analyzed',
+								),
+								'date' => array(
+									'type' => 'date',
+									'format' => 'yyyy-MM-dd',
+									'index' => 'not_analyzed',
+								),
+								'datetime' => array(
+									'type' => 'date',
+									'format' => 'yyyy-MM-dd HH:mm:ss',
+									'index' => 'not_analyzed',
+								),
+								'time' => array(
+									'type' => 'date',
+									'format' => 'HH:mm:ss',
+									'index' => 'not_analyzed',
+								),
+							),
 						),
 					),
 				),
@@ -273,6 +272,9 @@ return array(
 					'type' => 'object',
 				),
 				'post_meta' => array(
+					'type' => 'object',
+				),
+				'meta' => array(
 					'type' => 'object',
 				),
 				'date_terms' => array(

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/10up/ElasticPress
 Tags: search, elasticsearch, fuzzy, facet, searching, autosuggest, suggest, elastic, advanced search
 Requires at least: 3.7.1
 Tested up to: 4.4
-Stable tag: 1.6.2
+Stable tag: 1.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,6 +59,21 @@ configuring single site and multi-site cross-site search are slightly different.
 4. Using WP-CLI, do an initial sync (with mapping) with your ES server by running: `wp elasticpress index --setup --network-wide`.
 
 == Changelog ==
+
+= 1.7 (Mapping change, requires reindex) =
+
+ElasticPress 1.7 restructures meta mapping for posts for much more flexible meta queries. The `post_meta` Elasticsearch post property has been left for backwards compatibility. As of this version, post meta will be stored in the `meta` Elasticsearch property. `meta` is structured as follows:
+
+* `meta.value` (string)
+* `meta.raw` (unanalyzed string)
+* `meta.long` (unanalyzed number)
+* `meta.double` (unanalyzed number)
+* `meta.boolean` (unanalyzed number)
+* `meta.date` (unanalyzed yyyy-MM-dd date)
+* `meta.datetime` (unanalyzed yyyy-MM-dd HH:mm:ss datetime)
+* `time` (unanalyzed HH:mm:ss time)
+
+When querying posts, you will get back `meta.value`. However, if you plan to mess with the new post mapping, it's important to understand the intricacies.
 
 = 1.6.2 =
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2153,7 +2153,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	/**
 	 * Test numeric integer meta queries
 	 *
-	 * @since  1.7
+	 * @since 1.7
 	 */
 	public function testMetaValueTypeQueryNumeric() {
 
@@ -2219,7 +2219,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	/**
 	 * Test decimal meta queries
 	 *
-	 * @since  1.7
+	 * @since 1.7
 	 */
 	public function testMetaValueTypeQueryDecimal() {
 
@@ -2262,5 +2262,183 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
+	}
+
+	/**
+	 * Test character meta queries. Really just defaults to a normal string query
+	 *
+	 * @since 1.7
+	 */
+	public function testMetaValueTypeQueryChar() {
+
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => 'abc' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => 'acc' ) );
+
+		ep_refresh_index();
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => 'abc',
+					'compare' => '=',
+					'type' => 'char',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+	}
+
+	/**
+	 * Test date meta queries
+	 *
+	 * @since 1.7
+	 */
+	public function testMetaValueTypeQueryDate() {
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '11/13/15' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '11/15/15' ) );
+
+		ep_refresh_index();
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => '2015-11-14',
+					'compare' => '>',
+					'type' => 'date',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => '2015-11-15',
+					'compare' => '=',
+					'type' => 'date',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+	}
+
+	/**
+	 * Test time meta queries
+	 *
+	 * @since 1.7
+	 */
+	public function testMetaValueTypeQueryTime() {
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '5:00am' ) );
+
+		ep_refresh_index();
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => '17:00:00',
+					'compare' => '<',
+					'type' => 'time',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => '05:00:00',
+					'compare' => '=',
+					'type' => 'time',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+	}
+
+	/**
+	 * Test date time meta queries
+	 *
+	 * @since 1.7
+	 */
+	public function testMetaValueTypeQueryDatetime() {
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '5:00am 1/2/12' ) );
+
+		ep_refresh_index();
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => '2013-03-02 06:00:15',
+					'compare' => '<',
+					'type' => 'datetime',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => '2012-01-02 05:00:00',
+					'compare' => '=',
+					'type' => 'datetime',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => '2011-01-02 07:30:00',
+					'compare' => '>',
+					'type' => 'datetime',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
 	}
 }

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2150,6 +2150,11 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	}
 
+	/**
+	 * Test numeric integer meta queries
+	 *
+	 * @since  1.7
+	 */
 	public function testMetaValueTypeQueryNumeric() {
 
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
@@ -2175,5 +2180,87 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
 
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => 100,
+					'compare' => '=',
+					'type' => 'numeric',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => 103,
+					'compare' => '<=',
+					'type' => 'numeric',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+
+	}
+
+	/**
+	 * Test decimal meta queries
+	 *
+	 * @since  1.7
+	 */
+	public function testMetaValueTypeQueryDecimal() {
+
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => 15.5 ) );
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => 16.5 ) );
+
+		ep_refresh_index();
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => 16.5,
+					'compare' => '<',
+					'type' => 'decimal',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => 16.5,
+					'compare' => '=',
+					'type' => 'decimal',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
 	}
 }

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2116,4 +2116,37 @@ class EPTestSingleSite extends EP_Test_Base {
 		return $meta_keys;
 
 	}
+
+	/**
+	 * Test meta preparation
+	 *
+	 * Tests meta perparation
+	 *
+	 * @since 1.7
+	 */
+	public function testMetaValueTypes() {
+
+		$api = new EP_API();
+
+		$intval         = $api->prepare_meta_value_types( 13 );
+		$floatval       = $api->prepare_meta_value_types( 13.43 );
+		$textval        = $api->prepare_meta_value_types( 'some text' );
+		$bool_false_val = $api->prepare_meta_value_types( false );
+		$bool_true_val  = $api->prepare_meta_value_types( true );
+		$dateval        = $api->prepare_meta_value_types( '2015-01-01' );
+
+		$this->assertTrue( is_array( $intval ) && 5 === sizeof( $intval ) );
+		$this->assertTrue( is_array( $intval ) && array_key_exists( 'long', $intval ) && 13 === $intval['long'] );
+		$this->assertTrue( is_array( $floatval ) && 5 === sizeof( $floatval ) );
+		$this->assertTrue( is_array( $floatval ) && array_key_exists( 'double', $floatval ) && 13.43 === $floatval['double'] );
+		$this->assertTrue( is_array( $textval ) && 6 === sizeof( $textval ) );
+		$this->assertTrue( is_array( $textval ) && array_key_exists( 'raw', $textval ) && 'some text' === $textval['raw'] );
+		$this->assertTrue( is_array( $bool_false_val ) && 3 === sizeof( $bool_false_val ) );
+		$this->assertTrue( is_array( $bool_false_val ) && array_key_exists( 'boolean', $bool_false_val ) && false === $bool_false_val['boolean'] );
+		$this->assertTrue( is_array( $bool_true_val ) && 3 === sizeof( $bool_true_val ) );
+		$this->assertTrue( is_array( $bool_true_val ) && array_key_exists( 'boolean', $bool_true_val ) && true === $bool_true_val['boolean'] );
+		$this->assertTrue( is_array( $dateval ) && 6 === sizeof( $dateval ) );
+		$this->assertTrue( is_array( $dateval ) && array_key_exists( 'datetime', $dateval ) && '2015-01-01 00:00:00' === $dateval['datetime'] );
+
+	}
 }

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1909,82 +1909,23 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
-	 * Test wrapper around wp_remote_request
+	 * Helper method for mocking indexable post statuses
+	 * 
+	 * @param   array $post_statuses
+	 * @return  array
 	 */
-	public function testEPRemoteRequest() {
-
-		global $ep_backup_host;
-
-		$ep_backup_host = false;
-
-		define( 'EP_FORCE_HOST_REFRESH', true );
-
-		//Test with EP_HOST constant
-		$request_1 = false;
-		$request   = ep_remote_request( '', array() );
-
-		if ( ! is_wp_error( $request ) ) {
-			if ( isset( $request['response']['code'] ) && 200 === $request['response']['code'] ) {
-				$request_1 = true;
-			}
-		}
-
-		//Test with only backups
-
-		define( 'EP_HOST_USE_ONLY_BACKUPS', true );
-
-		$request_2      = false;
-		$ep_backup_host = array( 'http://127.0.0.1:9200' );
-		$request        = ep_remote_request( '', array() );
-
-		if ( ! is_wp_error( $request ) ) {
-			if ( isset( $request['response']['code'] ) && 200 === $request['response']['code'] ) {
-				$request_2 = true;
-			}
-		}
-
-		$request_3      = false;
-		$ep_backup_host = array( 'bad host 1', 'bad host 2' );
-		$request        = ep_remote_request( '', array() );
-
-		if ( is_wp_error( $request ) ) {
-			$request_3 = $request;
-		}
-
-		$request_4      = false;
-		$ep_backup_host = array( 'http://127.0.0.1:9200', 'bad host 2' );
-		$request        = ep_remote_request( '', array() );
-
-		if ( ! is_wp_error( $request ) ) {
-			if ( isset( $request['response']['code'] ) && 200 === $request['response']['code'] ) {
-				$request_4 = true;
-			}
-		}
-
-		$request_5      = false;
-		$ep_backup_host = array( 'bad host 1', 'http://127.0.0.1:9200' );
-		$request        = ep_remote_request( '', array() );
-
-		if ( ! is_wp_error( $request ) ) {
-			if ( isset( $request['response']['code'] ) && 200 === $request['response']['code'] ) {
-				$request_5 = true;
-			}
-		}
-
-		$this->assertTrue( $request_1 );
-		$this->assertTrue( $request_2 );
-		$this->assertWPError( $request_3 );
-		$this->assertTrue( $request_4 );
-		$this->assertTrue( $request_5 );
-
-	}
-
-	public function mock_indexable_post_status($post_statuses){
+	public function mock_indexable_post_status( $post_statuses ) {
 		$post_statuses = array();
 		$post_statuses[] = "draft";
 		return $post_statuses;
 	}
 
+	/**
+	 * Test invalid post date time
+	 * 
+	 * @param   array $post_statuses
+	 * @return  array
+	 */
 	public function testPostInvalidDateTime(){
 		add_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10, 1 );
 		$post_id = ep_create_and_sync_post( array( 'post_status' => 'draft' ) );
@@ -2012,7 +1953,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	
 	/**
 	 * Test to verify that a post type that is set to exclude_from_search isn't indexable.
-	 * @group 321
+	 * 
 	 * @since 1.6
 	 * @link https://github.com/10up/ElasticPress/issues/321
 	 */
@@ -2024,7 +1965,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	
 	/**
 	 * Test to make sure that brand new posts with 'auto-draft' post status do not fire delete or sync.
-	 * @group 343
+	 * 
 	 * @since 1.6
 	 * @link https://github.com/10up/ElasticPress/issues/343
 	 */
@@ -2045,6 +1986,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	/**
 	 * Runs on http_api_debug action to check for a returned 404 status code.
+	 * 
 	 * @param array|WP_Error $response  HTTP response or WP_Error object.
 	 * @param string $type Context under which the hook is fired.
 	 * @param string $class HTTP transport used.
@@ -2101,6 +2043,12 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	}
 
+	/**
+	 * Helper method for filtering private meta keys
+	 * 
+	 * @param  array $meta_keys
+	 * @return array
+	 */
 	public function filter_ep_prepare_meta_allowed_protected_keys( $meta_keys ) {
 
 		$meta_keys[] = '_test_private_meta_1';
@@ -2109,6 +2057,12 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	}
 
+	/**
+	 * Helper method for filtering excluded meta keys
+	 * 
+	 * @param  array $meta_keys
+	 * @return array
+	 */
 	public function filter_ep_prepare_meta_excluded_public_keys( $meta_keys ) {
 
 		$meta_keys[] = 'test_meta_1';

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2149,4 +2149,31 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertTrue( is_array( $dateval ) && array_key_exists( 'datetime', $dateval ) && '2015-01-01 00:00:00' === $dateval['datetime'] );
 
 	}
+
+	public function testMetaValueTypeQueryNumeric() {
+
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => 100 ) );
+		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => 101 ) );
+
+		ep_refresh_index();
+		$args = array(
+			's' => 'findme',
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+					'value' => 101,
+					'compare' => '>=',
+					'type' => 'numeric',
+				)
+			),
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+
+	}
 }


### PR DESCRIPTION
Added new dynamic template mapping for long, double, date, datetime, time as well -- same as #372

- [x] Unit test for all `'type'` options for `'meta_query'`
- [x] README.md documentation update
- [x] Update `@since` if needed