### PR TITLE
Add search scope filter. Closes #544

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -226,6 +226,16 @@ class EP_WP_Query_Integration {
 
 			$formatted_args = ep_format_args( $query_vars );
 
+			/**
+			 * Filter search scope
+			 *
+			 * @since 2.1
+			 *
+			 * @param mixed $scope The search scope. Accepts `all` (string), a single
+			 *                     site id (int or string), or an array of site ids (array).
+			 */
+			$scope = apply_filters( 'ep_search_scope', $scope );
+
 			$ep_query = ep_query( $formatted_args, $query->query_vars, $scope );
 
 			if ( false === $ep_query ) {


### PR DESCRIPTION
Adds a search scope filter before query generation.  Accepts `all` (string), a single site id (int or string), or an array of site ids (array).

Example usage:

```php
/**
 * Global search of all the blogs in a network.
 */
function filter_ep_search_scope( $scope ) {
    $scope = 'all';
    return $scope;
}
add_filter( 'ep_search_scope', 'filter_ep_search_scope' );
```