### PR TITLE
fix error for old woocommerce version

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -572,7 +572,7 @@ function ep_wc_search_order( $wp ){
 	} else {
 		//we found the order. don't query ES
 		unset( $wp->query_vars['s'] );
-		$wp->query_vars['post__in'] = array( $order->get_id() );
+		$wp->query_vars['post__in'] = array( absint( $search_key_safe ) );
 	}
 }
 


### PR DESCRIPTION
WC_Order::get_id() only available in WooCoommerce >= 3.0.0
since we know that the order id is equal with $search_key_safe, let's just use it. so we don't have backward compatibility issue