### PR TITLE
Changed Facet widget taxonomies to be filterable.

### DIFF
--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -343,6 +343,7 @@ class Widget extends WP_Widget {
 		$facet = ( ! empty( $instance['facet'] ) ) ? $instance['facet'] : '';
 
 		$taxonomies = get_taxonomies( array( 'public' => true ), 'object' );
+		$taxonomies = apply_filters( 'ep_facet_search_taxonomies', $taxonomies );
 		?>
 		<div class="widget-ep-facet">
 			<p>


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
- It's not possible to extend the Facet widget taxonomies in the backend, which make it hard to replace the WooCommerce layered nav widgets by the Facet widget as they offer to select non-public product attributes as well
- This PR adds a basic filter resolve this potential issue
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
- For my case: We use the WooCommerce layered nav widgets to filter for attributes.
- As described in #1290, this used to happen when using the WC layered nav widgets which seem to use `filter_name` instead of `filter_pa_name`
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
- Give developers more flexibility
<!-- What benefits will be realized by the code change? -->

### Usage:
here's how I resolve the issue for our case:

```php
add_filter('ep_facet_search_taxonomies', __CLASS__ . '::ep_facet_search_taxonomies');

public static function ep_facet_search_taxonomies($taxonomies) {
  $taxonomies = wp_list_filter(get_taxonomies([], 'object'), [
    'object_type' => ['product'],
  ]);
  return $taxonomies;
}
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
