### PR TITLE
Stop loading the EP_Settings class on the front end

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -57,8 +57,10 @@ function ep_loader() {
 		load_plugin_textdomain( 'elasticpress', false, basename( dirname( __FILE__ ) ) . '/lang' ); // Load any available translations first.
 
 		// Load the settings page.
-		require_once( dirname( __FILE__ ) . '/classes/class-ep-settings.php' );
-		new EP_Settings();
+		if( is_admin() && is_user_logged_in() ) {
+			require_once( dirname( __FILE__ ) . '/classes/class-ep-settings.php' );
+			new EP_Settings();
+		}
 
 		// Load the indexing GUI.
 		if ( true === apply_filters( 'ep_load_index_gui', true ) ) {

--- a/tests/includes/class-ep-test-base.php
+++ b/tests/includes/class-ep-test-base.php
@@ -11,7 +11,15 @@ class EP_Test_Base extends WP_UnitTestCase {
 		if ( property_exists( __CLASS__, 'ignore_files' ) ) {
 			self::$ignore_files = true;
 		}
+		$this->plugin_path = str_replace( '/tests/includes', '', dirname( __FILE__ ) );
 	}
+
+	/**
+	 * Stores the root path for the plugin
+	 *
+	 * @var string
+	 */
+	protected $plugin_path = '';
 
 	/**
 	 * Helps us keep track of actions that have fired

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -2977,6 +2977,10 @@ class EPTestSingleSite extends EP_Test_Base {
 	 */
 	function testByteSize() {
 
+		if ( ! class_exists( 'EP_Settings' ) ) {
+			require( $this->plugin_path . '/classes/class-ep-settings.php' );
+		}
+
 		$one_kb = EP_Settings::ep_byte_size( 1056, 0 );
 
 		$one_mb = EP_Settings::ep_byte_size( 1056000, 0 );


### PR DESCRIPTION
Hello

Looks like there's a bug when loading ElasticPress (based on release 2.0) which results in a significant amount of unnecessary remote requests to the ElasticSearch server.

[`ep_loader`](https://github.com/10up/ElasticPress/blob/master/elasticpress.php#L53), hooked on `plugins_loaded`, instantiates a new EP_Settings regardless of need. This triggers a call to [`ep_check_host();`](https://github.com/10up/ElasticPress/blob/master/classes/class-ep-settings.php#L39) resulting the remote request to the ElasticSearch server.

It seems that EP_Settings should be limited to load only in admin. The class loads a handful of admin pages, along with this call to `ep_check_host();`
