### PR TITLE
Hide EP_HOST value on settings page

### DIFF
--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -35,7 +35,9 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 				<tr>
 					<th scope="row"><label for="ep_host"><?php esc_html_e( 'Elasticsearch Host', 'elasticpress' ); ?></label></th>
 					<td>
-						<input <?php if ( defined( 'EP_HOST' ) && EP_HOST ) : ?>disabled<?php endif; ?> placeholder="http://" type="text" value="<?php echo esc_url( ep_get_host() ); ?>" name="ep_host" id="ep_host">
+						<?php if ( apply_filters( 'ep_admin_show_host', true ) ) : ?>
+							<input <?php if ( defined( 'EP_HOST' ) && EP_HOST ) : ?>disabled<?php endif; ?> placeholder="http://" type="text" value="<?php echo esc_url( ep_get_host() ); ?>" name="ep_host" id="ep_host">
+						<?php endif ?>
 						<?php if ( defined( 'EP_HOST' ) && EP_HOST ) : ?>
 							<span class="description"><?php esc_html_e( 'Your Elasticsearch host is set in wp-config.php', 'elasticpress' ); ?></span>
 						<?php else : ?>


### PR DESCRIPTION
Principle of least privilege: WordPress admin users don't need to know
this.

---

In our case, we host WP sites. The clients who use them shouldn't know the username, password, and hostname of the Elasticsearch instance.

Great plugin by the way. Thanks.