### PR TITLE
Product attribute facets for 3.0.

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -202,7 +202,10 @@ checked<?php endif; ?> value="any"><?php echo wp_kses_post( __( 'Show all conten
 			return false;
 		}
 
-		if ( ! ( $query->is_post_type_archive() || $query->is_search() || ( is_home() && empty( $query->get( 'page_id' ) ) ) ) ) {
+		if ( ! ( ( function_exists( 'is_product_category' ) && is_product_category() )
+		         || $query->is_post_type_archive()
+		         || $query->is_search()
+		         || ( is_home() && empty( $query->get( 'page_id' ) ) ) ) ) {
 			return false;
 		}
 
@@ -224,9 +227,13 @@ checked<?php endif; ?> value="any"><?php echo wp_kses_post( __( 'Show all conten
 
 		$taxonomies = get_taxonomies( array( 'public' => true ) );
 
+		// Allow other plugins to modify the available taxonomies.
+		$taxonomies = apply_filters( 'ep_facet_include_taxonomies', $taxonomies, false );
+
 		if ( empty( $taxonomies ) ) {
 			return;
 		}
+
 
 		$query->set( 'ep_integrate', true );
 		$query->set( 'ep_facet', true );

--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -343,6 +343,7 @@ class Widget extends WP_Widget {
 		$facet = ( ! empty( $instance['facet'] ) ) ? $instance['facet'] : '';
 
 		$taxonomies = get_taxonomies( array( 'public' => true ), 'object' );
+		$taxonomies = apply_filters( 'ep_facet_include_taxonomies', $taxonomies );
 		?>
 		<div class="widget-ep-facet">
 			<p>

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -733,6 +733,23 @@ class WooCommerce extends Feature {
 	}
 
 	/**
+	 * Add WooCommerce Product Attributes to EP Facets.
+	 *
+	 * @param array $taxonomies
+	 *
+	 * @return array
+	 */
+	function add_product_attributes( $taxonomies = [] ) {
+		$attribute_names = wc_get_attribute_taxonomy_names();
+
+		foreach ( $attribute_names as $name ) {
+			$taxonomies[ $name ] = $name;
+		}
+
+		return $taxonomies;
+	}
+
+	/**
 	 * Add WC post type to autosuggest
 	 *
 	 * @param array $post_types Array of post types (e.g. post, page).
@@ -766,6 +783,7 @@ class WooCommerce extends Feature {
 			add_action( 'ep_wp_query_search_cached_posts', [ $this, 'disallow_duplicated_query' ], 10, 2 );
 			add_action( 'parse_query', [ $this, 'search_order' ], 11, 1 );
 			add_filter( 'ep_term_suggest_post_type', [ $this, 'suggest_wc_add_post_type' ] );
+			add_filter( 'ep_facet_include_taxonomies', [ $this, 'add_product_attributes' ] );
 		}
 	}
 


### PR DESCRIPTION
### Description of the Change

This PR allows WooCommerce product attributes to be facetable in 3.0. The initial implementation of attribute facets (in 2.8) caused a bug where attributes were disabled on product category pages.

