### PR TITLE
Mapping for ES 5 for total_field_limit

### DIFF
--- a/includes/mappings/5-0.php
+++ b/includes/mappings/5-0.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 return array(
 	'settings' => array(
+	    'index.mapping.total_fields.limit' => apply_filters( 'ep_total_field_limit', 1000 ),
 		'analysis' => array(
 			'analyzer' => array(
 				'default' => array(


### PR DESCRIPTION
Adds a mapping parameter for ES 5.0 to allow for the adjustment of the total_field_limit value that was introduced in ES 5.x (https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_mapping_changes.html)  If you look for "Field Mapping Limit's" on that page you will see the change.