### PR TITLE
Exclude password protected posts in search results. 

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -794,6 +794,11 @@ class EP_API {
 	public function prepare_meta( $post ) {
 		$meta = (array) get_post_meta( $post->ID );
 
+		// If post is password protected, save post meta saying so.
+		if ( ! empty( $post->post_password ) ) {
+			$meta['password_protected'] = true;
+		}
+
 		if ( empty( $meta ) ) {
 			return array();
 		}
@@ -1326,6 +1331,17 @@ class EP_API {
 		}
 
 		$meta_queries = array();
+
+		/**
+		 * Exclude password protected posts in search.
+		 */
+		if ( ! is_admin() ) {
+			$meta_queries[] = array(
+				'key'     => 'password_protected',
+				'value'   => true,
+				'compare' => '!=',
+			);
+		}
 
 		/**
 		 * Support meta_key


### PR DESCRIPTION
This PR adds post meta to posts that are password protected. It then alters the public query to ElasticSearch by checking against this meta value to prevent password protected posts from appear in search results.

This approach seemed to be the least intrusive as I did not want to alter mappings or prevent the post from being indexed completely, which would not allow it to show in the WP admin if protected content is activated.

This PR fixes #1083 