### PR TITLE
Adding filter to modify post meta data.

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -417,7 +417,18 @@ class Post extends Indexable {
 	 * @return array
 	 */
 	public function prepare_meta( $post ) {
-		$meta = (array) get_post_meta( $post->ID );
+
+		/**
+		 * Filter meta data
+		 *
+		 * Allows for adding virtual meta data to current post.
+		 *
+		 * @since 3.1.2
+		 *
+		 * @param         array Meta data (raw).
+		 * @param WP_Post $post The current post to be indexed.
+		 */
+		$meta = apply_filters( 'ep_prepare_meta_data', (array) get_post_meta( $post->ID ), $post );
 
 		if ( empty( $meta ) ) {
 			return [];


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Proposed change to prepare_meta() method allows modification of post meta data so that virtual/dynamic meta data could be inserted into ElasticSearch even though the data itself technically is not available as post meta data for that object.

e.g. inserting dynamically created product code / SKU.

### Alternate Designs

No alternatives were considered. Open to ideas.

### Benefits

Possibility to insert custom meta data. Use cases may vary, my primary goal autosuggest improvements.

### Possible Drawbacks

New filter might be misued by 3rd party developers where use of existing filters (`ep_prepare_meta_allowed_protected_keys`, `ep_prepare_meta_excluded_public_keys` and `ep_prepare_meta_whitelist_key`) could be more efficient .

### Verification Process

Ran sync processes with and without additional filters to insert "virtual" meta data. Confirmed data to be indexed as expected.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
https://github.com/10up/ElasticPress/issues/1427
