### PR TITLE
Fixed widgets setup issue

### DIFF
--- a/classes/class-ep-features.php
+++ b/classes/class-ep-features.php
@@ -26,6 +26,7 @@ class EP_Features {
 	 * @since 2.1
 	 */
 	public function setup() {
+		// hooks order matters, please, make sure feature activation goes before features setup
 		add_action( 'init', array( $this, 'handle_feature_activation' ), 0 );
 		add_action( 'init', array( $this, 'setup_features' ), 0 );
 	}

--- a/classes/class-ep-features.php
+++ b/classes/class-ep-features.php
@@ -26,8 +26,8 @@ class EP_Features {
 	 * @since 2.1
 	 */
 	public function setup() {
-		add_action( 'init', array( $this, 'handle_feature_activation' ), 1 );
-		add_action( 'init', array( $this, 'setup_features' ), 2 );
+		add_action( 'init', array( $this, 'handle_feature_activation' ), 0 );
+		add_action( 'init', array( $this, 'setup_features' ), 0 );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,7 @@ Version 2.4.1 is a bug fix release. Here are a listed of issues that have been r
 
 * Updated stats cli command to properly display index size.
 * Updated WooCommerce feature to properly detect signle product page.
+* Fixed widgets setup issue.
 
 = 2.4 =
 


### PR DESCRIPTION
Feature setup has to be executed as soon as possible to be able to hook actions and filters which are called on `init` action. 