### PR TITLE
Add default support for "product_type" (Woo)

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -223,6 +223,7 @@ function ep_wc_translate_args( $query ) {
 		'product_cat',
 		'pa_brand',
 		'product_tag',
+		'product_type',
 		'pa_sort-by',
 	);
 


### PR DESCRIPTION
It is currently not possible to filter by product type in the backend. This PR should solve that by adding `product_type` taxonomy support by default.