### PR TITLE
Pass $post_id twice in ep_post_sync_kill for backwards compatibility

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -80,7 +80,7 @@ class SyncManager extends SyncManagerAbstract {
 			$indexable_post_types = $indexable->get_indexable_post_types();
 
 			if ( in_array( $post_type, $indexable_post_types, true ) ) {
-				if ( apply_filters( 'ep_post_sync_kill', false, $object_id ) ) {
+				if ( apply_filters( 'ep_post_sync_kill', false, $object_id, $object_id ) ) {
 					return;
 				}
 
@@ -158,7 +158,7 @@ class SyncManager extends SyncManagerAbstract {
 			if ( in_array( $post_type, $indexable_post_types, true ) ) {
 				do_action( 'ep_sync_on_transition', $post_id );
 
-				if ( apply_filters( 'ep_post_sync_kill', false, $post_id ) ) {
+				if ( apply_filters( 'ep_post_sync_kill', false, $post_id, $post_id ) ) {
 					return;
 				}
 


### PR DESCRIPTION
### Description of the Change

v2 passes $post_id as the 3rd argument. This also prevents a fatal for existing filters that expect 3 arguments to be passed.

v2 implementation
https://github.com/10up/ElasticPress/blob/ca929db2869576b5e1975436eda4d21f150e50b3/classes/class-ep-sync-manager.php#L268

### Benefits

Updates to v3 from v2 won't trigger a fatal error for common `ep_post_sync_kill` filter usage.

### Possible Drawbacks

Developer/maintainer may not be aware of the change to this filter.

### Applicable Issues

Resolves #1351 
