### PR TITLE
Disable xdebug (for non-HHVM builds) to speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
     - if [ "$(phpenv version-name)" != "5.2" ]; then composer install --dev; fi;
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
     - sleep 5
+    - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
 
 script:
     - if [ "$(phpenv version-name)" != "5.2" ]; then phpunit --coverage-clover build/logs/clover.xml; else phpunit; fi;


### PR DESCRIPTION
Related:

https://github.com/easydigitaldownloads/Easy-Digital-Downloads/pull/4086
https://github.com/pods-framework/pods/issues/3283