### PR TITLE
Provide option to sync prior to shutdown

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -85,7 +85,7 @@ class SyncManager extends SyncManagerAbstract {
 					return;
 				}
 
-				$this->sync_queue[ $object_id ] = true;
+				$this->add_to_queue( $object_id );
 			}
 		}
 	}
@@ -163,7 +163,7 @@ class SyncManager extends SyncManagerAbstract {
 					return;
 				}
 
-				$this->sync_queue[ $post_id ] = true;
+				$this->add_to_queue( $post_id );
 			}
 		}
 	}

--- a/includes/classes/Indexable/User/SyncManager.php
+++ b/includes/classes/Indexable/User/SyncManager.php
@@ -58,7 +58,7 @@ class SyncManager extends SyncManagerAbstract {
 	public function action_queue_meta_sync( $meta_id, $object_id, $meta_key, $meta_value ) {
 		$indexable = Indexables::factory()->get( 'user' );
 
-		$this->sync_queue[ $object_id ] = true;
+		$this->add_to_queue( $object_id );
 	}
 
 	/**
@@ -92,6 +92,6 @@ class SyncManager extends SyncManagerAbstract {
 
 		do_action( 'ep_sync_user_on_transition', $user_id );
 
-		$this->sync_queue[ $user_id ] = true;
+		$this->add_to_queue( $user_id );
 	}
 }

--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -38,6 +38,13 @@ abstract class SyncManager {
 	public function __construct( $indexable_slug ) {
 		$this->indexable_slug = $indexable_slug;
 
+		if ( defined( 'EP_SYNC_CHUNK_LIMIT' ) && is_numeric( EP_SYNC_CHUNK_LIMIT ) ) {
+			/**
+			 * We also sync when we exceed Chunk limit set.
+			 * This is sometimes useful when posts are generated programatically.
+			 */
+			 add_action( 'ep_after_add_to_queue', [ $this, 'index_sync_on_chunk_limit' ] );
+		}
 		/**
 		 * We do all syncing on shutdown or redirect
 		 */
@@ -46,6 +53,38 @@ abstract class SyncManager {
 
 		// Implemented by children.
 		$this->setup();
+	}
+
+	/**
+	 * Add an object to the sync queue.
+	 *
+	 * @param  id $object_id object ID to sync
+	 * @since  3.1.2
+	 * @return boolean
+	 */
+	public function add_to_queue( $object_id ) {
+		if ( ! is_numeric( $object_id ) ) {
+			return false;
+		}
+		$this->sync_queue[ $object_id ] = true;
+
+		do_action( 'ep_after_add_to_queue', $object_id, $this->sync_queue );
+
+		return true;
+	}
+
+	/**
+	 * Sync queued objects if the EP_SYNC_CHUNK_LIMIT is reached.
+	 *
+	 * @since 3.1.2
+	 * @return boolean
+	 */
+	public function index_sync_on_chunk_limit() {
+		if ( defined( 'EP_SYNC_CHUNK_LIMIT' ) && is_numeric( EP_SYNC_CHUNK_LIMIT ) &&
+			is_array( $this->sync_queue ) && count( $this->sync_queue ) > EP_SYNC_CHUNK_LIMIT ) {
+			$this->index_sync_queue();
+		}
+		return true;
 	}
 
 	/**
@@ -61,6 +100,7 @@ abstract class SyncManager {
 
 		return $location;
 	}
+
 
 	/**
 	 * Sync objects in queue.

--- a/tests/indexables/TestUser.php
+++ b/tests/indexables/TestUser.php
@@ -64,7 +64,7 @@ class TestUser extends BaseTestCase {
 	 * @since 3.0
 	 */
 	public function createAndIndexUsers() {
-		ElasticPress\Indexables::factory()->get( 'user' )->sync_manager->sync_queue[1] = true;
+		ElasticPress\Indexables::factory()->get( 'user' )->sync_manager->add_to_queue( 1 );
 
 		ElasticPress\Indexables::factory()->get( 'user' )->bulk_index( array_keys( ElasticPress\Indexables::factory()->get( 'user' )->sync_manager->sync_queue ) );
 
@@ -194,7 +194,7 @@ class TestUser extends BaseTestCase {
 		update_user_meta( $user_id, 'test_key', true );
 
 		$this->assertEquals( 1, count( ElasticPress\Indexables::factory()->get( 'user' )->sync_manager->sync_queue ) );
-		$this->assertTrue( ! empty( ElasticPress\Indexables::factory()->get( 'user' )->sync_manager->sync_queue[ $user_id ] ) );
+		$this->assertTrue( ! empty( ElasticPress\Indexables::factory()->get( 'user' )->sync_manager->add_to_queue( $user_id ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Adding possibility to trigger sync whenever a limit of objects in the queue is reached.
This is sometimes useful when during one page load a lot of content is
updated (ie. during programatic content imports).
In these cases it's possible that if the import process fails due to a
SIGKILL or SIGTERM signal the queued up changes will not be synced and a
full reindex is required.

In order to activate this feature a define needs to be set in
wp-config.php or similar suitable place.

```define( 'EP_SYNC_CHUNK_LIMIT', <max_amount_of_objects_in_queue> );```

Additionally this change implements a add_to_queue() method in the sync
manager allowing an action to fire whenever an object is added to the
queue.

```do_action( 'ep_after_add_to_queue', $object_id, $this->sync_queue);```