### PR TITLE
Add filter for max results window size

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -969,7 +969,7 @@ class EP_API {
 				 *
 				 * @return int The max results window size.
 				 *
-				 * @since 2.2.1
+				 * @since 2.3.0
 				 */
 				$posts_per_page = apply_filters( 'ep_max_results_window', 10000 );
 			}

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -958,8 +958,20 @@ class EP_API {
 		if ( ! empty( $args['posts_per_page'] ) ) {
 			$posts_per_page = (int) $args['posts_per_page'];
 
+			// ES have a maximum size allowed so we have to convert "-1" to a maximum size.
 			if ( -1 === $posts_per_page ) {
-				$posts_per_page = 10000; // -1 does not work, use max result window for ES
+				/**
+				 * Set the maximum results window size.
+				 *
+				 * The request will return a HTTP 500 Internal Error if the size of the
+				 * request is larger than the [index.max_result_window] parameter in ES.
+				 * See the scroll api for a more efficient way to request large data sets.
+				 *
+				 * @return int The max results window size.
+				 *
+				 * @since 2.2.1
+				 */
+				$posts_per_page = apply_filters( 'ep_max_results_window', 10000 );
 			}
 		} else {
 			$posts_per_page = (int) get_option( 'posts_per_page' );


### PR DESCRIPTION
Added a more detailed explanation of what is going on with the `posts_per_page` conversion and added the option to alter the max results window size hardcoded in EP.

You might be wondering: "Hey, why do we need this?" – well, it is basically documentation with the added functionality of increasing/decreasing the size so you can optimise it for your own server (some might have cheaper ES instances where the window size have been reduced etc.).