### PR TITLE
Fix woocommerce product search default order

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -355,6 +355,14 @@ function ep_wc_translate_args( $query ) {
 		if ( ! empty( $s ) ) {
 			$query->set( 'orderby', false ); // Just order by relevance.
 
+			/**
+			 * Default order when doing search in Woocommerce is 'ASC'
+			 * These lines will change it to 'DESC' as we want to most relevant result
+			 */
+			if ( empty( $_GET['orderby'] ) && $query->is_main_query() ) {
+				$query->set( 'order', 'DESC' );
+			}
+
 			// Search query
 			if ( 'shop_order' === $post_type ) {
 				$search_fields = $query->get( 'search_fields', array( 'post_title', 'post_content', 'post_excerpt' ) );
@@ -422,14 +430,6 @@ function ep_wc_translate_args( $query ) {
 				default:
 					$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( 'menu_order' ) ); // Order by menu and title.
 			}
-		}
-
-		/**
-		 * Default order when doing search in woocommerce is 'ASC'
-         * These lines will change it to 'DESC' as we want to most relevant result
-		 */
-		if ( empty( $_GET['orderby'] ) && ! empty( $_GET['s'] ) && $query->is_main_query() ) {
-			$query->set( 'order', 'DESC' );
 		}
 
 	}

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -423,6 +423,15 @@ function ep_wc_translate_args( $query ) {
 					$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( 'menu_order' ) ); // Order by menu and title.
 			}
 		}
+
+		/**
+		 * Default order when doing search in woocommerce is 'ASC'
+         * These lines will change it to 'DESC' as we want to most relevant result
+		 */
+		if ( empty( $_GET['orderby'] ) && ! empty( $_GET['s'] ) && $query->is_main_query() ) {
+			$query->set( 'order', 'DESC' );
+		}
+
 	}
 }
 


### PR DESCRIPTION
Woocommerce product search default order is 'ASC'. We want it to be 'DESC'. Fixed #737 