### PR TITLE
Pass query object to EP response so we can check for main query

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -247,10 +247,11 @@ class Elasticsearch {
 	 * @param  string $type Index type. Previously this was used for index type. Now it's just passed to hooks for legacy reasons.
 	 * @param  array  $query Prepared ES query.
 	 * @param  array  $query_args WP query args.
+	 * @param  mixed  $query_object Could be WP_Query, WP_User_Query, etc.
 	 * @since  3.0
 	 * @return bool|array
 	 */
-	public function query( $index, $type, $query, $query_args ) {
+	public function query( $index, $type, $query, $query_args, $query_object = null ) {
 		if ( version_compare( $this->get_elasticsearch_version(), '7.0', '<' ) ) {
 			$path = $index . '/' . $type . '/_search';
 		} else {
@@ -267,9 +268,10 @@ class Elasticsearch {
 		 * @param  {string} $type Index type
 		 * @param  {array} $query Prepared Elasticsearch query
 		 * @param  {array} $query_args Query arguments
+		 * @param  {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
 		 * @return  {string} New path
 		 */
-		$path = apply_filters( 'ep_search_request_path', $path, $index, $type, $query, $query_args );
+		$path = apply_filters( 'ep_search_request_path', $path, $index, $type, $query, $query_args, $query_object );
 
 		/**
 		 * Filter Elasticsearch query request path
@@ -280,9 +282,10 @@ class Elasticsearch {
 		 * @param  {string} $type Index type
 		 * @param  {array} $query Prepared Elasticsearch query
 		 * @param  {array} $query_args Query arguments
+		 * @param  {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
 		 * @return  {string} New path
 		 */
-		$path = apply_filters( 'ep_query_request_path', $path, $index, $type, $query, $query_args );
+		$path = apply_filters( 'ep_query_request_path', $path, $index, $type, $query, $query_args, $query_object );
 
 		$request_args = array(
 			'body'    => wp_json_encode( $query ),
@@ -326,10 +329,11 @@ class Elasticsearch {
 			 *
 			 * @hook ep_valid_response
 			 * @param {array} $response Elasticsearch decoded response
-			 * @param  {WP_Query} $query Current WP Query
+			 * @param  {array} $query Prepared Elasticsearch query
 			 * @param  {array} $query_args Current WP Query arguments
+			 * @param  {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
 			 */
-			do_action( 'ep_valid_response', $response, $query, $query_args );
+			do_action( 'ep_valid_response', $response, $query, $query_args, $query_object );
 
 			// Backwards compat
 			/**
@@ -337,10 +341,11 @@ class Elasticsearch {
 			 *
 			 * @hook ep_retrieve_raw_response
 			 * @param {array} $response Elasticsearch request
-			 * @param  {WP_Query} $query Current WP Query
+			 * @param  {array} $query Prepared Elasticsearch query
 			 * @param  {array} $query_args Current WP Query arguments
+			 * @param  {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
 			 */
-			do_action( 'ep_retrieve_raw_response', $request, $query, $query_args );
+			do_action( 'ep_retrieve_raw_response', $request, $query, $query_args, $query_object );
 
 			$documents = [];
 
@@ -368,6 +373,7 @@ class Elasticsearch {
 			 * @param  {response} $response Raw response from Elasticsearch
 			 * @param  {array} $query Raw Elasticsearch query
 			 * @param  {array} $query_args Query arguments
+			 * @param  {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
 			 * @return  {array} New results
 			 */
 			return apply_filters(
@@ -378,7 +384,8 @@ class Elasticsearch {
 				],
 				$response,
 				$query,
-				$query_args
+				$query_args,
+				$query_object
 			);
 		}
 

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -47,7 +47,7 @@ class Facets extends Feature {
 	 */
 	public function setup() {
 		add_action( 'widgets_init', [ $this, 'register_widgets' ] );
-		add_action( 'ep_valid_response', [ $this, 'get_aggs' ] );
+		add_action( 'ep_valid_response', [ $this, 'get_aggs' ], 10, 4 );
 		add_filter( 'ep_post_formatted_args', [ $this, 'set_agg_filters' ], 10, 3 );
 		add_action( 'pre_get_posts', [ $this, 'facet_query' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
@@ -299,9 +299,15 @@ class Facets extends Feature {
 	 * Hacky. Save aggregation data for later in a global
 	 *
 	 * @param  array $response ES response
+	 * @param  array $query Prepared Elasticsearch query
+	 * @param  array $query_args Current WP Query arguments
+	 * @param  mixed $query_object Could be WP_Query, WP_User_Query, etc.
 	 * @since  2.5
 	 */
-	public function get_aggs( $response ) {
+	public function get_aggs( $response, $query, $query_args, $query_object ) {
+		if ( empty( $query_object ) || 'WP_Query' !== get_class( $query_object ) || ! $query_object->is_main_query() ) {
+			return;
+		}
 
 		$GLOBALS['ep_facet_aggs'] = false;
 

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -315,15 +315,16 @@ abstract class Indexable {
 	 * @param  array  $formatted_args Formatted es query arguments.
 	 * @param  array  $query_args WP_Query args.
 	 * @param  string $index Index(es) to query. Comma separate for multiple. Defaults to current.
+	 * @param  mixed  $query_object Could be WP_Query, WP_User_Query, etc.
 	 * @since  3.0
 	 * @return array
 	 */
-	public function query_es( $formatted_args, $query_args, $index = null ) {
+	public function query_es( $formatted_args, $query_args, $index = null, $query_object = null ) {
 		if ( null === $index ) {
 			$index = $this->get_index_name();
 		}
 
-		return Elasticsearch::factory()->query( $index, $this->slug, $formatted_args, $query_args );
+		return Elasticsearch::factory()->query( $index, $this->slug, $formatted_args, $query_args, $query_object );
 	}
 
 	/**

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -275,7 +275,7 @@ class QueryIntegration {
 				$index = implode( ',', $index );
 			}
 
-			$ep_query = Indexables::factory()->get( 'post' )->query_es( $formatted_args, $query->query_vars, $index );
+			$ep_query = Indexables::factory()->get( 'post' )->query_es( $formatted_args, $query->query_vars, $index, $query );
 
 			/**
 			 * ES failed. Go back to MySQL.

--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -76,7 +76,7 @@ class QueryIntegration {
 		if ( null === $new_users ) {
 			$formatted_args = $user_indexable->format_args( $query->query_vars, $query );
 
-			$ep_query = $user_indexable->query_es( $formatted_args, $query->query_vars );
+			$ep_query = $user_indexable->query_es( $formatted_args, $query->query_vars, null, $query );
 
 			if ( false === $ep_query ) {
 				return $results;


### PR DESCRIPTION
This fixes the problem addressed in #1575. Before saving aggs, we make sure we are getting the aggs from the main query.