### PR TITLE
Feature/non blocking index

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -31,10 +31,11 @@ class EP_API {
 	 * Index a post under a given site index or the global index ($site_id = 0)
 	 *
 	 * @param array $post
+	 * @param bool $blocking
 	 * @since 0.1.0
 	 * @return array|bool|mixed
 	 */
-	public function index_post( $post ) {
+	public function index_post( $post, $blocking = true ) {
 
 		/**
 		 * Filter post prior to indexing
@@ -65,6 +66,7 @@ class EP_API {
 			'body'    => $encoded_post,
 			'method'  => 'PUT',
 			'timeout' => 15,
+			'blocking' => $blocking,
 		);
 
 		$request = ep_remote_request( $path, apply_filters( 'ep_index_post_request_args', $request_args, $post ) );
@@ -1641,6 +1643,11 @@ class EP_API {
 			$request = wp_remote_request( esc_url( trailingslashit( $host ) . $path ), $args ); //try the existing host to avoid unnecessary calls
 		}
 
+		// Return now if we're not blocking, since we won't have a response yet
+		if ( isset( $args['blocking'] ) && false === $args['blocking' ] ) {
+			return $request;
+		}
+
 		//If we have a failure we'll try it again with a backup host
 		if ( false === $request || is_wp_error( $request ) || ( isset( $request['response']['code'] ) && 200 !== $request['response']['code'] ) ) {
 
@@ -1666,8 +1673,8 @@ EP_API::factory();
  * Accessor functions for methods in above class. See doc blocks above for function details.
  */
 
-function ep_index_post( $post ) {
-	return EP_API::factory()->index_post( $post );
+function ep_index_post( $post, $blocking = true ) {
+	return EP_API::factory()->index_post( $post, $blocking );
 }
 
 function ep_search( $args, $scope = 'current' ) {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -224,16 +224,17 @@ class EP_API {
 	 * is used to determine the index to delete from.
 	 *
 	 * @param int $post_id
+	 * @param bool $blocking
 	 * @since 0.1.0
 	 * @return bool
 	 */
-	public function delete_post( $post_id  ) {
+	public function delete_post( $post_id, $blocking = true  ) {
 
 		$index = trailingslashit( ep_get_index_name() );
 
 		$path = $index . '/post/' . $post_id;
 
-		$request_args = array( 'method' => 'DELETE', 'timeout' => 15 );
+		$request_args = array( 'method' => 'DELETE', 'timeout' => 15, 'blocking' => $blocking );
 
 		$request = ep_remote_request( $path, apply_filters( 'ep_delete_post_request_args', $request_args, $post_id ) );
 
@@ -1685,8 +1686,8 @@ function ep_get_post( $post_id ) {
 	return EP_API::factory()->get_post( $post_id );
 }
 
-function ep_delete_post( $post_id ) {
-	return EP_API::factory()->delete_post( $post_id );
+function ep_delete_post( $post_id, $blocking = true ) {
+	return EP_API::factory()->delete_post( $post_id, $blocking );
 }
 
 function ep_put_mapping() {

--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -70,7 +70,7 @@ class EP_Sync_Manager {
 
 		do_action( 'ep_delete_post', $post_id );
 
-		ep_delete_post( $post_id );
+		ep_delete_post( $post_id, false );
 	}
 
 	/**

--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -117,7 +117,7 @@ class EP_Sync_Manager {
 
 				do_action( 'ep_sync_on_transition', $post_ID );
 
-				$this->sync_post( $post_ID);
+				$this->sync_post( $post_ID, false );
 			}
 		}
 	}
@@ -142,10 +142,11 @@ class EP_Sync_Manager {
 	 * Sync a post for a specific site or globally.
 	 *
 	 * @param int $post_id
+	 * @param bool $blocking
 	 * @since 0.1.0
 	 * @return bool|array
 	 */
-	public function sync_post( $post_id ) {
+	public function sync_post( $post_id, $blocking = true ) {
 
 		$post_args = ep_prepare_post( $post_id );
 
@@ -153,7 +154,7 @@ class EP_Sync_Manager {
 			return;
 		}
 
-		$response = ep_index_post( $post_args );
+		$response = ep_index_post( $post_args, $blocking );
 
 		return $response;
 	}
@@ -165,6 +166,6 @@ $ep_sync_manager = EP_Sync_Manager::factory();
  * Accessor functions for methods in above class. See doc blocks above for function details.
  */
 
-function ep_sync_post( $post_id ) {
-	return EP_Sync_Manager::factory()->sync_post( $post_id );
+function ep_sync_post( $post_id, $blocking = true ) {
+	return EP_Sync_Manager::factory()->sync_post( $post_id, $blocking );
 }


### PR DESCRIPTION
Retains a default of blocking requests, but transforms requests for post update actions (save, delete, etc) to be non-blocking requests.

Resolves issue #410