### PR TITLE
Fix hierarchical queries in WP4.6+

### DIFF
--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -47,8 +47,12 @@ class EP_WP_Query_Integration {
 		// Nukes the FOUND_ROWS() database query
 		add_filter( 'found_posts_query', array( $this, 'filter_found_posts_query' ), 5, 2 );
 
-		// Query and filter in EP_Posts to WP_Query
-		add_filter( 'the_posts', array( $this, 'filter_the_posts' ), 10, 2 );
+	        // Query and filter in EP_Posts to WP_Query
+		if ( version_compare( get_bloginfo( 'version' ), '4.6', '>=' ) ) {
+			add_filter( 'posts_pre_query', array( $this, 'filter_the_posts' ), 10, 2 );
+		} else {
+			add_filter( 'the_posts', array( $this, 'filter_the_posts' ), 10, 2 );
+		}
 
 		// Ensure we're in a loop before we allow blog switching
 		add_action( 'loop_start', array( $this, 'action_loop_start' ), 10, 1 );


### PR DESCRIPTION
Suggested fix for: https://github.com/10up/ElasticPress/issues/677

Issue is due to the early return when `fields => "id=>parent"` and never reaching the `get_posts` filter.
https://github.com/WordPress/WordPress/blob/4.7.2/wp-includes/class-wp-query.php#L2785

There doesn't appear to be any issue hooking the `posts_pre_query` (as long as it's available... 4.6.0+ only)