### PR TITLE
Add support for custom taxonomies in WooCommerce

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -226,6 +226,13 @@ function ep_wc_translate_args( $query ) {
 		'pa_sort-by',
 	);
 
+	/**
+	 * Add support for custom taxonomies.
+	 *
+	 * @since 2.3.0
+	 */
+	$supported_taxonomies = apply_filters( 'ep_woocommerce_supported_taxonomies', $supported_taxonomies );
+
 	if ( ! empty( $tax_query ) ) {
 
 		/**

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -229,6 +229,8 @@ function ep_wc_translate_args( $query ) {
 	/**
 	 * Add support for custom taxonomies.
 	 *
+	 * @param array $supported_taxonomies An array of default taxonomies.
+	 *
 	 * @since 2.3.0
 	 */
 	$supported_taxonomies = apply_filters( 'ep_woocommerce_supported_taxonomies', $supported_taxonomies );


### PR DESCRIPTION
It might be useful to automate the product taxonomies but, for now, I would love to see support for "custom taxonomies" for the WooCommerce feature.

The reason is that custom taxonomies added to "products" by plugins are not sortable in the admin view if they are not added to the `$supported_taxonomies` array.