### PR TITLE
#781 - Search by product variations SKU

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -580,6 +580,22 @@ function ep_wc_sync_variation_parent( $post_args, $post_id ) {
 }
 
 /**
+ * Handle product variation deletion.
+ *
+ * @since 2.4
+ *
+ * @param int $post_id Post ID.
+ */
+function ep_wc_delete_variation( $post_id ) {
+	if ( 'product_variation' !== get_post_type( $post_id ) ) {
+		return;
+	}
+
+	$post = get_post( $post_id );
+	ep_sync_post( $post->post_parent, false );
+}
+
+/**
  * Make search coupons don't go through ES
  *
  * @param  bool $enabled
@@ -684,6 +700,7 @@ function ep_wc_setup() {
 		add_action( 'pre_get_posts', 'ep_wc_translate_args', 11, 1 );
 		add_action( 'parse_query', 'ep_wc_search_order', 11, 1 );
 		add_filter( 'ep_search_fields', 'ep_wc_support_variations_skus_search', 9999, 2 );
+		add_action( 'delete_post', 'ep_wc_delete_variation', 10, 1 );
 	}
 }
 

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -559,6 +559,27 @@ function ep_wc_add_variations_skus( $post_args, $post_id ) {
 }
 
 /**
+ * Trigger parent syncing when product variation meta are updated. Parent has to be synced if product variation SKU changes.
+ *
+ * @since 2.4
+ *
+ * @param array $post_args Post arguments.
+ * @param int   $post_id   Post ID.
+ *
+ * @return array
+ */
+function ep_wc_sync_variation_parent( $post_args, $post_id ) {
+	if ( 'product_variation' !== get_post_type( $post_id ) ) {
+		return $post_args;
+	}
+
+	$post = get_post( $post_id );
+	ep_sync_post( $post->post_parent, false );
+
+	return $post_args;
+}
+
+/**
  * Make search coupons don't go through ES
  *
  * @param  bool $enabled
@@ -659,6 +680,7 @@ function ep_wc_setup() {
 		add_filter( 'ep_sync_taxonomies', 'ep_wc_whitelist_taxonomies', 10, 2 );
 		add_filter( 'ep_post_sync_args_post_prepare_meta', 'ep_wc_remove_legacy_meta', 10, 2 );
 		add_filter( 'ep_post_sync_args_post_prepare_meta', 'ep_wc_add_variations_skus', 11, 2 );
+		add_filter( 'ep_post_sync_args_post_prepare_meta', 'ep_wc_sync_variation_parent', 12, 2 );
 		add_action( 'pre_get_posts', 'ep_wc_translate_args', 11, 1 );
 		add_action( 'parse_query', 'ep_wc_search_order', 11, 1 );
 		add_filter( 'ep_search_fields', 'ep_wc_support_variations_skus_search', 9999, 2 );


### PR DESCRIPTION
@tlovett1 This is a proof of concept of handling searching by products variations SKU and returning parent product (https://github.com/10up/ElasticPress/issues/781).

This is quite experimental approach as it seems that the easiest way of achieving this is creating artificial meta with SKUs of _product_variation_ children posts. Values of this artificial meta is calculated during posts indexing and it supports scenarios when variation product is edited/added/removed.

If you don't like using _meta_ for this then how about creating extra post property for storing this kind of "dynamically calculated static data" separately from metas?