### PR TITLE
Add apply_filters to ep_host.

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -85,7 +85,7 @@ class EP_Config {
 			$host = get_option( 'ep_host', false );
 		}
 
-		return $host;
+		return apply_filters( 'ep_host', $host );
 	}
 
 	/**


### PR DESCRIPTION
We use the `ep_index_name` to hot index. If we ever need to reindex a large site we don't want to delete the index and start using mysql until the new index is ready. This works really well by using this filter and adding a suffix to our index name for the current index version. We don't update the version until the new index is ready and then the front end will start using it.

We want to be able to do a similar thing to ep_host. We are currently running v2.1 of EP and 2.3 ES on a large multisite. We want to be able to spin up a non web traffic box where we can override the `ep_host`. This will allow us to index all of our sites on the new elastic search instance behind the scenes and when the index is ready we can change our `EP_HOST` so it's now using the new instance.