### PR TITLE
Disable dashboard sync with constant. Closes #701

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,17 @@ The following commands are supported by ElasticPress:
 define( 'ES_SHIELD', 'username:password' );
 ```
 
+## Disable Dashboard Sync
+
+Dashboard sync can be disabled by defining the constant `EP_DASHBOARD_SYNC` as `false` in your wp-config.php file.
+
+```php
+define( 'EP_DASHBOARD_SYNC', false );
+```
+
+* This can be helpful for managed sites where users initiating a sync from the dashboard could potentially cause issues such as deleting the index and limiting this control to WP-CLI is preferred.
+* When disabled, features that would require reindexing are also prevented from being enabled/disabled from the dashboard.
+
 ## Custom Features
 
 ElasticPress has a robust API for registering your own features. Refer to the code within each feature for detailed examples. To register a feature, you will need to call the `ep_register_feature()` function like so:

--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -191,6 +191,16 @@ class EP_Dashboard {
 			if ( false === $last_sync && ! isset( $_GET['do_sync'] ) ) {
 				$notice = 'no-sync';
 			}
+
+			if ( defined( 'EP_DASHBOARD_SYNC' ) && ! EP_DASHBOARD_SYNC ) {
+				if ( 'auto-activate-sync' == $notice ) {
+					$notice = 'sync-disabled-auto-activate';
+				} elseif ( 'upgrade-sync' == $notice ) {
+					$notice = 'sync-disabled-upgrade';
+				} elseif ( 'no-sync' == $notice ) {
+					$notice = 'sync-disabled-no-sync';
+				}
+			}
 		}
 
 		$es_version = ep_get_elasticsearch_version( $force );
@@ -320,6 +330,28 @@ class EP_Dashboard {
 				</div>
 				<?php
 				break;
+			case 'sync-disabled-auto-activate':
+				$feature = ep_get_registered_feature( $auto_activate_sync );
+				?>
+				<div data-ep-notice="sync-disabled-auto-activate" class="notice notice-warning is-dismissible">
+					<p><?php printf( __( 'Dashboard sync is disabled. The ElasticPress %s feature has been auto-activated! You will need to reindex using WP-CLI for it to work.', 'elasticpress' ), esc_html( $feature->title ) ); ?></p>
+				</div>
+				<?php
+				break;
+			case 'sync-disabled-upgrade':
+				?>
+				<div data-ep-notice="sync-disabled-upgrade" class="notice notice-warning is-dismissible">
+					<p><?php printf( __( 'Dashboard sync is disabled. The new version of ElasticPress requires that you to reindex using WP-CLI.', 'elasticpress' ) ); ?></p>
+				</div>
+				<?php
+				break;
+			case 'sync-disabled-no-sync':
+				?>
+				<div data-ep-notice="sync-disabled-no-sync" class="notice notice-warning is-dismissible">
+					<p><?php printf( __( 'Dashboard sync is disabled. You will need to index using WP-CLI to finish setup.', 'elasticpress' ) ); ?></p>
+				</div>
+				<?php
+				break;
 		}
 
 		return $notice;
@@ -368,6 +400,30 @@ class EP_Dashboard {
 
 				break;
 			case 'auto-activate-sync':
+				if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+					delete_site_option( 'ep_feature_auto_activated_sync' );
+				} else {
+					delete_option( 'ep_feature_auto_activated_sync' );
+				}
+
+				break;
+			case 'sync-disabled-no-sync':
+				if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+					update_site_option( 'ep_last_sync', 'never' );
+				} else {
+					update_option( 'ep_last_sync', 'never' );
+				}
+
+				break;
+			case 'sync-disabled-upgrade':
+				if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+					delete_site_option( 'ep_need_upgrade_sync' );
+				} else {
+					delete_option( 'ep_need_upgrade_sync' );
+				}
+
+				break;
+			case 'sync-disabled-auto-activate':
 				if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 					delete_site_option( 'ep_feature_auto_activated_sync' );
 				} else {

--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -660,7 +660,7 @@ class EP_Dashboard {
 					$index_meta['wpcli_sync'] = true;
 				}
 
-				if ( isset( $_GET['do_sync'] ) ) {
+				if ( isset( $_GET['do_sync'] ) && defined( 'EP_DASHBOARD_SYNC' ) && EP_DASHBOARD_SYNC ) {
 					$data['auto_start_index'] = true;
 				}
 

--- a/classes/class-ep-feature.php
+++ b/classes/class-ep-feature.php
@@ -162,6 +162,12 @@ class EP_Feature {
 			$status = call_user_func( $this->requirements_status_cb, $status, $this );
 		}
 
+		if ( true === $this->requires_install_reindex && defined( 'EP_DASHBOARD_SYNC' ) && ! EP_DASHBOARD_SYNC ) {
+      $status->code = 2;
+      $status->message = "Dashboard sync is disabled.
+      Features that require content reindexing after activation must be enabled/disabled using WP-CLI."; 
+    }
+
 		return apply_filters( 'ep_feature_requirements_status', $status, $this );
 	}
 

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -67,6 +67,18 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 /**
+ * Set the availability of dashboard sync functionality. Defaults to true (enabled).
+ *
+ * Sync can be disabled by defining EP_DASHBOARD_SYNC as false in wp-config.php.
+ * NOTE: Must be defined BEFORE `require_once(ABSPATH . 'wp-settings.php');` in wp-config.php.
+ *
+ * @since  2.3
+ */
+if ( ! defined( 'EP_DASHBOARD_SYNC' ) ) {
+	define( 'EP_DASHBOARD_SYNC', true );
+}
+
+/**
  * Handle upgrades
  *
  * @since  2.2

--- a/includes/header.php
+++ b/includes/header.php
@@ -22,7 +22,7 @@ $base_url =  ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ? admin_url( 'netwo
 			<a class="dashicons pause-sync dashicons-controls-pause"></a>
 			<a class="dashicons resume-sync dashicons-controls-play"></a>
 			<a class="dashicons cancel-sync dashicons-no"></a>
-			<?php if ( ep_get_elasticsearch_version() ) : ?>
+			<?php if ( ep_get_elasticsearch_version() && defined( 'EP_DASHBOARD_SYNC' ) && EP_DASHBOARD_SYNC ) : ?>
 				<a class="dashicons start-sync dashicons-update"></a>
 			<?php endif; ?>
 		<?php endif; ?>


### PR DESCRIPTION
## Disable Dashboard Sync

Dashboard sync can be disabled by defining the constant `EP_DASHBOARD_SYNC` as `false` in your wp-config.php file.

```php
define( 'EP_DASHBOARD_SYNC', false );
```

* This can be helpful for managed sites where users initiating a sync from the dashboard could potentially cause issues such as deleting the index and limiting this control to WP-CLI is preferred.
* When disabled, features that would require reindexing are also prevented from being enabled/disabled from the dashboard.

## Additional Details
When `EP_DASHBOARD_SYNC` is defined as `false`:
* Attempting to manually trigger a dashboard sync via `admin.php?page=elasticpress&do_sync` will not initiate a sync. This is to prevent any tomfoolery, intentional or otherwise.
* The `resume`, `pause` and `stop` buttons are not disabled by this constant. This is to prevent situations where a dashboard sync my be in progress (or paused) when sync is disabled and will allow the in-progress sync to be managed.  If no sync is in-progress, these buttons will not appear.
* Dashboard notifications for `no-sync`, `upgrade-sync` and `auto-activate-sync` will be replaced with new dismissible notifications tailored to their respective conditions.
  * These notifications are unlikely to display on the dashboard as most use cases for disabling dashboard sync should (in theory) already be handling their respective situations from WP-CLI and their trigger conditions should already be cleared, but I thought it was safer to include them for situations such as someone updating enabling a feature but forgetting to reindex.

### New Notifications
`sync-disabled-no-sync`
![image](https://cloud.githubusercontent.com/assets/12876929/24221920/31f15274-0f1e-11e7-88e2-cb83f7ec35df.png)

`sync-disabled-upgrade`
![screenshot5028](https://cloud.githubusercontent.com/assets/12876929/24221931/4078c32c-0f1e-11e7-896c-e3659a52b025.png)

`sync-disabled-auto-activate`
![image](https://cloud.githubusercontent.com/assets/12876929/24222104/f4e35796-0f1e-11e7-8603-a06da7d133c7.png)

