### PR TITLE
Fix/intro page

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -362,6 +362,11 @@ function sync() {
 			// Sync finished
 			syncStatus = 'finished';
 			updateSyncDash();
+
+			if( ! epDash.intro_shown ) {
+				document.location.replace( epDash.ep_intro_url );
+			}
+
 		} else {
 			// We are starting a sync
 			syncStatus = 'sync';
@@ -377,6 +382,7 @@ function sync() {
 			cancelSync();
 		}
 	} );
+
 }
 
 $startSyncButton.on( 'click', () => {

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -965,7 +965,7 @@ function action_admin_init() {
 function intro_or_dashboard() {
 	global $pagenow;
 
-	if ( 'admin.php' !== $pagenow || empty( $_GET['page'] ) || ( 'elasticpress' !== $_GET['page'] && 'elasticpress-settings' !== $_GET['page'] ) ) {
+	if ( 'admin.php' !== $pagenow || empty( $_GET['page'] ) || 'elasticpress' !== $_GET['page'] ) {
 		return;
 	}
 
@@ -979,9 +979,9 @@ function intro_or_dashboard() {
 
 	if ( ! $intro_shown ) {
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			wp_safe_redirect( admin_url( 'network/admin.php?page=elasticpress-intro' ) );
+			wp_redirect( admin_url( 'network/admin.php?page=elasticpress-intro' ) );
 		} else {
-			wp_safe_redirect( admin_url( 'admin.php?page=elasticpress-intro' ) );
+			wp_redirect( admin_url( 'admin.php?page=elasticpress-intro' ) );
 		}
 		exit;
 	}

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -784,6 +784,7 @@ function action_wp_ajax_ep_index() {
 	}
 
 	wp_send_json_success( $index_meta );
+
 }
 
 /**
@@ -873,6 +874,8 @@ function action_admin_enqueue_dashboard_scripts() {
 				$data['sync_indexable_labels'][ $indexable->slug ] = $indexable->labels;
 			}
 
+			$data['intro_shown']   = esc_html( get_option( 'ep_intro_shown' ) );
+			$data['ep_intro_url']  = esc_html( admin_url( 'admin.php?page=elasticpress-intro' ) );
 			$data['sync_complete'] = esc_html__( 'Sync complete', 'elasticpress' );
 			$data['sync_paused']   = esc_html__( 'Sync paused', 'elasticpress' );
 			$data['sync_syncing']  = esc_html__( 'Syncing', 'elasticpress' );

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -982,9 +982,9 @@ function intro_or_dashboard() {
 
 	if ( ! $intro_shown ) {
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			wp_redirect( admin_url( 'network/admin.php?page=elasticpress-intro' ) );
+			wp_safe_redirect( admin_url( 'network/admin.php?page=elasticpress-intro' ) );
 		} else {
-			wp_redirect( admin_url( 'admin.php?page=elasticpress-intro' ) );
+			wp_safe_redirect( admin_url( 'admin.php?page=elasticpress-intro' ) );
 		}
 		exit;
 	}


### PR DESCRIPTION
Hi @tlovett1 ,

Could you please review this PR which fixes the intro page not redirecting correctly to the settings page ?

I added one last redirect when a initial sync is complete and `ep_intro_shown` has not been set to true, to redirect automatically to the "Setup complete" step.

With regards of the mobile issues, I'm attaching the screenshots of what I currently see, would you mind giving me some direction of what needs to be addressed ? Thanks!

Mobile screenshots:

![mobilecomplete](https://user-images.githubusercontent.com/31049169/52831305-c41ee780-3099-11e9-9f78-05fce7b3a56f.png)

![mobilestep2](https://user-images.githubusercontent.com/31049169/52831306-c41ee780-3099-11e9-966c-2ad84e09658c.png)
