### PR TITLE
Add new condition to determine whether results are empty or not.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -284,6 +284,10 @@ class EP_API {
 			return true;
 		}
 
+		if ( isset( $response['hits']['total'] ) && 0 === (int)$response['hits']['total'] ) {
+			return true;
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
This fixes an issue when Elasticsearch returns empty results for a given query.

Here is the original response of Elasticserch 5.2.2

```json
{"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}
```