### PR TITLE
Allow setting fuzziness in search query arguments

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1277,6 +1277,8 @@ class EP_API {
 
 		$search_fields = apply_filters( 'ep_search_fields', $search_fields, $args );
 
+        $fuzziness = (!isset($args['fuzziness'])) ? 2 : $args['fuzziness'];
+
 		$query = array(
 			'bool' => array(
 				'should' => array(
@@ -1292,7 +1294,7 @@ class EP_API {
 						'multi_match' => array(
 							'fields' => $search_fields,
 							'query' => '',
-							'fuzziness' => 2,
+							'fuzziness' => $fuzziness,
 							'operator' => 'or',
 						),
 					)


### PR DESCRIPTION
Hi,
This is related to issue #397.
I didn't find a way to change the fuzziness level when performing a search query so here is an attempt to make this option configurable with a `fuzziness` argument that you can pass in your `WP_Query` :
```
$query = new WP_Query( array(
    's'             => 'term',
    'fuzziness'		=> 0
) );
```
