### PR TITLE
Sync searchable_post_types with indexable_post_types.

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -285,6 +285,10 @@ function ep_get_indexable_post_types() {
 	return EP_Config::factory()->get_indexable_post_types();
 }
 
+function ep_get_searchable_post_types() {
+	return EP_Config::factory()->get_searchable_post_types();
+}
+
 function ep_get_indexable_post_status() {
 	return EP_Config::factory()->get_indexable_post_status();
 }

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -128,6 +128,18 @@ class EP_Config {
 	}
 
 	/**
+	 * Returns searchable post types for the current site
+	 *
+	 * @since 1.9
+	 * @return mixed|void
+	 */
+	public function get_searchable_post_types() {
+		$post_types = get_post_types( array( 'exclude_from_search' => false ) );
+
+		return apply_filters( 'ep_searchable_post_types', $post_types );
+	}
+
+	/**
 	 * Return indexable post_status for the current site
 	 *
 	 * @since 1.3

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -226,7 +226,7 @@ class EP_WP_Query_Integration {
 				 * To follow WordPress conventions,
 				 * make sure we only search 'searchable' post types
 				 */
-				$searchable_post_types = get_post_types( array( 'exclude_from_search' => false ) );
+				$searchable_post_types = ep_get_indexable_post_types();
 
 				// If we have no searchable post types, there's no point going any further
 				if ( empty( $searchable_post_types ) ) {

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -226,7 +226,7 @@ class EP_WP_Query_Integration {
 				 * To follow WordPress conventions,
 				 * make sure we only search 'searchable' post types
 				 */
-				$searchable_post_types = ep_get_indexable_post_types();
+				$searchable_post_types = ep_get_searchable_post_types();
 
 				// If we have no searchable post types, there's no point going any further
 				if ( empty( $searchable_post_types ) ) {


### PR DESCRIPTION
Switching this out allows the `any` query to match the indexed post types. Because the [function](https://github.com/rossluebe/ElasticPress/blob/develop/classes/class-ep-config.php#L115-L119) already returns `get_post_types( array( 'exclude_from_search' => false ) );`, this will only affect users who have made changes to the indexable post types through the `ep_indexable_post_types` filter.