### PR TITLE
Fix query when sites is set in query string.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -142,7 +142,15 @@ class EP_API {
 
 		if ( 'all' === $scope ) {
 			$index = ep_get_network_alias();
-		} elseif ( is_int( $scope ) ) {
+		} elseif ( strpos($scope, ',') ) {
+			$scope = explode(',', $scope);
+
+			foreach ( $scope as $site_id ) {
+				$index[] = ep_get_index_name( $site_id );
+			}
+
+			$index = implode( ',', $index );
+		} elseif ( is_numeric( $scope ) ) {
 			$index = ep_get_index_name( $scope );
 		} elseif ( is_array( $scope ) ) {
 			$index = array();


### PR DESCRIPTION
When specifying 1 or more site ID's via "sites" var in the query string it is ignored.