### PR TITLE
Do not allow 0 to be set as bulk settings

### DIFF
--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -367,6 +367,21 @@ function ep_sanitize_credentials( $credentials ) {
 }
 
 /**
+ * Sanitize bulk settings.
+ *
+ * @param $bulk_settings
+ * @return int
+ */
+function ep_sanitize_bulk_settings( $bulk_settings ) {
+	$bulk_settings = (int) $bulk_settings;
+	if ( empty( $bulk_settings) || 0 === $bulk_settings || ! isset( $bulk_settings ) ) {
+		return $bulk_settings = 350;
+	} else {
+		return $bulk_settings;
+	}
+}
+
+/**
  * Prepare credentials if they are set for future use.
  */
 function ep_setup_credentials(){

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -372,13 +372,9 @@ function ep_sanitize_credentials( $credentials ) {
  * @param $bulk_settings
  * @return int
  */
-function ep_sanitize_bulk_settings( $bulk_settings ) {
+function ep_sanitize_bulk_settings( $bulk_settings = 350 ) {
 	$bulk_settings = (int) $bulk_settings;
-	if ( empty( $bulk_settings) || 0 === $bulk_settings || ! isset( $bulk_settings ) ) {
-		return $bulk_settings = 350;
-	} else {
-		return $bulk_settings;
-	}
+	return ( 0 === $bulk_settings ) ? 350 : $bulk_settings;
 }
 
 /**

--- a/classes/class-ep-config.php
+++ b/classes/class-ep-config.php
@@ -373,7 +373,7 @@ function ep_sanitize_credentials( $credentials ) {
  * @return int
  */
 function ep_sanitize_bulk_settings( $bulk_settings = 350 ) {
-	$bulk_settings = (int) $bulk_settings;
+	$bulk_settings = absint( $bulk_settings );
 	return ( 0 === $bulk_settings ) ? 350 : $bulk_settings;
 }
 

--- a/classes/class-ep-dashboard.php
+++ b/classes/class-ep-dashboard.php
@@ -919,7 +919,7 @@ class EP_Dashboard {
 			register_setting( 'elasticpress', 'ep_host', 'esc_url_raw' );
 			register_setting( 'elasticpress', 'ep_prefix', 'sanitize_text_field' );
 			register_setting( 'elasticpress', 'ep_credentials', 'ep_sanitize_credentials' );
-			register_setting( 'elasticpress', 'ep_bulk_setting', array( 'type' => 'integer', 'sanitize_callback' => 'absint' ) );
+			register_setting( 'elasticpress', 'ep_bulk_setting', array( 'type' => 'integer', 'sanitize_callback' => 'ep_sanitize_bulk_settings' ) );
 		}
 	}
 


### PR DESCRIPTION
Hi @allan23 ,

Can you please review this PR ?

This adds a new function to first convert the bulk settings input into a integer, then check if the value is 0 or empty, as this can sometimes be the result of converting into an integer : http://php.net/manual/en/language.types.string.php#language.types.string.conversion

If it is empty or 0, then set bulk settings to default of 350.

This was being problematic as `register_setting()` was submitting an empty string the first time a user sets his elasticsearch host, hence the option was getting updated and ended up getting converted to 0.

Thanks!