### PR TITLE
added do_action( 'ep_add_query_log' ) to _add_query_log

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -2150,7 +2150,10 @@ class EP_API {
 	}
 
 	/**
-	 * Query logging. Don't log anything when WP_DEBUG is not enabled.
+	 * Query logging. Don't log anything to the queries property when
+	 * WP_DEBUG is not enabled. Calls action 'ep_add_query_log' if you
+	 * want to access the query outside of the ElasticPress plugin. This
+	 * runs regardless of debufg settings.
 	 *
 	 * @param array $query Query.
 	 *

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -2160,6 +2160,8 @@ class EP_API {
 		if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
 			$this->queries[] = $query;
 		}
+
+		do_action( 'ep_add_query_log', $query );
 	}
 
 }


### PR DESCRIPTION
After running into some issues with debugging requests/responses from ElasticSearch, this seems like it would be a handy addition to allow other plugins to hook into this to perform more robust logging without requiring debug turned on or the user to be logged in (based on https://github.com/10up/ElasticPress/commit/82acd71e0a948782da42ae2505ea0d0c4b415755)