### PR TITLE
make user mapping compatible with earlier versions than 5.0

### DIFF
--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -645,7 +645,18 @@ class User extends Indexable {
 	 * @return boolean
 	 */
 	public function put_mapping() {
-		$mapping = require apply_filters( 'ep_user_mapping_file', __DIR__ . '/../../../mappings/user/initial.php' );
+		$es_version = Elasticsearch::factory()->get_elasticsearch_version();
+		if ( empty( $es_version ) ) {
+			$es_version = apply_filters( 'ep_fallback_elasticsearch_version', '2.0' );
+		}
+
+		$mapping_file = 'initial.php';
+
+		if ( version_compare( $es_version, '5.0', '<' ) ) {
+			$mapping_file = 'pre-5-0.php';
+		}
+
+		$mapping = require apply_filters( 'ep_user_mapping_file', __DIR__ . '/../../../mappings/user/' . $mapping_file );
 
 		$mapping = apply_filters( 'ep_user_mapping', $mapping );
 

--- a/includes/mappings/user/pre-5-0.php
+++ b/includes/mappings/user/pre-5-0.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Elasticsearch mapping for users
+ *
+ * @since  3.0
+ * @package elasticpress
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+return array(
+	'settings' => array(
+		'index.mapping.total_fields.limit' => apply_filters( 'ep_user_total_field_limit', 5000 ),
+		'index.max_result_window'          => apply_filters( 'ep_user_max_result_window', 1000000 ),
+		'analysis'                         => array(
+			'analyzer'   => array(
+				'default'          => array(
+					'tokenizer' => 'standard',
+					'filter'    => array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
+					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
+				),
+				'shingle_analyzer' => array(
+					'type'      => 'custom',
+					'tokenizer' => 'standard',
+					'filter'    => array( 'lowercase', 'shingle_filter' ),
+				),
+				'ewp_lowercase'    => array(
+					'type'      => 'custom',
+					'tokenizer' => 'keyword',
+					'filter'    => array( 'lowercase' ),
+				),
+			),
+			'filter'     => array(
+				'shingle_filter'     => array(
+					'type'             => 'shingle',
+					'min_shingle_size' => 2,
+					'max_shingle_size' => 5,
+				),
+				'ewp_word_delimiter' => array(
+					'type'              => 'word_delimiter',
+					'preserve_original' => true,
+				),
+				'ewp_snowball'       => array(
+					'type'     => 'snowball',
+					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
+				),
+				'edge_ngram'         => array(
+					'side'     => 'front',
+					'max_gram' => 10,
+					'min_gram' => 3,
+					'type'     => 'edgeNGram',
+				),
+			),
+			'normalizer' => array(
+				'lowerasciinormalizer' => array(
+					'type'   => 'custom',
+					'filter' => array( 'lowercase', 'asciifolding' ),
+				),
+			),
+		),
+	),
+	'mappings' => array(
+		'user' => array(
+			'date_detection'    => false,
+			'dynamic_templates' => array(
+				array(
+					'template_meta_types' => array(
+						'path_match' => 'meta.*',
+						'mapping'    => array(
+							'type'       => 'object',
+							'path'       => 'full',
+							'properties' => array(
+								'value'    => array(
+									'type'   => 'string',
+									'fields' => array(
+										'sortable' => array(
+											'type'         => 'string',
+											'ignore_above' => 10922,
+											'normalizer'   => 'lowerasciinormalizer',
+										),
+										'raw'      => array(
+											'type'         => 'string',
+											'ignore_above' => 10922,
+										),
+									),
+								),
+								'raw'      => array( /* Left for backwards compat */
+								                     'type'         => 'string',
+								                     'ignore_above' => 10922,
+								),
+								'long'     => array(
+									'type' => 'long',
+								),
+								'double'   => array(
+									'type' => 'double',
+								),
+								'boolean'  => array(
+									'type' => 'boolean',
+								),
+								'date'     => array(
+									'type'   => 'date',
+									'format' => 'yyyy-MM-dd',
+								),
+								'datetime' => array(
+									'type'   => 'date',
+									'format' => 'yyyy-MM-dd HH:mm:ss',
+								),
+								'time'     => array(
+									'type'   => 'date',
+									'format' => 'HH:mm:ss',
+								),
+							),
+						),
+					),
+				),
+				array(
+					'template_capabilities' => array(
+						'path_match' => 'capabilities.*',
+						'mapping'    => array(
+							'type'       => 'object',
+							'path'       => 'full',
+							'properties' => array(
+								'roles' => array(
+									'type' => 'string',
+								),
+							),
+						),
+					),
+				),
+			),
+			'_all'              => array(
+				'analyzer' => 'simple',
+			),
+			'properties'        => array(
+				'ID'              => array(
+					'type' => 'long',
+				),
+				'user_registered' => array(
+					'type'   => 'date',
+					'format' => 'YYYY-MM-dd HH:mm:ss',
+				),
+				'user_nicename'   => array(
+					'type'   => 'string',
+					'fields' => array(
+						'user_nicename' => array(
+							'type' => 'string',
+						),
+						'raw'           => array(
+							'type'         => 'string',
+							'ignore_above' => 10922,
+						),
+					),
+				),
+				'user_login'      => array(
+					'type'   => 'string',
+					'fields' => array(
+						'user_login' => array(
+							'type' => 'string',
+						),
+						'raw'        => array(
+							'type'         => 'string',
+							'ignore_above' => 10922,
+						),
+					),
+				),
+				'display_name'    => array(
+					'type'   => 'string',
+					'fields' => array(
+						'display_name' => array(
+							'type' => 'string',
+						),
+						'raw'          => array(
+							'type'         => 'string',
+							'ignore_above' => 10922,
+						),
+					),
+				),
+				'user_email'      => array(
+					'type'   => 'string',
+					'fields' => array(
+						'user_email' => array(
+							'type' => 'string',
+						),
+						'raw'        => array(
+							'type'         => 'string',
+							'ignore_above' => 10922,
+						),
+					),
+				),
+				'capabilities'    => array(
+					'type' => 'object',
+				),
+				'user_url'        => array(
+					'type'   => 'string',
+					'fields' => array(
+						'user_url' => array(
+							'type' => 'string',
+						),
+						'raw'      => array(
+							'type'         => 'string',
+							'ignore_above' => 10922,
+						),
+					),
+				),
+				'status'          => array(
+					'type' => 'long',
+				),
+				'spam'            => array(
+					'type' => 'long',
+				),
+				'deleted'         => array(
+					'type' => 'long',
+				),
+				'meta'            => array(
+					'type' => 'object',
+				),
+			),
+		),
+	),
+);

--- a/includes/mappings/user/pre-5-0.php
+++ b/includes/mappings/user/pre-5-0.php
@@ -87,8 +87,8 @@ return array(
 									),
 								),
 								'raw'      => array( /* Left for backwards compat */
-								                     'type'         => 'string',
-								                     'ignore_above' => 10922,
+									'type'         => 'string',
+									'ignore_above' => 10922,
 								),
 								'long'     => array(
 									'type' => 'long',


### PR DESCRIPTION
### Description of the Change
Currently, ElasticPress supports Elasticsearch 1.7. However, user mapping is not compatible with the earlier versions due to `text` and `keyword` support. – https://www.elastic.co/blog/strings-are-dead-long-live-strings 

In these changes, backporting user mapping with `string` type.  

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->


### Benefits
Supporting user search to existing Elasticpress setups without worry about the version.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Probably, we don't want to maintain the mapping for legacy setups. Instead, we can update the related part of the documentation. (User feature requires WordPress 5.1+ and Elasticsearch 5.0+) 

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
run `wp elasticpress index --setup` with the earlier versions of Elasticsearch (5.0 <)

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
