### PR TITLE
Tweak search algorithm for more relevant results

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1337,7 +1337,7 @@ class EP_API {
 							'fields' => $search_fields,
 							'query' => '',
 							'fuzziness' => apply_filters( 'ep_fuzziness_arg', 2, $search_fields, $args ),
-							'operator' => 'or',
+							'operator' => 'and',
 						),
 					)
 				),

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1339,6 +1339,7 @@ class EP_API {
 							'fields' => $search_fields,
 							'boost' => apply_filters( 'ep_match_boost', 2, $search_fields, $args ),
 							'fuzziness' => 0,
+							'operator' => 'and',
 						)
 					),
 					array(

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1347,7 +1347,6 @@ class EP_API {
 							'fields' => $search_fields,
 							'query' => '',
 							'fuzziness' => apply_filters( 'ep_fuzziness_arg', 1, $search_fields, $args ),
-							'operator' => 'and',
 						),
 					)
 				),

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1336,7 +1336,7 @@ class EP_API {
 						'multi_match' => array(
 							'fields' => $search_fields,
 							'query' => '',
-							'fuzziness' => apply_filters( 'ep_fuzziness_arg', 2, $search_fields, $args ),
+							'fuzziness' => apply_filters( 'ep_fuzziness_arg', 1, $search_fields, $args ),
 							'operator' => 'and',
 						),
 					)

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1327,6 +1327,15 @@ class EP_API {
 					array(
 						'multi_match' => array(
 							'query' => '',
+							'type' => 'phrase',
+							'fields' => $search_fields,
+							'boost' => apply_filters( 'ep_match_phrase_boost', 4, $search_fields, $args ),
+							'fuzziness' => 0,
+						)
+					),
+					array(
+						'multi_match' => array(
+							'query' => '',
 							'fields' => $search_fields,
 							'boost' => apply_filters( 'ep_match_boost', 2, $search_fields, $args ),
 							'fuzziness' => 0,
@@ -1352,6 +1361,7 @@ class EP_API {
 		 */
 
 		if ( ! empty( $args['s'] ) && empty( $args['ep_match_all'] ) && empty( $args['ep_integrate'] ) ) {
+			$query['bool']['should'][2]['multi_match']['query'] = $args['s'];
 			$query['bool']['should'][1]['multi_match']['query'] = $args['s'];
 			$query['bool']['should'][0]['multi_match']['query'] = $args['s'];
 			$formatted_args['query'] = $query;


### PR DESCRIPTION
This PR is not ready for merge but rather review. @allan23 @ChrisWiegman @lukaspawlik @dkotter @AaronHolbrook 

Here are the proposed changes:

1. Decrease fuzzy clause fuzziness to 1 from 2. With a fuzziness of 2, the word yell matches yeti since they are two levenshtein changes apart. The point of fuzziness is to account for misspellings which 1 does for the most part. 2 is resulting in way too many bad results.
2. Add `operator => 'and'` to `multi_match` clause. Right now any document containing ANY of the search terms returns a match with a 2x boost. Let's only give the 2x boost to docs that contain ALL the terms.
3. Finally, add a `multi_match` query of type `phrase`. This clause gives a 4x boost to documents containing the terms exactly as is in the EXACT order.

P.S. If anyone wants a cool project, we need a way to unit test relevancy accuracy.