### PR TITLE
Ensuring stats are built prior to requesting information. Not impleme…

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -408,7 +408,8 @@ class Weighting {
 	/**
 	 * Determine if a post type has any fields enabled for search
 	 *
-	 * @param string $post_type
+	 * @param string $post_type  Post Type
+	 * @param array  $args       WP_Query args
 	 * @return boolean true/false depending on any fields enabled == true
 	 */
 	public function post_type_has_fields( $post_type, $args = [] ) {

--- a/includes/classes/Stats.php
+++ b/includes/classes/Stats.php
@@ -151,6 +151,7 @@ class Stats {
 	 * @since 3.2
 	 */
 	public function get_health() {
+		$this->build_stats();
 		return $this->health;
 	}
 
@@ -161,6 +162,7 @@ class Stats {
 	 * @return int
 	 */
 	public function get_nodes() {
+		$this->build_stats();
 		return $this->nodes;
 	}
 
@@ -171,6 +173,7 @@ class Stats {
 	 * @return array
 	 */
 	public function get_totals() {
+		$this->build_stats();
 		return $this->totals;
 	}
 
@@ -181,6 +184,7 @@ class Stats {
 	 * @return mixed Data used in localization for chart creation.
 	 */
 	public function get_localized() {
+		$this->build_stats();
 		return $this->localized;
 	}
 


### PR DESCRIPTION
### Changelog Entry
this fixes #1526 by ensuring that the stats are built whenever information is requested. 
I am not adding this to the factory method to ensure this is only run when the information is actually needed and not on every initialization of the class itself.
