### PR TITLE
Ensure new sites within multisite have the correct mappings and global alias

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -385,7 +385,7 @@ class Command extends WP_CLI_Command {
 
 			$indexable->delete_network_alias();
 
-			$create_result = $this->create_network_alias_helper();
+			$create_result = $this->create_network_alias_helper( $indexable );
 
 			if ( $create_result ) {
 				WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -445,6 +445,10 @@ class Elasticsearch {
 		);
 
 		foreach ( $indexes as $index ) {
+			if ( empty( $index ) ) {
+				continue;
+			}
+
 			$args['actions'][] = array(
 				'add' => array(
 					'index' => $index,

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -47,6 +47,7 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'updated_post_meta', array( $this, 'action_queue_meta_sync' ), 10, 4 );
 		add_action( 'added_post_meta', array( $this, 'action_queue_meta_sync' ), 10, 4 );
 		add_action( 'deleted_post_meta', array( $this, 'action_queue_meta_sync' ), 10, 4 );
+		add_action( 'wp_initialize_site', array( $this, 'action_create_blog_index') );
 	}
 
 	/**
@@ -165,5 +166,30 @@ class SyncManager extends SyncManagerAbstract {
 				$this->sync_queue[ $post_id ] = true;
 			}
 		}
+	}
+
+	/**
+	 * Create mapping and network alias when a new blog is created.
+	 *
+	 * @param WP_Site $blog New site object.
+	 */
+	public function action_create_blog_index( $blog ) {
+		if ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) {
+			return;
+		}
+
+		$non_global_indexable_objects = Indexables::factory()->get_all( false );
+
+		switch_to_blog( $blog->blog_id );
+
+		foreach ( $non_global_indexable_objects as $indexable ) {
+			$indexable->delete_index();
+			$indexable->put_mapping();
+
+			$index_name = $indexable->get_index_name( $blog->blog_id );
+			$indexable->create_network_alias( [ $index_name ] );
+		}
+
+		restore_current_blog();
 	}
 }


### PR DESCRIPTION
### Description of the Change
Currently when a new site is created within a network the mappings are not sent so no index exists. When the first index happens ElasticSearch will create the index for us, but without the correct mappings - this also means the network alias isn't created, preventing the site from being visible in the global index.

This PR addresses two issues -

- Creates mapping once a new site is created within a multisite and creates the network alias
- Fixes fatal error when using the `recreate-network-alias` command

Note: Using the hook `wp_insert_site` seemed too early and didn't give me the index name therefore using `wp_initialize_site` instead.

### Benefits
New sites will have correct mapping and will be searchable within the network index.

### Possible Drawbacks
None - but this fix doesn't address old sites. Site admins will need to run commands to fix mappings/alias on previously added sites prior to this fix.

### Verification Process
- Create new site in multisite
- Check that the index is created
- Check the mappings are correct
- Check the global alias is added
- Publish a post and verify it can be searched within the global alias

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

