### PR TITLE
Prevent EP from altering $query object when ep_skip_query_integration…

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -168,6 +168,10 @@ function ep_wc_translate_args( $query ) {
 		return;
 	}
 
+	if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query ) ) {
+		return;
+	}
+
 	$admin_integration = apply_filters( 'ep_admin_wp_query_integration', false );
 
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {


### PR DESCRIPTION
… filter returns true. Fixes issue #552 

This issue was the source of thousands of `Object of class WP_Post could not be converted to string` PHP errors. A standard WooCommerce / StoreFront theme install includes a 404.php template which displays featured products in addition to the 'Page Not Found' error, which can be traced to `/wp-content/plugins/woocommerce/includes/wc-product-functions.php -> wc_get_featured_product_ids(202)`.

The `array_merge` call is expecting associative arrays, but is getting and array of WP_Post objects via the `$featured` variable when EP is enabled. This is due to `ep_wc_translate_args` changing the `fields` parameter from `id=>parent` to `default`. 

By making `ep_wc_translate_args` apply the `ep_skip_query_integration` filter, we can selectively disable this behavior. 