### PR TITLE
Index Prefixing Constant

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -125,6 +125,10 @@ class EP_Config {
 			$index_name = false;
 		}
 
+		if ( defined( 'EP_INDEX_PREFIX' ) && EP_INDEX_PREFIX ) {
+			$index_name = EP_INDEX_PREFIX . $index_name;
+		}
+
 		return apply_filters( 'ep_index_name', $index_name, $blog_id );
 	}
 
@@ -162,6 +166,10 @@ class EP_Config {
 		$slug = preg_replace( '#[^\w]#', '', $slug );
 
 		$alias = $slug . '-global';
+
+		if ( defined( 'EP_INDEX_PREFIX' ) && EP_INDEX_PREFIX ) {
+			$alias = EP_INDEX_PREFIX . $alias;
+		}
 
 		return apply_filters( 'ep_global_alias', $alias );
 	}


### PR DESCRIPTION
In order to leverage the full capabilities of wildcard permissions offered by X-Pack, it is required to be able to set a unique index prefix that is applied to all indexes.

This PR allows developers to define a constant in wp-config.php that will add a prefix to their index and alias names without the need to use filters.

`define( 'EP_INDEX_PREFIX', 'abc-' );`