### PR TITLE
Removed ep_elasticpress_enabled check.

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -168,7 +168,7 @@ function ep_wc_translate_args( $query ) {
 		return;
 	}
 
-	if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query ) ) {
+	if ( apply_filters( 'ep_skip_query_integration', false, $query ) ) {
 		return;
 	}
 


### PR DESCRIPTION
After further testing I found an oversight in my previous PR.

The `$query->query-vars['ep_integrate']` value has not been set at this point, so the `ep_elasticpress_enabled` function will always return false unless explicitly enabled by the `ep_elasticpress_enabled` filter.