### PR TITLE
Use order by unique key - ID

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -300,7 +300,8 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				'post_type'           => ep_get_indexable_post_types(),
 				'post_status'         => ep_get_indexable_post_status(),
 				'offset'              => $offset,
-				'ignore_sticky_posts' => true
+				'ignore_sticky_posts' => true,
+				'orderby'             => array( 'ID' => 'DESC' ),
 			) );
 
 			$query = new WP_Query( $args );


### PR DESCRIPTION
In some situations ElasticPress wp-cli index doesn't index all posts.

How to reproduce it:

- clear posts from your WordPress
- use wp-cli to generate some content

```
wp --allow-root post generate --count=2500 --post_author=some_author
```

- run above command one more time - wait few seconds before doing this again
- run index command

```
wp elasticpress index --setup
```

Go to your Elasticsearch and check number of documents. Expected number should be 5000

Command result:

> Number of posts synced on site 1: 5000
Total time elapsed: 23.017
Warning: ElasticPress is already activated.
Success: Done!

Elasticsearch data
![elasticsearch-indexing](https://cloud.githubusercontent.com/assets/7304218/11306655/83a49086-8fb3-11e5-93d7-e2f48de5e2b8.png)

This comes from the fact that by default posts are ordered by `post_date` column which doesn't have to be unique (and `wp post generate` generates all posts with the same date) and it results in duplicated posts IDs in WP_Query results. In edge cases some posts import tools may do the same. Ordering by primary key `ID` solves that issue.

