### PR TITLE
Support term id and name tax queries; add raw/sortable to property to term mapping; add raw/sortable property to meta mapping; add raw/sortable to author display name and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ After running an index, ElasticPress integrates with `WP_Query` if and only if t
     ```
 
     ```tax_query``` accepts an array of arrays where each inner array *only* supports ```taxonomy``` (string), ```field``` (string), and
-    ```terms``` (string|array) parameters. ```field``` must be set to ```slug``` and ```terms``` must be a string or array of term slug(s).
+    ```terms``` (string|array) parameters. ```field``` must be set to `slug`, `name`, or `term_id`. The default value for `field` is `term_id`. ```terms``` must be a string or an array of term slug(s), name(s), or id(s).
 
 * The following shorthand parameters can be used for querying posts by specific dates:
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -586,7 +586,6 @@ class EP_API {
 						'term_id'  => $term->term_id,
 						'slug'     => $term->slug,
 						'name'     => $term->name,
-						'name_raw' => $term->name,
 						'parent'   => $term->parent
 					);
 					if( $allow_hierarchy ){
@@ -922,7 +921,7 @@ class EP_API {
 					$field = ( ! empty( $single_tax_query['field'] ) ) ? $single_tax_query['field'] : 'term_id';
 
 					if ( 'name' === $field ) {
-						$field = 'name_raw';
+						$field = 'name.raw';
 					}
 
 					// Set up our terms object

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1537,9 +1537,15 @@ class EP_API {
 							'order' => $order,
 						),
 					);
-				} elseif ( 'name' === $orderby_clause || 'title' === $orderby_clause  ) {
+				} elseif ( 'name' === $orderby_clause ) {
 					$sort[] = array(
 						'post_' . $orderby_clause . '.raw' => array(
+							'order' => $order,
+						),
+					);
+				} elseif ( 'title' === $orderby_clause ) {
+					$sort[] = array(
+						'post_' . $orderby_clause . '.sortable' => array(
 							'order' => $order,
 						),
 					);

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -583,10 +583,11 @@ class EP_API {
 			foreach ( $object_terms as $term ) {
 				if( ! isset( $terms_dic[ $term->term_id ] ) ) {
 					$terms_dic[ $term->term_id ] = array(
-						'term_id' => $term->term_id,
-						'slug'    => $term->slug,
-						'name'    => $term->name,
-						'parent'  => $term->parent
+						'term_id'  => $term->term_id,
+						'slug'     => $term->slug,
+						'name'     => $term->name,
+						'name_raw' => $term->name,
+						'parent'   => $term->parent
 					);
 					if( $allow_hierarchy ){
 						$terms_dic = $this->get_parent_terms( $terms_dic, $term, $taxonomy->name );
@@ -904,7 +905,7 @@ class EP_API {
 		/**
 		 * Tax Query support
 		 *
-		 * Support for the tax_query argument of WP_Query. Currently only provides support for the 'AND' relation 
+		 * Support for the tax_query argument of WP_Query. Currently only provides support for the 'AND' relation
 		 * between taxonomies. Field only supports slug, term_id, and name defaulting to term_id.
 		 *
 		 * @use field = slug
@@ -928,7 +929,7 @@ class EP_API {
 					$terms_obj = array(
 						'terms.' . $single_tax_query['taxonomy'] . '.' . $field => $terms,
 					);
-					
+
 					// Use the AND operator if passed
 					if ( ! empty( $single_tax_query['operator'] ) && 'AND' === $single_tax_query['operator'] ) {
 						$terms_obj['execution'] = 'and';

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -904,8 +904,8 @@ class EP_API {
 		/**
 		 * Tax Query support
 		 *
-		 * Support for the tax_query argument of WP_Query
-		 * Currently only provides support for the 'AND' relation between taxonomies
+		 * Support for the tax_query argument of WP_Query. Currently only provides support for the 'AND' relation 
+		 * between taxonomies. Field only supports slug, term_id, and name defaulting to term_id.
 		 *
 		 * @use field = slug
 		 *      terms array
@@ -915,14 +915,20 @@ class EP_API {
 			$tax_filter = array();
 
 			foreach( $args['tax_query'] as $single_tax_query ) {
-				if ( ! empty( $single_tax_query['terms'] ) && ! empty( $single_tax_query['field'] ) && 'slug' === $single_tax_query['field'] ) {
+				if ( ! empty( $single_tax_query['terms'] ) ) {
 					$terms = (array) $single_tax_query['terms'];
+
+					$field = ( ! empty( $single_tax_query['field'] ) ) ? $single_tax_query['field'] : 'term_id';
+
+					if ( 'name' === $field ) {
+						$field = 'name_raw';
+					}
 
 					// Set up our terms object
 					$terms_obj = array(
-						'terms.' . $single_tax_query['taxonomy'] . '.slug' => $terms,
+						'terms.' . $single_tax_query['taxonomy'] . '.' . $field => $terms,
 					);
-
+					
 					// Use the AND operator if passed
 					if ( ! empty( $single_tax_query['operator'] ) && 'AND' === $single_tax_query['operator'] ) {
 						$terms_obj['execution'] = 'and';

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -20,7 +20,7 @@ return array(
 				),
 				'ewp_lowercase' => array(
 					'type' => 'custom',
-					'tokenizer' => 'standard',
+					'tokenizer' => 'keyword',
 					'filter' => array( 'lowercase' ),
 				),
 			),

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -80,6 +80,13 @@ return array(
 							'properties' => array(
 								'value' => array(
 									'type' => 'string',
+									'fields' => array(
+										'sortable' => array(
+											'type' => 'string',
+											'analyzer' => 'ewp_lowercase',
+											'include_in_all' => false,
+										),
+									),
 								),
 								'raw' => array(
 									'type' => 'string',

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -122,6 +122,10 @@ return array(
 								'name' => array(
 									'type' => 'string',
 								),
+								'name_raw' => array(
+									'type' => 'string',
+									'index' => 'not_analyzed',
+								),
 								'term_id' => array(
 									'type' => 'long',
 								),

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -18,6 +18,11 @@ return array(
 					'tokenizer' => 'standard',
 					'filter' => array( 'lowercase', 'shingle_filter' ),
 				),
+				'ewp_lowercase' => array(
+					'type' => 'custom',
+					'tokenizer' => 'standard',
+					'filter' => array( 'lowercase' ),
+				),
 			),
 			'filter' => array(
 				'shingle_filter' => array(
@@ -121,10 +126,12 @@ return array(
 							'properties' => array(
 								'name' => array(
 									'type' => 'string',
-								),
-								'name_raw' => array(
-									'type' => 'string',
-									'index' => 'not_analyzed',
+									'fields' => array(
+										'raw' => array(
+											'type' => 'string',
+											'index' => 'ewp_lowercase',
+										),
+									),
 								),
 								'term_id' => array(
 									'type' => 'long',

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -215,6 +215,11 @@ return array(
 							'index' => 'not_analyzed',
 							'include_in_all' => false,
 						),
+						'sortable' => array(
+							'type' => 'string',
+							'analyzer' => 'ewp_lowercase',
+							'include_in_all' => false,
+						),
 					),
 				),
 				'post_excerpt' => array(

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -129,7 +129,7 @@ return array(
 									'fields' => array(
 										'raw' => array(
 											'type' => 'string',
-											'index' => 'ewp_lowercase',
+											'analyzer' => 'ewp_lowercase',
 										),
 									),
 								),

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -129,6 +129,10 @@ return array(
 									'fields' => array(
 										'raw' => array(
 											'type' => 'string',
+											'index' => 'not_analyzed',
+										),
+										'sortable' => array(
+											'type' => 'string',
 											'analyzer' => 'ewp_lowercase',
 										),
 									),

--- a/includes/mappings.php
+++ b/includes/mappings.php
@@ -86,9 +86,14 @@ return array(
 											'analyzer' => 'ewp_lowercase',
 											'include_in_all' => false,
 										),
+										'raw' => array(
+											'type' => 'string',
+											'index' => 'not_analyzed',
+											'include_in_all' => false,
+										),
 									),
 								),
-								'raw' => array(
+								'raw' => array( /* Left for backwards compat */
 									'type' => 'string',
 									'index' => 'not_analyzed',
 									'include_in_all' => false,
@@ -182,11 +187,29 @@ return array(
 					'properties' => array(
 						'display_name' => array(
 							'type' => 'string',
-							'analyzer' => 'standard',
+							'fields' => array(
+								'raw' => array(
+									'type' => 'string',
+									'index' => 'not_analyzed',
+								),
+								'sortable' => array(
+									'type' => 'string',
+									'analyzer' => 'ewp_lowercase',
+								),
+							),
 						),
 						'login' => array(
 							'type' => 'string',
-							'analyzer' => 'standard',
+							'fields' => array(
+								'raw' => array(
+									'type' => 'string',
+									'index' => 'not_analyzed',
+								),
+								'sortable' => array(
+									'type' => 'string',
+									'analyzer' => 'ewp_lowercase',
+								),
+							),
 						),
 						'id' => array(
 							'type' => 'long',

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -524,11 +524,11 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
-	 * Test a taxonomy query
+	 * Test a taxonomy query with slug field
 	 *
-	 * @since 1.0
+	 * @since 1.8
 	 */
-	public function testTaxQuery() {
+	public function testTaxQuerySlug() {
 		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'tags_input' => array( 'one', 'two' ) ) );
 		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
 		ep_create_and_sync_post( array( 'post_content' => 'findme test 3', 'tags_input' => array( 'one', 'three' ) ) );
@@ -542,6 +542,92 @@ class EPTestSingleSite extends EP_Test_Base {
 					'taxonomy' => 'post_tag',
 					'terms'    => array( 'one' ),
 					'field'    => 'slug',
+				)
+			)
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+	}
+
+	/**
+	 * Test a taxonomy query with term id field
+	 *
+	 * @since 1.8
+	 */
+	public function testTaxQueryTermId() {
+		$post = ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'tags_input' => array( 'one', 'two' ) ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 3', 'tags_input' => array( 'one', 'three' ) ) );
+
+		$tags = wp_get_post_tags( $post );
+		$tag_id = 0;
+
+		foreach ( $tags as $tag ) {
+			if ( 'one' === $tag->slug ) {
+				$tag_id = $tag->term_id;
+			}
+		}
+
+		ep_refresh_index();
+
+		$args = array(
+			's'         => 'findme',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'post_tag',
+					'terms'    => array( $tag_id ),
+					'field'    => 'term_id',
+				)
+			)
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+
+		$args = array(
+			's'         => 'findme',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'post_tag',
+					'terms'    => array( $tag_id ),
+				)
+			)
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+	}
+
+	/**
+	 * Test a taxonomy query with term name field
+	 *
+	 * @since 1.8
+	 */
+	public function testTaxQueryTermName() {
+		$cat1 =  wp_create_category( 'category one' );
+		$cat2 =  wp_create_category( 'category two' );
+		$cat3 =  wp_create_category( 'category three' );
+
+		$post = ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'post_category' => array( $cat1, $cat2 ) ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2' ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 3', 'post_category' => array( $cat1, $cat3 ) ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'         => 'findme',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'category',
+					'terms'    => array( 'category one' ),
+					'field'    => 'name',
 				)
 			)
 		);

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1151,7 +1151,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testSearchPostTitleOrderbyQuery() {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ) );
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222' ) );
 
 		ep_refresh_index();
 
@@ -1166,7 +1166,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
 		$this->assertEquals( 'ordertest 333', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertest 111', $query->posts[2]->post_title );
 	}
 
@@ -1177,7 +1177,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	 */
 	public function testSearchPostMetaStringOrderbyQueryAsc() {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 'c' ) );
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 'b' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222' ), array( 'test_key' => 'B' ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 'a' ) );
 
 		ep_refresh_index();
@@ -1193,7 +1193,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
 		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
 	}
 
@@ -1205,7 +1205,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testSearchPostMetaNumOrderbyQueryAsc() {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 3 ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444' ), array( 'test_key' => 4 ) );
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 2 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222' ), array( 'test_key' => 2 ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 1 ) );
 
 		ep_refresh_index();
@@ -1221,7 +1221,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 4, $query->post_count );
 		$this->assertEquals( 4, $query->found_posts );
 		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
 		$this->assertEquals( 'ordertest 444', $query->posts[3]->post_title );
 	}
@@ -1239,7 +1239,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333', 'post_category' => array( $cat4 ) ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444', 'post_category' => array( $cat1 ) ) );
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222', 'post_category' => array( $cat3 ) ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222', 'post_category' => array( $cat3 ) ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111', 'post_category' => array( $cat2 ) ) );
 
 		ep_refresh_index();
@@ -1255,7 +1255,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 4, $query->post_count );
 		$this->assertEquals( 4, $query->found_posts );
 		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
 		$this->assertEquals( 'ordertest 444', $query->posts[3]->post_title );
 	}
@@ -1268,7 +1268,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testSearchPostMetaNumOrderbyQueryDesc() {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 3 ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444' ), array( 'test_key' => 4 ) );
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 2 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222' ), array( 'test_key' => 2 ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 1 ) );
 
 		ep_refresh_index();
@@ -1284,7 +1284,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 4, $query->post_count );
 		$this->assertEquals( 4, $query->found_posts );
 		$this->assertEquals( 'ordertest 111', $query->posts[3]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[2]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[2]->post_title );
 		$this->assertEquals( 'ordertest 333', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertest 444', $query->posts[0]->post_title );
 	}
@@ -1297,7 +1297,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testSearchPostMetaNumMultipleOrderbyQuery() {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444' ), array( 'test_key' => 3, 'test_key2' => 2 ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333' ), array( 'test_key' => 3, 'test_key2' => 1 ) );
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ), array( 'test_key' => 2, 'test_key2' => 1 ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222' ), array( 'test_key' => 2, 'test_key2' => 1 ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ), array( 'test_key' => 1, 'test_key2' => 1 ) );
 
 		ep_refresh_index();
@@ -1313,7 +1313,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 4, $query->post_count );
 		$this->assertEquals( 4, $query->found_posts );
 		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
 		$this->assertEquals( 'ordertest 444', $query->posts[3]->post_title );
 	}
@@ -1330,7 +1330,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111' ) );
 		sleep( 3 );
 
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222' ) );
 
 		ep_refresh_index();
 
@@ -1344,7 +1344,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
-		$this->assertEquals( 'ordertest 222', $query->posts[0]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertest 111', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertes 333', $query->posts[2]->post_title );
 	}
@@ -1361,7 +1361,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest ordertest order test 111' ) );
 		sleep( 3 );
 
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest 222' ) );
 
 		ep_refresh_index();
 
@@ -1374,7 +1374,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
-		$this->assertEquals( 'ordertest 222', $query->posts[0]->post_title );
+		$this->assertEquals( 'Ordertest 222', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertest ordertest order test 111', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
 	}
@@ -1460,7 +1460,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	public function testSearchPostNameOrderbyQuery() {
 		ep_create_and_sync_post( array( 'post_title' => 'postname-ordertest-333' ) );
 		ep_create_and_sync_post( array( 'post_title' => 'postname-ordertest-111' ) );
-		ep_create_and_sync_post( array( 'post_title' => 'postname-ordertest-222' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'postname-Ordertest-222' ) );
 
 
 		ep_refresh_index();
@@ -1476,7 +1476,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
 		$this->assertEquals( 'postname-ordertest-111', $query->posts[0]->post_name );
-		$this->assertEquals( 'postname-ordertest-222', $query->posts[1]->post_name );
+		$this->assertEquals( 'postname-Ordertest-222', $query->posts[1]->post_name );
 		$this->assertEquals( 'postname-ordertest-333', $query->posts[2]->post_name );
 	}
 
@@ -1489,7 +1489,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	 */
 	public function testSearchDefaultOrderbyQuery() {
 		ep_create_and_sync_post();
-		ep_create_and_sync_post( array( 'post_title' => 'ordertet' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertet' ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertest' ) );
 
 		ep_refresh_index();
@@ -1503,7 +1503,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertest', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertet', $query->posts[1]->post_title );
+		$this->assertEquals( 'Ordertet', $query->posts[1]->post_title );
 	}
 
 	/**
@@ -1515,7 +1515,7 @@ class EPTestSingleSite extends EP_Test_Base {
 	 */
 	public function testSearchDefaultOrderbyASCOrderQuery() {
 		ep_create_and_sync_post();
-		ep_create_and_sync_post( array( 'post_title' => 'ordertest' ) );
+		ep_create_and_sync_post( array( 'post_title' => 'Ordertest' ) );
 		ep_create_and_sync_post( array( 'post_title' => 'ordertestt' ) );
 
 		ep_refresh_index();
@@ -1530,7 +1530,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertestt', $query->posts[0]->post_title );
-		$this->assertEquals( 'ordertest', $query->posts[1]->post_title );
+		$this->assertEquals( 'Ordertest', $query->posts[1]->post_title );
 	}
 
 	/**

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1246,7 +1246,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$args = array(
 			's'       => 'ordertest',
-			'orderby' => 'terms.category.name_raw',
+			'orderby' => 'terms.category.name.raw',
 			'order'   => 'ASC',
 		);
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1246,7 +1246,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$args = array(
 			's'       => 'ordertest',
-			'orderby' => 'terms.category.name.raw',
+			'orderby' => 'terms.category.name.sortable',
 			'order'   => 'ASC',
 		);
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1476,7 +1476,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
 		$this->assertEquals( 'postname-ordertest-111', $query->posts[0]->post_name );
-		$this->assertEquals( 'postname-Ordertest-222', $query->posts[1]->post_name );
+		$this->assertEquals( 'postname-ordertest-222', $query->posts[1]->post_name );
 		$this->assertEquals( 'postname-ordertest-333', $query->posts[2]->post_name );
 	}
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -3,10 +3,10 @@
 class EPTestSingleSite extends EP_Test_Base {
 	/**
 	 * Checking if HTTP request returns 404 status code.
-	 * @var boolean 
+	 * @var boolean
 	 */
 	var $is_404=false;
-	
+
 	/**
 	 * Setup each test.
 	 *
@@ -317,7 +317,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
 
 		$this->assertTrue( count( $indexedTerms ) > 0 );
-		
+
 		foreach ( $indexedTerms as $term ) {
 			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		}
@@ -365,7 +365,7 @@ class EPTestSingleSite extends EP_Test_Base {
 		$expectedTerms = array( $term1['term_id'], $term2['term_id'], $term3['term_id'] );
 
 		$this->assertTrue( count( $indexedTerms ) > 0 );
-		
+
 		foreach ( $indexedTerms as $term ) {
 			$this->assertTrue( in_array( $term['term_id'], $expectedTerms ) );
 		}
@@ -2079,8 +2079,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$this->assertTrue( empty( $cache ) );
 	}
-	
-		
+
+
 	/**
 	 * Test if $post object values exist after receiving odd values from the 'ep_search_post_return_args' filter.
 	 * @group 306
@@ -2147,7 +2147,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	/**
 	 * Helper method for mocking indexable post statuses
-	 * 
+	 *
 	 * @param   array $post_statuses
 	 * @return  array
 	 */
@@ -2159,7 +2159,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	/**
 	 * Test invalid post date time
-	 * 
+	 *
 	 * @param   array $post_statuses
 	 * @return  array
 	 */
@@ -2187,10 +2187,10 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertNotNull( $post );
 		remove_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10);
 	}
-	
+
 	/**
 	 * Test to verify that a post type that is set to exclude_from_search isn't indexable.
-	 * 
+	 *
 	 * @since 1.6
 	 * @link https://github.com/10up/ElasticPress/issues/321
 	 */
@@ -2199,10 +2199,10 @@ class EPTestSingleSite extends EP_Test_Base {
 		$this->assertArrayNotHasKey( 'ep_test_excluded', $post_types );
 		$this->assertArrayNotHasKey( 'ep_test_not_public', $post_types );
 	}
-	
+
 	/**
 	 * Test to make sure that brand new posts with 'auto-draft' post status do not fire delete or sync.
-	 * 
+	 *
 	 * @since 1.6
 	 * @link https://github.com/10up/ElasticPress/issues/343
 	 */
@@ -2223,7 +2223,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	/**
 	 * Runs on http_api_debug action to check for a returned 404 status code.
-	 * 
+	 *
 	 * @param array|WP_Error $response  HTTP response or WP_Error object.
 	 * @param string $type Context under which the hook is fired.
 	 * @param string $class HTTP transport used.
@@ -2282,7 +2282,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	/**
 	 * Helper method for filtering private meta keys
-	 * 
+	 *
 	 * @param  array $meta_keys
 	 * @return array
 	 */
@@ -2296,7 +2296,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 	/**
 	 * Helper method for filtering excluded meta keys
-	 * 
+	 *
 	 * @param  array $meta_keys
 	 * @return array
 	 */

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1198,6 +1198,70 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Sort by an author login
+	 *
+	 * @since 1.8
+	 */
+	public function testAuthorLoginOrderbyQueryAsc() {
+		$bob = $this->factory->user->create( array( 'user_login' => 'Bob', 'role' => 'administrator' ) );
+		$al = $this->factory->user->create( array( 'user_login' => 'al', 'role' => 'administrator' ) );
+		$jim = $this->factory->user->create( array( 'user_login' => 'Jim', 'role' => 'administrator' ) );
+
+		ep_create_and_sync_post( array( 'post_title' => 'findme test 1', 'post_author' => $al ) );
+		ep_create_and_sync_post( array( 'post_title' => 'findme test 2', 'post_author' => $bob ) );
+		ep_create_and_sync_post( array( 'post_title' => 'findme test 3', 'post_author' => $jim ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'findme',
+			'orderby' => 'post_author.login.sortable',
+			'order'   => 'asc',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+
+		$this->assertEquals( 'findme test 1', $query->posts[0]->post_title );
+		$this->assertEquals( 'findme test 2', $query->posts[1]->post_title );
+		$this->assertEquals( 'findme test 3', $query->posts[2]->post_title );
+	}
+
+	/**
+	 * Sort by an author display name
+	 *
+	 * @since 1.8
+	 */
+	public function testAuthorDisplayNameOrderbyQueryAsc() {
+		$bob = $this->factory->user->create( array( 'display_name' => 'Bob', 'role' => 'administrator' ) );
+		$al = $this->factory->user->create( array( 'display_name' => 'al', 'role' => 'administrator' ) );
+		$jim = $this->factory->user->create( array( 'display_name' => 'Jim', 'role' => 'administrator' ) );
+
+		ep_create_and_sync_post( array( 'post_title' => 'findme test 1', 'post_author' => $al ) );
+		ep_create_and_sync_post( array( 'post_title' => 'findme test 2', 'post_author' => $bob ) );
+		ep_create_and_sync_post( array( 'post_title' => 'findme test 3', 'post_author' => $jim ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'findme',
+			'orderby' => 'post_author.display_name.sortable',
+			'order'   => 'desc',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+
+		$this->assertEquals( 'findme test 3', $query->posts[0]->post_title );
+		$this->assertEquals( 'findme test 2', $query->posts[1]->post_title );
+		$this->assertEquals( 'findme test 1', $query->posts[2]->post_title );
+	}
+
+	/**
 	 * Test post meta number orderby query asc
 	 *
 	 * @since 1.8

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1184,7 +1184,7 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		$args = array(
 			's'       => 'ordertest',
-			'orderby' => 'meta.test_key.raw',
+			'orderby' => 'meta.test_key.value.sortable',
 			'order'   => 'ASC',
 		);
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -1227,6 +1227,40 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test post category orderby query asc
+	 *
+	 * @since 1.8
+	 */
+	public function testSearchTaxNameOrderbyQueryAsc() {
+		$cat1 =  wp_create_category( 'Category 1' );
+		$cat2 =  wp_create_category( 'Another category two' );
+		$cat3 =  wp_create_category( 'basic category' );
+		$cat4 =  wp_create_category( 'Category 0' );
+
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 333', 'post_category' => array( $cat4 ) ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 444', 'post_category' => array( $cat1 ) ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 222', 'post_category' => array( $cat3 ) ) );
+		ep_create_and_sync_post( array( 'post_title' => 'ordertest 111', 'post_category' => array( $cat2 ) ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'       => 'ordertest',
+			'orderby' => 'terms.category.name_raw',
+			'order'   => 'ASC',
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 4, $query->post_count );
+		$this->assertEquals( 4, $query->found_posts );
+		$this->assertEquals( 'ordertest 111', $query->posts[0]->post_title );
+		$this->assertEquals( 'ordertest 222', $query->posts[1]->post_title );
+		$this->assertEquals( 'ordertest 333', $query->posts[2]->post_title );
+		$this->assertEquals( 'ordertest 444', $query->posts[3]->post_title );
+	}
+
+	/**
 	 * Test post meta number orderby query desc
 	 *
 	 * @since 1.8


### PR DESCRIPTION
This PR adds some missing functionality to taxonomies (term IDs), adds a sortable field to all the things, and adds some missing raw properties.

* Support `term_id` for `field` in `tax_query`
* Support `name` for `field` in `tax_query`
* Adds `name_raw` to term mapping since we need an unanalyzed version of the name property to compare against. CC @sc0ttkclark 
* Support `sortable` and `raw` properties for `post_name.login` and `post_name.display_name`
* Support `sortable` and `raw` properties for `meta.value`
* Test all the things