### PR TITLE
Change hook used to setup modules.

### DIFF
--- a/classes/class-ep-modules.php
+++ b/classes/class-ep-modules.php
@@ -26,7 +26,7 @@ class EP_Modules {
 	 * @since 2.1
 	 */
 	public function setup() {
-		add_action( 'after_setup_theme', array( $this, 'setup_modules' ) );
+		add_action( 'plugins_loaded', array( $this, 'setup_modules' ) );
 	}
 
 	/**


### PR DESCRIPTION
Currently modules run their setup callbacks on the `after_setup_theme` hook. I ran into an issue where I needed the setup callback to override some functionality another plugin was adding on the  `plugins_loaded` hook, which wasn't possible in the current setup.

So this changes the hook from `after_setup_theme` to `plugins_loaded`. I don't believe this will impact anything else but does make these setup callbacks run sooner, which should hopefully prevent any issues in the future with code not running in time.