### PR TITLE
Filter prefiltered post_types when protected content feature enabled.

### DIFF
--- a/features/protected-content/protected-content.php
+++ b/features/protected-content/protected-content.php
@@ -32,10 +32,12 @@ function ep_pc_setup() {
 function ep_pc_post_types( $post_types ) {
 	$pc_post_types = get_post_types( array( 'public' => false ) );
 
-	// We don't want to deal with nav menus
-	unset( $pc_post_types['nav_menu_item'] );
+	// We don't want to deal with nav menus if there are
+	if ( $pc_post_types['nav_menu_item'] ) {
+		unset( $pc_post_types['nav_menu_item'] );
+	}
 
-	return array_unique( array_merge( $post_types, $pc_post_types) );
+	return array_merge( $post_types, $pc_post_types);
 }
 
 /**

--- a/features/protected-content/protected-content.php
+++ b/features/protected-content/protected-content.php
@@ -30,12 +30,12 @@ function ep_pc_setup() {
  * @return  array
  */
 function ep_pc_post_types( $post_types ) {
-	$all_post_types = get_post_types();
+	$pc_post_types = get_post_types( array( 'public' => false ) );
 
 	// We don't want to deal with nav menus
-	unset( $all_post_types['nav_menu_item'] );
+	unset( $pc_post_types['nav_menu_item'] );
 
-	return array_unique( array_merge( $post_types, $all_post_types ) );
+	return array_unique( array_merge( $post_types, $pc_post_types) );
 }
 
 /**

--- a/features/protected-content/protected-content.php
+++ b/features/protected-content/protected-content.php
@@ -30,13 +30,15 @@ function ep_pc_setup() {
  * @return  array
  */
 function ep_pc_post_types( $post_types ) {
+	// Let's get non public post types first
 	$pc_post_types = get_post_types( array( 'public' => false ) );
 
-	// We don't want to deal with nav menus if there are
+	// We don't want to deal with nav menus
 	if ( $pc_post_types['nav_menu_item'] ) {
 		unset( $pc_post_types['nav_menu_item'] );
 	}
 
+	// Merge non public post types with any pre-filtered post_type
 	return array_merge( $post_types, $pc_post_types);
 }
 


### PR DESCRIPTION
Hi @allan23 , @brandwaffle ,

Could you please use this PR which addresses issue #1133 ?

This commit sets a parameter when calling `get_post_types()` to get all non public post_types, and merges them with the previously filtered post_types in `ep_indexable_post_types ` , in case post_types were filtered before` ep_pc_post_types()`. Probably `array_unique()` is not needed anymore, but happy to read your feedback.

Thanks!
