### PR TITLE
fix incorrect author_name usage.

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -677,9 +677,12 @@ class Post extends Indexable {
 
 			$use_filters = true;
 		} elseif ( ! empty( $args['author_name'] ) ) {
+			// Since this was set to use the display name initially, there might be some code that used this feature.
+			// Let's ensure that any query vars coming in using author_name are in fact slugs.
+			$author_login = sanitize_user( $args['author_name'] );
 			$filter['bool']['must'][] = array(
 				'term' => array(
-					'post_author.raw' => $args['author'],
+					'post_author.login.raw' => $author_login,
 				),
 			);
 


### PR DESCRIPTION
### Description of the Change
The `author_name` query var is meant to use the [user nicename](https://developer.wordpress.org/reference/classes/wp_query/#author-parameters). 

Currently the Post indexable is setting this value to the display_name. This means we can't search using this field without altering the query via the `ep_formatted_args` hook.

### Alternate Designs
I currently have this code in place to force the code to work as expected, but it will need to loop twice over the args to ensure that the indexes for both `post_filter` and `aggs` are the same. I assume they are, but I would also not be surprised if they weren't.
```
function set_search_args( $formatted_args, $args ) {
	if ( ! empty( $args['s'] ) && ! empty( $args['author_name'] ) ) {
		foreach ( $formatted_args['post_filter']['bool']['must'] as $i => $filter ) {
			if ( isset( $filter['term']['post_author.raw'] ) ) {
				unset( $formatted_args['post_filter']['bool']['must'][ $i ]['term']['post_author.raw'] );
				$formatted_args['post_filter']['bool']['must'][ $i ]['term']['post_author.login.raw'] = $args['author_name'];
			}
		}
		foreach ( $formatted_args['post_filter']['bool']['must'] as $i => $filter ) {
			if ( isset( $filter['term']['post_author.raw'] ) ) {
				unset( $formatted_args['aggs']['terms']['filter']['bool']['must'][ $i ]['term']['post_author.raw'] );
				$formatted_args['aggs']['terms']['filter']['bool']['must'][ $i ]['term']['post_author.login.raw'] = $args['author_name'];
			}
		}
	}
	return $formatted_args;
}
```
### Benefits

It will work as expected.

### Possible Drawbacks

I believe this is relatively non-invasive.

### Verification Process

This is tested on an local docker instance running ES as well as an instance over at elastic.co. I used the debugging log to compare queries and ran local curl calls with altered queries to find the solution. After making changes, the queries are now returning posts of only a specific author slug.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues
I have not checked.