### PR TITLE
Support inner tax query array and operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ ElasticPress integrates with `WP_Query` if the `ep_integrate` parameter is passe
     ) );
     ```
 
-    ```tax_query``` accepts an array of arrays where each inner array *only* supports ```taxonomy``` (string), ```field``` (string), and
-    ```terms``` (string|array) parameters. ```field``` must be set to `slug`, `name`, or `term_id`. The default value for `field` is `term_id`. ```terms``` must be a string or an array of term slug(s), name(s), or id(s).
+    ```tax_query``` accepts an array of arrays where each inner array *only* supports ```taxonomy``` (string), ```field``` (string), `operator` (string), and
+    ```terms``` (string|array) parameters. ```field``` must be set to `slug`, `name`, or `term_id`. The default value for `field` is `term_id`. ```terms``` must be a string or an array of term slug(s), name(s), or id(s). `operator` defaults to `in` and also supports `not in` and `and`.
+
+    The outer array supports the `relation` parameter. Acceptable values are `and` and `or`. The default is `and`.
 
 * The following shorthand parameters can be used for querying posts by specific dates:
 

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1100,15 +1100,44 @@ class EP_API {
 						'terms.' . $single_tax_query['taxonomy'] . '.' . $field => $terms,
 					);
 
-					/*
-					 * add support for "NOT IN" operator
-					 *
-					 * @since 2.1
-					 */
-					if ( ! empty( $single_tax_query['operator'] ) && 'NOT IN' === $single_tax_query['operator'] ) {
+					$operator = ( ! empty( $single_tax_query['operator'] ) ) ? strtolower( $single_tax_query['operator'] ) : 'in';
+
+					if ( 'not in' === $operator ) {
+						/**
+						 * add support for "NOT IN" operator
+						 *
+						 * @since 2.1
+						 */
+
 						// If "NOT IN" than it should filter as must_not
 						$tax_must_not_filter[]['terms'] = $terms_obj;
+					} elseif ( 'and' === $operator ) {
+						/**
+						 * add support for "and" operator
+						 *
+						 * @since 2.4
+						 */
+
+						$and_nest = array(
+							'bool' => array(
+								'must' => array()
+							),
+						);
+
+						foreach ( $terms as $term ) {
+							$and_nest['bool']['must'][] = array(
+								'terms' => array(
+									'terms.' . $single_tax_query['taxonomy'] . '.' . $field => (array) $term,
+								)
+							);
+						}
+
+						$tax_filter[] = $and_nest;
 					} else {
+						/**
+						 * Default to IN operator
+						 */
+
 						// Add the tax query filter
 						$tax_filter[]['terms'] = $terms_obj;
 					}

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -3364,6 +3364,37 @@ class EPTestSingleSite extends EP_Test_Base {
 	}
 
 	/**
+	 * Test Tax Query and operator
+	 *
+	 * @since 2.4
+	 * @group single-site
+	 */
+	public function testTaxQueryOperatorAnd() {
+		$this->assertEquals( 1, 1 );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 1', 'tags_input' => array( 'one', 'two' ) ) );
+		ep_create_and_sync_post( array( 'post_content' => 'findme test 2', 'tags_input' => array( 'one' ) ) );
+
+		ep_refresh_index();
+
+		$args = array(
+			's'         => 'findme',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'post_tag',
+					'terms'    => array( 'one', 'two' ),
+					'field'    => 'slug',
+					'operator' => 'and',
+				)
+			)
+		);
+
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+	}
+
+	/**
 	 * If a taxonomy is not public but is publicly queryable, it should return a result.
 	 *
 	 * @link https://github.com/10up/ElasticPress/issues/890


### PR DESCRIPTION
This adds support for `and` of the tax array `operator` parameter. This will now work:

```php
new WP_Query( [
  'tax_query' => [
    [
      'taxonomy' => 'test',
      'field' => 'slug',
      'terms' => [ 'test1', 'test2' ]
      'operator' => 'and',
    ]
  ]
] );
```