### PR TITLE
Skip query translation for "NOT IN" tax queries.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -964,6 +964,12 @@ class EP_API {
 
 			foreach( $args['tax_query'] as $single_tax_query ) {
 				if ( ! empty( $single_tax_query['terms'] ) ) {
+
+					// Skip NOT IN queries
+					if ( ! empty( $single_tax_query['operator'] ) && 'NOT IN' === $single_tax_query['operator'] ) {
+						continue;
+					}
+
 					$terms = (array) $single_tax_query['terms'];
 
 					$field = ( ! empty( $single_tax_query['field'] ) ) ? $single_tax_query['field'] : 'term_id';


### PR DESCRIPTION
Right now these "NOT IN" queries are translated as `must` queries, which is the opposite of the expected behavior.

I took a look at trying to implement affirmative support for NOT IN queries, but getting that to work logically with the OR operator in a way that would work for everyone isn't all that simple (at least not for my somewhat limited knowledge of Elasticsearch Query DSL). But at the very least, I figure that since the current behavior is more destructive that should probably be stopped as a step forward.

This also opens the door for plugin/theme devs add their own temporary support for NOT IN queries if they so choose, without having a conflict where the plugin has already marked them as `must`.