### PR TITLE
Do not override custom fields on wc search.

### DIFF
--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -459,8 +459,12 @@ function ep_wc_translate_args( $query ) {
 				// Remove author_name from this search.
 				$search_fields = ep_wc_remove_author($search_fields);
 
-				// Make sure we search skus on the front end
-				$search_fields['meta'] = array( '_sku' );
+				// Make sure we search skus on the front end and do not override meta search fields
+				if( ! empty( $search_fields['meta'] ) ) {
+					$search_fields['meta'] = array_merge( $search_fields['meta'], array( '_sku' ) );
+				} else {
+					$search_fields['meta'] = array( '_sku' );
+				}
 
 				// Search by proper taxonomies on the front end
 				$search_fields['taxonomies'] = array( 'category', 'post_tag', 'product_tag', 'product_cat' );

--- a/features/woocommerce/woocommerce.php
+++ b/features/woocommerce/woocommerce.php
@@ -466,9 +466,12 @@ function ep_wc_translate_args( $query ) {
 					$search_fields['meta'] = array( '_sku' );
 				}
 
-				// Search by proper taxonomies on the front end
-				$search_fields['taxonomies'] = array( 'category', 'post_tag', 'product_tag', 'product_cat' );
-
+				// Search by proper taxonomies on the front end and do not override taxonomy search fields
+				if( ! empty( $search_fields['taxonomies'] ) ) {
+					$search_fields['meta'] = array_merge( $search_fields['meta'], array( 'category', 'post_tag', 'product_tag', 'product_cat' ) );
+				} else {
+					$search_fields['taxonomies'] = array( 'category', 'post_tag', 'product_tag', 'product_cat' );
+				}
 				$query->set( 'search_fields', $search_fields );
 			}
 		} else {


### PR DESCRIPTION
Hi @allan23 ,

Could you please check this pull request which addresses #1137 ?

As noted by the OP in the issue, `$search_fields['meta'] = array( '_sku' );}` is overriding custom meta search fields.

By using his suggestion, we make sure the `_sku` field is still searchable.

Thanks!