### PR TITLE
Fixed wrong ES version in doc block.

### DIFF
--- a/includes/mappings/pre-5-0.php
+++ b/includes/mappings/pre-5-0.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Elasticsearch mapping for pre 2.0 ES installs
+ * Elasticsearch mapping for pre 5.0 ES installs
  *
  * @since  1.3
  * @package elasticpress


### PR DESCRIPTION
Note: Github added a new line at the end automatically since this should be the default.