### PR TITLE
Remove post_meta key from ES post object

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -593,7 +593,7 @@ class EP_API {
 			'post_mime_type'    => $post->post_mime_type,
 			'permalink'         => get_permalink( $post_id ),
 			'terms'             => $this->prepare_terms( $post ),
-			'post_meta'         => $this->prepare_meta( $post ),
+			'meta'              => $this->prepare_meta_types( $this->prepare_meta( $post ) ), // post_meta removed in 2.4
 			'date_terms'        => $this->prepare_date_terms( $post_date ),
 			'comment_count'     => $comment_count,
 			'comment_status'    => $comment_status,
@@ -607,8 +607,6 @@ class EP_API {
 		 * This filter is named poorly but has to stay to keep backwards compat
 		 */
 		$post_args = apply_filters( 'ep_post_sync_args', $post_args, $post_id );
-
-		$post_args['meta'] = $this->prepare_meta_types( $post_args['post_meta'] );
 
 		$post_args = apply_filters( 'ep_post_sync_args_post_prepare_meta', $post_args, $post_id );
 


### PR DESCRIPTION
This was left around for backwards compat. It caused issues for people since it doubled the size of meta stored in ES.

@ivankristianto can you test?