### PR TITLE
Fix/bulk index kill

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -366,7 +366,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	 * @param $bulk_trigger
 	 * @param bool $show_bulk_errors true to show individual post error messages for bulk errors
 	 *
-	 * @return bool
+	 * @return bool|int true if successfully synced, false if not or 2 if post was killed before sync
 	 */
 	private function queue_post( $post_id, $bulk_trigger, $show_bulk_errors = false ) {
 		static $post_count = 0;
@@ -377,8 +377,8 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		// Mimic EP_Sync_Manager::sync_post( $post_id ), otherwise posts can slip
 		// through the kill filter... that would be bad!
 		if ( apply_filters( 'ep_post_sync_kill', false, $post_args, $post_id ) ) {
-			return true;
 			$killed_post_count++;
+			return 2;
 		}
 
 		// put the post into the queue

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -319,7 +319,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 					if ( ! $result ) {
 						$errors[] = get_the_ID();
-					} else {
+					} elseif ( true === $result ) {
 						$synced ++;
 					}
 				}

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -241,10 +241,10 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 				$total_indexed += $result['synced'];
 
-				WP_CLI::log( sprintf( __( 'Number of posts synced on site %d: %d', 'elasticpress' ), $site['blog_id'], $result['synced'] ) );
+				WP_CLI::log( sprintf( __( 'Number of posts indexed on site %d: %d', 'elasticpress' ), $site['blog_id'], $result['synced'] ) );
 
 				if ( ! empty( $result['errors'] ) ) {
-					WP_CLI::error( sprintf( __( 'Number of post sync errors on site %d: %d', 'elasticpress' ), $site['blog_id'], count( $result['errors'] ) ) );
+					WP_CLI::error( sprintf( __( 'Number of post index errors on site %d: %d', 'elasticpress' ), $site['blog_id'], count( $result['errors'] ) ) );
 				}
 
 				restore_current_blog();
@@ -262,10 +262,10 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 			$result = $this->_index_helper( isset( $assoc_args['no-bulk'] ), $assoc_args['posts-per-page'], $assoc_args['offset'], isset( $assoc_args['show-bulk-errors'] ) );
 
-			WP_CLI::log( sprintf( __( 'Number of posts synced on site %d: %d', 'elasticpress' ), get_current_blog_id(), $result['synced'] ) );
+			WP_CLI::log( sprintf( __( 'Number of posts indexed on site %d: %d', 'elasticpress' ), get_current_blog_id(), $result['synced'] ) );
 
 			if ( ! empty( $result['errors'] ) ) {
-				WP_CLI::error( sprintf( __( 'Number of post sync errors on site %d: %d', 'elasticpress' ), get_current_blog_id(), count( $result['errors'] ) ) );
+				WP_CLI::error( sprintf( __( 'Number of post index errors on site %d: %d', 'elasticpress' ), get_current_blog_id(), count( $result['errors'] ) ) );
 			}
 		}
 
@@ -327,7 +327,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				break;
 			}
 
-			WP_CLI::log( 'Indexed ' . ( $query->post_count + $offset ) . '/' . $query->found_posts . ' entries. . .' );
+			WP_CLI::log( 'Processed ' . ( $query->post_count + $offset ) . '/' . $query->found_posts . ' entries. . .' );
 
 			$offset += $posts_per_page;
 


### PR DESCRIPTION
Currently if bulk indexing and using the ep_post_sync_kill filter the bulk indexing operation will miss posts due to a difference in the number of posts it thinks it should have vs the number of posts present after the kill operation as it doesn't take into effect posts that are no longer there due to the kill filter. This takes care of that by tracking the number of posts killed and making this a bit easier to read in the logs as the post statuses display.

Note that previously EP counted all posts and told you they were all synced as queue_posts always returned true unless there was an actual error. This could be quite confusing as, for example, if you have 150 posts on a site and ep_post_sync_kill eliminates 5 of them (which happens after the initial query) The status will tell you that all posts are synced but because there are now less posts than the trigger accounts for (the post counter doesn't increment until after the kill already returns true) the bulk trigger will never be hit as it the post count will never reach the threshold.

Another option for this would have been to simply move up the post counter but that leads to inaccurate statuses as EP will list all the posts as synced without regard to whether that post data was sent. Now it will tell you posts processed (which should be all of them) and list posts "indexed" when the site completes for a better reflection on what has actually happened. It is actually this confusion in display that made this bug so hard to find in the first place.