### PR TITLE
Use wildcard query with compare like.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1928,10 +1928,8 @@ class EP_API {
 						case 'like':
 							if ( isset( $single_meta_query['value'] ) ) {
 								$terms_obj = array(
-									'query' => array(
-										'match' => array(
-											$meta_key_path => $single_meta_query['value'],
-										)
+									'wildcard' => array(
+										$meta_key_path => $single_meta_query['value'] . '*',
 									),
 								);
 							}


### PR DESCRIPTION
Hi @allan23 , @tott ,

Could you please review this PR which addresses #1127 ?

The compare like query was previously defined as: 

						case 'like':
							if ( isset( $single_meta_query['value'] ) ) {
								$terms_obj = array(
									'query' => array(
										'match' => array(
											$meta_key_path => $single_meta_query['value'],
										)
									),
								);
							}
							break;

However we can't make a query within a filter query context. We can however use a type of a query inside post_filter to filter out results. 

Since compare-> like is defined like this: 

https://github.com/WordPress/WordPress/blob/df0958697a5d897a15ea78d37a001e2f3752875f/wp-includes/class-wp-meta-query.php#L595

I think we could mimic the same behavior by using a wildcard query : 

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html

I've tested this succesfully returning posts that match the provided meta value.

Steps to reproduce testing:

1.- Create 3 posts
2.- Add new meta to the 3 of them like this: 

`add_post_meta( $post_id, 'test', 'single_pr');
add_post_meta( $post_id, 'test', 'single_tr'); add_post_meta( $post_id, 'test', 'singlewow');`

3.-  Make a custom query to search for posts that match 'single' in some part: 

		$test_query = new WP_Query( array('ep_integrate'   => true,
				'post_type'      => 'post',
				'post_status'    => 'publish',
				'posts_per_page' => - 1,
				'fields' => 'ids',
				'meta_query'     => array(
						'relation' => 'AND',
						array(
								array(
										'relation' => 'AND',
										array(
												'key'     => 'test',
												'value'   => single,
												'compare' => 'LIKE'
										),
										array(
												'key' => 'test',
												'value' => 'redundant'
										)

								)
						),
						array(
								$meta_query
						),
				),
                'category__not_in' => array(109078)
		) );

This returns the following response from elasticsearch:

```
{
    "took": 30,
    "timed_out": false,
    "_shards": {
        "total": 5,
        "successful": 5,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": 3,
        "max_score": null,
        "hits": [
            {
                "_index": "estest1devlocalhost-1",
                "_type": "post",
                "_id": "10",
                "_score": null,
                "_source": {
                    "post_id": 10
                },
                "sort": [
                    1542305933000
                ]
            },
            {
                "_index": "estest1devlocalhost-1",
                "_type": "post",
                "_id": "9",
                "_score": null,
                "_source": {
                    "post_id": 9
                },
                "sort": [
                    1542305927000
                ]
            },
            {
                "_index": "estest1devlocalhost-1",
                "_type": "post",
                "_id": "8",
                "_score": null,
                "_source": {
                    "post_id": 8
                },
                "sort": [
                    1542305917000
                ]
            }
        ]
    }
}

```
Thanks!