### PR TITLE
Add a filter around the second fuzziness argument

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1292,7 +1292,7 @@ class EP_API {
 						'multi_match' => array(
 							'fields' => $search_fields,
 							'query' => '',
-							'fuzziness' => 2,
+							'fuzziness' => apply_filters( 'ep_fuzziness_arg', 2 ),
 							'operator' => 'or',
 						),
 					)

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1284,7 +1284,7 @@ class EP_API {
 						'multi_match' => array(
 							'query' => '',
 							'fields' => $search_fields,
-							'boost' => apply_filters( 'ep_match_boost', 2 ),
+							'boost' => apply_filters( 'ep_match_boost', 2, $search_fields, $args ),
 							'fuzziness' => 0,
 						)
 					),
@@ -1292,7 +1292,7 @@ class EP_API {
 						'multi_match' => array(
 							'fields' => $search_fields,
 							'query' => '',
-							'fuzziness' => apply_filters( 'ep_fuzziness_arg', 2 ),
+							'fuzziness' => apply_filters( 'ep_fuzziness_arg', 2, $search_fields, $args ),
 							'operator' => 'or',
 						),
 					)


### PR DESCRIPTION
In version 1.6.2, the ```fuzzy_like_this``` param was removed, as it's deprecated in elasticsearch. The ```min_similarity``` field was also removed and replaced with the ```fuzziness``` field. This field had a filter around it so you could modify these results a bit. This adds a new filter around the new ```fuzziness``` field to give you the same freedom.