### PR TITLE
When using the 'ep_wp_query_search_cached_posts' filter, if it return…

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -300,7 +300,7 @@ class EP_WP_Query_Integration {
 
 		$this->posts_by_query[spl_object_hash( $query )] = $new_posts;
 
-		do_action( 'ep_wp_query_search', $new_posts, $ep_query, $query );
+		do_action( 'ep_wp_query_search', $new_posts, (isset($ep_query) ? $ep_query : null), $query );
 
 		global $wpdb;
 

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -217,6 +217,8 @@ class EP_WP_Query_Integration {
 
 		$new_posts = apply_filters( 'ep_wp_query_search_cached_posts', array(), $query );
 
+		$ep_query = array();
+
 		if( count( $new_posts ) < 1 ) {
 
 			$scope = 'current';
@@ -300,7 +302,7 @@ class EP_WP_Query_Integration {
 
 		$this->posts_by_query[spl_object_hash( $query )] = $new_posts;
 
-		do_action( 'ep_wp_query_search', $new_posts, (isset($ep_query) ? $ep_query : null), $query );
+		do_action( 'ep_wp_query_search', $new_posts, $ep_query, $query );
 
 		global $wpdb;
 


### PR DESCRIPTION
…s a non empty response $ep_query is never set and as a result line 303 generates a PHP warning indicating so. Added a check to see if it is set before attempting to use it.