### PR TITLE
Query for object IDs when indexing

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -703,25 +703,25 @@ class Command extends WP_CLI_Command {
 
 			if ( ! empty( $query['objects'] ) ) {
 
-				foreach ( $query['objects'] as $object ) {
+				foreach ( $query['objects'] as $object_id ) {
 
 					if ( $no_bulk ) {
 						/**
 						 * Index objects one by one
 						 */
-						$result = $indexable->index( $object->ID, true );
+						$result = $indexable->index( $object_id, true );
 
 						$this->reset_transient();
 
-						do_action( 'ep_cli_object_index', $object->ID, $indexable );
+						do_action( 'ep_cli_object_index', $object_id, $indexable );
 
 						WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d...', 'elasticpress' ), ( $synced + 1 ), (int) $query['total_objects'] ) );
 					} else {
-						$result = $this->queue_object( $indexable, $object->ID, count( $query['objects'] ), $show_bulk_errors );
+						$result = $this->queue_object( $indexable, $object_id, count( $query['objects'] ), $show_bulk_errors );
 					}
 
 					if ( ! $result ) {
-						$errors[] = $object->ID;
+						$errors[] = $object_id;
 					} elseif ( true === $result || isset( $result->_index ) ) {
 						$synced ++;
 					}

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -61,6 +61,7 @@ class Post extends Indexable {
 			'ignore_sticky_posts' => true,
 			'orderby'             => 'ID',
 			'order'               => 'desc',
+			'fields'              => 'ids',
 		];
 
 		if ( isset( $args['per_page'] ) ) {

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -631,7 +631,7 @@ class User extends Indexable {
 		 * WP_User_Query doesn't let us get users across all blogs easily. This is the best
 		 * way to do that.
 		 */
-		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->prefix}users ORDER BY %s %s LIMIT %d, %d", $args['orderby'], $args['orderby'], (int) $args['offset'], (int) $args['number'] ) );
+		$objects = $wpdb->get_col( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->prefix}users ORDER BY %s %s LIMIT %d, %d", $args['orderby'], $args['orderby'], (int) $args['offset'], (int) $args['number'] ) );
 
 		return [
 			'objects'       => $objects,

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -484,13 +484,13 @@ function action_wp_ajax_ep_index() {
 		if ( ! empty( $query['objects'] ) ) {
 			$queued_items = [];
 
-			foreach ( $query['objects'] as $object ) {
+			foreach ( $query['objects'] as $object_id ) {
 				$killed_item_count = 0;
 
-				if ( apply_filters( 'ep_item_sync_kill', false, $object, $indexable ) ) {
+				if ( apply_filters( 'ep_item_sync_kill', false, $object_id, $indexable ) ) {
 					$killed_item_count++;
 				} else {
-					$queued_items[ $object->ID ] = true;
+					$queued_items[ $object_id ] = true;
 				}
 			}
 


### PR DESCRIPTION
### Description of the Change
This is pretty similar to the previous pull request prior to 3.x #1145. Currently we query for the entire post object which is unnecessary since we call `get_post()` later on anyway (within `prepare_document()`).

On large databases this has a noticeable difference on the indexing time, especially for posts with a lot of content.

### Benefits
Improves performance of indexing posts.

### Possible Drawbacks
The only potiental breaking change that I've noticed is with the `ep_item_sync_kill` filter. The second parameter was previously the entire object, whereas now it's only the object ID.

Open to suggestions on how we handle backwards compatibly for this.

### Verification Process
Performed a full index via WPCLI and within the dashboard and compared the results to the previous index.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
