### PR TITLE
id is not a valid order by value

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -59,7 +59,7 @@ class Post extends Indexable {
 			'post_status'         => $this->get_indexable_post_status(),
 			'offset'              => 0,
 			'ignore_sticky_posts' => true,
-			'orderby'             => 'id',
+			'orderby'             => 'ID',
 			'order'               => 'desc',
 		];
 

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -610,7 +610,7 @@ class User extends Indexable {
 		$defaults = [
 			'number'  => 350,
 			'offset'  => 0,
-			'orderby' => 'id',
+			'orderby' => 'ID',
 			'order'   => 'desc',
 		];
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

orderby is set to 'id' but 'id' is not a valid orderby type. The inline docs state...

```
*     @type string|array $orderby                 Sort retrieved posts by parameter. One or more options may be
	 *                                                 passed. To use 'meta_value', or 'meta_value_num',
	 *                                                 'meta_key=keyname' must be also be defined. To sort by a
	 *                                                 specific `$meta_query` clause, use that clause's array key.
	 *                                                 Accepts 'none', 'name', 'author', 'date', 'title',
	 *                                                 'modified', 'menu_order', 'parent', 'ID', 'rand',
	 *                                                 'relevance', 'RAND(x)' (where 'x' is an integer seed value),
	 *                                                 'comment_count', 'meta_value', 'meta_value_num', 'post__in',
	 *                                                 'post_name__in', 'post_parent__in', and the array keys
	 *                                                 of `$meta_query`. Default is 'date', except when a search
	 *                                                 is being performed, when the default is 'relevance'.
```

Without 'ID' the sort defaults to a date sort. This PR sets it to the intended value.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

More consistent with desired behavior

### Possible Drawbacks

Still slow on large sites

### Verification Process

Observed queries generated by the indexing process. Noted that it was sorting on date until I changed the value to ID, then it sorted on ID instead.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [?] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->


