### PR TITLE
Ignore category_name if tax_query is provided.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1021,11 +1021,13 @@ class EP_API {
 		}
 
 		/**
-		 * 'category_name' arg support.
+		 * 'category_name' arg support. Skip entirely if `tax_query` has already been provided. WP_Query
+		 * has some quirky backwards compat functionality that will fill `category_name` if the category
+		 * taxonomy is provided within `tax_query` which leads to duplicate filters.
 		 *
 		 * @since 1.5
 		 */
-		if ( ! empty( $args[ 'category_name' ] ) ) {
+		if ( ! empty( $args[ 'category_name' ] ) && empty( $tax_filter ) ) {
 			$terms_obj = array(
 				'terms.category.slug' => array( $args[ 'category_name' ] ),
 			);


### PR DESCRIPTION
Let's skip `category_name` entirely if `tax_query` has already been provided as a query argument. WP_Query has some [quirky backward compat functionality](https://core.trac.wordpress.org/browser/tags/4.5.1/src/wp-includes/query.php#L2872) that will fill `category_name` if the category taxonomy is provided within `tax_query` which leads to duplicate filters.

@dkotter or @allan23 can you review?