### PR TITLE
Merge Network enabled modules with Site enabled modules

### DIFF
--- a/classes/class-ep-modules.php
+++ b/classes/class-ep-modules.php
@@ -66,10 +66,9 @@ class EP_Modules {
 	 * @since  2.1
 	 */
 	public function activate_module( $slug ) {
+		$modules = get_option( 'ep_active_modules', array() );
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$modules = get_site_option( 'ep_active_modules', array() );
-		} else {
-			$modules = get_option( 'ep_active_modules', array() );
+			$modules = array_merge( $modules, get_site_option( 'ep_active_modules', array() ) );
 		}
 
 		if ( false === array_search( $slug, $modules ) ) {


### PR DESCRIPTION
Currently if you network enable the plugin, you cannot activate any modules on a site by site basis. This is a suggested PR which will enable the plugin to be network active, and sites to maintain their own configuration of active modules.

The wp-cli command list-modules may need tweaking to list modules and how they are activated for the current site.
