### PR TITLE
add github issue template for easier tracking issue

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
 - Did you search for similar issues before submitting this one?
 
+- Is this an issue, question or feature request:
+
 - Describe the issue you encountered:
 
 - Tell me your WordPress version:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,18 +1,22 @@
-Did you search for similar issues before submitting this one?
+Have you search for similar issues before submitting this one?
 
 Is this a bug, question or feature request?
 
 Describe the issue you encountered:
 
-Tell me your Environment settings:
-- WordPress version:
-- ElasticPress version:
-- Elasticsearch version:
+Current WordPress version:
+
+Current ElasticPress version:
+
+Current Elasticsearch version:
 
 Where do you host your Elasticsearch server:
 
 Other plugins installed (WooCommerce, Simple Redirect Manager, etc..):
 
 Steps to reproduce:
+1.
+2.
+3.
 
 Screenshots, if needed:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,25 +1,19 @@
-- Did you search for similar issues before submitting this one?
+Did you search for similar issues before submitting this one (Yes/No)?
 
-- Is this a bug, question or feature request:
+Is this a bug, question or feature request:
 
-- Describe the issue you encountered:
+Describe the issue you encountered:
 
-- Tell me your WordPress version:
+Tell me your WordPress version:
 
-- Tell me your ElasticPress version:
+Tell me your ElasticPress version:
 
-- Tell me your Elasticsearch version:
+Tell me your Elasticsearch version:
 
-- Where do you host your Elasticsearch server:
+Where do you host your Elasticsearch server:
 
-- Other plugins installed (woocommerce, cache plugins, etc..):
-    1.
-    2.
-    3.
+Other plugins installed (woocommerce, cache plugins, etc..):
 
-- Steps to reproduce:
-    1.
-    2.
-    3.
+Steps to reproduce:
 
-- Screenshots if needed:
+Screenshots if needed:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+- Did you search for similar issues before submitting this one?
+
+- Describe the issue you encountered:
+
+- Tell me your WordPress version:
+
+- Tell me your ElasticPress version:
+
+- Tell me your Elasticsearch version:
+
+- Where do you host your Elasticsearch server:
+
+- Other plugins installed (woocommerce, cache plugins, etc..):
+    1.
+    2.
+    3.
+
+- Steps to reproduce:
+    1.
+    2.
+    3.
+
+- Screenshots if needed:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-Did you search for similar issues before submitting this one (Yes/No)?
+Did you search for similar issues before submitting this one?
 
-Is this a bug, question or feature request:
+Is this a bug, question or feature request?
 
 Describe the issue you encountered:
 
@@ -12,8 +12,8 @@ Tell me your Environment settings:
 
 Where do you host your Elasticsearch server:
 
-Other plugins installed (woocommerce, cache plugins, etc..):
+Other plugins installed (WooCommerce, Simple Redirect Manager, etc..):
 
 Steps to reproduce:
 
-Screenshots if applicable:
+Screenshots, if needed:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,6 @@ Tell me your Environment settings:
 - WordPress version:
 - ElasticPress version:
 - Elasticsearch version:
-- Woocommerce version (if applicable):
 
 Where do you host your Elasticsearch server:
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Have you search for similar issues before submitting this one?
+Have you searched for similar issues before submitting this one?
 
 Is this a bug, question or feature request?
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,8 +15,9 @@ Where do you host your Elasticsearch server:
 Other plugins installed (WooCommerce, Simple Redirect Manager, etc..):
 
 Steps to reproduce:
-1.
-2.
-3.
+
+1. 
+2. 
+3. 
 
 Screenshots, if needed:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 - Did you search for similar issues before submitting this one?
 
-- Is this an issue, question or feature request:
+- Is this a bug, question or feature request:
 
 - Describe the issue you encountered:
 


### PR DESCRIPTION
Let's standardize when the user open an issue.
I create a issue template, so we can easily replicate the issue.
Read more: https://help.github.com/articles/creating-an-issue-template-for-your-repository/