### PR TITLE
Disallow duplicated Elasticsearch requests on WooCommerce Orders page

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -163,6 +163,37 @@ function ep_wc_whitelist_taxonomies( $taxonomies, $post ) {
 }
 
 /**
+ * Disallow duplicated ES queries on Orders page.
+ *
+ * @since 2.4
+ *
+ * @param array    $value Original filter values.
+ * @param WP_Query $query WP_Query
+ *
+ * @return array
+ */
+function ep_wc_disallow_duplicated_query( $value, $query ) {
+	global $pagenow;
+
+	/**
+	 * Make sure we're on edit.php in admin dashboard.
+	 */
+	if ( 'edit.php' !== $pagenow || ! is_admin() || 'shop_order' !== $query->get( 'post_type' ) ) {
+		return $value;
+	}
+
+	/**
+	 * Check if EP API request was already done. If request was sent return its results.
+	 */
+	if ( isset( $query->elasticsearch_success ) && $query->elasticsearch_success ) {
+		return $query->posts;
+	}
+
+	return $value;
+
+}
+
+/**
  * Translate args to ElasticPress compat format. This is the meat of what the feature does
  *
  * @param  WP_Query $query
@@ -647,6 +678,7 @@ function ep_wc_setup() {
 		add_filter( 'ep_post_sync_args_post_prepare_meta', 'ep_wc_remove_legacy_meta', 10, 2 );
 		add_filter( 'ep_post_sync_args_post_prepare_meta', 'ep_wc_add_order_items_search', 20, 2 );
 		add_action( 'pre_get_posts', 'ep_wc_translate_args', 11, 1 );
+		add_action( 'ep_wp_query_search_cached_posts', 'ep_wc_disallow_duplicated_query', 10, 2 );
 		add_action( 'parse_query', 'ep_wc_search_order', 11, 1 );
 	}
 }

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -613,8 +613,12 @@ function ep_wc_search_order( $wp ){
 	}
 
 	$search_key_safe = str_replace( array( 'Order #', '#' ), '', wc_clean( $_GET['s'] ) );
+	$order_id        = absint( $search_key_safe );
 
-	$order = wc_get_order( absint( $search_key_safe ) );
+	/**
+	 * Order ID 0 is not valid value.
+	 */
+	$order = $order_id > 0 ? wc_get_order( $order_id ) : false;
 
 	//If the order doesn't exist, fallback to other fields
 	if ( ! $order ) {


### PR DESCRIPTION
@tlovett1 This is fix for #938 when duplicated Elasticsearch queries are made on WooCommerce (2.x only) orders page. Yoast is calling global `$wp_query->get_posts()` that tries to run ES query again. First thing that it is abundant as there is no point in making the same query again. The second issue is that first `$wp_query->get_posts()` call sets up `$_GLOBAL['post']` object to first post from ES response and this forces all calls to `get_post()` to return this post always (even if `get_post()` is called with numeric parameter).  Duplicated `$wp_query->get_posts()` makes `ep_wc_search_order` (action hook for `parse_query` action) to incorrectly execute following logic:

```php
$search_key_safe = str_replace( array( 'Order #', '#' ), '', wc_clean( $_GET['s'] ) );

	$order = wc_get_order( absint( $search_key_safe ) );

	//If the order doesn't exist, fallback to other fields
	if ( ! $order ) {
		unset( $wp->query_vars['post__in'] );
		$wp->query_vars['s'] = $search_key_safe;
	} else {
		//we found the order. don't query ES
		unset( $wp->query_vars['s'] );
		$wp->query_vars['post__in'] = array( absint( $search_key_safe ) );
	}
```
`absint( $search_key_safe )` returns `0` (for all non numeric search terms) and `wc_get_order()` calling `get_post()` (with an argument of value `0`) pulls always first post from previous ES request. Having `$order` non empty code goes to `else` statement and unsets search term from ES query and adds `post__in` query argument with a value of `0` that makes the second call returning empty results and overwrites main `$wp_query` results with empty set. My fix also makes sure that if `absint( $search_key_safe )` is `0` then `$order` is always false as there can't be a post with ID `0`.