### PR TITLE
Adds header for Elasticsearch 6.0 compatibility

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -334,6 +334,7 @@ class EP_API {
 	 */
 	public function format_request_headers() {
 		$headers = array();
+		$headers['Content-Type'] = 'application/json';
 
 		// Check for ElasticPress API key and add to header if needed.
 		if ( defined( 'EP_API_KEY' ) && EP_API_KEY ) {


### PR DESCRIPTION
Read more here: https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests

This change should enable ElasticPress to work with Elasticsearch 6.0 and not thrown an "Error: Not Acceptable" while trying to index.