### PR TITLE
change post content filter to just do_shortcode

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -568,9 +568,6 @@ class EP_API {
 			}
 		}
 
-		// Turn off oEmbed auto discovery as this will create an error while indexing
-		add_filter( 'embed_oembed_discover', '__return_false' );
-
 		$post_args = array(
 			'post_id'           => $post_id,
 			'ID'                => $post_id,
@@ -579,7 +576,7 @@ class EP_API {
 			'post_date_gmt'     => $post_date_gmt,
 			'post_title'        => $this->prepare_text_content( get_the_title( $post_id ) ),
 			'post_excerpt'      => $this->prepare_text_content( $post->post_excerpt ),
-			'post_content'      => $this->prepare_text_content( apply_filters( 'the_content', $post->post_content ) ),
+			'post_content'      => $this->prepare_text_content( do_shortcode( $post->post_content ) ) ,
 			'post_status'       => $post->post_status,
 			'post_name'         => $post->post_name,
 			'post_modified'     => $post_modified,
@@ -607,9 +604,6 @@ class EP_API {
 		$post_args['meta'] = $this->prepare_meta_types( $post_args['post_meta'] );
 
 		$post_args = apply_filters( 'ep_post_sync_args_post_prepare_meta', $post_args, $post_id );
-
-		// Turn back on oEmbed discovery
-		remove_filter( 'embed_oembed_discover', '__return_false' );
 
 		return $post_args;
 	}


### PR DESCRIPTION
Do `apply_filter` on `the_content` when doing indexing might cause an infinite loop.
Someone might use apply_filter the_content to parse anything and try to update_post_meta, this will cause infinite loop doing indexing. I've experience this a lot.
For example oembeds.

This PR might rise some concern and need discussion.
cc: @tott and @tlovett1 