### PR TITLE
Added configuration constant for ElasticSearch index name

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -118,9 +118,11 @@ class EP_Config {
 
 		$site_url = get_site_url( $blog_id );
 
-		if ( ! empty( $site_url ) ) {
+		if ( ! empty( $site_url ) && ! defined( 'EP_INDEX_NAME') ) ) {
 			$index_name = preg_replace( '#https?://(www\.)?#i', '', $site_url );
 			$index_name = preg_replace( '#[^\w]#', '', $index_name ) . '-' . $blog_id;
+		} elseif(EP_INDEX_NAME) {
+			$index_name = EP_INDEX_NAME;
 		} else {
 			$index_name = false;
 		}

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -118,7 +118,7 @@ class EP_Config {
 
 		$site_url = get_site_url( $blog_id );
 
-		if ( ! empty( $site_url ) && ! defined( 'EP_INDEX_NAME') ) ) {
+		if ( ! empty( $site_url ) && ! defined( 'EP_INDEX_NAME') ) {
 			$index_name = preg_replace( '#https?://(www\.)?#i', '', $site_url );
 			$index_name = preg_replace( '#[^\w]#', '', $index_name ) . '-' . $blog_id;
 		} elseif(EP_INDEX_NAME) {

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -121,7 +121,7 @@ class EP_Config {
 		if ( ! empty( $site_url ) && ! defined( 'EP_INDEX_NAME') ) {
 			$index_name = preg_replace( '#https?://(www\.)?#i', '', $site_url );
 			$index_name = preg_replace( '#[^\w]#', '', $index_name ) . '-' . $blog_id;
-		} elseif(EP_INDEX_NAME) {
+		} elseif ( defined( 'EP_INDEX_NAME') ) {
 			$index_name = EP_INDEX_NAME;
 		} else {
 			$index_name = false;


### PR DESCRIPTION
Allows users to define the name for the ES index rather than using siteurl and blog id and/or prefix. 

Makes index naming more readable and brief, and great if using a single WP instance and an ES cluster with many indices.