### PR TITLE
Fix post_type array on bulk action filtered by category

### DIFF
--- a/modules/woocommerce/woocommerce.php
+++ b/modules/woocommerce/woocommerce.php
@@ -276,9 +276,9 @@ function ep_wc_translate_args( $query ) {
 
 		if ( empty( $post_type ) ) {
 			$post_type = 'product';
-		} elseif ( is_array( $post_type ) ) {
+		} elseif ( is_array( $post_type ) && ! in_array( 'product', $post_type, true ) ) {
 			$post_type[] = 'product';
-		} else {
+		} elseif ( $post_type !== 'product' ) {
 			$post_type = array( $post_type, 'product' );
 		}
 


### PR DESCRIPTION
In WooCommerce products backend bulk actions not working, if they filtered by a category.
Than the form (for bulk actions) filed post_type has a value of Array.
Also in the Array is product defined twice.
