### PR TITLE
Reduce memory consumption during indexing

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -340,14 +340,16 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		while ( true ) {
 
 			$args = apply_filters( 'ep_index_posts_args', array(
-				'posts_per_page'      => $posts_per_page,
-				'post_type'           => $post_type,
-				'post_status'         => ep_get_indexable_post_status(),
-				'offset'              => $offset,
-				'ignore_sticky_posts' => true,
-				'orderby'             => array( 'ID' => 'DESC' ),
+				'posts_per_page'         => $posts_per_page,
+				'post_type'              => $post_type,
+				'post_status'            => ep_get_indexable_post_status(),
+				'offset'                 => $offset,
+				'ignore_sticky_posts'    => true,
+				'orderby'                => array( 'ID' => 'DESC' ),
+				'cache_results '         => false,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
 			) );
-
 			$query->query( $args );
 
 			if ( $query->have_posts() ) {
@@ -408,6 +410,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		static $killed_post_count = 0;
 
 		$killed_post = false;
+
 		$post_args = ep_prepare_post( $post_id );
 
 		// Mimic EP_Sync_Manager::sync_post( $post_id ), otherwise posts can slip

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -332,6 +332,11 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			$post_type = array_map( 'trim', $post_type );
 		}
 
+		/**
+		 * Create WP_Query here and reuse it in the loop to avoid high memory consumption.
+		 */
+		$query = new WP_Query();
+
 		while ( true ) {
 
 			$args = apply_filters( 'ep_index_posts_args', array(
@@ -343,7 +348,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				'orderby'             => array( 'ID' => 'DESC' ),
 			) );
 
-			$query = new WP_Query( $args );
+			$query->query( $args );
 
 			if ( $query->have_posts() ) {
 
@@ -375,6 +380,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 			// Avoid running out of memory
 			$this->stop_the_insanity();
+
 		}
 
 		if ( ! $no_bulk ) {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1711,7 +1711,7 @@ class EP_API {
 		if ( isset( $args['blocking'] ) && false === $args['blocking' ] ) {
 			$query['blocking'] = true;
 			$query['request']  = $request;
-			$this->queries[]   = $query;
+			$this->_add_query_log( $query );
 
 			return $request;
 		}
@@ -1724,7 +1724,7 @@ class EP_API {
 			if ( is_wp_error( $host ) ) {
 				$query['failed_hosts'][] = $host;
 				$query['time_finish']    = microtime( true );
-				$this->queries[]         = $query;
+				$this->_add_query_log( $query );
 
 				return $host;
 			}
@@ -1738,7 +1738,7 @@ class EP_API {
 		$query['request'] = $request;
 		$query['url']     = $request_url;
 		$query['host']    = $host;
-		$this->queries[]  = $query;
+		$this->_add_query_log( $query );
 
 		return $request;
 
@@ -2028,6 +2028,19 @@ class EP_API {
 
 		return false;
 
+	}
+
+	/**
+	 * Query logging. Don't log anything when WP_DEBUG is not enabled.
+	 *
+	 * @param array $query Query.
+	 *
+	 * @return void Method does not return.
+	 */
+	protected function _add_query_log( $query ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$this->queries[] = $query;
+		}
 	}
 
 }


### PR DESCRIPTION
Those changes reduces memory consuption during indexing. wp-cli memory usage was growing until process was killed by Out Of Memory exception. I've added query logging only when WP_DEBUG is enabled. RIght now wp-cli doesn't use more than 50M even when indexing large datasets.