### PR TITLE
added filter to flatten hits that are come within aggregations.

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -414,7 +414,17 @@ class Elasticsearch {
 			return [];
 		}
 
-		return $response['hits']['hits'];
+		/**
+		 * Filter Elasticsearch allows to flatten hits, if searched hits are come within aggregations.
+		 *
+		 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
+		 *
+		 * @hook ep_get_hits_from_query
+		 * @param {array} $hits from Elasticsearch
+		 * @param {response} $response Raw response from Elasticsearch
+		 * @return {array} hits
+		 */
+		return apply_filters( 'ep_get_hits_from_query', $response['hits']['hits'], $response );
 	}
 
 	/**


### PR DESCRIPTION
We can receive top X hits for each post_type with just one ES request. The searched hits are placed in this case not in $result['hits']['hits'] but deep in $result['aggregations'][...]...[...]['hits']['hits']

s. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
