### PR TITLE
Harden the "Is single" check in WooCommerce feature

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -201,7 +201,7 @@ function ep_wc_translate_args( $query ) {
 	/**
 	 * Do nothing for single product queries
 	 */
-	if ( ! empty( $product_name ) ) {
+	if ( ! empty( $product_name ) || $query->is_single() ) {
 		return;
 	}
 


### PR DESCRIPTION
It is currently possible to trigger the WooCommerce feature's arguments translation on single post/product queries which can cause trouble for some projects. One of the problems I've experienced is that the page should be triggered as a 404 page, since the requested product doesn't exist, but instead returns a HTTP 200 with results (I'm guess that the result varies depending on the individual theme - but I have experienced that I get a collection of products).

Example of Woo URL that can cause this issue: https://example.com/?post_type=product&p=12341234
The URL example satisfies the WooCommerce feature's single condition by not containing a `product` query_var.