### PR TITLE
Update EP_ES_VERSION_MAX to 6.4.1

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -33,7 +33,7 @@ define( 'EP_VERSION', '2.6.1' );
  *
  * @since  2.2
  */
-define( 'EP_ES_VERSION_MAX', '6.2' );
+define( 'EP_ES_VERSION_MAX', '6.4.1' );
 define( 'EP_ES_VERSION_MIN', '1.7' );
 
 require_once( 'classes/class-ep-config.php' );


### PR DESCRIPTION
Hi @allan23 ,

After QA of elasticsearch 6.3.2 and 6.4.1 through the user stories document I did not find any issues whatsoever with the current develop branch of ElasticPress.

Could you please use this PR to update the `EP_ES_VERSION_MAX` to 6.4.1 ? 

Thank you, 