### PR TITLE
Feature/recursionguard

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -612,7 +612,7 @@ class EP_API {
 			'post_date_gmt'     => $post_date_gmt,
 			'post_title'        => $this->prepare_text_content( get_the_title( $post_id ) ),
 			'post_excerpt'      => $this->prepare_text_content( $post->post_excerpt ),
-			'post_content'      => $this->prepare_text_content( self::apply_filters_recursion_guarded( 'the_content', $post->post_content ) ),
+			'post_content'      => $this->prepare_text_content( self::apply_filters_recursion_guarded( 2, 'the_content', $post->post_content ) ),
 			'post_status'       => $post->post_status,
 			'post_name'         => $post->post_name,
 			'post_modified'     => $post_modified,

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -532,9 +532,9 @@ class EP_API {
 	 */
 	private function apply_filters_recursion_guarded( $max_levels = 1, $tag, $value ) {
 
-		$rg = new EP_RecursionGuard( $max_levels, 'the_content' );
+		$rg = new EP_RecursionGuard( $max_levels, $tag );
 		try {
-			$value = apply_filters( 'the_content', $value );
+			$value = apply_filters( $tag, $value );
 		} catch ( EP_RecursionTooDeepException $e ) {
 			$value = $e->value();
 		} finally {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -522,6 +522,31 @@ class EP_API {
 	}
 
 	/**
+	 * Call the functions added to a filter hook but with protection against deep recursion.
+	 *
+	 * @see           apply_filters() This function works effectively the same, but with extra prevention against recursion.
+	 * @param  int    $max_levels The maximum level of recursion permitted.
+	 * @param  string $tag The name of the filter hook.
+	 * @param  mixed  $value The value on which the filters hooked to `$tag` are applied on.
+	 * @return mixed  The filtered value after all hooked functions are applied to it.
+	 */
+	private function apply_filters_recursion_guarded( $max_levels = 1, $tag, $value ) {
+
+		$rg = new EP_RecursionGuard( $max_levels, 'the_content' );
+		try {
+			$value = apply_filters( 'the_content', $value );
+		} catch ( EP_RecursionTooDeepException $e ) {
+			$value = $e->value();
+		} finally {
+			$rg->cleanup();
+			unset( $rg );
+		}
+
+		return $value;
+
+	}
+
+	/**
 	 * Prepare a post for syncing
 	 *
 	 * @param int $post_id
@@ -587,7 +612,7 @@ class EP_API {
 			'post_date_gmt'     => $post_date_gmt,
 			'post_title'        => $this->prepare_text_content( get_the_title( $post_id ) ),
 			'post_excerpt'      => $this->prepare_text_content( $post->post_excerpt ),
-			'post_content'      => $this->prepare_text_content( apply_filters( 'the_content', $post->post_content ) ),
+			'post_content'      => $this->prepare_text_content( self::apply_filters_recursion_guarded( 'the_content', $post->post_content ) ),
 			'post_status'       => $post->post_status,
 			'post_name'         => $post->post_name,
 			'post_modified'     => $post_modified,

--- a/classes/class-ep-recursionguard.php
+++ b/classes/class-ep-recursionguard.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Guard against recursive WordPress filter application.
+ *
+ * @since  2.4
+ * @package elasticpress
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Guard against recursive WordPress filter application.
+ */
+class EP_RecursionGuard {
+
+	/**
+	 * The maximum level of recursion permitted.
+	 *
+	 * @var int
+	 */
+	private $max_levels;
+
+	/**
+	 * The filter this guard protects.
+	 *
+	 * @var string
+	 */
+	private $tag;
+
+	/**
+	 * Constructor. Sets up a guarded version of the filter.
+	 *
+	 * @param integer $max_levels The maximum level of recursion permitted.
+	 * @param string  $tag The name of the filter hook.
+	 */
+	public function __construct( $max_levels = 1, $tag ) {
+		$this->max_levels = $max_levels;
+		$this->tag = $tag;
+		add_filter( $this->tag, $this->get_fn_ref(), 1 );
+	}
+
+	/**
+	 * Returns a reference to this instance's filter handler function.
+	 * Pass the result of this function to add_filter() so it can
+	 * later be removed by remove_filter().
+	 *
+	 * @return Callable
+	 */
+	public function get_fn_ref() {
+		return [ $this, 'handle' ];
+	}
+
+	/**
+	 * Filter handler with a guard against too much recursion.
+	 * If the filter is applied recursively too many times, it
+	 * throws a EP_RecursionTooDeepException with its $value set
+	 * to the current $value WordPress passed it for filtering.
+	 *
+	 * @param mixed $value The value on which the filters hooked to `$tag` are applied on.
+	 * @return mixed
+	 * @throws EP_RecursionTooDeepException Passes a value back when recursion goes too deep.
+	 */
+	public function handle( $value ) {
+		$this->max_levels -= 1;
+		if ( 0 === $this->max_levels ) {
+			throw new EP_RecursionTooDeepException( $value );
+		}
+		return $value;
+	}
+
+	/**
+	 * Clean up after use. Removes the filter handler.
+	 *
+	 * @return void
+	 */
+	public function cleanup() {
+		remove_filter( $this->tag, $this->get_fn_ref() );
+	}
+
+}

--- a/classes/class-ep-recursiontoodeepexception.php
+++ b/classes/class-ep-recursiontoodeepexception.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Exception thrown when deep recursion is detected.
+ *
+ * @since  2.4
+ * @package elasticpress
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Exception thrown when deep recursion is detected.
+ */
+class EP_RecursionTooDeepException extends RuntimeException {
+
+	/**
+	 * A value passed via the Exception.
+	 *
+	 * @var mixed
+	 */
+	private $value;
+
+	/**
+	 * Constructs the Exception.
+	 *
+	 * @param mixed     $value A value passed via the Exception.
+	 * @param string    $message The exception message.
+	 * @param integer   $code The exception code.
+	 * @param Exception $previous The previous exception used for the exception chaining.
+	 */
+	public function __construct( $value, $message = 'Recursion Too Deep', $code = 0, Exception $previous = null ) {
+		$this->value = $value;
+		parent::__construct( $message, $code, $previous );
+	}
+
+	/**
+	 * Retrieve the value passed via this Exception.
+	 *
+	 * @return mixed
+	 */
+	public function value() {
+		return $this->value;
+	}
+
+}

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -52,6 +52,8 @@ require_once( 'classes/class-ep-wp-date-query.php' );
 require_once( 'classes/class-ep-feature.php' );
 require_once( 'classes/class-ep-features.php' );
 require_once( 'classes/class-ep-dashboard.php' );
+require_once( 'classes/class-ep-recursionguard.php' );
+require_once( 'classes/class-ep-recursiontoodeepexception.php' );
 
 // Include core features
 require_once( 'features/search/search.php' );


### PR DESCRIPTION
ElasticPress calls the `the_content` filter when indexing content. But, theme & plugin out there code calls `the_content` independently when they render content in some contexts, spiraling into recursion until PHP exhausts its resources.

This was tested independently, but not in the context of a client that was seeing this issue. The engineers on that project haven't had time. Still, I wanted to get this PR out there.