### PR TITLE
Add filter on the admin notices to more granularly control them.

### DIFF
--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -273,6 +273,8 @@ class EP_Dashboard {
 			$notice = 'need-setup';
 		}
 
+		$notice = apply_filters( 'ep_admin_notice_type', $notice );
+
 		switch ( $notice ) {
 			case 'bad-host':
 				if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {


### PR DESCRIPTION
Example case:

Using Elasticsearch >5.3. Confirmed working. EP outputs a notice that cannot be suppressed. I want to suppress for all users.