### PR TITLE
Add WP_Query fields support

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1505,6 +1505,30 @@ class EP_API {
 		}
 
 		/**
+		 * Support fields.
+		 */
+		if ( isset( $args['fields'] ) ) {
+			switch ( $args['fields'] ) {
+				case 'ids':
+					$formatted_args['_source'] = [
+						'include' => [
+							'post_id',
+						],
+					];
+					break;
+
+				case 'id=>parent':
+					$formatted_args['_source'] = [
+						'include' => [
+							'post_id',
+							'post_parent',
+						],
+					];
+					break;
+			}
+		}
+
+		/**
 		 * Aggregations
 		 */
 		if ( isset( $args['aggs'] ) && ! empty( $args['aggs']['aggs'] ) ) {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1510,20 +1510,20 @@ class EP_API {
 		if ( isset( $args['fields'] ) ) {
 			switch ( $args['fields'] ) {
 				case 'ids':
-					$formatted_args['_source'] = [
-						'include' => [
+					$formatted_args['_source'] = array(
+						'include' => array(
 							'post_id',
-						],
-					];
+						),
+					);
 					break;
 
 				case 'id=>parent':
-					$formatted_args['_source'] = [
-						'include' => [
+					$formatted_args['_source'] = array(
+						'include' => array(
 							'post_id',
 							'post_parent',
-						],
-					];
+						),
+					);
 					break;
 			}
 		}

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -47,6 +47,9 @@ class EP_WP_Query_Integration {
 		// Nukes the FOUND_ROWS() database query
 		add_filter( 'found_posts_query', array( $this, 'filter_found_posts_query' ), 5, 2 );
 
+		// Support "fields".
+		add_filter( 'posts_pre_query', array( $this, 'posts_fields' ), 10, 2 );
+
 		// Query and filter in EP_Posts to WP_Query
 		add_filter( 'the_posts', array( $this, 'filter_the_posts' ), 10, 2 );
 
@@ -189,6 +192,36 @@ class EP_WP_Query_Integration {
 	}
 
 	/**
+	 * Workaround for when WP_Query short circuits for special fields arguments.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array $posts
+	 *   Return an array of post data to short-circuit WP's query,
+	 *   or null to allow WP to run its normal queries.
+	 * @param WP_Query $query
+	 *   WP_Query object.
+	 *
+	 * @return array
+	 *   An array of fields.
+	 */
+	public function posts_fields( $posts, $query ) {
+		// Make sure the query is EP enabled.
+		if ( ! ep_elasticpress_enabled( $query ) || apply_filters( 'ep_skip_query_integration', false, $query ) || ! isset( $this->posts_by_query[ spl_object_hash( $query ) ] ) ) {
+			return $posts;
+		}
+
+		// Only touch the default behaviour of "ep_fields" is defined to make
+		// sure we only affect places we specifically ask for.
+		$fields = $query->get( 'fields', '' );
+		if ( $fields === 'ids' || $fields === 'id=>parent' ) {
+			return $this->posts_by_query[ spl_object_hash( $query ) ];
+		} else {
+			return $posts;
+		}
+	}
+
+	/**
 	 * Filter query string used for get_posts(). Query for posts and save for later.
 	 * Return a query that will return nothing.
 	 *
@@ -266,55 +299,17 @@ class EP_WP_Query_Integration {
 			$query->found_posts = $ep_query['found_posts'];
 			$query->max_num_pages = ceil( $ep_query['found_posts'] / $query->get( 'posts_per_page' ) );
 
-			foreach ( $ep_query['posts'] as $post_array ) {
-				$post = new stdClass();
-
-				$post->ID = $post_array['post_id'];
-				$post->site_id = get_current_blog_id();
-
-				if ( ! empty( $post_array['site_id'] ) ) {
-					$post->site_id = $post_array['site_id'];
-				}
-				// ep_search_request_args
-				$post_return_args = apply_filters( 'ep_search_post_return_args',
-					array(
-						'post_type',
-						'post_author',
-						'post_name',
-						'post_status',
-						'post_title',
-						'post_parent',
-						'post_content',
-						'post_excerpt',
-						'post_date',
-						'post_date_gmt',
-						'post_modified',
-						'post_modified_gmt',
-						'post_mime_type',
-						'comment_count',
-						'comment_status',
-						'ping_status',
-						'menu_order',
-						'permalink',
-						'terms',
-						'post_meta',
-						'meta',
-					)
-				);
-
-				foreach ( $post_return_args as $key ) {
-					if( $key === 'post_author' ) {
-						$post->$key = $post_array[$key]['id'];
-					} elseif ( isset( $post_array[ $key ] ) ) {
-						$post->$key = $post_array[$key];
-					}
-				}
-
-				$post->elasticsearch = true; // Super useful for debugging
-
-				if ( $post ) {
-					$new_posts[] = $post;
-				}
+			// Determine how we should format the results from ES based on the fields
+			// parameter.
+			$fields = $query->get( 'fields', '' );
+			if ( $fields === 'ids' ) {
+				$new_posts = $this->format_hits_as_ids( $ep_query['posts'], $new_posts );
+			}
+			elseif ( $fields === 'id=>parent' ) {
+				$new_posts = $this->format_hits_as_id_parents( $ep_query['posts'], $new_posts );
+			}
+			else {
+				$new_posts = $this->format_hits_as_posts( $ep_query['posts'], $new_posts );
 			}
 
 			do_action( 'ep_wp_query_non_cached_search', $new_posts, $ep_query, $query );
@@ -327,6 +322,108 @@ class EP_WP_Query_Integration {
 		return "SELECT * FROM $wpdb->posts WHERE 1=0";
 	}
 
+	/**
+	 * Format the ES hits/results as post objects.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array $posts The posts that should be formatted.
+	 * @param array $new_posts Array of posts from cache.
+	 *
+	 * @return array
+	 */
+	protected function format_hits_as_posts( $posts, $new_posts ) {
+		foreach ( $posts as $post_array ) {
+			$post = new stdClass();
+
+			$post->ID = $post_array['post_id'];
+			$post->site_id = get_current_blog_id();
+
+			if ( ! empty( $post_array['site_id'] ) ) {
+				$post->site_id = $post_array['site_id'];
+			}
+			// ep_search_request_args
+			$post_return_args = apply_filters( 'ep_search_post_return_args',
+				array(
+					'post_type',
+					'post_author',
+					'post_name',
+					'post_status',
+					'post_title',
+					'post_parent',
+					'post_content',
+					'post_excerpt',
+					'post_date',
+					'post_date_gmt',
+					'post_modified',
+					'post_modified_gmt',
+					'post_mime_type',
+					'comment_count',
+					'comment_status',
+					'ping_status',
+					'menu_order',
+					'permalink',
+					'terms',
+					'post_meta',
+					'meta',
+				)
+			);
+
+			foreach ( $post_return_args as $key ) {
+				if( $key === 'post_author' ) {
+					$post->$key = $post_array[$key]['id'];
+				} elseif ( isset( $post_array[ $key ] ) ) {
+					$post->$key = $post_array[$key];
+				}
+			}
+
+			$post->elasticsearch = true; // Super useful for debugging
+
+			if ( $post ) {
+				$new_posts[] = $post;
+			}
+		}
+
+		return $new_posts;
+	}
+
+	/**
+	 * Format the ES hits/results as an array of ids.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array $posts The posts that should be formatted.
+	 * @param array $new_posts Array of posts from cache.
+	 *
+	 * @return array
+	 */
+	protected function format_hits_as_ids( $posts, $new_posts ) {
+		foreach ( $posts as $post_array ) {
+			$new_posts[] = $post_array['post_id'];
+		}
+
+		return $new_posts;
+	}
+
+	/**
+	 * Format the ES hits/results as objects containing id and parent id.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array $posts The posts that should be formatted.
+	 * @param array $new_posts Array of posts from cache.
+	 *
+	 * @return array
+	 */
+	protected function format_hits_as_id_parents( $posts, $new_posts ) {
+		foreach ( $posts as $post_array ) {
+			$post = new stdClass();
+			$post->ID = $post_array['post_id'];
+			$post->post_parent = $post_array['post_parent'];
+			$new_posts[] = $post;
+		}
+		return $new_posts;
+	}
 
 	/**
 	 * Return a singleton instance of the current class

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -211,8 +211,8 @@ class EP_WP_Query_Integration {
 			return $posts;
 		}
 
-		// Only touch the default behaviour of "ep_fields" is defined to make
-		// sure we only affect places we specifically ask for.
+		// Determine how we should return the posts. The official WP_Query
+		// supports: ids, id=>parent and post objects.
 		$fields = $query->get( 'fields', '' );
 		if ( $fields === 'ids' || $fields === 'id=>parent' ) {
 			return $this->posts_by_query[ spl_object_hash( $query ) ];

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -302,14 +302,18 @@ class EP_WP_Query_Integration {
 			// Determine how we should format the results from ES based on the fields
 			// parameter.
 			$fields = $query->get( 'fields', '' );
-			if ( $fields === 'ids' ) {
-				$new_posts = $this->format_hits_as_ids( $ep_query['posts'], $new_posts );
-			}
-			elseif ( $fields === 'id=>parent' ) {
-				$new_posts = $this->format_hits_as_id_parents( $ep_query['posts'], $new_posts );
-			}
-			else {
-				$new_posts = $this->format_hits_as_posts( $ep_query['posts'], $new_posts );
+			switch ( $fields ) {
+				case 'ids' :
+					$new_posts = $this->format_hits_as_ids( $ep_query['posts'], $new_posts );
+					break;
+
+				case 'id=>parent' :
+					$new_posts = $this->format_hits_as_id_parents( $ep_query['posts'], $new_posts );
+					break;
+
+				default:
+					$new_posts = $this->format_hits_as_posts( $ep_query['posts'], $new_posts );
+					break;
 			}
 
 			do_action( 'ep_wp_query_non_cached_search', $new_posts, $ep_query, $query );

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -216,9 +216,9 @@ class EP_WP_Query_Integration {
 		$fields = $query->get( 'fields', '' );
 		if ( 'ids' === $fields || 'id=>parent' === $fields ) {
 			return $this->posts_by_query[ spl_object_hash( $query ) ];
-		} else {
-			return $posts;
 		}
+
+		return $posts;
 	}
 
 	/**

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -424,6 +424,7 @@ class EP_WP_Query_Integration {
 			$post = new stdClass();
 			$post->ID = $post_array['post_id'];
 			$post->post_parent = $post_array['post_parent'];
+			$post->elasticsearch = true; // Super useful for debugging
 			$new_posts[] = $post;
 		}
 		return $new_posts;

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -214,7 +214,7 @@ class EP_WP_Query_Integration {
 		// Determine how we should return the posts. The official WP_Query
 		// supports: ids, id=>parent and post objects.
 		$fields = $query->get( 'fields', '' );
-		if ( $fields === 'ids' || $fields === 'id=>parent' ) {
+		if ( 'ids' === $fields || 'id=>parent' === $fields ) {
 			return $this->posts_by_query[ spl_object_hash( $query ) ];
 		} else {
 			return $posts;

--- a/classes/class-ep-wp-query-integration.php
+++ b/classes/class-ep-wp-query-integration.php
@@ -194,7 +194,7 @@ class EP_WP_Query_Integration {
 	/**
 	 * Workaround for when WP_Query short circuits for special fields arguments.
 	 *
-	 * @since 2.2.1
+	 * @since 2.4.0
 	 *
 	 * @param array $posts
 	 *   Return an array of post data to short-circuit WP's query,
@@ -329,7 +329,7 @@ class EP_WP_Query_Integration {
 	/**
 	 * Format the ES hits/results as post objects.
 	 *
-	 * @since 2.2.1
+	 * @since 2.4.0
 	 *
 	 * @param array $posts The posts that should be formatted.
 	 * @param array $new_posts Array of posts from cache.
@@ -394,7 +394,7 @@ class EP_WP_Query_Integration {
 	/**
 	 * Format the ES hits/results as an array of ids.
 	 *
-	 * @since 2.2.1
+	 * @since 2.4.0
 	 *
 	 * @param array $posts The posts that should be formatted.
 	 * @param array $new_posts Array of posts from cache.
@@ -412,7 +412,7 @@ class EP_WP_Query_Integration {
 	/**
 	 * Format the ES hits/results as objects containing id and parent id.
 	 *
-	 * @since 2.2.1
+	 * @since 2.4.0
 	 *
 	 * @param array $posts The posts that should be formatted.
 	 * @param array $new_posts Array of posts from cache.

--- a/features/search/search.php
+++ b/features/search/search.php
@@ -233,6 +233,17 @@ function ep_integrate_search_queries( $enabled, $query ) {
 		$enabled = false;
 	} else if ( method_exists( $query, 'is_search' ) && $query->is_search() && ! empty( $query->query_vars['s'] ) ) {
 		$enabled = true;
+
+		/**
+		 * WordPress have to be version 4.6 or newer to have "fields" support
+		 * since it requires the "posts_pre_query" filter.
+		 *
+		 * @see WP_Query::get_posts
+		 */
+		$fields = $query->get( 'fields' );
+		if ( ! version_compare( get_bloginfo( 'version' ), '4.6', '>=' ) && ! empty( $fields ) ) {
+			$enabled = false;
+		}
 	}
 
 	return $enabled;

--- a/features/search/search.php
+++ b/features/search/search.php
@@ -233,12 +233,6 @@ function ep_integrate_search_queries( $enabled, $query ) {
 		$enabled = false;
 	} else if ( method_exists( $query, 'is_search' ) && $query->is_search() && ! empty( $query->query_vars['s'] ) ) {
 		$enabled = true;
-
-		$fields = $query->get( 'fields' );
-
-		if ( ! empty( $fields ) ) {
-			$enabled = false;
-		}
 	}
 
 	return $enabled;

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -312,14 +312,6 @@ function ep_wc_translate_args( $query ) {
 		}
 
 		/**
-		 * We can't support any special fields parameters
-		 */
-		$fields = $query->get( 'fields', false );
-		if ( 'ids' === $fields || 'id=>parent' === $fields ) {
-			$query->set( 'fields', 'default' );
-		}
-
-		/**
 		 * Handle meta queries
 		 */
 		$meta_query = $query->get( 'meta_query', array() );

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -312,6 +312,17 @@ function ep_wc_translate_args( $query ) {
 		}
 
 		/**
+		 * WordPress have to be version 4.6 or newer to have "fields" support
+		 * since it requires the "posts_pre_query" filter.
+		 *
+		 * @see WP_Query::get_posts
+		 */
+		$fields = $query->get( 'fields', false );
+		if ( ! version_compare( get_bloginfo( 'version' ), '4.6', '>=' ) && ( 'ids' === $fields || 'id=>parent' === $fields ) ) {
+			$query->set( 'fields', 'default' );
+		}
+
+		/**
 		 * Handle meta queries
 		 */
 		$meta_query = $query->get( 'meta_query', array() );


### PR DESCRIPTION
Support the two `WP_Query` fields cases that are supported in core.

You can read more about my rant of why/how/thoughts in the open issue: #724 

_**NB**: I have not written any tests and I am not sure that I have covered all cases in the different modules (ex `WooCommerce`) - but I have manually tested it on regular searches on a vanilla Woo install with `storefront` theme and dummy data._

/ Kallehauge