### PR TITLE
More comprehensive tests for 'compare' on number meta values to ensure proper comparisons

### DIFF
--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -3,10 +3,10 @@
 class EPTestSingleSite extends EP_Test_Base {
 	/**
 	 * Checking if HTTP request returns 404 status code.
-	 * @var boolean 
+	 * @var boolean
 	 */
 	var $is_404=false;
-	
+
 	/**
 	 * Setup each test.
 	 *
@@ -317,7 +317,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
 
 		$this->assertTrue( count( $indexedTerms ) > 0 );
-		
+
 		foreach ( $indexedTerms as $term ) {
 			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		}
@@ -365,7 +365,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
 
 		$this->assertTrue( count( $indexedTerms ) > 0 );
-		
+
 		foreach ( $indexedTerms as $term ) {
 			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		}
@@ -1462,8 +1462,11 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testMetaQueryGreaterThan() {
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '99' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '100' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '101' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '1000' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '9999' ) );
 
 		ep_refresh_index();
 		$args = array(
@@ -1479,8 +1482,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$query = new WP_Query( $args );
 
-		$this->assertEquals( 1, $query->post_count );
-		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
 	}
 
 	/**
@@ -1491,8 +1494,11 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testMetaQueryGreaterThanEqual() {
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '99' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '100' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '101' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '1000' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '9999' ) );
 
 		ep_refresh_index();
 		$args = array(
@@ -1508,8 +1514,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$query = new WP_Query( $args );
 
-		$this->assertEquals( 2, $query->post_count );
-		$this->assertEquals( 2, $query->found_posts );
+		$this->assertEquals( 4, $query->post_count );
+		$this->assertEquals( 4, $query->found_posts );
 	}
 
 	/**
@@ -1520,8 +1526,11 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testMetaQueryLessThan() {
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '99' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '100' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '101' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '1000' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '9999' ) );
 
 		ep_refresh_index();
 		$args = array(
@@ -1537,8 +1546,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$query = new WP_Query( $args );
 
-		$this->assertEquals( 1, $query->post_count );
-		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
 	}
 
 	/**
@@ -1549,8 +1558,11 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testMetaQueryLessThanEqual() {
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'the post content findme' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '99' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '100' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '101' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '1000' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'post content findme' ), array( 'test_key' => '9999' ) );
 
 		ep_refresh_index();
 		$args = array(
@@ -1566,8 +1578,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$query = new WP_Query( $args );
 
-		$this->assertEquals( 2, $query->post_count );
-		$this->assertEquals( 2, $query->found_posts );
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
 	}
 
 	/**
@@ -1838,8 +1850,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertTrue( empty( $cache ) );
 	}
-	
-		
+
+
 	/**
 	 * Test if $post object values exist after receiving odd values from the 'ep_search_post_return_args' filter.
 	 * @group 306
@@ -2005,7 +2017,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertNotNull( $post );
 		remove_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10);
 	}
-	
+
 	/**
 	 * Test to verify that a post type that is set to exclude_from_search isn't indexable.
 	 * @group 321
@@ -2017,7 +2029,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertArrayNotHasKey( 'ep_test_excluded', $post_types );
 		$this->assertArrayNotHasKey( 'ep_test_not_public', $post_types );
 	}
-	
+
 	/**
 	 * Test to make sure that brand new posts with 'auto-draft' post status do not fire delete or sync.
 	 * @group 343


### PR DESCRIPTION
Just to ensure range comparisons are working as intended for numeric values. May need follow-up related to #376 to use a numeric mapping instead of `.raw` if it doesn't pass with the added test data.