### PR TITLE
Stats reported by wp-cli are incorrect

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -780,8 +780,9 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 			if (isset( $body['indices'][$current_index] ) ) {
 				WP_CLI::log( '====== Stats for: ' . $current_index . " ======" );
-				WP_CLI::log( 'Documents:  ' . $body['indices'][$current_index]['total']['docs']['count'] );
-				WP_CLI::log( 'Index Size: ' . size_format($body['indices'][$current_index]['total']['store']['size_in_bytes'], 2 ) );
+				WP_CLI::log( 'Documents:  ' . $body['indices'][$current_index]['primaries']['docs']['count'] );
+				WP_CLI::log( 'Index Size: ' . size_format($body['indices'][$current_index]['primaries']['store']['size_in_bytes'], 2 ) );
+				WP_CLI::log( 'Index Size (including replicas): ' . size_format($body['indices'][$current_index]['total']['store']['size_in_bytes'], 2 ) );
 				WP_CLI::log( '====== End Stats ======' );
 			} else {
 				WP_CLI::warning( $current_index . ' is not currently indexed.' );


### PR DESCRIPTION
This PR adjusts the values that wp-cli reports to the end-user when `wp elasticpress stats` is issued. The original version was using the 'total' value which reports the number of documents multiplied by the number of replicas that exist for the given index inflating the number. By default, Elasticsearch uses 5 shards and 2 replicas meaning number of documents is twice the expected value. The PR uses the 'primaries' value which reports the actual number of documents in the index. 

It also adjusts the output so that both the size of the indexed documents is reported as well as the total size of the index including all of the replicas.