### PR TITLE
Fixed: support post_parent = 0

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1001,7 +1001,7 @@ class EP_API {
 		 *
 		 * @since 2.0
 		 */
-		if ( ! empty( $args['post_parent'] ) && 'any' !== strtolower( $args['post_parent'] ) ) {
+		if ( isset( $args['post_parent'] ) && '' !== $args['post_parent'] && 'any' !== strtolower( $args['post_parent'] ) ) {
 			$filter['and'][]['bool']['must'] = array(
 				'term' => array(
 					'post_parent' => $args['post_parent'],


### PR DESCRIPTION
- Important for searching unattached media (post_parent = 0)
- empty( $args['post_parent’]): returns true if $args['post_parent’] = 0