### PR TITLE
Add support for nested taxonomy queries

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -546,121 +546,23 @@ class Post extends Indexable {
 		}
 
 		if ( ! empty( $args['tax_query'] ) ) {
-			$tax_filter          = [];
-			$tax_must_not_filter = [];
-
 			// Main tax_query array for ES.
 			$es_tax_query = [];
 
-			foreach ( $args['tax_query'] as $single_tax_query ) {
-				if ( ! empty( $single_tax_query['taxonomy'] ) ) {
-					$terms = isset( $single_tax_query['terms'] ) ? (array) $single_tax_query['terms'] : array();
-					$field = ( ! empty( $single_tax_query['field'] ) ) ? $single_tax_query['field'] : 'term_id';
+			$tax_queries = $this->parse_tax_query( $args['tax_query'] );
 
-					if ( 'name' === $field ) {
-						$field = 'name.raw';
-					}
-
-					// Set up our terms object
-					$terms_obj = array(
-						'terms.' . $single_tax_query['taxonomy'] . '.' . $field => $terms,
-					);
-
-					$operator = ( ! empty( $single_tax_query['operator'] ) ) ? strtolower( $single_tax_query['operator'] ) : 'in';
-
-					switch ( $operator ) {
-						case 'exists':
-							/**
-							 * add support for "EXISTS" operator
-							 *
-							 * @since 2.5
-							 */
-							$tax_filter[]['bool'] = array(
-								'must' => array(
-									array(
-										'exists' => array(
-											'field' => key( $terms_obj ),
-										),
-									),
-								),
-							);
-
-							break;
-						case 'not exists':
-							/**
-							 * add support for "NOT EXISTS" operator
-							 *
-							 * @since 2.5
-							 */
-							$tax_filter[]['bool'] = array(
-								'must_not' => array(
-									array(
-										'exists' => array(
-											'field' => key( $terms_obj ),
-										),
-									),
-								),
-							);
-
-							break;
-						case 'not in':
-							/**
-							 * add support for "NOT IN" operator
-							 *
-							 * @since 2.1
-							 */
-							// If "NOT IN" than it should filter as must_not
-							$tax_must_not_filter[]['terms'] = $terms_obj;
-
-							break;
-						case 'and':
-							/**
-							 * add support for "and" operator
-							 *
-							 * @since 2.4
-							 */
-							$and_nest = array(
-								'bool' => array(
-									'must' => array(),
-								),
-							);
-
-							foreach ( $terms as $term ) {
-								$and_nest['bool']['must'][] = array(
-									'terms' => array(
-										'terms.' . $single_tax_query['taxonomy'] . '.' . $field => (array) $term,
-									),
-								);
-							}
-
-							$tax_filter[] = $and_nest;
-
-							break;
-						case 'in':
-						default:
-							/**
-							 * Default to IN operator
-							 */
-							// Add the tax query filter
-							$tax_filter[]['terms'] = $terms_obj;
-
-							break;
-					}
-				}
-			}
-
-			if ( ! empty( $tax_filter ) ) {
+			if ( ! empty( $tax_queries['tax_filter'] ) ) {
 				$relation = 'must';
 
 				if ( ! empty( $args['tax_query']['relation'] ) && 'or' === strtolower( $args['tax_query']['relation'] ) ) {
 					$relation = 'should';
 				}
 
-				$es_tax_query[ $relation ] = $tax_filter;
+				$es_tax_query[ $relation ] = $tax_queries['tax_filter'];
 			}
 
-			if ( ! empty( $tax_must_not_filter ) ) {
-				$es_tax_query['must_not'] = $tax_must_not_filter;
+			if ( ! empty( $tax_queries['tax_must_not_filter'] ) ) {
+				$es_tax_query['must_not'] = $tax_queries['tax_must_not_filter'];
 			}
 
 			if ( ! empty( $es_tax_query ) ) {
@@ -1155,6 +1057,146 @@ class Post extends Indexable {
 		$formatted_args = apply_filters( 'ep_formatted_args', $formatted_args, $args );
 
 		return apply_filters( 'ep_post_formatted_args', $formatted_args, $args );
+	}
+
+	/**
+	 * Parse and build out our tax query.
+	 *
+	 * @access protected
+	 *
+	 * @param array $query Tax query
+	 * @return array
+	 */
+	protected function parse_tax_query( $query ) {
+		$tax_query = [
+			'tax_filter'          => [],
+			'tax_must_not_filter' => [],
+		];
+		$relation  = '';
+
+		foreach ( $query as $tax_queries ) {
+			// If we have a nested tax query, recurse through that
+			if ( is_array( $tax_queries ) && empty( $tax_queries['taxonomy'] ) ) {
+				$result      = $this->parse_tax_query( $tax_queries );
+				$relation    = ( ! empty( $tax_queries['relation'] ) ) ? strtolower( $tax_queries['relation'] ) : 'and';
+				$filter_type = 'and' === $relation ? 'must' : 'should';
+
+				// Set the proper filter type and must_not filter, as needed
+				if ( ! empty( $result['tax_must_not_filter'] ) ) {
+					$tax_query['tax_filter'][] = [
+						'bool' => [
+							$filter_type => $result['tax_filter'],
+							'must_not'   => $result['tax_must_not_filter'],
+						],
+					];
+				} else {
+					$tax_query['tax_filter'][] = [
+						'bool' => [
+							$filter_type => $result['tax_filter'],
+						],
+					];
+				}
+			}
+
+			// Parse each individual tax query part
+			$single_tax_query = $tax_queries;
+			if ( ! empty( $single_tax_query['taxonomy'] ) ) {
+				$terms = isset( $single_tax_query['terms'] ) ? (array) $single_tax_query['terms'] : array();
+				$field = ( ! empty( $single_tax_query['field'] ) ) ? $single_tax_query['field'] : 'term_id';
+
+				if ( 'name' === $field ) {
+					$field = 'name.raw';
+				}
+
+				// Set up our terms object
+				$terms_obj = array(
+					'terms.' . $single_tax_query['taxonomy'] . '.' . $field => $terms,
+				);
+
+				$operator = ( ! empty( $single_tax_query['operator'] ) ) ? strtolower( $single_tax_query['operator'] ) : 'in';
+
+				switch ( $operator ) {
+					case 'exists':
+						/**
+						 * add support for "EXISTS" operator
+						 *
+						 * @since 2.5
+						 */
+						$tax_query['tax_filter'][]['bool'] = array(
+							'must' => array(
+								array(
+									'exists' => array(
+										'field' => key( $terms_obj ),
+									),
+								),
+							),
+						);
+
+						break;
+					case 'not exists':
+						/**
+						 * add support for "NOT EXISTS" operator
+						 *
+						 * @since 2.5
+						 */
+						$tax_query['tax_filter'][]['bool'] = array(
+							'must_not' => array(
+								array(
+									'exists' => array(
+										'field' => key( $terms_obj ),
+									),
+								),
+							),
+						);
+
+						break;
+					case 'not in':
+						/**
+						 * add support for "NOT IN" operator
+						 *
+						 * @since 2.1
+						 */
+						// If "NOT IN" than it should filter as must_not
+						$tax_query['tax_must_not_filter'][]['terms'] = $terms_obj;
+
+						break;
+					case 'and':
+						/**
+						 * add support for "and" operator
+						 *
+						 * @since 2.4
+						 */
+						$and_nest = array(
+							'bool' => array(
+								'must' => array(),
+							),
+						);
+
+						foreach ( $terms as $term ) {
+							$and_nest['bool']['must'][] = array(
+								'terms' => array(
+									'terms.' . $single_tax_query['taxonomy'] . '.' . $field => (array) $term,
+								),
+							);
+						}
+
+						$tax_query['tax_filter'][] = $and_nest;
+
+						break;
+					case 'in':
+					default:
+						/**
+						 * Default to IN operator
+						 */
+						// Add the tax query filter
+						$tax_query['tax_filter'][]['terms'] = $terms_obj;
+
+						break;
+				}
+			}
+		}
+
+		return $tax_query;
 	}
 
 	/**

--- a/tests/indexables/TestPost.php
+++ b/tests/indexables/TestPost.php
@@ -4523,6 +4523,8 @@ class TestPost extends BaseTestCase {
 			)
 		);
 
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
 		$args = array(
 			'ep_integrate' => 1,
 			'post_type'    => 'post',


### PR DESCRIPTION
### Description of the Change

Currently, when building out taxonomy query information to send to elasticsearch, we only account for a single level of nesting. But WordPress supports taxonomy queries that are nested, so that information ends up being lost and the query results don't match what we want.

This PR fixes that by recursively looping through the passed in `tax_query` information. This ensures that we process all levels of nesting that may exist. The majority of the code here is the same as before, as far as building out the query. I've added the recursive looping and changed slightly how we set this tax query information in our main elasticsearch query.

### Benefits

Nested tax queries currently do not work, so adding this feature brings us closer in line to the core functionality WordPress supports

### Possible Drawbacks

Logic to build out the tax query is slightly changed, so there's always a chance of having missed some use case that this might break.

### Verification Process

I ran a WP_Query that contained a nested tax query, first without ElasticPress enabled for that query and then with ElasticPress enabled. I verified the results in both instances matched. I also did the same test a few other times with non-nested tax queries, to ensure those still worked.

For reference, here's one of the nested queries I tested with:
```
$args = array(
	'ep_integrate' => 1,
	'post_type'    => 'post',
	'tax_query'    => array(
		'relation' => 'OR',
		array(
			'taxonomy' => 'category',
			'field'    => 'slug',
			'terms'    => array( 'category-1' ),
		),
		array(
			'relation' => 'AND',
			array(
				'taxonomy' => 'post_tag',
				'field'    => 'slug',
				'terms'    => array( 'tag2' ),
				'operator' => 'NOT IN',
			),
			array(
				'taxonomy' => 'category',
				'field'    => 'slug',
				'terms'    => array( 'category-2' ),
			),
		),
	),
);
```
### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

#971