### PR TITLE
Cache the index names in the DB (Feedback & opinions please)

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -158,6 +158,57 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Clear the index cache for one or all of the blogs
+	 *
+	 * @subcommand clear-index-cache
+	 *
+	 * @param  array $args
+	 * @param  array $assoc_args
+	 */
+	public function clear_index_cache( $args, $assoc_args ) {
+
+		WP_CLI::line( __( 'Clearing index cache...', 'elasticpress' ) );
+		
+		$flushed = ep_flush_index_name_cache( $blog_id );
+
+		if ( $flushed ) {
+			WP_CLI::success( __( 'Done!', 'elasticpress' ) );
+		} else {
+			WP_CLI::error( __( "Error flushing cache, maybe it's already been flushed?", 'elasticpress' ) );
+		}
+
+	}
+
+	/**
+	 * Set the index cache for a blog
+	 *
+	 * @subcommand set-index
+	 * @synopsis <index-name>
+	 *
+	 * @param  array $args
+	 * @param  array $assoc_args
+	 */
+	public function set_index_cache( $args, $assoc_args ) {
+
+		$index_name = isset( $args[0] ) ? $args[0] : false;
+
+		if ( ! $index_name ) {
+			WP_CLI::error( __( 'An index name is required', 'elasticpress' ) );
+		}
+
+		$blog_id = get_current_blog_id();
+
+		$set = ep_set_cached_index_name( $blog_id, $index_name );
+
+		if ( $set ) {
+			WP_CLI::success( __( 'Done!', 'elasticpress' ) );
+		} else {
+			WP_CLI::error( __( 'An error occurred', 'elasticpress' ) );
+		}
+
+	}
+
+	/**
 	 * Helper method for creating the network alias
 	 *
 	 * @since 0.9

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -418,6 +418,8 @@ class EP_API {
 
 		$mapping = apply_filters( 'ep_config_mapping', $mapping );
 
+		ep_flush_index_name_cache();
+
 		$index = ep_get_index_name();
 
 		$request_args = array(
@@ -809,6 +811,8 @@ class EP_API {
 		// 404 means the index was non-existent, but we should still pass this through as we will occasionally want to delete an already deleted index
 		if ( ! is_wp_error( $request ) && ( 200 === wp_remote_retrieve_response_code( $request ) || 404 === wp_remote_retrieve_response_code( $request ) ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
+
+			ep_flush_index_name_cache();
 
 			return json_decode( $response_body );
 		}

--- a/uninstall.php
+++ b/uninstall.php
@@ -65,10 +65,12 @@ class EP_Uninstaller {
 		// Delete options.
 		delete_site_option( 'ep_host' );
 		delete_site_option( 'ep_activate' );
+		delete_site_option( 'ep_index_names' );
 
 		// Delete options if we're not network activated.
 		delete_option( 'ep_host' );
 		delete_option( 'ep_activate' );
+		delete_option( 'ep_index_name' );
 
 		// Delete transients.
 		delete_transient( 'ep_post_count' );


### PR DESCRIPTION
As Elasticpress generated index names on the fly, it doesn't play nicely with domain mapping plugins.

For example, we have multiple subdomains across multiple environments:
- uat1.www.site.com.sites.abc.net
- uat2.www.site.com.sites.abc.net
- preprod1.www.site.com.sites.abc.net
- prod4.www.site.com.sites.abc.net
- www.site.com

The above example should use the same index name, regardless of the current domain. However, as the indexes are generated on the fly, accessing one of the sites from a UAT url will generate something along the lines of `uat1wwwsitecomsitesabcnet-2`. By persisting the index names in the DB, we can eliminate this issue.

This still needs some test coverage, but I'm going to hold off until we've managed to have a chat about it, any feedback / opinions appreciated!