### PR TITLE
Do not pre-filter content.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -500,7 +500,7 @@ class EP_API {
 			'post_date_gmt'     => $post_date_gmt,
 			'post_title'        => get_the_title( $post_id ),
 			'post_excerpt'      => $post->post_excerpt,
-			'post_content'      => apply_filters( 'the_content', $post->post_content ),
+			'post_content'      => $post->post_content,
 			'post_status'       => $post->post_status,
 			'post_name'         => $post->post_name,
 			'post_modified'     => $post_modified,


### PR DESCRIPTION
As the_content filter handles items such as oembed it can break things, such as TinyMCE when EP data is used instead of raw data in the database. 

This addresses #467 in the most basic of ways. 