### PR TITLE
moved the request_url update to after the is_wp_error() check in remote_request()

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1688,7 +1688,6 @@ class EP_API {
 		if ( false === $request || is_wp_error( $request ) || ( isset( $request['response']['code'] ) && 200 !== $request['response']['code'] ) ) {
 
 			$host = ep_get_host( true, $use_backups );
-			$request_url = esc_url( trailingslashit( $host ) . $path );
 
 			if ( is_wp_error( $host ) ) {
 				$query['failed_hosts'][] = $host;
@@ -1698,6 +1697,7 @@ class EP_API {
 				return $host;
 			}
 
+			$request_url = esc_url( trailingslashit( $host ) . $path );
 			$request = wp_remote_request( $request_url, $args );
 
 		}


### PR DESCRIPTION
With ElasticPress installed but no host running, the untrailingslashit() call was being passed a WP_Error object and causing a PHP warning.  

```
PHP Warning:  rtrim() expects parameter 1 to be string, object
given in /srv/www/test-site/htdocs/wp-includes/formatting.php on line 1995
```

This update moves the slashit call to $request_url after the is_wp_error() check.

Backtrace of the warning:
```
array(20) {
  [0]=>
  array(4) {
    ["file"]=>
    string(61) "/srv/www/test-site/htdocs/wp-includes/formatting.php"
    ["line"]=>
    int(1980)
    ["function"]=>
    string(17) "untrailingslashit"
    ["args"]=>
    array(1) {
      [0]=>
      object(WP_Error)#476 (2) {
        ["errors"]=>
        array(1) {
          ["elasticpress"]=>
          array(1) {
            [0]=>
            string(26) "No running host available."
          }
        }
        ["error_data"]=>
        array(0) {
        }
      }
    }
  }
  [1]=>
  array(4) {
    ["file"]=>
    string(91) "/srv/www/test-site/htdocs/wp-content/plugins/elasticpress/classes/class-ep-api.php"
    ["line"]=>
    int(1691)

```