### PR TITLE
Do not apply absint to comment_status

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -583,14 +583,14 @@ class EP_API {
 			);
 		}
 
-		$post_date = $post->post_date;
-		$post_date_gmt = $post->post_date_gmt;
-		$post_modified = $post->post_modified;
+		$post_date         = $post->post_date;
+		$post_date_gmt     = $post->post_date_gmt;
+		$post_modified     = $post->post_modified;
 		$post_modified_gmt = $post->post_modified_gmt;
-		$comment_count = absint( $post->comment_count );
-		$comment_status = absint( $post->comment_status );
-		$ping_status = absint( $post->ping_status );
-		$menu_order = absint( $post->menu_order );
+		$comment_count     = absint( $post->comment_count );
+		$comment_status    = $post->comment_status;
+		$ping_status       = absint( $post->ping_status );
+		$menu_order        = absint( $post->menu_order );
 
 		if ( apply_filters( 'ep_ignore_invalid_dates', true, $post_id, $post ) ) {
 			if ( ! strtotime( $post_date ) || $post_date === "0000-00-00 00:00:00" ) {

--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -589,7 +589,7 @@ class EP_API {
 		$post_modified_gmt = $post->post_modified_gmt;
 		$comment_count     = absint( $post->comment_count );
 		$comment_status    = $post->comment_status;
-		$ping_status       = absint( $post->ping_status );
+		$ping_status       = $post->ping_status;
 		$menu_order        = absint( $post->menu_order );
 
 		if ( apply_filters( 'ep_ignore_invalid_dates', true, $post_id, $post ) ) {


### PR DESCRIPTION
Hi @allan23 ,

Could you please use this PR which solves #1153 ?

Previously the $comment_status was set to 0 while applying `absint()`. Now, it gets either an open / closed status which is what it should. 

Thanks! 