### PR TITLE
TravisCI - support multiple ES versions (5.0 and 5.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ php:
   - "5.5"
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=latest WP_MULTISITE=1 ES_VERSION="5.0.2"
+  - WP_VERSION=latest WP_MULTISITE=1 ES_VERSION="5.2.2"
 
 before_install:
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.2.deb && sudo dpkg -i --force-confnew elasticsearch-5.2.2.deb && sudo service elasticsearch restart
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch restart
 
 before_script:
   - composer install --dev


### PR DESCRIPTION
This PR will create two additional builds in Travis to test out Elasticsearch 5.0 and 5.2.