### PR TITLE
Potential mapping solution for #643

### DIFF
--- a/includes/mappings/5-0.php
+++ b/includes/mappings/5-0.php
@@ -85,8 +85,7 @@ return array(
 									'type' => 'text',
 									'fields' => array(
 										'sortable' => array(
-											'type' => 'text',
-											'analyzer' => 'ewp_lowercase',
+											'type' => 'keyword',
 										),
 										'raw' => array(
 											'type' => 'keyword',
@@ -135,8 +134,7 @@ return array(
 											'type' => 'keyword',
 										),
 										'sortable' => array(
-											'type' => 'text',
-											'analyzer' => 'ewp_lowercase',
+											'type' => 'keyword',
 										),
 									),
 								),
@@ -183,8 +181,7 @@ return array(
 									'type' => 'keyword',
 								),
 								'sortable' => array(
-									'type' => 'text',
-									'analyzer' => 'ewp_lowercase',
+									'type' => 'keyword',
 								),
 							),
 						),
@@ -195,8 +192,7 @@ return array(
 									'type' => 'keyword',
 								),
 								'sortable' => array(
-									'type' => 'text',
-									'analyzer' => 'ewp_lowercase',
+									'type' => 'keyword',
 								),
 							),
 						),
@@ -227,8 +223,7 @@ return array(
 							'type' => 'keyword',
 						),
 						'sortable' => array(
-							'type' => 'text',
-							'analyzer' => 'ewp_lowercase',
+							'type' => 'keyword',
 						),
 					),
 				),


### PR DESCRIPTION
This mapping seems to work for me. I tried to keep the `analyzer` parameter in the `sortable` field, but Elasticsearch doesn't like it. Not sure if there is an alternative. Perhaps the standard analyzer is sufficient?