### PR TITLE
(Version 1.6.1) Make mapping compatible with Elasticsearch version 2.0.0

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: ElasticPress
  * Description: Integrate WordPress search with Elasticsearch
- * Version:     1.6
+ * Version:     1.6.1
  * Author:      Aaron Holbrook, Taylor Lovett, Matt Gross, 10up
  * Author URI:  http://10up.com
  * License:     GPLv2 or later

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -111,8 +111,7 @@ return array(
 				),
 				'post_author' => array(
 					'type' => 'object',
-					'path' => 'full',
-					'fields' => array(
+					'properties' => array(
 						'display_name' => array(
 							'type' => 'string',
 							'analyzer' => 'standard',
@@ -229,8 +228,7 @@ return array(
 				),
 				'date_terms' => array(
 					'type' => 'object',
-					'path' => 'full',
-					'fields' => array(
+					'properties' => array(
 						'year' => array( //4 digit year (e.g. 2011)
 							'type' => 'integer',
 						),

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/10up/ElasticPress
 Tags: search, elasticsearch, fuzzy, facet, searching, autosuggest, suggest, elastic, advanced search
 Requires at least: 3.7.1
 Tested up to: 4.4
-Stable tag: 1.6
+Stable tag: 1.6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,6 +59,13 @@ configuring single site and multi-site cross-site search are slightly different.
 4. Using WP-CLI, do an initial sync (with mapping) with your ES server by running: `wp elasticpress index --setup --network-wide`.
 
 == Changelog ==
+
+= 1.6.1 =
+
+ElasticPress 1.6.1 fixes mapping backwards compatibility issues with Elasticsearch 2.0:
+
+* Removes the fields field type from object typed fields as they should be called properties.
+* Remove path from object field types.
 
 = 1.6 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === ElasticPress ===
-Contributors: aaronholbrook, tlovett1, 10up
+Contributors: aaronholbrook, tlovett1, ChrisWiegman, sc0ttkclark, collinsinternet, 10up
 Author URI: http://10up.com
 Plugin URI: https://github.com/10up/ElasticPress
 Tags: search, elasticsearch, fuzzy, facet, searching, autosuggest, suggest, elastic, advanced search


### PR DESCRIPTION
This fix does two things:

* Removes the fields field type from object typed fields as they should be called properties.
* Remove path from object field types.

Dockunit is upgrading to ES 2.0.0 today. Not sure where Travis CI is at, but at least we can see it's backwards compat.