### PR TITLE
Add compatibility for new MLT structure

### DIFF
--- a/features/related-posts/related-posts.php
+++ b/features/related-posts/related-posts.php
@@ -7,18 +7,34 @@
  */
 
 function ep_related_posts_formatted_args( $formatted_args, $args ) {
-	if ( ! empty( $args[ 'more_like' ] ) ) {
-		$formatted_args[ 'query' ] = array(
-			'more_like_this' => array(
-				'ids'			  => is_array( $args[ 'more_like' ] ) ? $args[ 'more_like' ] : array( $args[ 'more_like' ] ),
-				'fields'		  => apply_filters( 'ep_related_posts_fields', array( 'post_title', 'post_content', 'terms.post_tag.name' ) ),
-				'min_term_freq'	  => 1,
-				'max_query_terms' => 12,
-				'min_doc_freq'	  => 1,
-			)
-		);
+	// Since 6.0 ElasticSearch uses a new mlt search structure
+	$new_mlt = 6.0 < ep_get_elasticsearch_version();
+
+	switch ( ! empty ( $args[ 'more_like' ] ) ) {
+		case $new_mlt && is_array( $args[ 'more_like' ] ) :
+			foreach( $args['more_like'] as $id ) {
+				$ids[] = array( '_id' => $id ) ;
+			}
+			break;
+			//let's account for multiple id's too
+		case  $new_mlt && ! is_array( $args[ 'more_like' ] ) :
+			$ids = array( '_id' => $args[ 'more_like' ]);
+			break;
+		case  ! $new_mlt :
+			$ids = is_array( $args[ 'more_like' ] ) ? $args[ 'more_like' ] : array( $args[ 'more_like' ] );
+			break;
 	}
-	
+
+	$formatted_args[ 'query' ] = array(
+		'more_like_this' => array(
+			'like'            => $ids,
+			'fields'		  => apply_filters( 'ep_related_posts_fields', array( 'post_title', 'post_content', 'terms.post_tag.name' ) ),
+			'min_term_freq'	  => 1,
+			'max_query_terms' => 12,
+			'min_doc_freq'	  => 1,
+		)
+	);
+
 	return $formatted_args;
 }
 

--- a/features/related-posts/related-posts.php
+++ b/features/related-posts/related-posts.php
@@ -6,6 +6,13 @@
  * @package elasticpress
  */
 
+/**
+ * Format the args for related posts for ElasticSearch
+ *
+ * @param $formatted_args
+ * @param $args
+ * @return mixed
+ */
 function ep_related_posts_formatted_args( $formatted_args, $args ) {
 	if ( ! empty ( $args[ 'more_like' ] ) ) {
 		//lets compare ES version to see if new MLT structure applies

--- a/features/related-posts/related-posts.php
+++ b/features/related-posts/related-posts.php
@@ -28,13 +28,19 @@ function ep_related_posts_formatted_args( $formatted_args, $args ) {
 			$ids = is_array( $args[ 'more_like' ] ) ? $args[ 'more_like' ] : array( $args[ 'more_like' ] );
 		}
 
+		$mlt_key = ( $new_mlt ) ? 'like' : 'ids';
+
 		$formatted_args[ 'query' ] = array(
 			'more_like_this' => array(
-				'ids'			  => $ids,
-				'fields'		  => apply_filters( 'ep_related_posts_fields', array( 'post_title', 'post_content', 'terms.post_tag.name' ) ),
-				'min_term_freq'	  => 1,
+				$mlt_key          => $ids,
+				'fields'          => apply_filters( 'ep_related_posts_fields', array(
+					'post_title',
+					'post_content',
+					'terms.post_tag.name'
+				) ),
+				'min_term_freq'   => 1,
 				'max_query_terms' => 12,
-				'min_doc_freq'	  => 1,
+				'min_doc_freq'    => 1,
 			)
 		);
 	}

--- a/tests/features/test-related-posts.php
+++ b/tests/features/test-related-posts.php
@@ -67,10 +67,12 @@ class EPTestRelatedPostsFeature extends EP_Test_Base {
 
 		$related = ep_find_related( $post_id );
 		$this->assertEquals( 1, sizeof( $related ) );
+		$this->assertTrue( isset( $related[0] ) && isset( $related[0]->elasticsearch ) );
 
 		add_filter( 'ep_find_related_args', array( $this, 'find_related_posts_filter' ), 10, 1 );
 		$related = ep_find_related( $post_id );
 		$this->assertEquals( 2, sizeof( $related ) );
+		$this->assertTrue( isset( $related[0] ) && isset( $related[0]->elasticsearch ) );
 		remove_filter( 'ep_find_related_args', array( $this, 'find_related_posts_filter' ), 10, 1 );
 	}
 	


### PR DESCRIPTION
Hi @brandwaffle , @allan23 ,

When you have some time, could you please check this PR which fixes the related post feature? This  seems to be broken since ElasticSearch 6.0 and above.

Currently, a 400 error happens and you get this response when using the ElasticPress debug bar :

```
{
    "error": {
        "root_cause": [
            {
                "type": "parsing_exception",
                "reason": "[mlt] query does not support [ids]",
                "line": 1,
                "col": 93
            }
        ],
        "type": "parsing_exception",
        "reason": "[mlt] query does not support [ids]",
        "line": 1,
        "col": 93
    },
    "status": 400
}

```
The feature is broken due to a change in the way MLT (more like this) is structured in ElasticSearch: 
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html and in my testing, this happens since version 6.0 . I tested 6.4, 6.3, 6.0 and 5.6 which seems to be the latest one before the release of 6.0 : https://www.elastic.co/downloads/past-releases . The problem seems to start since 6.0

The PR keeps the compatibility for users that use versions below 6.0, and also adds compatibility for more complicated queries (see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html )

Thanks