### PR TITLE
Specify language filter

### DIFF
--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -11,7 +11,7 @@ return array(
 				'default' => array(
 					'tokenizer' => 'standard',
 					'filter' => array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
-					'language' => apply_filters( 'ep_analyzer_language', 'english' ),
+					'language' => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				),
 				'shingle_analyzer' => array(
 					'type' => 'custom',
@@ -31,7 +31,7 @@ return array(
 				),
 				'ewp_snowball' => array(
 					'type' => 'snowball',
-					'language' => apply_filters( 'ep_analyzer_language', 'english' ),
+					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
 				'edge_ngram' => array(
 					'side' => 'front',


### PR DESCRIPTION
It turns out that snowball (http://snowball.tartarus.org/) doesn't support the same languages as Lucene so, for example, using ep_analyzer_language of arabic will work for the analyzer but causes a crash on the snowball filter. This adds a 2nd param to the filter to specify which spot it is filtering allowing the ability to avoid issues.