### PR TITLE
Stop the insanity should be private

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -769,7 +769,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Resets some values to reduce memory footprint.
 	 */
-	public function stop_the_insanity() {
+	private function stop_the_insanity() {
 		global $wpdb, $wp_object_cache, $wp_actions, $wp_filter;
 
 		$wpdb->queries = array();


### PR DESCRIPTION
Right now, `wp elasticpress stop_the_insanity` is available for use, which wasn't the intention.