### PR TITLE
Fallback to different endpoint if plugins endpoint is unavailable

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -2171,6 +2171,27 @@ class EP_API {
 			if ( is_wp_error( $request ) ) {
 				$this->elasticsearch_version = false;
 				$this->elasticsearch_plugins = false;
+
+				/**
+				 * Try a different endpoint in case the plugins url is restricted
+				 * 
+				 * @since 2.2.1
+				 */
+
+				$request = ep_remote_request( '', array( 'method' => 'GET' ) );
+
+				if ( ! is_wp_error( $request ) ) {
+					if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+						$response_body = wp_remote_retrieve_body( $request );
+						$response = json_decode( $response_body, true );
+
+						try {
+							$version = $response['version']['number'];
+						} catch ( Exception $e ) {
+							// Do nothing
+						}
+					}
+				}
 			} else {
 				$response = json_decode( wp_remote_retrieve_body( $request ), true );
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -2168,7 +2168,7 @@ class EP_API {
 
 			$request = ep_remote_request( $path, array( 'method' => 'GET' ) );
 
-			if ( is_wp_error( $request ) ) {
+			if ( is_wp_error( $request ) || 200 !== wp_remote_retrieve_response_code( $request ) ) {
 				$this->elasticsearch_version = false;
 				$this->elasticsearch_plugins = false;
 
@@ -2180,16 +2180,14 @@ class EP_API {
 
 				$request = ep_remote_request( '', array( 'method' => 'GET' ) );
 
-				if ( ! is_wp_error( $request ) ) {
-					if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
-						$response_body = wp_remote_retrieve_body( $request );
-						$response = json_decode( $response_body, true );
+				if ( ! is_wp_error( $request ) && 200 === wp_remote_retrieve_response_code( $request ) ) {
+					$response_body = wp_remote_retrieve_body( $request );
+					$response = json_decode( $response_body, true );
 
-						try {
-							$version = $response['version']['number'];
-						} catch ( Exception $e ) {
-							// Do nothing
-						}
+					try {
+						$this->elasticsearch_version = $response['version']['number'];
+					} catch ( Exception $e ) {
+						// Do nothing
 					}
 				}
 			} else {

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,7 @@ Please refer to [Github](https://github.com/10up/ElasticPress) for detailed usag
 = 2.2.1 =
 
 * Fix dashboard syncing delayed start issues.
+* If plugins endpoint errors, try root endpoint to get the ES version.
 
 = 2.2 (Requires re-index) =
 


### PR DESCRIPTION
This should fix #749.

Apparently on some ES hosts, the plugins endpoint is restricted. This PR will default to the root endpoint if the plugins one is unavailable.