### PR TITLE
Fix/560

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 node_modules
+.idea

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -165,8 +165,12 @@ class EP_API {
 		);
 
 		$request = ep_remote_request( $path, apply_filters( 'ep_search_request_args', $request_args, $args, $scope, $query_args ), $query_args );
-
-		if ( ! is_wp_error( $request ) ) {
+		
+		$allowed_res_codes = apply_filters( 'ep_remote_request_allowed_response_codes', array( 200 ), $request );
+		
+		$is_valid_res = in_array( intval( wp_remote_retrieve_response_code( $request ) ), $allowed_res_codes );
+		
+		if ( ! is_wp_error( $request ) && $is_valid_res ) {
 
 			// Allow for direct response retrieval
 			do_action( 'ep_retrieve_raw_response', $request, $args, $scope, $query_args );

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -166,11 +166,11 @@ class EP_API {
 
 		$request = ep_remote_request( $path, apply_filters( 'ep_search_request_args', $request_args, $args, $scope, $query_args ), $query_args );
 		
-		$allowed_res_codes = apply_filters( 'ep_remote_request_allowed_response_codes', array( 200 ), $request );
+		$remote_req_res_code = intval( wp_remote_retrieve_response_code( $request ) );
 		
-		$is_valid_res = in_array( intval( wp_remote_retrieve_response_code( $request ) ), $allowed_res_codes );
+		$is_valid_res = ( $remote_req_res_code >= 200 && $remote_req_res_code <= 299 );
 		
-		if ( ! is_wp_error( $request ) && $is_valid_res ) {
+		if ( ! is_wp_error( $request ) && apply_filters( 'ep_remote_request_is_valid_res', $is_valid_res, $request ) ) {
 
 			// Allow for direct response retrieval
 			do_action( 'ep_retrieve_raw_response', $request, $args, $scope, $query_args );


### PR DESCRIPTION
- Check remote request response code of Elasticsearch query and fallback to WP query if not allowed valid request response code
- Add PhpUnit test case for "If index is deleted, search should fallback to WP Query"