### PR TITLE
Log queries for debugging

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1662,7 +1662,7 @@ class EP_API {
 				$query['url'] = $request_url;
 			}
 
-			$request = wp_remote_request( esc_url( $request_url, $args ); //try the existing host to avoid unnecessary calls
+			$request = wp_remote_request( $request_url, $args ); //try the existing host to avoid unnecessary calls
 		} else {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				$query['failed_hosts'][] = $host;

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -16,7 +16,7 @@ class EP_API {
 	 *
 	 * @since  1.8
 	 */
-	public $queries = array();
+	private $queries = array();
 
 	/**
 	 * Return singleton instance of class
@@ -1615,6 +1615,16 @@ class EP_API {
 	}
 
 	/**
+	 * Return queries for debugging
+	 *
+	 * @since  1.8
+	 * @return array
+	 */
+	public function get_query_log() {
+		return $this->queries;
+	}
+
+	/**
 	 * Wrapper for wp_remote_request
 	 *
 	 * This is a wrapper function for wp_remote_request that will switch to a backup server
@@ -1794,4 +1804,8 @@ function ep_format_request_headers() {
 
 function ep_remote_request( $path, $args ) {
 	return EP_API::factory()->remote_request( $path, $args );
+}
+
+function ep_get_query_log() {
+	return EP_API::factory()->get_query_log();
 }

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1629,7 +1629,7 @@ class EP_API {
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$query = array(
-				'time_start' => time(),
+				'time_start' => microtime( true ),
 				'args' => $args,
 				'blocking' => true,
 				'failed_hosts' => array(),
@@ -1688,7 +1688,7 @@ class EP_API {
 			if ( is_wp_error( $host ) ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					$query['failed_hosts'][] = $host;
-					$query['time_finish'] = time();
+					$query['time_finish'] = microtime( true );
 					$this->queries[] = $query;
 				}
 
@@ -1700,7 +1700,7 @@ class EP_API {
 		}
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$query['time_finish'] = time();
+			$query['time_finish'] = microtime( true );
 			$query['request'] = $request;
 			$query['url'] = $request_url;
 			$this->queries[] = $query;

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -12,7 +12,9 @@ class EP_API {
 	public function __construct() { }
 
 	/**
-	 * Logged queries for debugging. Only used when WP_DEBUG is on.
+	 * Logged queries for debugging
+	 *
+	 * @since  1.8
 	 */
 	public $queries = array();
 
@@ -1627,15 +1629,14 @@ class EP_API {
 	 */
 	public function remote_request( $path, $args = array() ) {
 
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$query = array(
-				'time_start' => microtime( true ),
-				'args' => $args,
-				'blocking' => true,
-				'failed_hosts' => array(),
-				'request' => false,
-			);
-		}
+		$query = array(
+			'time_start' => microtime( true ),
+			'args' => $args,
+			'blocking' => true,
+			'failed_hosts' => array(),
+			'request' => false,
+			'host' => false,
+		);
 
 		//The allowance of these variables makes testing easier.
 		$force       = false;
@@ -1658,23 +1659,18 @@ class EP_API {
 		if ( ! is_wp_error( $host ) ) { // probably only reachable in testing but just to be safe
 			$request_url = esc_url( trailingslashit( $host ) . $path );
 
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				$query['url'] = $request_url;
-			}
+			$query['url'] = $request_url;
+			$query['host'] = $host;
 
 			$request = wp_remote_request( $request_url, $args ); //try the existing host to avoid unnecessary calls
 		} else {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				$query['failed_hosts'][] = $host;
-			}
+			$query['failed_hosts'][] = $host;
 		}
 
 		// Return now if we're not blocking, since we won't have a response yet
 		if ( isset( $args['blocking'] ) && false === $args['blocking' ] ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				$query['blocking'] = true;
-				$this->queries[] = $query;
-			}
+			$query['blocking'] = true;
+			$this->queries[] = $query;
 
 			return $request;
 		}
@@ -1686,11 +1682,9 @@ class EP_API {
 			$request_url = esc_url( trailingslashit( $host ) . $path );
 
 			if ( is_wp_error( $host ) ) {
-				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					$query['failed_hosts'][] = $host;
-					$query['time_finish'] = microtime( true );
-					$this->queries[] = $query;
-				}
+				$query['failed_hosts'][] = $host;
+				$query['time_finish'] = microtime( true );
+				$this->queries[] = $query;
 
 				return $host;
 			}
@@ -1699,12 +1693,11 @@ class EP_API {
 
 		}
 
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$query['time_finish'] = microtime( true );
-			$query['request'] = $request;
-			$query['url'] = $request_url;
-			$this->queries[] = $query;
-		}
+		$query['time_finish'] = microtime( true );
+		$query['request'] = $request;
+		$query['url'] = $request_url;
+		$query['host'] = $host;
+		$this->queries[] = $query;
 
 		return $request;
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1681,6 +1681,7 @@ class EP_API {
 		// Return now if we're not blocking, since we won't have a response yet
 		if ( isset( $args['blocking'] ) && false === $args['blocking' ] ) {
 			$query['blocking'] = true;
+			$query['request']  = $request;
 			$this->queries[]   = $query;
 
 			return $request;

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1630,12 +1630,13 @@ class EP_API {
 	public function remote_request( $path, $args = array() ) {
 
 		$query = array(
-			'time_start' => microtime( true ),
-			'args' => $args,
-			'blocking' => true,
+			'time_start'   => microtime( true ),
+			'time_finish'  => false,
+			'args'         => $args,
+			'blocking'     => true,
 			'failed_hosts' => array(),
-			'request' => false,
-			'host' => false,
+			'request'      => false,
+			'host'         => false,
 		);
 
 		//The allowance of these variables makes testing easier.
@@ -1657,9 +1658,9 @@ class EP_API {
 		$request = false;
 
 		if ( ! is_wp_error( $host ) ) { // probably only reachable in testing but just to be safe
-			$request_url = esc_url( trailingslashit( $host ) . $path );
+			$request_url   = esc_url( trailingslashit( $host ) . $path );
 
-			$query['url'] = $request_url;
+			$query['url']  = $request_url;
 			$query['host'] = $host;
 
 			$request = wp_remote_request( $request_url, $args ); //try the existing host to avoid unnecessary calls
@@ -1670,7 +1671,7 @@ class EP_API {
 		// Return now if we're not blocking, since we won't have a response yet
 		if ( isset( $args['blocking'] ) && false === $args['blocking' ] ) {
 			$query['blocking'] = true;
-			$this->queries[] = $query;
+			$this->queries[]   = $query;
 
 			return $request;
 		}
@@ -1683,8 +1684,8 @@ class EP_API {
 
 			if ( is_wp_error( $host ) ) {
 				$query['failed_hosts'][] = $host;
-				$query['time_finish'] = microtime( true );
-				$this->queries[] = $query;
+				$query['time_finish']    = microtime( true );
+				$this->queries[]         = $query;
 
 				return $host;
 			}
@@ -1695,9 +1696,9 @@ class EP_API {
 
 		$query['time_finish'] = microtime( true );
 		$query['request'] = $request;
-		$query['url'] = $request_url;
-		$query['host'] = $host;
-		$this->queries[] = $query;
+		$query['url']     = $request_url;
+		$query['host']    = $host;
+		$this->queries[]  = $query;
 
 		return $request;
 


### PR DESCRIPTION
This let's us do the following:
* Track the time taken for each query
* Log broken hosts
* Track the amount of EP queries per page
* Track actual arguments being sent to Elasticsearch