### PR TITLE
Fixes 400 error when popularity is default sorting

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -553,11 +553,17 @@ class WooCommerce extends Feature {
 			}
 
 			/**
-			 * Set orderby and order for price when GET param not set
+			 * Set orderby and order for price/popularity when GET param not set
 			 */
-			if ( isset( $query->query_vars['orderby'], $query->query_vars['order'] ) && 'price' === $query->query_vars['orderby'] && $query->is_main_query() ) {
-				$query->set( 'order', $query->query_vars['order'] );
-				$query->set( 'orderby', $this->get_orderby_meta_mapping( '_price' ) );
+			if ( isset( $query->query_vars['orderby'], $query->query_vars['order'] ) && $query->is_main_query() ) {
+				switch ( $query->query_vars['orderby'] ) {
+					case 'price':
+						$query->set( 'order', $query->query_vars['order'] );
+						$query->set( 'orderby', $this->get_orderby_meta_mapping( '_price' ) );
+					case 'popularity':
+						$query->set( 'orderby', $this->get_orderby_meta_mapping( 'total_sales' ) );
+						$query->set( 'order', 'DESC' );
+				}
 			}
 
 			/**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR fixes #1376 by checking the orderby param of the query and if it is `popularity` rewrites it to `meta.total_sales.long date ` to sort in Elasticsearch when popularity is set as the default sorting from the customizer

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1.- Set a woocommerce theme like storefront
2.- On the frontend, go to customize->woocommerce->product catalog->Default product sorting and select popularity as sorting default
3.- Refresh and check status in debug bar/query body/results

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
