### PR TITLE
Add support for comma separated shorthand taxonomies

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -247,7 +247,14 @@ function ep_wc_translate_args( $query ) {
 		if ( ! empty( $term ) ) {
 			$integrate = true;
 
-			$terms = explode( ',', $term );
+			// Shorthand taxonomies can be one of two data types: array and
+			// string. So we assume that if the provided value is not a string,
+			// then it must be an array.
+			// If it is a string then we convert it to an array with one or more
+			// values to handle it with the same logic.
+			if ( is_string( $term ) ) {
+				$terms = explode( ',', $term );
+			}
 
 			// to add child terms to the tax query
 			if ( is_taxonomy_hierarchical( $taxonomy ) ) {

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -247,19 +247,20 @@ function ep_wc_translate_args( $query ) {
 		if ( ! empty( $term ) ) {
 			$integrate = true;
 
-			$terms = array( $term );
+			$terms = explode( ',', $term );
 
 			// to add child terms to the tax query
 			if ( is_taxonomy_hierarchical( $taxonomy ) ) {
-				$term_object = get_term_by( 'slug', $term, $taxonomy );
-				$children    = get_term_children( $term_object->term_id, $taxonomy );
-				if ( $children ) {
-					foreach ( $children as $child ) {
-						$child_object = get_term( $child, $taxonomy );
-						$terms[]      = $child_object->slug;
+				foreach ( $terms as $term ) {
+					$term_object = get_term_by( 'slug', $term, $taxonomy );
+					$children    = get_term_children( $term_object->term_id, $taxonomy );
+					if ( $children ) {
+						foreach ( $children as $child ) {
+							$child_object = get_term( $child, $taxonomy );
+							$terms[]      = $child_object->slug;
+						}
 					}
 				}
-
 			}
 
 			$tax_query[] = array(

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -242,9 +242,9 @@ function ep_wc_translate_args( $query ) {
 	 * Next check if any taxonomies are in the root of query vars (shorthand form)
 	 */
 	foreach ( $supported_taxonomies as $taxonomy ) {
-		$term = $query->get( $taxonomy, false );
+		$terms = $query->get( $taxonomy, NULL );
 
-		if ( ! empty( $term ) ) {
+		if ( ! empty( $terms ) ) {
 			$integrate = true;
 
 			// Shorthand taxonomies can be one of two data types: array and
@@ -252,8 +252,8 @@ function ep_wc_translate_args( $query ) {
 			// then it must be an array.
 			// If it is a string then we convert it to an array with one or more
 			// values to handle it with the same logic.
-			if ( is_string( $term ) ) {
-				$terms = explode( ',', $term );
+			if ( is_string( $terms ) ) {
+				$terms = explode( ',', $terms );
 			}
 
 			// to add child terms to the tax query


### PR DESCRIPTION
The current implementation of handling "supported taxonomies" assumes that the `query_var` argument is a single value (example: `'product_brand' => 'adidas'`) - It does not support multiple terms separated by a comma (example: `'product_brand' => 'adidas,nike'`).