### PR TITLE
Fix/reduce overhead

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1926,6 +1926,18 @@ class EP_API {
 	 */
 	public function get_index_status( $blog_id = null, $force = false ) {
 
+		if ( null === $blog_id ) {
+
+			$cache_id = '0';
+
+		} else {
+
+			$cache_id = (string)$blog_id;
+
+		}
+
+		$cache_key = 'ep_index_status_' . $cache_id;
+
 		if ( true === $force ) {
 
 			$status = false;
@@ -1934,11 +1946,11 @@ class EP_API {
 
 			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 
-				$status = get_site_transient( 'ep_index_status' );
+				$status = get_site_transient( $cache_key );
 
 			} else {
 
-				$status = get_transient( 'ep_index_status' );
+				$status = get_transient( $cache_key );
 
 			}
 		}
@@ -1976,11 +1988,11 @@ class EP_API {
 
 				if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 
-					set_site_transient( 'ep_index_status', $status, 600 );
+					set_site_transient( $cache_key, $status, 600 );
 
 				} else {
 
-					set_transient( 'ep_index_status', $status, 600 );
+					set_transient( $cache_key, $status, 600 );
 
 				}
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -819,23 +819,31 @@ class EP_API {
 	 * Checks if index exists by index name, returns true or false
 	 *
 	 * @param null $index_name
+	 * @param bool $force True to force remote check or false to use cached check if available.
 	 *
 	 * @return bool
 	 */
-	public function index_exists( $index_name = null ) {
+	public function index_exists( $index_name = null, $force = false ) {
 
 		$index = ( null === $index_name ) ? ep_get_index_name() : sanitize_text_field( $index_name );
 
 		$cache_key = 'ep_index_exists_' . $index;
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+		if ( true === $force ) {
 
-			$request = get_site_transient( $cache_key );
+			$request = false;
 
 		} else {
 
-			$request = get_transient( $cache_key );
+			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 
+				$request = get_site_transient( $cache_key );
+
+			} else {
+
+				$request = get_transient( $cache_key );
+
+			}
 		}
 
 		if ( false === $request ) {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -420,6 +420,18 @@ class EP_API {
 
 		$index = ep_get_index_name();
 
+		$cache_key = 'ep_index_exists_' . $index;
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+
+			delete_site_transient( $cache_key );
+
+		} else {
+
+			delete_transient( $cache_key );
+
+		}
+
 		$request_args = array(
 			'body'    => json_encode( $mapping ),
 			'method'  => 'PUT',

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -800,6 +800,18 @@ class EP_API {
 
 		$index = ( null === $index_name ) ? ep_get_index_name() : sanitize_text_field( $index_name );
 
+		$cache_key = 'ep_index_exists_' . $index;
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+
+			delete_site_transient( $cache_key );
+
+		} else {
+
+			delete_transient( $cache_key );
+
+		}
+
 		$request_args = array( 'method' => 'DELETE' );
 
 		$request = ep_remote_request( $index, apply_filters( 'ep_delete_index_request_args', $request_args ) );

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -2241,8 +2241,8 @@ function ep_elasticsearch_alive( $host = null ) {
 	return EP_API::factory()->elasticsearch_alive( $host );
 }
 
-function ep_index_exists( $index_name = null ) {
-	return EP_API::factory()->index_exists( $index_name );
+function ep_index_exists( $index_name = null, $force = false ) {
+	return EP_API::factory()->index_exists( $index_name, $force );
 }
 
 function ep_format_request_headers() {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1920,19 +1920,27 @@ class EP_API {
 	 * @since 1.9
 	 *
 	 * @param int $blog_id Id of blog to get stats.
+	 * @param bool $force Whether to force a refresh or use cache.
 	 *
 	 * @return array Contains the status message or the returned statistics.
 	 */
-	public function get_index_status( $blog_id = null ) {
+	public function get_index_status( $blog_id = null, $force = false ) {
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+		if ( true === $force ) {
 
-			$status = get_site_transient( 'ep_index_status' );
+			$status = false;
 
 		} else {
 
-			$status = get_transient( 'ep_index_status' );
+			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 
+				$status = get_site_transient( 'ep_index_status' );
+
+			} else {
+
+				$status = get_transient( 'ep_index_status' );
+
+			}
 		}
 
 		if ( false === $status ) {
@@ -2191,8 +2199,8 @@ function ep_get_search_status( $blog_id = null ) {
 	return EP_API::factory()->get_search_status( $blog_id );
 }
 
-function ep_get_index_status( $blog_id = null ) {
-	return EP_API::factory()->get_index_status( $blog_id );
+function ep_get_index_status( $blog_id = null, $force = false ) {
+	return EP_API::factory()->get_index_status( $blog_id, $force );
 }
 
 function ep_get_cluster_status() {

--- a/classes/class-ep-settings.php
+++ b/classes/class-ep-settings.php
@@ -36,8 +36,6 @@ class EP_Settings {
 	 */
 	public function __construct() {
 
-		ep_check_host();
-
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) { // Must be network admin in multisite.
 
 			add_action( 'network_admin_menu', array( $this, 'action_admin_menu' ) );

--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -51,7 +51,7 @@ class EP_Sync_Manager {
 	 * @param $blog_id
 	 */
 	public function action_delete_blog_from_index( $blog_id ) {
-		if ( ep_index_exists( ep_get_index_name( $blog_id ) ) && ! apply_filters( 'ep_keep_index', false ) ) {
+		if ( ep_index_exists( ep_get_index_name( $blog_id ), true ) && ! apply_filters( 'ep_keep_index', false ) ) {
 			ep_delete_index( ep_get_index_name( $blog_id ) );
 		}
 	}

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -8,6 +8,8 @@
  *
  * @author  Allan Collins <allan.collins@10up.com>
  */
+global $ep_host_status;
+$ep_host_status = ep_check_host();
 ?>
 <div class="wrap">
 	<?php printf( '<h2>%s</h2>', esc_html__( 'ElasticPress', 'elasticpress' ) ); ?>

--- a/includes/settings/form.php
+++ b/includes/settings/form.php
@@ -8,6 +8,7 @@
  *
  * @author  Allan Collins <allan.collins@10up.com>
  */
+global $ep_host_status;
 ?>
 
 <?php
@@ -35,7 +36,7 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 
 	}
 
-	if ( ( ! ep_host_by_option() && ! is_wp_error( ep_check_host() ) ) || is_wp_error( ep_check_host() ) || $host ) {
+	if ( ( ! ep_host_by_option() && ! is_wp_error( $ep_host_status ) ) || is_wp_error( $ep_host_status ) || $host ) {
 		submit_button();
 	}
 

--- a/includes/settings/index.php
+++ b/includes/settings/index.php
@@ -8,6 +8,7 @@
  *
  * @author  Chris Wiegman <chris.wiegman@10up.com>
  */
+global $ep_host_status;
 ?>
 <?php
 if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
@@ -16,7 +17,6 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 	$paused = absint( get_option( 'ep_index_paused' ) );
 }
 
-$host_alive = ep_check_host();
 $run_class  = ( false === get_transient( 'ep_index_offset' ) ) ? ' button-primary' : '';
 
 if ( false === get_transient( 'ep_index_offset' ) ) {
@@ -36,7 +36,7 @@ $restart_class = $paused ? ' button-secondary' : ' button-secondary hidden';
 ?>
 
 <p>
-	<?php if ( $host_alive && ! is_wp_error( $host_alive ) ) : ?>
+	<?php if ( $ep_host_status && ! is_wp_error( $ep_host_status ) ) : ?>
 		<input type="submit" name="ep_run_index" id="ep_run_index" class="button<?php echo esc_attr( $run_class ); ?> button-large" value="<?php echo esc_attr( $run_text ); ?>"<?php if ( $paused ) : echo ' disabled="disabled"'; endif; ?>>
 		<input type="submit" name="ep_pause_index" id="ep_pause_index" class="button<?php echo esc_attr( $stop_class ); ?> button-large" value="<?php echo esc_attr( $stop_text ); ?>"<?php if ( $paused ) : echo ' data-paused="enabled"'; endif; ?>>
 		<input type="submit" name="ep_restart_index" id="ep_restart_index" class="button<?php echo esc_attr( $restart_class ); ?> button-large" value="<?php esc_attr_e( 'Restart Index', 'elasticpress' ); ?>">

--- a/includes/settings/status.php
+++ b/includes/settings/status.php
@@ -8,7 +8,7 @@
  *
  * @author  Allan Collins <allan.collins@10up.com>
  */
-
+global $ep_host_status;
 $site_stats_id = null;
 
 if ( is_multisite() && ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) ) {
@@ -25,7 +25,7 @@ echo '<div id="ep_stats">';
 		<table class="form-table">
 			<tr>
 				<th scope="row"><?php esc_html_e( 'Elasticsearch Host', 'elasticpress' ) ?>:</th>
-				<?php if ( ! is_wp_error( ep_check_host() ) ) { ?>
+				<?php if ( ! is_wp_error( $ep_host_status ) ) { ?>
 
 					<?php $current_host = ep_get_host( true ); ?>
 

--- a/includes/settings/status.php
+++ b/includes/settings/status.php
@@ -15,7 +15,7 @@ if ( is_multisite() && ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) ) {
 	$site_stats_id = get_current_blog_id();
 }
 
-$stats = ep_get_index_status( $site_stats_id );
+$stats = ep_get_index_status( $site_stats_id , true );
 
 echo '<div id="ep_stats">';
 

--- a/tests/includes/functions.php
+++ b/tests/includes/functions.php
@@ -117,7 +117,7 @@ function ep_count_indexes() {
 	$count_indexes = 0;
 	foreach ( $sites as $site ) {
 		if ( $index_name = ep_get_index_name( $site[ 'blog_id' ] ) ) {
-			if ( ep_index_exists( $index_name ) ) {
+			if ( ep_index_exists( $index_name, true ) ) {
 				$count_indexes++;
 				$last_blog_id_with_index = $site[ 'blog_id' ];
 			}

--- a/tests/test-multisite.php
+++ b/tests/test-multisite.php
@@ -1849,11 +1849,11 @@ class EPTestMultisite extends EP_Test_Base {
 
 		$blog = get_current_blog_id();
 
-		$status_indexed = ep_get_index_status( $blog );
+		$status_indexed = ep_get_index_status( $blog, true );
 
 		ep_delete_index();
 
-		$status_unindexed = ep_get_index_status( $blog );
+		$status_unindexed = ep_get_index_status( $blog, true );
 
 		$this->setUp();
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2077,6 +2077,8 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		ep_refresh_index();
 
+		var_dump( ep_check_host() );
+
 		$args = array(
 			's' => 'findme',
 		);

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2058,14 +2058,6 @@ class EPTestSingleSite extends EP_Test_Base {
 	 * @since 1.3
 	 */
 	public function testNoAvailablePostTypesToSearch() {
-		$GLOBALS['wp_post_types'];
-
-		$backup_post_types = $GLOBALS['wp_post_types'];
-
-		// Set all post types to be excluded from search
-		foreach ( $GLOBALS['wp_post_types'] as $post_type ) {
-			$post_type->exclude_from_search = true;
-		}
 
 		$post_ids = array();
 
@@ -2075,6 +2067,15 @@ class EPTestSingleSite extends EP_Test_Base {
 		$post_ids[3] = ep_create_and_sync_post();
 		$post_ids[4] = ep_create_and_sync_post( array( 'post_content' => 'findme' ) );
 
+		$GLOBALS['wp_post_types'];
+
+		$backup_post_types = $GLOBALS['wp_post_types'];
+
+		// Set all post types to be excluded from search
+		foreach ( $GLOBALS['wp_post_types'] as $post_type ) {
+			$post_type->exclude_from_search = true;
+		}
+		
 		ep_refresh_index();
 
 		$args = array(

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2077,8 +2077,6 @@ class EPTestSingleSite extends EP_Test_Base {
 
 		ep_refresh_index();
 
-		var_dump( ep_check_host() );
-
 		$args = array(
 			's' => 'findme',
 		);


### PR DESCRIPTION
On a client project we realized just how inefficient calls per page can be with as many as 8 on every admin page load. This reduces that by properly caching some calls and removing others.

Note there is a unit test failure currently only with WordPress 4.4.2 and only on PHP 5.3. I've gone as far as installing a box with PHP5.3 yet I still can't reproduce. If you look at the difference between build 1355 and the current there should not be anything affecting that call yet post search with post types disabled is still returning posts only on Travis. Would love a second set of eyes who might be able to see what's going on there.