### PR TITLE
Ensure removal of filter with proper priority.

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -436,7 +436,7 @@ class Autosuggest extends Feature {
 			]
 		);
 
-		remove_filter( 'posts_pre_query', [ $features->get_registered_feature( $this->slug ), 'return_empty_posts' ] );
+		remove_filter( 'posts_pre_query', [ $features->get_registered_feature( $this->slug ), 'return_empty_posts' ], 100 );
 
 		remove_filter( 'ep_do_intercept_request', [ $features->get_registered_feature( $this->slug ), 'intercept_search_request' ] );
 


### PR DESCRIPTION
Hotfix to address issue reported in #1560 
Just ensure to pass proper priority when removing filter.