### PR TITLE
added is_object() check for auto-activate-sync notice

### DIFF
--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -363,7 +363,7 @@ class EP_Dashboard {
 				$feature = ep_get_registered_feature( $auto_activate_sync );
 				?>
 				<div data-ep-notice="sync-disabled-auto-activate" class="notice notice-warning is-dismissible">
-                    <p><?php printf( esc_html__( 'Dashboard sync is disabled. The ElasticPress %s feature has been auto-activated! You will need to reindex using WP-CLI for it to work.', 'elasticpress' ), esc_html( $feature->title ) ); ?></p>
+                    <p><?php printf( esc_html__( 'Dashboard sync is disabled. The ElasticPress %s feature has been auto-activated! You will need to reindex using WP-CLI for it to work.', 'elasticpress' ), esc_html( is_object( $feature ) ? $feature->title : '' ) ); ?></p>
 				</div>
 				<?php
 				break;

--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -355,7 +355,7 @@ class EP_Dashboard {
 
 				?>
 				<div data-ep-notice="auto-activate-sync" class="notice notice-warning is-dismissible">
-					<p><?php printf( __( 'The ElasticPress %s feature has been auto-activated! You will need to <a href="%s">run a sync</a> for it to work.', 'elasticpress' ), esc_html( $feature->title ), esc_url( $url ) ); ?></p>
+					<p><?php printf( __( 'The ElasticPress %s feature has been auto-activated! You will need to <a href="%s">run a sync</a> for it to work.', 'elasticpress' ), esc_html( is_object( $feature ) ? $feature->title : '' ), esc_url( $url ) ); ?></p>
 				</div>
 				<?php
 				break;


### PR DESCRIPTION
While working on a client project, I ran into the following notice: 
`Notice: Trying to get property 'title' of non-object in /var/www/html/wp-content/plugins/elasticpress/classes/class-ep-dashboard.php on line 358`

![screen shot 2018-09-05 at 1 39 16 pm](https://user-images.githubusercontent.com/1757075/45114383-77aaa580-b112-11e8-80cb-18f50cb5c276.png)

Seemed to only happen when switching branches on the client's project though. Since `ep_get_registered_feature()` can return a **false** value, this PR adds an `is_object()` check before accessing the title property on the object.