### PR TITLE
Allow caching results of WP_Query during index. Fixes #453

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -469,9 +469,6 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				'ignore_sticky_posts'    => true,
 				'orderby'                => 'ID',
 				'order'                  => 'DESC',
-				'cache_results '         => false,
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
 			) );
 			$query->query( $args );
 


### PR DESCRIPTION
There was no significant memory savings by having this here because of
the stop_the_insanity method, and removing it speeds up indexing
significantly