### PR TITLE
Date Decay Fix – First Pass

### DIFF
--- a/features/search/search.php
+++ b/features/search/search.php
@@ -164,6 +164,8 @@ function ep_weight_recent( $formatted_args, $args ) {
 						'offset' => apply_filters( 'epwr_offset', '7d', $formatted_args, $args ),
 					),
 				),
+				'score_mode' => 'avg',
+				'boost_mode' => 'sum'
 			),
 		);
 


### PR DESCRIPTION
First pass at fixing the date decay issue. Currently, date decay is completely usurping relevancy scores and taking otherwise perfect matches to relevancy of zero because they are too far away from the decay origin. By adding score_mode of avg, a relevancy score is calculated using a weighted average which is preferable since we have large boost values for some parts of the query. We want to maintain that. By setting boost_mode to sum, the scores are added instead of the default multiply which seems to have been the primary driver of lowering relevancy scores to zero.