### PR TITLE
Use match_phrase as alternative for wildcard

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -1952,8 +1952,8 @@ class EP_API {
 						case 'like':
 							if ( isset( $single_meta_query['value'] ) ) {
 								$terms_obj = array(
-									'wildcard' => array(
-										$meta_key_path => $single_meta_query['value'] . '*',
+									'match_phrase' => array(
+										$meta_key_path => $single_meta_query['value'],
 									),
 								);
 							}


### PR DESCRIPTION
Hi @allan23 ,

This PR replaces the use of wildcard query for a match_phrase. This way, we account for queries that are not a pattern.

Thank you,