### PR TITLE
Support all taxonomies in root WP_Query

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -697,45 +697,63 @@ class Post extends Indexable {
 		 * @since 0.9.1
 		 */
 
-		// set tax_query if it's implicitly set in the query.
-		// e.g. $args['tag'], $args['category_name'].
-		if ( empty( $args['tax_query'] ) ) {
-			switch ( $args ) {
-				case ! empty( $args['category_name'] ):
-					$args['tax_query'][] = array(
-						'taxonomy' => 'category',
-						'terms'    => array( $args['category_name'] ),
-						'field'    => 'slug',
-					);
-					break;
-				case ! empty( $args['cat'] ):
-					$args['tax_query'][] = array(
-						'taxonomy' => 'category',
-						'terms'    => array( $args['cat'] ),
-						'field'    => 'id',
-					);
-					break;
-				case ! empty( $args['tag'] ):
-					$args['tax_query'][] = array(
-						'taxonomy' => 'post_tag',
-						'terms'    => array( $args['tag'] ),
-						'field'    => 'slug',
-					);
-					break;
-				case ! empty( $args['tag__and'] ):
-					$args['tax_query'][] = array(
-						'taxonomy' => 'post_tag',
-						'terms'    => $args['tag__and'],
-						'field'    => 'term_id',
-					);
-					break;
-				case ! empty( $args['tag_id'] ) && ! is_array( $args['tag_id'] ):
-					$args['tax_query'][] = array(
-						'taxonomy' => 'post_tag',
-						'terms'    => $args['tag_id'],
-						'field'    => 'term_id',
-					);
-					break;
+		// Find root level taxonomies.
+		switch ( $args ) {
+			case ! empty( $args['category_name'] ):
+				$args['tax_query'][] = array(
+					'taxonomy' => 'category',
+					'terms'    => array( $args['category_name'] ),
+					'field'    => 'slug',
+				);
+				break;
+			case ! empty( $args['cat'] ):
+				$args['tax_query'][] = array(
+					'taxonomy' => 'category',
+					'terms'    => array( $args['cat'] ),
+					'field'    => 'id',
+				);
+				break;
+			case ! empty( $args['tag'] ):
+				$args['tax_query'][] = array(
+					'taxonomy' => 'post_tag',
+					'terms'    => array( $args['tag'] ),
+					'field'    => 'slug',
+				);
+				break;
+			case ! empty( $args['tag__and'] ):
+				$args['tax_query'][] = array(
+					'taxonomy' => 'post_tag',
+					'terms'    => $args['tag__and'],
+					'field'    => 'term_id',
+				);
+				break;
+			case ! empty( $args['tag_id'] ) && ! is_array( $args['tag_id'] ):
+				$args['tax_query'][] = array(
+					'taxonomy' => 'post_tag',
+					'terms'    => $args['tag_id'],
+					'field'    => 'term_id',
+				);
+				break;
+		}
+
+		/**
+		 * Try to find other taxonomies set in the root of WP_Query
+		 *
+		 * @since  3.4
+		 */
+		$taxonomies = get_taxonomies();
+
+		foreach ( $taxonomies as $tax_slug ) {
+			if ( 'ep_custom_result' === $tax_slug ) {
+				continue;
+			}
+
+			if ( ! empty( $args[ $tax_slug ] ) ) {
+				$args['tax_query'][] = array(
+					'taxonomy' => $tax_slug,
+					'terms'    => array( $args[ $tax_slug ] ),
+					'field'    => 'slug',
+				);
 			}
 		}
 


### PR DESCRIPTION
### Description of the Change

Right now we don't do a tax_query for taxonomies called in the root of `WP_Query` e.g.
```php
new WP_Query( [
  'tax_name' => 'slug',
] );
```

Should fix #1576.

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


