### PR TITLE
Use proper taxonomy name for WC attributes. Fixes #1444

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -264,7 +264,7 @@ class Facets extends Feature {
 
 		foreach ( $selected_filters['taxonomies'] as $taxonomy => $filter ) {
 			$tax_query[] = [
-				'taxonomy' => $taxonomy,
+				'taxonomy' => wc_attribute_taxonomy_name( $taxonomy ),
 				'field'    => 'slug',
 				'terms'    => array_keys( $filter['terms'] ),
 				'operator' => ( 'any' === $settings['match_type'] ) ? 'or' : 'and',


### PR DESCRIPTION
### Description of the Change

Uses correct `pa_` prefixed taxonomy name for product attributes.

### Applicable Issues

#1444 
