### PR TITLE
Changed max int to use core predefined constant.

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -316,7 +316,7 @@ abstract class Indexable {
 	 */
 	public function prepare_meta_value_types( $meta_value ) {
 
-		$max_java_int_value = 9223372036854775807;
+		$max_java_int_value = PHP_INT_MAX;
 
 		$meta_types = [];
 


### PR DESCRIPTION
### Problem
- Static value might interfere 32-bit signed integers as the max value is `2,147,483,647`, while for 64-bit it's `9,223,372,036,854,775,807`.

### Goal
- Avoid conflicts between 32- and 64-bit.


### Proposed solution
- Use predefined PHP constant to output the maximum integer value depending on the system.


### Unclear
- Was there an intention by use the static value instead of the constant?