### PR TITLE
When ep_integrate set to false, do not apply faceting. Closes #1589

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -195,6 +195,12 @@ class Facets extends Feature {
 			return false;
 		}
 
+		$ep_integrate = $query->get( 'ep_integrate', null );
+
+		if ( false === $ep_integrate ) {
+			return false;
+		}
+
 		if ( ! ( ( function_exists( 'is_product_category' ) && is_product_category() )
 			|| $query->is_post_type_archive()
 			|| $query->is_search()


### PR DESCRIPTION
### Description of the Change

Fixes a bug where faceting was ignoring `ep_integrate`.

### Verification Process

Add `ep_integrate` false to main query, turn faceting on. Faceting should not work.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

