### PR TITLE
Improve memory usage during indexing / Fix unnecessary cache flushes

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -389,6 +389,14 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				}
 				unset( $cache_property );
 
+				/*
+				 * In the case where we're not using an external object cache, we need to call flush on the default
+				 * WordPress object cache class to clear the values from the cache property
+				 */
+				if ( ! wp_using_ext_object_cache() ) {
+					wp_cache_flush();
+				}
+
 				if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
 					call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important
 				}

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -298,7 +298,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	 * @return array
 	 */
 	private function _index_helper( $args ) {
-		global $wpdb, $wp_object_cache;
+		global $wpdb, $wp_object_cache, $wp_actions;
 		$synced = 0;
 		$errors = array();
 
@@ -392,6 +392,9 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
 					call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important
 				}
+
+				// Prevent wp_actions from growing out of control
+				$wp_actions = array();
 			}
 		}
 

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -381,7 +381,13 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				$wp_object_cache->group_ops = array();
 				$wp_object_cache->stats = array();
 				$wp_object_cache->memcache_debug = array();
-				wp_cache_flush();
+
+				// Make sure this is a public property, before trying to clear it
+				$cache_property = new ReflectionProperty( $wp_object_cache, 'cache' );
+				if ( $cache_property->isPublic() ) {
+					$wp_object_cache->cache = array();
+				}
+				unset( $cache_property );
 
 				if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
 					call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -298,7 +298,6 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	 * @return array
 	 */
 	private function _index_helper( $args ) {
-		global $wpdb, $wp_object_cache, $wp_actions;
 		$synced = 0;
 		$errors = array();
 
@@ -375,35 +374,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			usleep( 500 );
 
 			// Avoid running out of memory
-			$wpdb->queries = array();
-
-			if ( is_object( $wp_object_cache ) ) {
-				$wp_object_cache->group_ops = array();
-				$wp_object_cache->stats = array();
-				$wp_object_cache->memcache_debug = array();
-
-				// Make sure this is a public property, before trying to clear it
-				$cache_property = new ReflectionProperty( $wp_object_cache, 'cache' );
-				if ( $cache_property->isPublic() ) {
-					$wp_object_cache->cache = array();
-				}
-				unset( $cache_property );
-
-				/*
-				 * In the case where we're not using an external object cache, we need to call flush on the default
-				 * WordPress object cache class to clear the values from the cache property
-				 */
-				if ( ! wp_using_ext_object_cache() ) {
-					wp_cache_flush();
-				}
-
-				if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
-					call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important
-				}
-
-				// Prevent wp_actions from growing out of control
-				$wp_actions = array();
-			}
+			$this->stop_the_insanity();
 		}
 
 		if ( ! $no_bulk ) {
@@ -698,6 +669,43 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		} else {
 			WP_CLI::log( 'ElasticPress is currently deactivated.' );
 		}
+	}
+
+	/**
+	 * Resets some values to reduce memory footprint.
+	 */
+	public function stop_the_insanity() {
+		global $wpdb, $wp_object_cache, $wp_actions;
+
+		$wpdb->queries = array();
+
+		if ( is_object( $wp_object_cache ) ) {
+			$wp_object_cache->group_ops = array();
+			$wp_object_cache->stats = array();
+			$wp_object_cache->memcache_debug = array();
+
+			// Make sure this is a public property, before trying to clear it
+			$cache_property = new ReflectionProperty( $wp_object_cache, 'cache' );
+			if ( $cache_property->isPublic() ) {
+				$wp_object_cache->cache = array();
+			}
+			unset( $cache_property );
+
+			/*
+			 * In the case where we're not using an external object cache, we need to call flush on the default
+			 * WordPress object cache class to clear the values from the cache property
+			 */
+			if ( ! wp_using_ext_object_cache() ) {
+				wp_cache_flush();
+			}
+
+			if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
+				call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important
+			}
+		}
+
+		// Prevent wp_actions from growing out of control
+		$wp_actions = array();
 	}
 
 	/**


### PR DESCRIPTION
7bbc66c introduced a `wp_cache_flush` call after every index batch. In the context of the default core `$wp_object_cache` object, this makes sense, since it just clears the `cache` property on the php object. 

In the case of external object cache drop-ins, this also flushes the external object cache, which is not ideal. Originally, we had to switch from setting `$wp_object_cache->cache = array();` because the property is sometimes private or protected - to get around this, I check first to make sure its public, then set it to an empty array to save on memory usage.

In the case of the default class, the `cache` property is private, but `wp_using_ext_object_cache()` will return false, so in THAT case, we can just call `wp_cache_flush()` since it will just reset the `cache` property in that case.

Additionally, I added a step to clear the global `$wp_actions` variable, to prevent that from growing out of control, similar to what the WordPress Importer does.