### PR TITLE
Make sure post type array doesn't have keys

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1149,7 +1149,7 @@ class Post extends Indexable {
 
 				$filter['bool']['must'][] = array(
 					$terms_map_name => array(
-						'post_type.raw' => $post_types,
+						'post_type.raw' => array_values( $post_types ),
 					),
 				);
 


### PR DESCRIPTION
This fixes search for bbPress. We make sure the post type array doesn't have keys.