### PR TITLE
Prep 3.2.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
+## [3.2.6] - 2019-11-27
+
+* Fix Under some edge conditions content for autosuggest can be large - don't cache it
+
 ## [3.2.5] - 2019-11-20
 
 * Fix WP <5.0 fatal error on register_block_type.

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ElasticPress
  * Description: A fast and flexible search and query engine for WordPress.
- * Version:     3.2.5
+ * Version:     3.2.6
  * Author:      10up
  * Author URI:  http://10up.com
  * License:     GPLv2 or later
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'EP_URL', plugin_dir_url( __FILE__ ) );
 define( 'EP_PATH', plugin_dir_path( __FILE__ ) );
-define( 'EP_VERSION', '3.2.5' );
+define( 'EP_VERSION', '3.2.6' );
 
 /**
  * PSR-4-ish autoloading

--- a/readme.txt
+++ b/readme.txt
@@ -43,12 +43,17 @@ Please refer to [Github](https://github.com/10up/ElasticPress) for detailed usag
 
 == Changelog ==
 
-= 3.2.5
+= 3.2.6 =
+This is a bugfix release
+
+* Under some edge conditions content for autosuggest can be large - don't cache it
+
+= 3.2.5 =
 This is a bug fix version.
 
 * Fix WP <5.0 fatal error on register_block_type.
 
-= 3.2.4
+= 3.2.4 =
 This is a bug fix version.
 
 * Fix Gutenberg block initialization


### PR DESCRIPTION
1### Description of the Change

Under some conditions the data object returned for the autosuggest query can include results and could get big if matching documents are larger files. This change ensures that returned body object is not cached.