### PR TITLE
Multisite GUI not working when plugin is not network enabled

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1934,7 +1934,7 @@ class EP_API {
 
 		} else {
 
-			if ( is_multisite() && null === $blog_id ) {
+			if ( is_multisite() && null === $blog_id && defined( 'EP_IS_NETWORK' ) && true == EP_IS_NETWORK ) {
 
 				$path = ep_get_network_alias() . '/_stats/indexing/';
 


### PR DESCRIPTION
Currently if you are on a single site within the network and only that site has the plugin enabled the GUI will not work as its trying to retrieve the network alias. This pull request adds a check in the get_index_status method to make sure the plugin is network enabled before it returns the network alias. 

@tlovett1 In order for the checkbox to appear now a user has to run the index. After the index is ran the checkbox will appear on the next refresh. 