### PR TITLE
Only query for post IDs when indexing posts

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -509,6 +509,7 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 				'ignore_sticky_posts'    => true,
 				'orderby'                => 'ID',
 				'order'                  => 'DESC',
+				'fields'                 => 'ids',
 			) );
 
 			if ( $post_in ) {
@@ -519,22 +520,21 @@ class ElasticPress_CLI_Command extends WP_CLI_Command {
 
 			if ( $query->have_posts() ) {
 
-				while ( $query->have_posts() ) {
-					$query->the_post();
+				foreach ( $query->posts as $post_id ) {
 
 					if ( $no_bulk ) {
 						// index the posts one-by-one. not sure why someone may want to do this.
-						$result = ep_sync_post( get_the_ID() );
+						$result = ep_sync_post( $post_id );
 
 						$this->reset_transient();
 
-						do_action( 'ep_cli_post_index', get_the_ID() );
+						do_action( 'ep_cli_post_index', $post_id );
 					} else {
-						$result = $this->queue_post( get_the_ID(), $query->post_count, $show_bulk_errors );
+						$result = $this->queue_post( $post_id, $query->post_count, $show_bulk_errors );
 					}
 
 					if ( ! $result ) {
-						$errors[] = get_the_ID();
+						$errors[] = $post_id;
 					} elseif ( true === $result || isset( $result->_index ) ) {
 						$synced ++;
 					}

--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -545,7 +545,7 @@ class EP_Dashboard {
 			'ignore_sticky_posts'    => true,
 			'orderby'                => 'ID',
 			'order'                  => 'DESC',
-			'fields' => 'all',
+			'fields'                 => 'ids',
 		) );
 
 		$query = new WP_Query( $args );
@@ -556,24 +556,23 @@ class EP_Dashboard {
 			if ( $query->have_posts() ) {
 				$queued_posts = array();
 
-				while ( $query->have_posts() ) {
-					$query->the_post();
+				foreach ( $query->posts as $post_id ) {
 					$killed_post_count = 0;
 
-					$post_args = ep_prepare_post( get_the_ID() );
+					$post_args = ep_prepare_post( $post_id );
 
-					if ( apply_filters( 'ep_post_sync_kill', false, $post_args, get_the_ID() ) ) {
+					if ( apply_filters( 'ep_post_sync_kill', false, $post_args, $post_id ) ) {
 
 						$killed_post_count++;
 
 					} else { // Post wasn't killed so process it.
 
-						$queued_posts[ get_the_ID() ][] = '{ "index": { "_id": "' . absint( get_the_ID() ) . '" } }';
+						$queued_posts[ $post_id ][] = '{ "index": { "_id": "' . absint( $post_id ) . '" } }';
 
 						if ( function_exists( 'wp_json_encode' ) ) {
-							$queued_posts[ get_the_ID() ][] = addcslashes( wp_json_encode( $post_args ), "\n" );
+							$queued_posts[ $post_id ][] = addcslashes( wp_json_encode( $post_args ), "\n" );
 						} else {
-							$queued_posts[ get_the_ID() ][] = addcslashes( json_encode( $post_args ), "\n" );
+							$queued_posts[ $post_id ][] = addcslashes( json_encode( $post_args ), "\n" );
 						}
 					}
 				}


### PR DESCRIPTION
We currently query for all fields, but I don't think this is necessary since we call `get_post( $post_id )` within the `queue_post()` function.

Changing the query to only query for IDs significantly improves the indexing time.

Testing locally with 5,833 documents the index time was an average of 90 seconds. Applying this patch lowered it to around 24 seconds.

Working on a bigger ElasticSearch instance with 819, 362 documents we can now index in about 2.5 hours, previously it took almost triple that. This was using AWS `t2.small.elasticsearch` instance.