### PR TITLE
Add ep_post_index_id filter to _id

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -423,7 +423,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 		} else { // Post wasn't killed so process it.
 
 			// put the post into the queue
-			$this->posts[ $post_id ][] = '{ "index": { "_id": "' . absint( $post_id ) . '" } }';
+            $this->posts[ $post_id ][] = '{ "index": { "_id": "' . apply_filters( 'ep_post_index_id', absint( $post_id ), $post_args ) . '" } }';
 
 			if ( function_exists( 'wp_json_encode' ) ) {
 

--- a/classes/class-ep-index-worker.php
+++ b/classes/class-ep-index-worker.php
@@ -229,9 +229,11 @@ class EP_Index_Worker {
 
 		static $post_count = 0;
 
-		// Put the post into the queue.
-		$this->posts[ $post_id ][] = '{ "index": { "_id": "' . absint( $post_id ) . '" } }';
-		$this->posts[ $post_id ][] = addcslashes( wp_json_encode( ep_prepare_post( $post_id ) ), "\n" );
+        $post_args = ep_prepare_post( $post_id );
+
+        // Put the post into the queue.
+        $this->posts[ $post_id ][] = '{ "index": { "_id": "' . apply_filters( 'ep_post_index_id', absint( $post_id ), $post_args ) . '" } }';
+		$this->posts[ $post_id ][] = addcslashes( wp_json_encode( $post_args ), "\n" );
 
 		// Augment the counter.
 		++ $post_count;


### PR DESCRIPTION
Add "ep_post_index_id" filter to allow other plugins to filter the "_id" value of the indexed post in elastic.

On a recent project, we needed the ability to control the index and had no way to edit the _id on elastic. This is useful if the wp application needs to change the mapping to support other applications or optimize the indexing.