### PR TITLE
Fix/woocommerce search order

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -534,6 +534,30 @@ function ep_wc_bypass_order_permissions_check( $override, $post_id ) {
 }
 
 /**
+ * Enhance WooCommerce search order by order id, email, phone number, name, etc..
+ *
+ * @param $wp
+ */
+function ep_wc_search_order( $wp ){
+	global $pagenow;
+
+	if ( 'edit.php' != $pagenow || 'shop_order' !== $wp->query_vars['post_type'] ||
+	     ! isset( $wp->query_vars['shop_order_search'] ) || true !== $wp->query_vars['shop_order_search'] ) {
+		return;
+	}
+
+	$search_key_safe = str_replace( array( 'Order #', '#' ), '', wc_clean( $_GET['s'] ) );
+	$order    = wc_get_order( absint( $search_key_safe ) );
+
+	//If the order doesn't exist, fallback to other fields
+	if( ! $order ){
+		unset( $wp->query_vars['shop_order_search'] );
+		unset( $wp->query_vars['post__in'] );
+		$wp->query_vars['s'] = $search_key_safe;
+	}
+}
+
+/**
  * Setup all feature filters
  *
  * @since  2.1
@@ -549,6 +573,7 @@ function ep_wc_setup() {
 		add_filter( 'ep_sync_taxonomies', 'ep_wc_whitelist_taxonomies', 10, 2 );
 		add_filter( 'ep_post_sync_args_post_prepare_meta', 'ep_wc_remove_legacy_meta', 10, 2 );
 		add_action( 'pre_get_posts', 'ep_wc_translate_args', 11, 1 );
+		add_action( 'parse_query', 'ep_wc_search_order', 11, 1 );
 	}
 }
 

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -573,7 +573,6 @@ function ep_wc_search_order( $wp ){
 		//we found the order. don't query ES
 		unset( $wp->query_vars['s'] );
 		$wp->query_vars['post__in'] = array( $order->get_id() );
-		$wp->query_vars['ep_integrate'] = true;
 	}
 }
 
@@ -594,7 +593,6 @@ function ep_wc_setup() {
 		add_filter( 'ep_post_sync_args_post_prepare_meta', 'ep_wc_remove_legacy_meta', 10, 2 );
 		add_action( 'pre_get_posts', 'ep_wc_translate_args', 11, 1 );
 
-		add_filter( 'woocommerce_shop_order_search_fields', '__return_empty_array' );
 		add_action( 'parse_query', 'ep_wc_search_order', 11, 1 );
 	}
 }


### PR DESCRIPTION
WooCommerce as default cannot search by phone number, billing email and billing name.
This PR address that issue. Fixed #802 