### PR TITLE
Adds filter to order & orderby args in facet

### DIFF
--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -116,7 +116,23 @@ class Widget extends WP_Widget {
 			}
 		}
 
-		$terms     = Utils\get_term_tree( $terms, 'count', 'desc', true );
+		/**
+		 * Filters the 'orderby' argument when querying for facet terms
+         *
+         * @var string $orderby One of either 'count' or 'name'. Defaults to 'count'.
+         * @var string $taxonomy The taxonomy slug used in the facet.
+		 */
+		$orderby = apply_filters( 'ep_facet_search_widget_orderby', 'count', $taxonomy );
+		
+		/**
+		 * Filters the 'order' argument when querying for facet terms
+		 *
+		 * @var string $order One of either 'desc' or 'asc'. Defaults to 'desc'.
+		 * @var string $taxonomy The taxonomy slug used in the facet.
+		 */
+		$order   = apply_filters( 'ep_facet_search_widget_order', 'desc', $taxonomy );
+
+		$terms     = Utils\get_term_tree( $terms, $orderby, $order, true );
 		$term_tree = Utils\get_term_tree( $terms, 'count', 'desc', false );
 
 		$outputted_terms = array();

--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -118,21 +118,21 @@ class Widget extends WP_Widget {
 
 		/**
 		 * Filters the 'orderby' argument when querying for facet terms
-         *
-         * @var string $orderby One of either 'count' or 'name'. Defaults to 'count'.
-         * @var string $taxonomy The taxonomy slug used in the facet.
+		 *
+		 * @var string $orderby  One of either 'count' or 'name'. Defaults to 'count'.
+		 * @var string $taxonomy The taxonomy slug used in the facet.
 		 */
 		$orderby = apply_filters( 'ep_facet_search_widget_orderby', 'count', $taxonomy );
-		
+
 		/**
 		 * Filters the 'order' argument when querying for facet terms
 		 *
-		 * @var string $order One of either 'desc' or 'asc'. Defaults to 'desc'.
+		 * @var string $order    One of either 'desc' or 'asc'. Defaults to 'desc'.
 		 * @var string $taxonomy The taxonomy slug used in the facet.
 		 */
-		$order   = apply_filters( 'ep_facet_search_widget_order', 'desc', $taxonomy );
+		$order = apply_filters( 'ep_facet_search_widget_order', 'desc', $taxonomy );
 
-		$terms     = Utils\get_term_tree( $terms, $orderby, $order, true );
+		$terms = Utils\get_term_tree( $terms, $orderby, $order, true );
 		$term_tree = Utils\get_term_tree( $terms, 'count', 'desc', false );
 
 		$outputted_terms = array();


### PR DESCRIPTION

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This adds two new filters to update the orderby and order arguments of get_term_tree used to query terms in the facets widget.


<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->


### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

