### PR TITLE
Add "ignore_sticky_posts" argument to find_related() method

### DIFF
--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -90,6 +90,7 @@ class RelatedPosts extends Feature {
 			'more_like'      => $post_id,
 			'posts_per_page' => $return,
 			'ep_integrate'   => true,
+			'ignore_sticky_posts' => true,
 		);
 
 		$query = new WP_Query( apply_filters( 'ep_find_related_args', $args ) );


### PR DESCRIPTION
Prevents unnecessary adding of sticky posts to related posts

This is a fix for issue #1323.

My related posts returned well over a thousand when I asked for 3.  After adding the "add_sticky_posts" argument, it properly returned the number of posts I asked the method to retrieve.