### PR TITLE
Redo: Add ability to define autosuggest selector

### DIFF
--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -245,7 +245,7 @@ function hideAutosuggestBox() {
 
 // No host/index set
 if ( epas.endpointUrl && '' !== epas.endpointUrl ) {
-	const $epInput       = jQuery( '.ep-autosuggest, input[type="search"], .search-field' );
+	const $epInput       = jQuery( '.ep-autosuggest, input[type="search"], .search-field, ' + epas.selector  );
 	const $epAutosuggest = jQuery( '<div class="ep-autosuggest"><ul class="autosuggest-list"></ul></div>' );
 
 	/**

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -95,6 +95,13 @@ class Autosuggest extends Feature {
 				<label for="defaults_disabled"><input name="defaults_enabled" id="defaults_disabled" data-field-name="defaults_enabled" class="setting-field" type="radio" <?php if ( ! (bool) $settings['defaults_enabled'] ) : ?>checked<?php endif; ?> value="0"><?php esc_html_e( 'Use safe values', 'elasticpress' ); ?></label>
 			</div>
 		</div>
+		<div class="field js-toggle-feature" data-feature="<?php echo esc_attr( $this->slug ); ?>">
+			<div class="field-name status"><label for="feature_autosuggest_selector"><?php esc_html_e( 'Autosuggest Selector', 'elasticpress' ); ?></label></div>
+			<div class="input-wrap">
+				<input value="<?php echo empty( $settings['autosuggest_selector'] ) ? 'ep-autosuggest' : esc_html( $settings['autosuggest_selector'] ); ?>" type="text" data-field-name="autosuggest_selector" class="setting-field" id="feature_autosuggest_selector">
+				<p class="field-description"><?php esc_html_e( 'Input additional selectors where you would like to include autosuggest separated by a comma. Example: .custom-selector, #custom-id, input[type="text"]', 'elasticpress' ); ?></p>
+			</div>
+		</div>
 		<?php
 
 		if ( Utils\is_epio() ) {
@@ -252,6 +259,7 @@ class Autosuggest extends Feature {
 					'endpointUrl'  => esc_url( untrailingslashit( $endpoint_url ) ),
 					'postType'     => apply_filters( 'ep_term_suggest_post_type', array_values( $post_types ) ),
 					'postStatus'   => apply_filters( 'ep_term_suggest_post_status', array_values( $post_status ) ),
+					'selector'     => esc_html( $settings['autosuggest_selector'] ),
 					'searchFields' => apply_filters(
 						'ep_term_suggest_search_fields',
 						array(


### PR DESCRIPTION
Hi @allan23 , can you please review this PR which addresses #1233 ?

This should add the ability to add autosuggest on elements/selectors that have been defined in the autosuggest settings. I tried it with custom selectors `.search-box, #search-test, input[type=text]` and so far they work for me. 

Thanks!