### PR TITLE
Set orderby and order by price from query_vars

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -492,7 +492,7 @@ function ep_wc_translate_args( $query ) {
 		/**
 		 * Set orderby and order for price when GET param not set
 		 */
-		if( 'price' === $query->query_vars['orderby'] && $query->is_main_query() ) {
+		if( isset( $query->query_vars['orderby'], $query->query_vars['order'] ) && 'price' === $query->query_vars['orderby'] && $query->is_main_query() ) {
 			$query->set( 'order', $query->query_vars['order'] );
 			$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( '_price' ) );
 		}

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -490,6 +490,14 @@ function ep_wc_translate_args( $query ) {
 		}
 
 		/**
+		 * Set orderby and order for price when GET param not set
+		 */
+		if( 'price' === $query->query_vars['orderby'] && $query->is_main_query() ) {
+			$query->set( 'order', $query->query_vars['order'] );
+			$query->set( 'orderby', ep_wc_get_orderby_meta_mapping( '_price' ) );
+		}
+
+		/**
 		 * Set orderby from GET param
 		 * Also make sure the orderby param affects only the main query
 		 */


### PR DESCRIPTION
Hi @allan23 ,

Could you please check this PR which addresses #1134 ?

This sets the order and orderby from `$query->query_vars['order']` and `$query->query_vars['orderby']` in case the `GET` param was not set. This comes handy on certain scenarios, for example when setting the sort option from the customizer.

Steps to reproduce issue:

1.- Have some products with different categories.
2.- From the customizer (latest version of woocommerce) go to woocommerce->product_catalog and set `shop page display` to `show categories` and `default sort pricing` to by `price asc` or `desc`. 
3.- Hit publish and visit a category.
4.- See a 400 error in the debug bar.

Thanks