### PR TITLE
Fix sync error when WooCommerce 2.x installed

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -620,8 +620,11 @@ function ep_wc_add_order_items_search( $post_args, $post_id ) {
 	$order     = wc_get_order( $post_id );
 	$item_meta = array();
 	foreach ( $order->get_items() as $delta => $product_item ) {
+		// WooCommerce 3.x uses WC_Order_Item_Product instance while 2.x an array
 		if ( is_object( $product_item ) && method_exists( $product_item, 'get_name' ) ) {
 			$item_meta['_items'][] = $product_item->get_name( 'edit' );
+		} elseif ( is_array( $product_item ) && isset( $product_item[ 'name' ] ) ) {
+			$item_meta['_items'][] = $product_item[ 'name' ];
 		}
 	}
 

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -620,7 +620,9 @@ function ep_wc_add_order_items_search( $post_args, $post_id ) {
 	$order     = wc_get_order( $post_id );
 	$item_meta = array();
 	foreach ( $order->get_items() as $delta => $product_item ) {
-		$item_meta['_items'][] = $product_item->get_name( 'edit' );
+		if ( is_object( $product_item ) && method_exists( $product_item, 'get_name' ) ) {
+			$item_meta['_items'][] = $product_item->get_name( 'edit' );
+		}
 	}
 
 	// Prepare order items.


### PR DESCRIPTION
@tlovett1 This fixes as issue introduced in https://github.com/10up/ElasticPress/pull/917. https://github.com/10up/ElasticPress/pull/917 doesn't work with WooCommerce 2.x that doesn't use  `WC_Order_Item_Product` as `$product_item` but raw array.