### PR TITLE
Default autosuggest to plugin settings.

### DIFF
--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -303,6 +303,12 @@ class EP_Dashboard {
 			$notice = 'need-setup';
 		}
 
+		//Autosuggest defaults notice
+		$autosuggest = ep_get_registered_feature( 'autosuggest' );
+		if ( $autosuggest->is_active() && (bool)$autosuggest->get_settings()['defaults_enabled'] ) {
+			$notice = 'using-autosuggest-defaults';
+		}
+
 		$notice = apply_filters( 'ep_admin_notice_type', $notice );
 
 		switch ( $notice ) {
@@ -427,10 +433,16 @@ class EP_Dashboard {
 			case 'sync-disabled-no-sync':
 				?>
 				<div data-ep-notice="sync-disabled-no-sync" class="notice notice-warning is-dismissible">
-                    <p><?php printf( esc_html__( 'Dashboard sync is disabled. You will need to index using WP-CLI to finish setup.', 'elasticpress' ) ); ?></p>
-                </div>
+					<p><?php printf( esc_html__( 'Dashboard sync is disabled. You will need to index using WP-CLI to finish setup.', 'elasticpress' ) ); ?></p>
+				</div>
 				<?php
 				break;
+			case 'using-autosuggest-defaults' :
+				?>
+				<div data-ep-notice="using-autosuggest-defaults" class="notice notice-warning is-dismissible">
+					<p><?php printf( esc_html__( 'Autosuggest feature is enabled. If protected content or documents feature is enabled, your protected content will also become searchable. Please checkmark the "Use safe values" checkbox in Autosuggest settings to default to safe content search', 'elasticpress' ) ); ?></p>
+				</div>
+				<?php
 		}
 
 		return $notice;


### PR DESCRIPTION
Hi @tott , @allan23 ,

Could you please review this PR which addresses #1205 ?

This adds a dismiss  notice when autosuggest feature is enabled and is using plugin defaults: 

![notices](https://user-images.githubusercontent.com/31049169/51547258-84af0380-1e2b-11e9-9363-dc0897dc3fe8.png)

As well as a radio button to switch between using defaults and safe post_type values `post`, `page` and post status `publish` : 

![radio](https://user-images.githubusercontent.com/31049169/51547267-8bd61180-1e2b-11e9-88f9-9dc58b8e0a51.png)

Thank you!