### PR TITLE
WooCommerce: remove product variations

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -601,7 +601,7 @@ function ep_wc_delete_product_variation_orphans_before_index_cli( $args, $assoc_
 		$woo_tools = new WC_REST_System_Status_Tools_Controller();
 		$delete_orphaned_variations = $woo_tools->execute_tool( 'delete_orphaned_variations' );
 
-		WP_CLI::log( __( 'Try to delete product variation orphans before indexing.', 'cx-search' ) );
+		WP_CLI::log( __( 'Try to delete product variation orphans before indexing.', 'elasticpress' ) );
 		if ( is_array( $delete_orphaned_variations ) && isset( $delete_orphaned_variations['success'] ) && $delete_orphaned_variations['success'] ) {
 			WP_CLI::log( $delete_orphaned_variations['message'] );
 		}


### PR DESCRIPTION
_I have completely forgotten to suggest this code. It's something that I've had in a general search plugin I share from project to project:_

We've often experienced clients who change a product from a "Variable product" to a "Simple product" or similar without deleting the variations, first.
The issue is so normal that WooCommerce themselves have a tool in WC Core to remove "variable product orphans".

But why is this relevant for ElasticPress? Well, we would sometimes get clients telling us that the "search doesn't work anymore" and it's due to a fatal PHP error. The crash was typically from a product variant trying to fetch its permalink but could not find it's parent.
In the latest version of WooCommerce, this would end out in a "Maximum function nestling level..." error.