### PR TITLE
Make mapping compatible with Elasticsearch 2.0

### DIFF
--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -111,8 +111,7 @@ return array(
 				),
 				'post_author' => array(
 					'type' => 'object',
-					'path' => 'full',
-					'fields' => array(
+					'properties' => array(
 						'display_name' => array(
 							'type' => 'string',
 							'analyzer' => 'standard',
@@ -229,8 +228,7 @@ return array(
 				),
 				'date_terms' => array(
 					'type' => 'object',
-					'path' => 'full',
-					'fields' => array(
+					'properties' => array(
 						'year' => array( //4 digit year (e.g. 2011)
 							'type' => 'integer',
 						),


### PR DESCRIPTION
This fix does two things:

* Removes the `fields` field type from `object` typed fields as they should be called `properties`.
* Remove `path` from `object` field types.

Dockunit is upgrading to ES 2.0.0 today. Not sure where Travis CI is at, but at least we can see it's backwards compat.