### PR TITLE
Normalizer for sortable fields

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -466,6 +466,8 @@ class EP_API {
 
 		if ( ! $es_version || version_compare( $es_version, '5.0' ) < 0 ) {
 			$mapping_file = 'pre-5-0.php';
+		} elseif ( version_compare( $es_version, '5.2' ) >= 0 ) {
+			$mapping_file = '5-2.php';
 		} else {
 			$mapping_file = '5-0.php';
 		}

--- a/includes/mappings/5-0.php
+++ b/includes/mappings/5-0.php
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 return array(
 	'settings' => array(
-	    'index.mapping.total_fields.limit' => apply_filters( 'ep_total_field_limit', 5000 ),
-	    'index.max_result_window' => apply_filters( 'ep_max_result_window', 1000000 ),
+		'index.mapping.total_fields.limit' => apply_filters( 'ep_total_field_limit', 5000 ),
+		'index.max_result_window' => apply_filters( 'ep_max_result_window', 1000000 ),
 		'analysis' => array(
 			'analyzer' => array(
 				'default' => array(
@@ -53,6 +53,12 @@ return array(
 					'type' => 'edgeNGram',
 				),
 			),
+			'normalizer' => array(
+				'lowerasciinormalizer' => array(
+					'type'   => 'custom',
+					'filter' => array( 'lowercase', 'asciifolding' ),
+				),
+			),
 		),
 	),
 	'mappings' => array(
@@ -90,6 +96,7 @@ return array(
 										'sortable' => array(
 											'type' => 'keyword',
 											'ignore_above' => 10922,
+											'normalizer' => 'lowerasciinormalizer',
 										),
 										'raw' => array(
 											'type' => 'keyword',
@@ -141,6 +148,7 @@ return array(
 										),
 										'sortable' => array(
 											'type' => 'keyword',
+											'normalizer' => 'lowerasciinormalizer',
 										),
 									),
 								),
@@ -191,6 +199,7 @@ return array(
 								),
 								'sortable' => array(
 									'type' => 'keyword',
+									'normalizer' => 'lowerasciinormalizer',
 								),
 							),
 						),
@@ -235,6 +244,7 @@ return array(
 						'sortable' => array(
 							'type' => 'keyword',
 							'ignore_above' => 10922,
+							'normalizer' => 'lowerasciinormalizer',
 						),
 					),
 				),

--- a/includes/mappings/5-2.php
+++ b/includes/mappings/5-2.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Elasticsearch mapping for ES 5.0
+ * Elasticsearch mapping for ES 5.2
  *
- * @since  2.1.2
+ * @since  2.4
  * @package elasticpress
  */
 
@@ -53,6 +53,12 @@ return array(
 					'type' => 'edgeNGram',
 				),
 			),
+			'normalizer' => array(
+				'lowerasciinormalizer' => array(
+					'type'   => 'custom',
+					'filter' => array( 'lowercase', 'asciifolding' ),
+				),
+			),
 		),
 	),
 	'mappings' => array(
@@ -90,6 +96,7 @@ return array(
 										'sortable' => array(
 											'type' => 'keyword',
 											'ignore_above' => 10922,
+											'normalizer' => 'lowerasciinormalizer',
 										),
 										'raw' => array(
 											'type' => 'keyword',
@@ -141,6 +148,7 @@ return array(
 										),
 										'sortable' => array(
 											'type' => 'keyword',
+											'normalizer' => 'lowerasciinormalizer',
 										),
 									),
 								),
@@ -191,6 +199,7 @@ return array(
 								),
 								'sortable' => array(
 									'type' => 'keyword',
+									'normalizer' => 'lowerasciinormalizer',
 								),
 							),
 						),
@@ -235,6 +244,7 @@ return array(
 						'sortable' => array(
 							'type' => 'keyword',
 							'ignore_above' => 10922,
+							'normalizer' => 'lowerasciinormalizer',
 						),
 					),
 				),

--- a/includes/mappings/5-2.php
+++ b/includes/mappings/5-2.php
@@ -211,6 +211,7 @@ return array(
 								),
 								'sortable' => array(
 									'type' => 'keyword',
+									'normalizer' => 'lowerasciinormalizer',
 								),
 							),
 						),


### PR DESCRIPTION
By adding a normalizer in the 5.0 mappings for sortable fields, the case-sensitivity issue is resolved. This results in five out of the six failing unit tests to pass. 
(The testSearchPostDateOrderbyQuery test is only returning two results instead of three. I'm not sure if this is because the post_title is `ordertes` instead of `ordertest`.)

@tlovett1 and @ivankristianto can you take a look at this to verify if this resolves the issue or if this has the potential to cause different issues to occur.

Edit: The normalizer was introduced in 5.2, so I have added a 5.2 mapping for backwards compatibility.