### PR TITLE
Let WC feature order by rand.

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -408,12 +408,6 @@ function ep_wc_translate_args( $query ) {
 		$query->query['suppress_filters'] = false;
 		$query->set( 'suppress_filters', false );
 
-		$orderby = $query->get( 'orderby' );
-
-		if ( ! empty( $orderby ) && 'rand' === $orderby ) {
-			$query->set( 'orderby', false ); // Just order by relevance.
-		}
-
 		$s = $query->get( 's' );
 
 		$query->query_vars['ep_integrate'] = true;


### PR DESCRIPTION
Hi @brandwaffle, @allan23 

Could you use  this PR which addresses #906 ?

As noted by the OP, feature woocomerce sets the order to relevance overriding https://github.com/10up/ElasticPress/blob/develop/classes/class-ep-api.php#L1523 

By removing these lines, product queries can be sorted now by rand.

Thanks

