### PR TITLE
allow 20x

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1731,7 +1731,7 @@ class EP_API {
 		}
 
 		//If we have a failure we'll try it again with a backup host
-		if ( false === $request || is_wp_error( $request ) || ( isset( $request['response']['code'] ) && 200 !== $request['response']['code'] ) ) {
+		if ( false === $request || is_wp_error( $request ) || ( isset( $request['response']['code'] ) && 0 !== strpos( $request['response']['code'], '20' ) ) ) {
 
 			$host = ep_get_host( true, $use_backups );
 


### PR DESCRIPTION
I realized that when using `PUT` method for `ep_remote_request` hits backup host.

(3-5 doing same thing)
![screen shot 2016-04-12 at 16 20 22](https://cloud.githubusercontent.com/assets/1421387/14461374/ed10eb9a-00ca-11e6-89f0-545782cbc3fb.png)

Can support all 20x responses?