### PR TITLE
Correct a  comment in autosuggest.js.

### DIFF
--- a/features/autosuggest/assets/js/src/autosuggest.js
+++ b/features/autosuggest/assets/js/src/autosuggest.js
@@ -39,8 +39,8 @@
 
 	/**
 	 * Respond to an item selection based on the predefined behavior.
-	 * If epas.action is set to "navigate", redirects the browser to the URL of the selected item
-	 * If epas.action is set to any other value (default "search"), fill in the value and perform the search
+	 * If epas.action is set to "navigate" (the default), redirects the browser to the URL of the selected item
+	 * If epas.action is set to any other value (such as "search"), fill in the value and perform the search
 	 *
 	 * @param $localInput
 	 * @param element


### PR DESCRIPTION
The comment for the `selectItem` function says:
https://github.com/10up/ElasticPress/blob/093b9ebbf8518420391706f47d7461a3e5cac136/features/autosuggest/assets/js/src/autosuggest.js#L40-L47

In reality the default action is "navigate", not "search":
https://github.com/10up/ElasticPress/blob/093b9ebbf8518420391706f47d7461a3e5cac136/features/autosuggest/autosuggest.php#L196-L206

The default used to be "search", but it was changed in this commit:
https://github.com/10up/ElasticPress/commit/5460d0ba758c70301a173e03837e0318c5631797#diff-e46ebd572b0b2cbd4a9efebfd00ea146