### PR TITLE
Hide prefix trailing dash on settings page

### DIFF
--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -56,7 +56,7 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 					</th>
 					<td>
 						<?php if ( apply_filters( 'ep_admin_show_index_prefix', true ) ) : ?>
-							<input <?php if ( EP_Config::$option_prefix ) : ?>disabled<?php endif; ?> type="text" value="<?php echo esc_attr( ep_get_index_prefix() ); ?>" name="ep_prefix" id="ep_prefix">
+							<input <?php if ( EP_Config::$option_prefix ) : ?>disabled<?php endif; ?> type="text" value="<?php echo esc_attr( substr( ep_get_index_prefix(), 0, -1 ) ); ?>" name="ep_prefix" id="ep_prefix">
 						<?php endif ?>
 						<?php if ( EP_Config::$option_prefix ) : ?>
 							<span class="description"><?php esc_html_e( 'Your Subscription ID is set in wp-config.php', 'elasticpress' ); ?></span>

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -56,7 +56,7 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 					</th>
 					<td>
 						<?php if ( apply_filters( 'ep_admin_show_index_prefix', true ) ) : ?>
-							<input <?php if ( EP_Config::$option_prefix ) : ?>disabled<?php endif; ?> type="text" value="<?php echo esc_attr( substr( ep_get_index_prefix(), 0, -1 ) ); ?>" name="ep_prefix" id="ep_prefix">
+							<input <?php if ( EP_Config::$option_prefix ) : ?>disabled<?php endif; ?> type="text" value="<?php echo esc_attr( rtrim( ep_get_index_prefix(), '-' ) ); ?>" name="ep_prefix" id="ep_prefix">
 						<?php endif ?>
 						<?php if ( EP_Config::$option_prefix ) : ?>
 							<span class="description"><?php esc_html_e( 'Your Subscription ID is set in wp-config.php', 'elasticpress' ); ?></span>


### PR DESCRIPTION
Hi @tott and @allan23 ,

Could you please review this PR which fixes #1202  ?

This PR hides the trailing dash for the EP_PREFIX ( Subscription ID ) on the settings page.

Thank you. 