### PR TITLE
ep.io backend fixes

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -211,8 +211,8 @@ class Elasticsearch {
 			),
 		);
 
-		// If search, send the search term as a header to ES
-		if ( isset( $query_args['s'] ) && (bool) $query_args['s'] && ! is_admin() ) {
+		// If search, send the search term as a header to ES so the backend understands what a normal query looks like
+		if ( isset( $query_args['s'] ) && (bool) $query_args['s'] && ! is_admin() && ! isset( $_GET['post_type'] ) ) {
 			$request_args['headers']['EP-Search-Term'] = $query_args['s'];
 		}
 


### PR DESCRIPTION
If the search is filtered by a post type, don't set the EP-Search-Term header