### PR TITLE
autosuggest.js: fixing unclickable auto-suggest element on Firefox

### DIFF
--- a/features/autosuggest/assets/js/src/autosuggest.js
+++ b/features/autosuggest/assets/js/src/autosuggest.js
@@ -190,7 +190,7 @@
 
 		// Listen to items to auto-fill search box and submit form
 		$( '.autosuggest-item' ).on( 'click', function( event ) {
-			selectItem( $localInput, event.srcElement );
+			selectItem( $localInput, (event.srcElement || event.target) );
 		} );
 
 		$localInput.off( 'keydown' );


### PR DESCRIPTION
The autosuggest.js script looks up a navigation URL within each suggestion HTML element. In Firefox 57 some JS event's srcElement is undefined, an the target URL cannot be found. Here is a quick fix for that. A .min.js file must be generated and comitted yet!