### PR TITLE
ep_indexable_blogs filter 

### DIFF
--- a/classes/class-ep-sync-manager.php
+++ b/classes/class-ep-sync-manager.php
@@ -303,7 +303,7 @@ class EP_Sync_Manager {
 			$sites = wp_list_pluck( wp_get_sites( $args ), 'blog_id' );
 		}
 
-		return in_array( $blog_id, $sites, true );
+		return in_array( $blog_id, apply_filters( 'ep_indexable_blogs', $sites ), true );
 	}
 }
 

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: ElasticPress
  * Description: A fast and flexible search and query engine for WordPress.
- * Version:     2.7.0
+ * Version:     2.7.1
  * Author:      Taylor Lovett, Matt Gross, Aaron Holbrook, 10up
  * Author URI:  http://10up.com
  * License:     GPLv2 or later
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'EP_URL', plugin_dir_url( __FILE__ ) );
 define( 'EP_PATH', plugin_dir_path( __FILE__ ) );
-define( 'EP_VERSION', '2.7.0' );
+define( 'EP_VERSION', '2.7.1' );
 
 /**
  * We compare the current ES version to this compatibility version number. Compatibility is true when:

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,11 @@ Please refer to [Github](https://github.com/10up/ElasticPress) for detailed usag
 
 == Changelog ==
 
+= 2.7.1 =
+
+* Introduces 'ep_indexable_blogs' filter allowing developers to specify blogs that should be indexed.
+
+
 = 2.7.0 (Requires re-index) =
 
 ElasticPress 2.7 provides some new enhancements and bug fixes.


### PR DESCRIPTION
Added in case developers want to override the results of the get_sites() call for public sites.