### PR TITLE
Fix/notice and autosuggest cache

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -499,11 +499,11 @@ class Autosuggest extends Feature {
 				$request = wp_remote_request( $query['url'], $args );
 				wp_cache_set( $cache_key, $request, 'ep_autosuggest' );
 			}
-		} else {
-			$request = new \WP_Error( 'ep_no_cache_skip_autosuggest_request', __( 'No external object cache found, skipping request', 'elasticpress' ) );
 		}
+
 		return $request;
 	}
+
 	/**
 	 * Tell user whether requirements for feature are met or not.
 	 *

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -492,12 +492,20 @@ class Autosuggest extends Feature {
 
 		// Let's make sure we also fire off the dummy request if settings have changed.
 		// But only fire this if we have object caching as otherwise this comes with a performance penalty.
+		// If we do not have object caching we cache only one value for 5 minutes in a transient.
 		if ( wp_using_ext_object_cache() ) {
 			$cache_key = md5( json_encode( $query['url'] ) . json_encode( $args ) );
 			$request   = wp_cache_get( $cache_key, 'ep_autosuggest' );
 			if ( false == $request ) {
 				$request = wp_remote_request( $query['url'], $args );
 				wp_cache_set( $cache_key, $request, 'ep_autosuggest' );
+			}
+		} else {
+			$cache_key = 'ep_autosuggest_query_request_cache';
+			$request   = get_transient( $cache_key );
+			if ( false == $request ) {
+				$request = wp_remote_request( $query['url'], $args );
+				set_transient( $cache_key, $request, 300 );
 			}
 		}
 


### PR DESCRIPTION
Returning a WP_Error for non-cacheable requests causes issues. Leaving a split logic for available object cache and non-external object cache in place to ensure that for external object cache requests are sent for each variation of query parameters while with transients only one key is used to avoid pollution of the options table while still keeping the requests updated.