### PR TITLE
Only download MySQLi dropin when it's needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ php:
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
-    - WP_VERSION=3.8 WP_MULTISITE=0
-    - WP_VERSION=3.8 WP_MULTISITE=1
+    - WP_VERSION=3.7.1 WP_MULTISITE=0
+    - WP_VERSION=3.7.1 WP_MULTISITE=1
 
 services:
     - elasticsearch

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -55,7 +55,9 @@ install_wp() {
 	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
 	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	if [ $WP_VERSION == '3.8' ]; then
+		download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db-legacy.php $WP_CORE_DIR/wp-content/db.php
+	fi
 }
 
 install_test_suite() {

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -55,7 +55,7 @@ install_wp() {
 	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
 	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
-	if [ $WP_VERSION == '3.8' ]; then
+	if [ $WP_VERSION == '3.7.1' ]; then
 		download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db-legacy.php $WP_CORE_DIR/wp-content/db.php
 	fi
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,7 @@
 	>
     <php>
         <const name="WP_TESTS_MULTISITE" value="1" />
+        <ini name="error_reporting" value="24575" />
     </php>
 	<testsuites>
 		<testsuite>


### PR DESCRIPTION
WordPress supports mysqli by default as of 3.9, so we only need this dropin for 3.8 (at least, that's the lowest version we test for in our travis matrix). We also need to make sure we're grabbing the legacy version (the actual dropin) since the one downloaded only defines a constant telling WordPress not to use the mysql_* functions.