### PR TITLE
Fix meta query paths

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1103,18 +1103,18 @@ class EP_API {
 
 					// Comparisons need to look at different paths
 					if ( in_array( $compare, array( 'exists', 'not exists' ) ) ) {
-						$meta_key_path = 'meta.' . $single_meta_query['key'];
+						$meta_key_path = 'post_meta.' . $single_meta_query['key'];
 					} elseif ( in_array( $compare, array( '=', '!=' ) ) && ! $type ) {
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.raw';
+						$meta_key_path = 'post_meta.' . $single_meta_query['key'] . '.raw';
 					} elseif ( 'like' === $compare ) {
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.value';
+						$meta_key_path = 'post_meta.' . $single_meta_query['key'] . '.value';
 					} elseif ( $type && isset( $meta_query_type_mapping[ $type ] ) ) {
 						// Map specific meta field types to different Elasticsearch core types
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.' . $meta_query_type_mapping[ $type ];
+						$meta_key_path = 'post_meta.' . $single_meta_query['key'] . '.' . $meta_query_type_mapping[ $type ];
 					} elseif ( in_array( $compare, array( '>=', '<=', '>', '<' ) ) ) {
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.double';
+						$meta_key_path = 'post_meta.' . $single_meta_query['key'] . '.double';
 					} else {
-						$meta_key_path = 'meta.' . $single_meta_query['key'] . '.raw';
+						$meta_key_path = 'post_meta.' . $single_meta_query['key'] . '.raw';
 					}
 
 					switch ( $compare ) {


### PR DESCRIPTION
Update meta query paths to post_meta.[KEY].raw to avoid search breaking with meta queries.