### PR TITLE
error_fix(SearchOrdering.php) - Invalid Argument

### DIFF
--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -195,7 +195,7 @@ class Documents extends Feature {
 				 * @param  {string} $id Pipeline ID
 				 * @return  {string} new ID
 				 */
-				$path  = trailingslashit( $index ) . 'post/' . $post['ID'] . '?pipeline=' . apply_filters( 'ep_documents_pipeline_id', Indexables::factory()->get( 'post' )->get_index_name() . '-attachment' );
+				$path = trailingslashit( $index ) . 'post/' . $post['ID'] . '?pipeline=' . apply_filters( 'ep_documents_pipeline_id', Indexables::factory()->get( 'post' )->get_index_name() . '-attachment' );
 			}
 		}
 

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -740,6 +740,10 @@ class SearchOrdering extends Feature {
 		$pointers = get_post_meta( $post_id, 'pointers', true );
 		$term     = $this->create_or_return_custom_result_term( $post->post_title );
 
+		if ( empty( $pointers ) ) {
+			return;
+		}
+		
 		foreach ( $pointers as $pointer ) {
 			$ref_id = $pointer['ID'];
 			wp_remove_object_terms( $ref_id, (int) $term->term_id, self::TAXONOMY_NAME );

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -743,7 +743,7 @@ class SearchOrdering extends Feature {
 		if ( empty( $pointers ) ) {
 			return;
 		}
-		
+
 		foreach ( $pointers as $pointer ) {
 			$ref_id = $pointer['ID'];
 			wp_remove_object_terms( $ref_id, (int) $term->term_id, self::TAXONOMY_NAME );


### PR DESCRIPTION
{"message":"Invalid argument supplied for foreach()","context":{"exception":{"class":"ErrorException","message":"Invalid argument supplied for foreach()","code":0,"file":"/var/www/html/pdinfo/releases/20190829162419/web/app/plugins/elasticpress/includes/classes/Feature/SearchOrdering/SearchOrdering.php:743"}

It is possible for the pointers variable in function handle_post_trash to be empty. This is generally not an issue unless running a very strict policy of not allowing any Errors. Our use case requires that we verify that variables being manipulated are verified as not empty.

Please consider accepting this change.

### Requirements

### Description of the Change

Elasticpress can attempt to manipulate an empty variable that it expected to be an array. This change will prevent this manipulation from happening and prevent an exception.


### Alternate Designs

No alternative was considered because this appears to be the easiest and clearest way of managing this possibility. If the array is empty, exit the function.

### Benefits

 This increases resiliency and helps prevent the system from logging an exception. We follow a strict policy when it comes to exceptions so without this fix our application cannot run.

### Possible Drawbacks

No known drawbacks. 

### Verification Process

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
    I added this change and ran it locally  in our live production environment. It resolved our issues and has demonstrated no odd behavior or produced any problems for us.
- How did you verify that all changed functionality works as expected?
    I used the application and verified I could add and subtract custom search results with no issues, errors, or additional shouts in the logs.
- How did you verify that the change has not introduced any regressions?
    This simple change only checks for the existence of a value and has no introduced regressions.

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
