### PR TITLE
Update to new tag filtering for GH Actions

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy to WordPress.org
 on:
   push:
-    branches:
-    - refs/tags/*
+    tags:
+    - "*"
 jobs:
   tag:
     name: New tag


### PR DESCRIPTION
They said yesterday they'd fix it "this week", guess they got to it quickly so the last tag failed to deploy. See https://github.community/t5/GitHub-API-Development-and/How-to-restrict-execution-of-GitHub-Actions-workflow-on-tags/m-p/29640#M2671