### PR TITLE
Adds 'number' param to satisfy WP v4.6+. Fixes #685

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1792,6 +1792,7 @@ class EP_API {
 	public function get_sites( $limit = 0 ) {
 		$args = apply_filters( 'ep_indexable_sites_args', array(
 			'limit' => $limit,
+			'number' => $limit,
 		) );
 
 		if ( function_exists( 'get_sites' ) ) {


### PR DESCRIPTION
In Wordpress v4.6 when get_sites() was introduced to replace `wp_get_sites()` the 'limit' argument parameter changed to `number`.  Without `number`, multisite installations will revert to only returning the first 100 sites. This update adds the `number` param to the `ep_indexable_sites_args()` filter to resolve this issue while maintaining backwards compatibility with `limit`.

Fixes #685