### PR TITLE
Orderby post_type.raw keyword field rather than post_type text field.…

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1218,7 +1218,7 @@ class Post extends Indexable {
 					);
 				} elseif ( 'type' === $orderby_clause ) {
 					$sort[] = array(
-						'post_type' => array(
+						'post_type.raw' => array(
 							'order' => $order,
 						),
 					);


### PR DESCRIPTION
… Fixes #1257

### Description of the Change

Fixes an error thrown by elasticsearch when trying to sort by a text field. Sorts by the keyword field instead and fixes the error.

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1257
