### PR TITLE
Remove weighting by date in admin

### DIFF
--- a/features/protected-content/protected-content.php
+++ b/features/protected-content/protected-content.php
@@ -40,7 +40,7 @@ function ep_pc_post_types( $post_types ) {
 
 /**
  * Integrate EP into proper queries
- * 
+ *
  * @param  WP_Query $query
  * @since  2.1
  */
@@ -89,11 +89,18 @@ function ep_pc_integrate( $query ) {
 			$query->set( 'ep_integrate', true );
 		}
 	}
+
+	/**
+	 * Remove articles weighting by date in admin.
+	 *
+	 * @since 2.4
+	 */
+	remove_filter( 'ep_formatted_args', 'ep_weight_recent', 10 );
 }
 
 /**
  * Output feature box summary
- * 
+ *
  * @since 2.1
  */
 function ep_pc_feature_box_summary() {
@@ -104,7 +111,7 @@ function ep_pc_feature_box_summary() {
 
 /**
  * Output feature box long
- * 
+ *
  * @since 2.1
  */
 function ep_pc_feature_box_long() {


### PR DESCRIPTION
@tlovett1 this is enhancement for https://github.com/10up/ElasticPress/issues/883.

@ivankristianto suggested three enhancements however I am not sure if we need/should implement all of them.

Removing weighting results by recency should be definitely added for admin queries (that's why I put it in _Protected Content_ feature). I don't think we should always sort by __score_ as we will override admin pages sorting feature (when clicked on a sortable column). If there is no sorting set on edit.php page then __score_ sorting is used by default.

Last @ivankristianto suggestion about adding _min_score_ sounds quite promising however we would need to find some correct number and this may be very personal preference. I wouldn't add _min_score_ unless we have some idea about its value that could be used by default. 

Re core of https://github.com/10up/ElasticPress/issues/883 - I don't confirm that reported problems with sorting and filtering by email are reproducible.