### PR TITLE
make sure the version value exist in get_elasticsearch_version 

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -159,7 +159,7 @@ class EP_API {
 
 		$info = $this->get_elasticsearch_info();
 
-		return $info['version'];
+		return isset( $info['version'] )? $info['version'] : false;
 	}
 
 	/**


### PR DESCRIPTION
If there is no host set, the get_elasticsearch_info will return false.
Thus we need to check the value of the array, otherwise it will return null
Fixed #702 