### PR TITLE
Fix/gutenberg block loading

### DIFF
--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -145,8 +145,7 @@ class RelatedPosts extends Feature {
 	public function setup() {
 		add_action( 'widgets_init', [ $this, 'register_widget' ] );
 		add_filter( 'ep_formatted_args', [ $this, 'formatted_args' ], 10, 2 );
-		add_action( 'enqueue_block_editor_assets', [ $this, 'register_block' ] );
-		add_action( 'enqueue_block_assets', [ $this, 'register_block' ] );
+		add_action( 'init', [ $this, 'register_block' ] );
 		add_action( 'rest_api_init', [ $this, 'setup_endpoint' ] );
 	}
 

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -240,12 +240,13 @@ class RelatedPosts extends Feature {
 			true
 		);
 
+		// The wp-edit-blocks style dependency is not needed on the front end of the site.
+		$style_dependencies = is_admin() ? [ 'wp-edit-blocks' ] : [];
+
 		wp_register_style(
 			'elasticpress-related-posts-block',
 			EP_URL . 'dist/css/related-posts-block-styles.min.css',
-			[
-				'wp-edit-blocks',
-			],
+			$style_dependencies,
 			EP_VERSION
 		);
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This makes two updates:

1. Registers the block registration callback on the `init` hook instead of in both `enqueue_block_editor_assets` and `enqueue_block_assets`. This fixes a PHP warning about the block being registered incorrectly.  
2. On the stylesheet that loads for the block both in the admin and on the front end, removes the `wp-edit-blocks` dependency when not in the admin. There shouldn't be any reason to load `wp-edit-blocks` outside the admin.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

Create two stylesheets for the block -- one for the admin and one for the front end. That might not be worthwhile in this case, though, since the stylesheet is so small. 

Another option, maybe better, is to inline the block's styles, rather than loading a whole CSS file just for three style rules.

### Benefits

<!-- What benefits will be realized by the code change? -->

Block now loads where expected and doesn't cause an extra stylesheet to loa don the front end.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

Checked locally.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

- Register Related Posts Gutenberg block on the `init` hook, and remove unnecessary style dependency when not in the admin.
