### PR TITLE
Use .raw for sorting and aggregations

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1322,7 +1322,7 @@ class Post extends Indexable {
 				} elseif ( 'meta_value' === $orderby_clause ) {
 					if ( ! empty( $args['meta_key'] ) ) {
 						$sort[] = array(
-							'meta.' . $args['meta_key'] . '.value' => array(
+							'meta.' . $args['meta_key'] . '.raw' => array(
 								'order' => $order,
 							),
 						);

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -571,7 +571,7 @@ class User extends Indexable {
 				} elseif ( 'meta_value' === $orderby_clause ) {
 					if ( ! empty( $query_vars['meta_key'] ) ) {
 						$sort[] = array(
-							'meta.' . $query_vars['meta_key'] . '.value' => array(
+							'meta.' . $query_vars['meta_key'] . '.raw' => array(
 								'order' => $order,
 							),
 						);


### PR DESCRIPTION
### Description of the Change

This PR changes `.value` to `.raw` when sorting by `meta_value`. The [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html#CO302-1) state that `.raw` is used for sorting and aggregations.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
