### PR TITLE
Fix product attribute archives

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -251,13 +251,16 @@ class WooCommerce extends Feature {
 
 		$supported_taxonomies = array(
 			'product_cat',
-			'pa_brand',
 			'product_tag',
 			'product_type',
-			'pa_sort-by',
 			'product_visibility',
 			'product_shipping_class',
 		);
+
+		// Add in any attribute taxonomies that exist
+		$attribute_taxonomies = wc_get_attribute_taxonomy_names();
+
+		$supported_taxonomies = array_merge( $supported_taxonomies, $attribute_taxonomies );
 
 		/**
 		 * Add support for custom taxonomies.


### PR DESCRIPTION
### Description of the Change

Dynamically adds all product attribute taxonomies that exist to the supported taxonomies in EP rather than supporting a small hardcoded subset.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1447 

### Changelog Entry

Fix issue where all products show up on a product attribute archive instead of just products that have the attribute.