### PR TITLE
Support arbitrary document paths in orderby

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
     
 * ```orderby``` (*string*)
 
-    Order results by field name instead of relevance. Supports: ```title```, ```name```, ```date```, and ```relevance```; anything else will be interpretted as a document path i.e. `meta.my_key.long` or `meta.my_key.raw`.
+    Order results by field name instead of relevance. Supports: ```title```, ```name```, ```date```, and ```relevance```; anything else will be interpretted as a document path i.e. `meta.my_key.long` or `meta.my_key.raw`. You can sort by multiple fields as well i.e. `title meta.my_key.raw`
 
 * ```order``` (*string*)
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
     
 * ```orderby``` (*string*)
 
-    Order results by field name instead of relevance. Currently only supports: ```title```, ```name```, ```date```, and ```relevance``` (default).
+    Order results by field name instead of relevance. Supports: ```title```, ```name```, ```date```, and ```relevance```; anything else will be interpretted as a document path i.e. `meta.my_key.long` or `meta.my_key.raw`.
 
 * ```order``` (*string*)
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1091,7 +1091,7 @@ class EP_API {
 					} elseif ( in_array( $compare, array( '>=', '<=', '>', '<' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.double';
 					} else {
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . 'value';
+						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.value';
 					}
 
 					switch ( $compare ) {
@@ -1519,26 +1519,20 @@ class EP_API {
 			if ( ! empty( $orderby_clause ) ) {
 				if ( 'relevance' === $orderby_clause ) {
 					$sort[] = array(
-						array(
-							'_score' => array(
-								'order' => $order,
-							),
+						'_score' => array(
+							'order' => $order,
 						),
 					);
 		 		} elseif ( 'date' === $orderby_clause ) {
 					$sort[] = array(
-						array(
-							'post_date' => array(
-								'order' => $order,
-							),
+						'post_date' => array(
+							'order' => $order,
 						),
 					);
 				} elseif ( 'name' === $orderby_clause || 'title' === $orderby_clause  ) {
 					$sort[] = array(
-						array(
-							'post_' . $orderby_clause . '.raw' => array(
-								'order' => $order,
-							),
+						'post_' . $orderby_clause . '.raw' => array(
+							'order' => $order,
 						),
 					);
 				} else {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1091,7 +1091,7 @@ class EP_API {
 					} elseif ( in_array( $compare, array( '>=', '<=', '>', '<' ) ) ) {
 						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.double';
 					} else {
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.value';
+						$meta_key_path = 'meta.' . $single_meta_query['key'] . 'value';
 					}
 
 					switch ( $compare ) {
@@ -1518,7 +1518,7 @@ class EP_API {
 		foreach ( $orderbys as $orderby_clause ) {
 			if ( ! empty( $orderby_clause ) ) {
 				if ( 'relevance' === $orderby_clause ) {
-					$sort = array(
+					$sort[] = array(
 						array(
 							'_score' => array(
 								'order' => $order,
@@ -1526,7 +1526,7 @@ class EP_API {
 						),
 					);
 		 		} elseif ( 'date' === $orderby_clause ) {
-					$sort = array(
+					$sort[] = array(
 						array(
 							'post_date' => array(
 								'order' => $order,
@@ -1534,7 +1534,7 @@ class EP_API {
 						),
 					);
 				} elseif ( 'name' === $orderby_clause || 'title' === $orderby_clause  ) {
-					$sort = array(
+					$sort[] = array(
 						array(
 							'post_' . $orderby_clause . '.raw' => array(
 								'order' => $order,

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1512,36 +1512,35 @@ class EP_API {
 	 * @return array
 	 */
 	protected function parse_orderby( $orderby, $order ) {
+		$orderbys = explode( ' ', $orderby );
+		$sort = array();
 
-		if ( 'relevance' === $orderby ) {
-			$sort = array(
-				array(
-					'_score' => array(
-						'order' => $order,
+		foreach ( $orderbys as $orderby_clause ) {
+			if ( 'relevance' === $orderby ) {
+				$sort = array(
+					array(
+						'_score' => array(
+							'order' => $order,
+						),
 					),
-				),
-			);
- 		} elseif ( 'date' === $orderby ) {
-			$sort = array(
-				array(
-					'post_date' => array(
-						'order' => $order,
+				);
+	 		} elseif ( 'date' === $orderby ) {
+				$sort = array(
+					array(
+						'post_date' => array(
+							'order' => $order,
+						),
 					),
-				),
-			);
-		} elseif ( 'name' === $orderby || ( 'title' === $orderby ) ) {
-			$sort = array(
-				array(
-					'post_' . $orderby . '.raw' => array(
-						'order' => $order,
+				);
+			} elseif ( 'name' === $orderby || ( 'title' === $orderby ) ) {
+				$sort = array(
+					array(
+						'post_' . $orderby . '.raw' => array(
+							'order' => $order,
+						),
 					),
-				),
-			);
-		} else {
-			$orderbys = explode( ' ', $orderby );
-			$sort = array();
-
-			foreach ( $orderbys as $orderby_clause ) {
+				);
+			} else {
 				$sort[] = array(
 					$orderby_clause => array(
 						'order' => $order,

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1538,13 +1538,16 @@ class EP_API {
 				),
 			);
 		} else {
-			$sort = array(
-				array(
-					$orderby => array(
+			$orderbys = explode( ' ', $orderby );
+			$sort = array();
+
+			foreach ( $orderbys as $orderby_clause ) {
+				$sort[] = array(
+					$orderby_clause => array(
 						'order' => $order,
 					),
-				),
-			);
+				);
+			}
 		}
 
 		return $sort;

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -880,15 +880,8 @@ class EP_API {
 
 		// Set sort type
 		if ( ! empty( $args['orderby'] ) ) {
-			$sort = $this->parse_orderby( $args['orderby'], $order );
-
-			if ( false !== $sort ) {
-				$formatted_args['sort'] = $sort;
-			}
-		}
-
-		// Either nothing was passed or the parse_orderby failed, use default sort
-		if ( empty( $args['orderby'] ) || false === $sort ) {
+			$formatted_args['sort'] = $this->parse_orderby( $args['orderby'], $order );
+		} else {
 			// Default sort is to use the score (based on relevance)
 			$default_sort = array(
 				array(
@@ -1509,59 +1502,49 @@ class EP_API {
 	}
 
 	/**
-	 * If the passed orderby value is allowed, convert the alias to a
-	 * properly-prefixed sort value.
+	 * Convert the alias to a properly-prefixed sort value.
 	 *
 	 * @since 1.1
 	 * @access protected
 	 *
-	 * @param string $orderby Alias for the field to order by.
+	 * @param string $orderby Alias or path for the field to order by.
 	 * @param string $order
-	 * @return array|bool Array formatted value to used in the sort DSL. False otherwise.
+	 * @return array
 	 */
 	protected function parse_orderby( $orderby, $order ) {
-		// Used to filter values.
-		$allowed_keys = array(
-			'relevance',
-			'name',
-			'title',
-			'date',
-		);
 
-		if ( ! in_array( $orderby, $allowed_keys ) ) {
-			return false;
-		}
-
-		switch ( $orderby ) {
-			case 'relevance':
-			default:
-				$sort = array(
-					array(
-						'_score' => array(
-							'order' => $order,
-						),
+		if ( 'relevance' === $orderby ) {
+			$sort = array(
+				array(
+					'_score' => array(
+						'order' => $order,
 					),
-				);
-				break;
-			case 'date':
-				$sort = array(
-					array(
-						'post_date' => array(
-							'order' => $order,
-						),
+				),
+			);
+ 		} elseif ( 'date' === $orderby ) {
+			$sort = array(
+				array(
+					'post_date' => array(
+						'order' => $order,
 					),
-				);
-				break;
-			case 'name':
-			case 'title':
-				$sort = array(
-					array(
-						'post_' . $orderby . '.raw' => array(
-							'order' => $order,
-						),
+				),
+			);
+		} elseif ( 'name' === $orderby || ( 'title' === $orderby ) ) {
+			$sort = array(
+				array(
+					'post_' . $orderby . '.raw' => array(
+						'order' => $order,
 					),
-				);
-				break;
+				),
+			);
+		} else {
+			$sort = array(
+				array(
+					$orderby => array(
+						'order' => $order,
+					),
+				),
+			);
 		}
 
 		return $sort;

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1516,36 +1516,38 @@ class EP_API {
 		$sort = array();
 
 		foreach ( $orderbys as $orderby_clause ) {
-			if ( 'relevance' === $orderby ) {
-				$sort = array(
-					array(
-						'_score' => array(
+			if ( ! empty( $orderby_clause ) ) {
+				if ( 'relevance' === $orderby_clause ) {
+					$sort = array(
+						array(
+							'_score' => array(
+								'order' => $order,
+							),
+						),
+					);
+		 		} elseif ( 'date' === $orderby_clause ) {
+					$sort = array(
+						array(
+							'post_date' => array(
+								'order' => $order,
+							),
+						),
+					);
+				} elseif ( 'name' === $orderby_clause || 'title' === $orderby_clause  ) {
+					$sort = array(
+						array(
+							'post_' . $orderby_clause . '.raw' => array(
+								'order' => $order,
+							),
+						),
+					);
+				} else {
+					$sort[] = array(
+						$orderby_clause => array(
 							'order' => $order,
 						),
-					),
-				);
-	 		} elseif ( 'date' === $orderby ) {
-				$sort = array(
-					array(
-						'post_date' => array(
-							'order' => $order,
-						),
-					),
-				);
-			} elseif ( 'name' === $orderby || ( 'title' === $orderby ) ) {
-				$sort = array(
-					array(
-						'post_' . $orderby . '.raw' => array(
-							'order' => $order,
-						),
-					),
-				);
-			} else {
-				$sort[] = array(
-					$orderby_clause => array(
-						'order' => $order,
-					),
-				);
+					);
+				}
 			}
 		}
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1414,34 +1414,6 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
-	 * Test unallowed orderby parameter
-	 *
-	 * Will revert to default _score orderby
-	 *
-	 * @since 1.1
-	 */
-	public function testSearchUnallowedOrderbyQuery() {
-		ep_create_and_sync_post();
-		ep_create_and_sync_post( array( 'post_title' => 'ordertestt' ) );
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest' ) );
-
-		ep_refresh_index();
-
-		$args = array(
-			's'       => 'ordertest',
-			'orderby' => 'SUPERRELEVANCE',
-			'order'   => 'ASC',
-		);
-
-		$query = new WP_Query( $args );
-
-		$this->assertEquals( 2, $query->post_count );
-		$this->assertEquals( 2, $query->found_posts );
-		$this->assertEquals( 'ordertestt', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertest', $query->posts[1]->post_title );
-	}
-
-	/**
 	 * Test a normal post trash
 	 *
 	 * @since 1.2

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1085,6 +1085,91 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test post meta string orderby query asc
+	 *
+	 * @since 1.8
+	 */
+	public function testSearchPostMetaStringOrderbyQueryAsc() {
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 'c' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 'b' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 'a' ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'ordertest',
+			'orderby' => 'meta.test_key.raw',
+			'order'   => 'ASC',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
+	}
+
+	/**
+	 * Test post meta number orderby query asc
+	 *
+	 * @since 1.8
+	 */
+	public function testSearchPostMetaNumOrderbyQueryAsc() {
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 3 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444' ), array( 'test_key' => 4 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 2 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 1 ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'ordertest',
+			'orderby' => 'meta.test_key.long',
+			'order'   => 'ASC',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 4, $query->post_count );
+		$this->assertEquals( 4, $query->found_posts );
+		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
+		$this->assertEquals( 'ordertest 444', $query->posts[3]->post_title );
+	}
+
+	/**
+	 * Test post meta number orderby query desc
+	 *
+	 * @since 1.8
+	 */
+	public function testSearchPostMetaNumOrderbyQueryDesc() {
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 3 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444' ), array( 'test_key' => 4 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 2 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 1 ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'ordertest',
+			'orderby' => 'meta.test_key.long',
+			'order'   => 'DESC',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 4, $query->post_count );
+		$this->assertEquals( 4, $query->found_posts );
+		$this->assertEquals( 'ordertest 111', $query->posts[3]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[2]->post_title );
+		$this->assertEquals( 'ordertest 333', $query->posts[1]->post_title );
+		$this->assertEquals( 'ordertest 444', $query->posts[0]->post_title );
+	}
+
+	/**
 	 * Test post_date orderby query
 	 *
 	 * @since 1.4

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1170,6 +1170,35 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test post meta num multiple fields orderby query asc
+	 *
+	 * @since 1.8
+	 */
+	public function testSearchPostMetaNumMultipleOrderbyQuery() {
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444' ), array( 'test_key' => 3, 'test_key2' => 2 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 3, 'test_key2' => 1 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 2, 'test_key2' => 1 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 1, 'test_key2' => 1 ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'ordertest',
+			'orderby' => 'meta.test_key.long meta.test_key2.long',
+			'order'   => 'ASC',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 4, $query->post_count );
+		$this->assertEquals( 4, $query->found_posts );
+		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
+		$this->assertEquals( 'ordertest 444', $query->posts[3]->post_title );
+	}
+
+	/**
 	 * Test post_date orderby query
 	 *
 	 * @since 1.4


### PR DESCRIPTION
As the title says this allows us to support arbitrary document paths in `orderby`. This in turn allows someone to easily order by post meta. Includes tests.

@ChrisWiegman please review.