### PR TITLE
Fix Status Command. Fixes #433

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -567,7 +567,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 		$request_args = array( 'headers' => ep_format_request_headers() );
 
-		$request = wp_remote_get( trailingslashit( ep_get_host( true ) ) . '_status/?pretty', $request_args );
+		$request = wp_remote_get( trailingslashit( ep_get_host( true ) ) . '_recovery/?pretty', $request_args );
 
 		if ( is_wp_error( $request ) ) {
 			WP_CLI::error( implode( "\n", $request->get_error_messages() ) );


### PR DESCRIPTION
Currently, running `wp elasticpress status` will fail if on Elasticsearch 2.1 or higher (maybe lower versions as well). Looking through the docs, that command was deprecated in [version 1.2.0](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/indices-status.html), and the recommendation is to use the `_recovery` API, which is what this PR does. Fixes #433 