### PR TITLE
Don't try and use wc_attribute_taxonomy_name on non WC Taxonomies

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -262,9 +262,19 @@ class Facets extends Feature {
 
 		$tax_query = $query->get( 'tax_query', [] );
 
+		// Account for taxonomies that should be woocommerce attributes, if WC is enabled
+		$attribute_taxonomies = [];
+		if ( function_exists( 'wc_attribute_taxonomy_name' ) ) {
+			$all_attr_taxonomies = wc_get_attribute_taxonomies();
+
+			foreach ( $all_attr_taxonomies as $attr_taxonomy ) {
+				$attribute_taxonomies[ $attr_taxonomy->attribute_name ] = wc_attribute_taxonomy_name( $attr_taxonomy->attribute_name );
+			}
+		}
+
 		foreach ( $selected_filters['taxonomies'] as $taxonomy => $filter ) {
 			$tax_query[] = [
-				'taxonomy' => wc_attribute_taxonomy_name( $taxonomy ),
+				'taxonomy' => isset( $attribute_taxonomies[ $taxonomy ] ) ? $attribute_taxonomies[ $taxonomy ] : $taxonomy,
 				'field'    => 'slug',
 				'terms'    => array_keys( $filter['terms'] ),
 				'operator' => ( 'any' === $settings['match_type'] ) ? 'or' : 'and',


### PR DESCRIPTION
Also accounts for WC not being activated at all).

### Description of the Change
Only uses WC attribute taxonomy name on actual WC taxonomies. Also completely ignores this if WC isn't activated.

### Verification Process
Tested with and without Woocommerce activated with standard (non-attribute) taxonomies as well as woocommerce attributes on both ElasticPress facet widget and Woocommerce widgets.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #1457

### Changelog Entry

Fixes error in facet widget when WooCommerce deactivated.