### PR TITLE
(Closes #478) Enable query logging

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -2053,7 +2053,7 @@ class EP_API {
 	 * @return void Method does not return.
 	 */
 	protected function _add_query_log( $query ) {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
 			$this->queries[] = $query;
 		}
 	}

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -76,6 +76,7 @@ function ep_loader() {
 
 		}
 	}
+
 	if ( is_user_logged_in() && ! defined( 'WP_EP_DEBUG' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		define( 'WP_EP_DEBUG', is_plugin_active( 'debug-bar-elasticpress/debug-bar-elasticpress.php' ) );

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -76,4 +76,8 @@ function ep_loader() {
 
 		}
 	}
+	if ( is_user_logged_in() && ! defined( 'WP_EP_DEBUG' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		define( 'WP_EP_DEBUG', is_plugin_active( 'debug-bar-elasticpress/debug-bar-elasticpress.php' ) );
+	}
 }


### PR DESCRIPTION
This PR solved issue reported in #478 

This seems to be the simplest solution to enable query logging even if `WP_DEBUG` is not enabled. 

I think it would be better if `Debug Bar ElasticPress` plugin would have defined some named constant like `define( 'DEBUG_BAR_ELASTICPRESS_ENABLED', true );` then this PR could use it instead of checking if `Debug Bar ElasticPress` plugin is enabled.

@tlovett1 & @allan23  if you don't like this approach I can go with proposed one - new option on GUI settings page with enabling debug mode via option. 