### PR TITLE
make sure the orderby is correct for default sorting

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -405,6 +405,26 @@ function ep_wc_translate_args( $query ) {
 		}
 
 		/**
+		 * For default sorting by popularity (total_sales) and rating
+         * Woocommerce doesn't set the orderby correctly.
+         * These lines will check the meta_key and correct the orderby based on that.
+         * And this won't run in search result and only run in main query
+		 */
+		$meta_key = $query->get( 'meta_key', false );
+		if ( $meta_key && empty( $s ) && $query->is_main_query() ){
+			switch ( $meta_key ){
+				case 'total_sales':
+					$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( 'total_sales' ) );
+					$query->set( 'order', 'DESC' );
+					break;
+				case '_wc_average_rating':
+					$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( '_wc_average_rating' ) );
+					$query->set( 'order', 'DESC' );
+					break;
+			}
+		}
+
+		/**
 		 * Set orderby from GET param
 		 * Also make sure the orderby param affects only the main query
 		 */
@@ -413,6 +433,7 @@ function ep_wc_translate_args( $query ) {
 			switch ( $_GET['orderby'] ) {
 				case 'popularity':
 					$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( 'total_sales' ) );
+					$query->set( 'order', 'DESC' );
 					break;
 				case 'price':
 				case 'price-desc':
@@ -420,6 +441,7 @@ function ep_wc_translate_args( $query ) {
 					break;
 				case 'rating' :
 					$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( '_wc_average_rating' ) );
+					$query->set( 'order', 'DESC' );
 					break;
 				case 'date':
 					$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( 'date' ) );


### PR DESCRIPTION
The source of the problem is from the WC_Query:
https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-query.php#L453-L483

if there is no querystring orderby then it fall back to the default settings.
But it set the orderby to menu_order title in line https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-query.php#L449

We can only check from the meta_key, and translate that into correct orderby

Fixed #745 