### PR TITLE
Add shipping class tax to supported taxonomies

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -234,6 +234,7 @@ function ep_wc_translate_args( $query ) {
 		'product_type',
 		'pa_sort-by',
 		'product_visibility',
+		'product_shipping_class',
 	);
 
 	/**


### PR DESCRIPTION
Add "Product shipping class" taxonomy to list of supported WooCommerce taxonomies.

The links to see all products with a specific shipping class at "WooCommerce > Settings > Shipping > Shipping classes" currently link to "broken lists" since we do not whitelist the shipping class taxonomy in the WooCommerce feature.

It is possible with `ep_woocommerce_supported_taxonomies` to add it but I feel like it should be there "natively".


_There might be some follow-up work to be done when the following issue gets answered/fixed in WooCommerce itself: https://github.com/woocommerce/woocommerce/issues/16435. If I manually provide the `&post_status=publish` in the URL, I still get some unexpected results. But at least it mimics the current status quo in WooCommerce, so I feel like it is ready to be merged in for 2.4_