### PR TITLE
If a WC draft is being previewed, do not use Elasticsearch.

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -206,6 +206,13 @@ function ep_wc_translate_args( $query ) {
 	}
 
 	/**
+	 * If this is just a preview, let's not use Elasticsearch.
+	 */
+	if ( isset( $_GET['preview'] ) ) {
+		return;
+	}
+
+	/**
 	 * Cant hook into WC API yet
 	 */
 	if ( defined( 'WC_API_REQUEST' ) && WC_API_REQUEST ) {

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -208,7 +208,7 @@ function ep_wc_translate_args( $query ) {
 	/**
 	 * If this is just a preview, let's not use Elasticsearch.
 	 */
-	if ( isset( $_GET['preview'] ) ) {
+	if ( $query->get( 'preview', false ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Mentioned in #811, ElasticPress returns the wrong product when being previewed. This PR simply checks to see if the `preview` query string is set and then prevents the search to be run on Elasticsearch.