### PR TITLE
Show managed platform message instead of ES version for EP.io

### DIFF
--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -176,7 +176,7 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 				<th scope="row">
 					<label for="ep_host"><?php esc_html_e( 'Elasticsearch Version', 'elasticpress' ); ?></label></th>
 				<td>
-					<?php if ( ! $is_epio ) : ?>
+					<?php if ( $is_epio ) : ?>
 						<?php esc_html_e( 'ElasticPress.io Managed Platform'); ?>
 					<?php else : ?>
 						<?php if ( ! empty( $version ) ) : ?>

--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -176,10 +176,14 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 				<th scope="row">
 					<label for="ep_host"><?php esc_html_e( 'Elasticsearch Version', 'elasticpress' ); ?></label></th>
 				<td>
-					<?php if ( ! empty( $version ) ) : ?>
-						<legend class="description"><?php echo esc_html( $version ); ?></legend>
+					<?php if ( ! $is_epio ) : ?>
+						<?php esc_html_e( 'ElasticPress.io Managed Platform'); ?>
 					<?php else : ?>
-						<legend class="description">&mdash;</legend>
+						<?php if ( ! empty( $version ) ) : ?>
+							<?php echo esc_html( $version ); ?>
+						<?php else : ?>
+							&mdash;
+						<?php endif; ?>
 					<?php endif; ?>
 				</td>
 			</tr>


### PR DESCRIPTION
Instead of showing ES version for .IO, we will just show Managed Platform as the .IO platform has customizations that make it unique from the core software.