### PR TITLE
Skip post meta for index if meta key empty/false.

### DIFF
--- a/classes/class-ep-api.php
+++ b/classes/class-ep-api.php
@@ -863,6 +863,11 @@ class EP_API {
 		$meta = array();
 
 		foreach ( $post_meta as $meta_key => $meta_values ) {
+			// Skip if no meta key.
+			if ( ! $meta_key ) {
+				continue;
+			}
+
 			if ( ! is_array( $meta_values ) ) {
 				$meta_values = array( $meta_values );
 			}


### PR DESCRIPTION
Issue: ElasticPress Failed To Index if Post Have Null for Meta Key #1240