### PR TITLE
Allow user to set bulk settings

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -120,6 +120,21 @@ class EP_Config {
 	}
 
 	/**
+	 * Retrieve bulk index settings
+	 *
+	 * @return Int The number of posts per cycle to index. Default 350.
+	 */
+	public function get_bulk_settings() {
+		if( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$bulk_settings =  get_site_option( 'ep_bulk_setting', 350 );
+		} else {
+			$bulk_settings =  get_option( 'ep_bulk_setting', 350 );
+		}
+
+		return $bulk_settings;
+	}
+
+	/**
 	 * Retrieve the EPIO subscription credentials.
 	 *
 	 * @since 2.5
@@ -286,6 +301,10 @@ function ep_get_host() {
 
 function ep_get_index_prefix() {
 	return EP_Config::factory()->get_index_prefix();
+}
+
+function ep_get_bulk_settings() {
+    return EP_Config::factory()->get_bulk_settings();
 }
 
 function ep_get_epio_credentials() {

--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -634,7 +634,7 @@ class EP_Dashboard {
 			}
 		}
 
-		$posts_per_page = apply_filters( 'ep_index_posts_per_page', 350 );
+		$posts_per_page =  apply_filters( 'ep_index_posts_per_page', ep_get_bulk_settings() );
 
 		do_action( 'ep_pre_dashboard_index', $index_meta, $status );
 
@@ -895,11 +895,15 @@ class EP_Dashboard {
 			];
 			update_site_option( 'ep_credentials', $credentials );
 
+			if( isset( $_POST['ep_bulk_setting'] ) ) {
+				update_site_option( 'ep_bulk_setting', intval( $_POST['ep_bulk_setting'] ) );
+			}
 
 		} else {
 			register_setting( 'elasticpress', 'ep_host', 'esc_url_raw' );
 			register_setting( 'elasticpress', 'ep_prefix', 'sanitize_text_field' );
 			register_setting( 'elasticpress', 'ep_credentials', 'ep_sanitize_credentials' );
+			register_setting( 'elasticpress', 'ep_bulk_setting', array( 'type' => 'integer', 'sanitize_callback' => 'absint' ) );
 		}
 	}
 

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -18,6 +18,8 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 } else {
 	$index_meta = get_option( 'ep_index_meta', false );
 }
+
+$ep_host = ep_get_host();
 ?>
 
 <?php require_once( dirname( __FILE__ ) . '/header.php' ); ?>
@@ -34,10 +36,11 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			<tbody>
 			<tr>
 				<th scope="row">
-					<label for="ep_host"><?php esc_html_e( 'Elasticsearch Host', 'elasticpress' ); ?></label></th>
+					<label for="ep_host"><?php esc_html_e( 'Elasticsearch Host', 'elasticpress' ); ?></label>
+				</th>
 				<td>
 					<?php if ( apply_filters( 'ep_admin_show_host', true ) ) : ?>
-						<input <?php if ( defined( 'EP_HOST' ) && EP_HOST ) : ?>disabled<?php endif; ?> placeholder="http://" type="text" value="<?php echo esc_url( ep_get_host() ); ?>" name="ep_host" id="ep_host">
+						<input <?php if ( defined( 'EP_HOST' ) && EP_HOST ) : ?>disabled<?php endif; ?> placeholder="http://" type="text" value="<?php echo esc_url( $ep_host ); ?>" name="ep_host" id="ep_host">
 					<?php endif ?>
 					<?php if ( defined( 'EP_HOST' ) && EP_HOST ) : ?>
 						<span class="description"><?php esc_html_e( 'Your Elasticsearch host is set in wp-config.php', 'elasticpress' ); ?></span>
@@ -84,7 +87,18 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 						<span class="description"><?php esc_html_e( 'Plug in your subscription token here.', 'elasticpress' ); ?></span>
 					</td>
 				</tr>
-			<?php } ?>
+			<?php }
+			if ( ! empty( $ep_host ) && ! has_filter( 'ep_index_posts_per_page' ) ) {
+				?>
+			<th scope="row">
+				<label for="ep_bulk_setting"><?php esc_html_e( 'Post index per cycle ', 'elasticpress' ); ?></label>
+			</th>
+				<td>
+					<input type="text" name="ep_bulk_setting" id="ep_bulk_setting" value="<?php echo esc_html( ep_get_bulk_settings() ); ?>">
+				</td>
+				<?php
+			}
+			?>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
Hi @allan23 ,

Could you please review this PR which adds feature #1179 ?

This PR adds a field  on the settings page if `ep_host` is set and filter `ep_index_posts_per_page` has no callback function: 

![epsettings](https://user-images.githubusercontent.com/31049169/51414946-b8dba900-1b39-11e9-926b-b139ebb0dbf2.png)

I've tested this works on single and multisite.

Please let me know your thoughts. 
Thanks! 