### PR TITLE
ES 7 fix: documents with leapyear-02-29 00:00:00 cannot be indexed

### DIFF
--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -287,11 +287,11 @@ return array(
 			),
 			'post_date'             => array(
 				'type'   => 'date',
-				'format' => 'YYYY-MM-dd HH:mm:ss',
+				'format' => 'yyyy-MM-dd HH:mm:ss',
 			),
 			'post_date_gmt'         => array(
 				'type'   => 'date',
-				'format' => 'YYYY-MM-dd HH:mm:ss',
+				'format' => 'yyyy-MM-dd HH:mm:ss',
 			),
 			'post_title'            => array(
 				'type'   => 'text',
@@ -337,11 +337,11 @@ return array(
 			),
 			'post_modified'         => array(
 				'type'   => 'date',
-				'format' => 'YYYY-MM-dd HH:mm:ss',
+				'format' => 'yyyy-MM-dd HH:mm:ss',
 			),
 			'post_modified_gmt'     => array(
 				'type'   => 'date',
-				'format' => 'YYYY-MM-dd HH:mm:ss',
+				'format' => 'yyyy-MM-dd HH:mm:ss',
 			),
 			'post_parent'           => array(
 				'type' => 'long',

--- a/includes/mappings/user/7-0.php
+++ b/includes/mappings/user/7-0.php
@@ -197,7 +197,7 @@ return array(
 			),
 			'user_registered' => array(
 				'type'   => 'date',
-				'format' => 'YYYY-MM-dd HH:mm:ss',
+				'format' => 'yyyy-MM-dd HH:mm:ss',
 			),
 			'user_nicename'   => array(
 				'type'   => 'text',


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
Requirements:
ES 7.5

Problem:
YYYY refers to a week based year and does not work

Error Log:
```
- 10796 (Post): 
type: mapper_parsing_exception
reason: failed to parse field [post_date] of type [date] in document with id '10796'. Preview of field's value: '2012-02-29 23:00:00'
type: date_time_exception
reason: Invalid date 'February 29' as '1970' is not a leap year

- 7860 (Post): 
type: mapper_parsing_exception
reason: failed to parse field [post_date] of type [date] in document with id '7860'. Preview of field's value: '2016-02-29 00:00:00'
type: date_time_exception
reason: Invalid date 'February 29' as '1970' is not a leap year
```
see [disqus on ES](https://discuss.elastic.co/t/type-date-time-exception-reason-invalid-date-february-29-as-1970-is-not-a-leap-year/205570)
