### PR TITLE
Add sanity checks before accessing object properties

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -274,25 +274,27 @@ function ep_wc_translate_args( $query ) {
 		if ( ! empty( $term ) ) {
 			$integrate = true;
 
-			$terms = array( $term );
+			$terms          = (array)$term;
+			$children_terms = array();
 
 			// to add child terms to the tax query
 			if ( is_taxonomy_hierarchical( $taxonomy ) ) {
-				$term_object = get_term_by( 'slug', $term, $taxonomy );
-				if ( $term_object && property_exists( $term_object, 'term_id' ) ) {
-					$children = get_term_children( $term_object->term_id, $taxonomy );
-					if ( $children ) {
-						foreach ( $children as $child ) {
-							$child_object = get_term( $child, $taxonomy );
-							if ( $child_object && ! is_wp_error( $child_object ) && property_exists( $child_object, 'slug' ) ) {
-								$terms[] = $child_object->slug;
+				foreach ( $terms as $term ) {
+					$term_object = get_term_by( 'slug', $term, $taxonomy );
+					if ( $term_object && property_exists( $term_object, 'term_id' ) ) {
+						$children = get_term_children( $term_object->term_id, $taxonomy );
+						if ( $children ) {
+							foreach ( $children as $child ) {
+								$child_object = get_term( $child, $taxonomy );
+								if ( $child_object && ! is_wp_error( $child_object ) && property_exists( $child_object, 'slug' ) ) {
+									$children_terms[] = $child_object->slug;
+								}
 							}
 						}
 					}
 				}
-
 			}
-
+			$terms = array_merge( $terms, $children_terms );
 			$tax_query[] = array(
 				'taxonomy' => $taxonomy,
 				'field'    => 'slug',

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -279,11 +279,15 @@ function ep_wc_translate_args( $query ) {
 			// to add child terms to the tax query
 			if ( is_taxonomy_hierarchical( $taxonomy ) ) {
 				$term_object = get_term_by( 'slug', $term, $taxonomy );
-				$children    = get_term_children( $term_object->term_id, $taxonomy );
-				if ( $children ) {
-					foreach ( $children as $child ) {
-						$child_object = get_term( $child, $taxonomy );
-						$terms[]      = $child_object->slug;
+				if ( $term_object && property_exists( $term_object, 'term_id' ) ) {
+					$children = get_term_children( $term_object->term_id, $taxonomy );
+					if ( $children ) {
+						foreach ( $children as $child ) {
+							$child_object = get_term( $child, $taxonomy );
+							if ( $child_object && ! is_wp_error( $child_object ) && property_exists( $child_object, 'slug' ) ) {
+								$terms[] = $child_object->slug;
+							}
+						}
 					}
 				}
 


### PR DESCRIPTION
@tlovett1,

This is a fix for #943 - I couldn't reproduce this on my local however it's possible that functions `get_term_by` and `get_term` may not return valid data as expected. Adding extra sanity checks before accessing their results won't do any harm.