### PR TITLE
Fixed Facet widget does not render WC product attribute options.

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -195,9 +195,10 @@ class Facets extends Feature {
 		}
 
 		if ( ! ( ( function_exists( 'is_product_category' ) && is_product_category() )
-		         || $query->is_post_type_archive()
-		         || $query->is_search()
-		         || ( is_home() && empty( $query->get( 'page_id' ) ) ) ) ) {
+			|| $query->is_post_type_archive()
+			|| $query->is_search()
+			|| ( is_home() && empty( $query->get( 'page_id' ) ) ) )
+		) {
 			return false;
 		}
 
@@ -217,22 +218,21 @@ class Facets extends Feature {
 			return;
 		}
 
-		$taxonomies = get_taxonomies( array( 'public' => true ) );
+		$taxonomies = get_taxonomies( array( 'public' => true ), 'object' );
 
 		// Allow other plugins to modify the available taxonomies.
-		$taxonomies = apply_filters( 'ep_facet_include_taxonomies', $taxonomies, false );
+		$taxonomies = apply_filters( 'ep_facet_include_taxonomies', $taxonomies );
 
 		if ( empty( $taxonomies ) ) {
 			return;
 		}
-
 
 		$query->set( 'ep_integrate', true );
 		$query->set( 'ep_facet', true );
 
 		$facets = [];
 
-		foreach ( $taxonomies as $slug ) {
+		foreach ( $taxonomies as $slug => $taxonomy ) {
 			$facets[ $slug ] = array(
 				'terms' => array(
 					'size'  => 10000,

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -756,6 +756,7 @@ class WooCommerce extends Feature {
 			}
 			$taxonomies[ $name ] = get_taxonomy( $name );
 		}
+
 		return $taxonomies;
 	}
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -751,9 +751,11 @@ class WooCommerce extends Feature {
 		$attribute_names = wc_get_attribute_taxonomy_names();
 
 		foreach ( $attribute_names as $name ) {
-			$taxonomies[ $name ] = $name;
+			if ( ! taxonomy_exists( $name ) ) {
+				continue;
+			}
+			$taxonomies[ $name ] = get_taxonomy( $name );
 		}
-
 		return $taxonomies;
 	}
 


### PR DESCRIPTION
- Also fixed linting errors and removed unnecessary 2nd argument from the `apply_filters` function

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
- The changes introduced in #1344 contained functional and code style issues as stated in my comment in the related PR
- This PR queries the WC attribute taxonomies to fulfil the requirements of the foreach when trying to access the label and name property of the taxonomy object
- Also fixes the code style
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
- As stated in my comment, another solution would have been to return names/slugs only which would probably more inconvenient for the users 
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
- Get it working :-)
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
- Performance issues due to return the objects instead of DB queried strings
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
- Insert Facet widget
- Select product attribute
- Check if ES query also contains the slug entry as added in [`Facets.php:236`](https://github.com/10up/ElasticPress/compare/develop...fabianmarz:fix/attribute-facets?expand=1#diff-f5945136b299ae578a000886b7078dfdR236)

💡 In `Facets.php` it'll also work if returning the taxonomies with the default `names` parameter. But I added the object return to be consistent
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
