### PR TITLE
Add option not to disable ElasticPress while indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ The following are special parameters that are only supported by ElasticPress.
 
 The following commands are supported by ElasticPress:
 
-* `wp elasticpress index [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset] [--show-bulk-errors] [--post-type]`
+* `wp elasticpress index [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset] [--show-bulk-errors] [--post-type] [--keep-active]`
 
     Index all posts in the current blog.
 
@@ -500,6 +500,7 @@ The following commands are supported by ElasticPress:
     * `--offset` let's you skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
     * `--show-bulk-errors` displays the error message returned from Elasticsearch when a post fails to index (as opposed to just the title and ID of the post).
     * `--post-type` let's you specify which post types will be indexed (by default: all indexable post types are indexed). For example, `--post-type="my_custom_post_type"` would limit indexing to only posts from the post type "my_custom_post_type". Accepts multiple post types separated by comma.
+    * `--keep-active` let's you keep ElasticPress active during indexing (cannot be used with --setup).
 
 * `wp elasticpress activate`
 

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -181,7 +181,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Index all posts for a site or network wide
 	 *
-	 * @synopsis [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset] [--show-bulk-errors] [--post-type]
+	 * @synopsis [--setup] [--network-wide] [--posts-per-page] [--no-bulk] [--offset] [--show-bulk-errors] [--post-type] [--keep-active]
 	 * @param array $args
 	 *
 	 * @since 0.1.2
@@ -209,6 +209,15 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 		$total_indexed = 0;
 
+		$keep_active = false;
+		if (
+			isset( $assoc_args['keep-active'] ) &&
+			true === $assoc_args['keep-active'] &&
+			( ! isset( $assoc_args['setup'] ) || false === $assoc_args['setup'] )
+		) {
+			$keep_active = true;
+		}
+
 		/**
 		 * Prior to the index command invoking
 		 * Useful for deregistering filters/actions that occur during a query request
@@ -218,7 +227,9 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		do_action( 'ep_wp_cli_pre_index', $args, $assoc_args );
 
 		// Deactivate our search integration
-		$this->deactivate();
+		if ( ! $keep_active ) {
+			$this->deactivate();
+		}
 
 		timer_start();
 

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -209,15 +209,6 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 		$total_indexed = 0;
 
-		$keep_active = false;
-		if (
-			isset( $assoc_args['keep-active'] ) &&
-			true === $assoc_args['keep-active'] &&
-			( ! isset( $assoc_args['setup'] ) || false === $assoc_args['setup'] )
-		) {
-			$keep_active = true;
-		}
-
 		/**
 		 * Prior to the index command invoking
 		 * Useful for deregistering filters/actions that occur during a query request
@@ -226,8 +217,13 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		 */
 		do_action( 'ep_wp_cli_pre_index', $args, $assoc_args );
 
-		// Deactivate our search integration
-		if ( ! $keep_active ) {
+		// Deactivate ElasticPress if setup is set to true.
+		if (
+			! isset( $assoc_args['keep-active'] ) ||
+			false === $assoc_args['keep-active'] ||
+			( isset( $assoc_args['setup'] ) && true === $assoc_args['setup'] )
+		) {
+			// Deactivate our search integration
 			$this->deactivate();
 		}
 


### PR DESCRIPTION
Sometimes it would be very useful not to disable ElasticPress search integration during wp-cli indexing operation. The reason behind this feature is that sometimes there is a need to reindex site and keep using ElasticPress turned on as reindexing may take very long time (1-2 hours).