### PR TITLE
Fix for missing attachments in AJAX indexing from Admin settings screen

### DIFF
--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -535,10 +535,21 @@ class EP_Dashboard {
 		
 		do_action( 'ep_pre_dashboard_index', $index_meta, $status );
 
+		$indexable_post_types = ep_get_indexable_post_types();
+		$indexable_post_status = ep_get_indexable_post_status();
+		/**
+		 * Ensures that the "inherit" post status is included if one of the
+		 * indexable post types is "attachment". Not doing this means the rest
+		 * of the plugin indexes attachments but the main sync process in the
+		 * Settings page in the Admin does not.
+		 */
+		if ( array_key_exists( 'attachment', $indexable_post_types ) && ! in_array( 'inherit', $indexable_post_status ) ) {
+			$indexable_post_status[] = 'inherit';
+		}
 		$args = apply_filters( 'ep_index_posts_args', array(
 			'posts_per_page'         => $posts_per_page,
-			'post_type'              => ep_get_indexable_post_types(),
-			'post_status'            => ep_get_indexable_post_status(),
+			'post_type'              => $indexable_post_types,
+			'post_status'            => $indexable_post_status,
 			'offset'                 => $index_meta['offset'],
 			'ignore_sticky_posts'    => true,
 			'orderby'                => 'ID',


### PR DESCRIPTION
This pull request contains a fix for when you use the Play / Pause / Resume / Refresh buttons on the ElasticPress admin screen which missed Attachments post type (which the rest of plugin seems to handle). 

When testing locally on my WordPress install, I noticed that Attachments were being excluded as the post status "inherit" was missing. The fix included is perhaps overly simple, but hopefully helpful in some form.

* Adds "inherit" post status to the indexable post status.
* But only if the post type Attachments indexable post type is included.
* Makes the AJAX indexing process work consistently with the rest of the plugin (by ensuring Attachments are indexed), which adds new "attachments" to Elasticsearch when added to the Media Library.
* Revisions are excluded (as it is stored as a separate post type).