### PR TITLE
Adds WP-API endpoint to fetch post_types. Fixes #334

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -203,7 +203,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		} else {
 			$assoc_args['offset'] = 0;
 		}
-
+		
 		if ( empty( $assoc_args['post-type'] ) ) {
 			$assoc_args['post-type'] = null;
 		}
@@ -245,9 +245,15 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			WP_CLI::log( __( 'Indexing posts network-wide...', 'elasticpress' ) );
 
 			$sites = ep_get_sites( $assoc_args['network-wide'] );
+			
+			$post_types = $assoc_args['post-type'];
 
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site['blog_id'] );
+
+				if ( is_null( $post_types ) ) {
+					$assoc_args[ 'post-type' ] = $this->_fetch_post_types();
+				}
 
 				$result = $this->_index_helper( $assoc_args );
 
@@ -749,4 +755,26 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( __( 'Unable to reach Elasticsearch Server! Check that service is running.', 'elasticpress' ) );
 		}
 	}
+	
+	/**
+	 * Hits WP-API endpoint to collect all post types.
+	 * @since 1.9
+	 * @url https://github.com/10up/ElasticPress/issues/334
+	 * @return string|null Comma separated post_types or null.
+	 */
+	private function _fetch_post_types() {
+		//Check to see if WP-API is installed or WP 4.4+.
+		if ( !function_exists( 'register_rest_route' ) ) {
+			return null;
+		}
+		$endpoint	 = site_url( '/wp-json/elasticpress/v1/posttypes/' );
+		$request	 = wp_remote_get( $endpoint );
+		if ( !is_wp_error( $request ) ) {
+			$response	 = json_decode( wp_remote_retrieve_body( $request ), true );
+			$response	 = implode( ',', $response );
+			return (!empty( $response )) ? $response : null;
+		}
+		return null;
+	}
+
 }

--- a/classes/class-ep-endpoint.php
+++ b/classes/class-ep-endpoint.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Registers a WP-API endpoint to fetch post_types.
+ *
+ * @package elasticpress
+ *
+ * @since   1.9
+ *
+ */
+class EP_Endpoint {
+
+	/**
+	 * Adds action to register endpoint routes (if WP-API is installed or WP 4.4 +.
+	 * 
+	 * @since 1.9
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers the WP-API routes.
+	 * 
+	 * Example: http://example.org/wp-json/elasticpress/v1/posttypes/
+	 * 
+	 * @since 1.9
+	 * 
+	 */
+	function register_routes() {
+		register_rest_route( 'elasticpress/v1', '/posttypes', array(
+			'methods'	 => 'GET',
+			'callback'	 => array( $this, 'post_types' ),
+		) );
+	}
+
+	/**
+	 * Fetches indexable post_types.
+	 * 
+	 * @since 1.9
+	 * 
+	 * @url https://github.com/10up/ElasticPress/issues/334
+	 * 
+	 * @return array
+	 */
+	function post_types() {
+		return ep_get_indexable_post_types();
+	}
+
+}
+
+new EP_Endpoint();

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -28,7 +28,7 @@ require_once( 'classes/class-ep-sync-manager.php' );
 require_once( 'classes/class-ep-elasticpress.php' );
 require_once( 'classes/class-ep-wp-query-integration.php' );
 require_once( 'classes/class-ep-wp-date-query.php' );
-
+require_once( 'classes/class-ep-endpoint.php' );
 
 // Define a constant if we're network activated to allow plugin to respond accordingly.
 $network_activated = ep_is_network_activated( plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Utilizing the WP-API incorporated into WP 4.4, this PR adds a route that returns all post_types that may have been registered from within a theme or plugin that was otherwise not accessible with a CLI indexing process.
