### PR TITLE
Fixes for WP_User_Query 'fields' parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .history
 docs-built
 npm-log.log
+test-coverage-html/
+.phpunit.result.cache

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,6 +28,18 @@ Now run the tests:
 EP_HOST="http://elasticsearch:9200" phpunit
 ```
 
+To run a specific test, pass the `--filter` parameter:
+
+```
+EP_HOST="http://elasticsearch:9200" phpunit --filter=testSanitizeCredentials
+```
+
+To verify all of the code paths are being tested, you can generate an HTML code coverage report for your tests. Pass `--coverage-html test-coverage-html` as a parameter and a report will be generated in that directory.
+
+```
+EP_HOST="http://elasticsearch:9200" phpunit --filter=testSanitizeCredentials --coverage-html test-coverage-html
+```
+
 To run WP Acceptance, navigate to the root of the plugin and run:
 
 ```

--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -91,7 +91,7 @@ class QueryIntegration {
 			$fields    = $query->get( 'fields' );
 			$new_users = [];
 
-			if ( 'all_with_meta' === $fields || 'all' === $fields ) {
+			if ( 'all_with_meta' === $fields ) {
 				foreach ( $ep_query['documents'] as $document ) {
 					$new_users[] = $document['ID'];
 				}
@@ -108,7 +108,7 @@ class QueryIntegration {
 
 					$new_users[] = $user;
 				}
-			} else if ( is_string( $fields ) && ! empty( $fields ) ) {
+			} else if ( is_string( $fields ) && ! empty( $fields ) && 'all' !== $fields ) {
 				foreach ( $ep_query['documents'] as $document ) {
 					$new_users[] = $document[ $fields ];
 				}

--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -88,11 +88,28 @@ class QueryIntegration {
 			 * $query->elasticsearch_success = true;
 			 */
 
-			if ( 'all_with_meta' === $query->get( 'fields' ) ) {
-				$new_users = [];
+			$fields    = $query->get( 'fields' );
+			$new_users = [];
 
+			if ( 'all_with_meta' === $fields ) {
 				foreach ( $ep_query['documents'] as $document ) {
 					$new_users[] = $document['ID'];
+				}
+			} else if ( is_array( $fields ) ) {
+				// WP_User_Query returns a stdClass.
+				foreach ( $ep_query['documents'] as $document ) {
+
+					$user = new \stdClass();
+
+					foreach ( $fields as $field ) {
+						$user->$field = $document[ $field ];
+					}
+
+					$new_users[] = $user;
+				}
+			} else if ( is_string( $fields ) && ! empty( $fields ) ) {
+				foreach ( $ep_query['documents'] as $document ) {
+					$new_users[] = $document[ $fields ];
 				}
 			} else {
 				$new_users = $this->format_hits_as_users( $ep_query['documents'] );

--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -91,7 +91,7 @@ class QueryIntegration {
 			$fields    = $query->get( 'fields' );
 			$new_users = [];
 
-			if ( 'all_with_meta' === $fields ) {
+			if ( 'all_with_meta' === $fields || 'all' === $fields ) {
 				foreach ( $ep_query['documents'] as $document ) {
 					$new_users[] = $document['ID'];
 				}
@@ -103,6 +103,7 @@ class QueryIntegration {
 
 					foreach ( $fields as $field ) {
 						$user->$field = $document[ $field ];
+						$user->elasticsearch = true; // Super useful for debugging.
 					}
 
 					$new_users[] = $user;

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -96,4 +96,64 @@ class TestUtils extends BaseTestCase {
 
 		$this->assertFalse( ElasticPress\Utils\is_site_indexable() );
 	}
+
+	/**
+	 * Tests the sanitize_credentials utils function.
+	 *
+	 * @return void
+	 */
+	public function testSanitizeCredentials() {
+
+		// First test anything that is not an array.
+		$creds = \ElasticPress\Utils\sanitize_credentials( false );
+		$this->assertTrue( is_array( $creds ) );
+
+		$this->assertArrayHasKey( 'username', $creds );
+		$this->assertArrayHasKey( 'token', $creds );
+
+		$this->assertSame( '', $creds['username'] );
+		$this->assertSame( '', $creds['token'] );
+
+		// Then test arrays with invalid data.
+		$creds = \ElasticPress\Utils\sanitize_credentials( [] );
+
+		$this->assertTrue( is_array( $creds ) );
+
+		$this->assertArrayHasKey( 'username', $creds );
+		$this->assertArrayHasKey( 'token', $creds );
+
+		$this->assertSame( '', $creds['username'] );
+		$this->assertSame( '', $creds['token'] );
+
+		$creds = \ElasticPress\Utils\sanitize_credentials(
+			[
+				'username' => '<strong>hello</strong> world',
+				'token' => 'able <script>alert("baker");</script>',
+			]
+		);
+
+		$this->assertTrue( is_array( $creds ) );
+
+		$this->assertArrayHasKey( 'username', $creds );
+		$this->assertArrayHasKey( 'token', $creds );
+
+		$this->assertSame( 'hello world', $creds['username'] );
+		$this->assertSame( 'able', $creds['token'] );
+
+		// Finally, test with valid data.
+		$creds = \ElasticPress\Utils\sanitize_credentials(
+			[
+				'username' => 'my-user-name',
+				'token' => 'my-token',
+			]
+		);
+
+		$this->assertTrue( is_array( $creds ) );
+
+		$this->assertArrayHasKey( 'username', $creds );
+		$this->assertArrayHasKey( 'token', $creds );
+
+		$this->assertSame( 'my-user-name', $creds['username'] );
+		$this->assertSame( 'my-token', $creds['token'] );
+	}
 }

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -976,7 +976,9 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( $user_ids, $user_query->results );
+		$ep_user_ids = array_map( 'absint', $user_query->results );
+
+		$this->assertSame( $user_ids, $ep_user_ids );
 	}
 
 	/**
@@ -1016,6 +1018,7 @@ class TestUser extends BaseTestCase {
 		for ( $i = 0; $i < 5; $i++ ) {
 			$this->assertSame( absint( $users[ $i ]->ID ), absint( $ep_users[ $i ]->ID ) );
 			$this->assertSame( $users[ $i ]->display_name, $ep_users[ $i ]->display_name );
+			var_dump( $ep_users[ $i ] );
 			$this->assertTrue( $ep_users[ $i ]->elasticsearch );
 		}
 	}

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -241,7 +241,7 @@ class TestUser extends BaseTestCase {
 	public function testBasicUserQuery() {
 		$this->createAndIndexUsers();
 
-		// First try without ES and make sure everything is right
+		// First try without ES and make sure everything is right.
 		$user_query = new \WP_User_Query(
 			[
 				'number' => 10,
@@ -255,8 +255,7 @@ class TestUser extends BaseTestCase {
 		$this->assertEquals( 5, count( $user_query->results ) );
 		$this->assertEquals( 5, $user_query->total_users );
 
-		// Now try with Elasticsearch
-
+		// Now try with Elasticsearch.
 		$user_query = new \WP_User_Query(
 			[
 				'ep_integrate' => true,
@@ -1017,6 +1016,7 @@ class TestUser extends BaseTestCase {
 		for ( $i = 0; $i < 5; $i++ ) {
 			$this->assertSame( absint( $users[ $i ]->ID ), absint( $ep_users[ $i ]->ID ) );
 			$this->assertSame( $users[ $i ]->display_name, $ep_users[ $i ]->display_name );
+			$this->assertTrue( $user->elasticsearch );
 		}
 	}
 }

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -1016,7 +1016,7 @@ class TestUser extends BaseTestCase {
 		for ( $i = 0; $i < 5; $i++ ) {
 			$this->assertSame( absint( $users[ $i ]->ID ), absint( $ep_users[ $i ]->ID ) );
 			$this->assertSame( $users[ $i ]->display_name, $ep_users[ $i ]->display_name );
-			$this->assertTrue( $user->elasticsearch );
+			$this->assertTrue( $ep_users[ $i ]->elasticsearch );
 		}
 	}
 }

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -979,4 +979,44 @@ class TestUser extends BaseTestCase {
 
 		$this->assertSame( $user_ids, $user_query->results );
 	}
+
+	/**
+	 * Tests multiple fields in the fields parameters for user queries.
+	 */
+	public function testMultipleUserFieldsQuery() {
+		$this->createAndIndexUsers();
+
+		$count = 5;
+
+		// First, get the IDs of the users.
+		$user_query = new \WP_User_Query(
+			[
+				'number' => $count,
+				'fields' => [ 'ID', 'display_name' ],
+			]
+		);
+
+		$users = $user_query->results;
+
+		$this->assertEquals( $count, count( $users ) );
+
+		// Run the same query against EP to verify we're getting classes
+		// with properties.
+		$user_query = new \WP_User_Query(
+			[
+				'ep_integrate' => true,
+				'number'       => $count,
+				'fields' => [ 'ID', 'display_name' ],
+			]
+		);
+
+		$ep_users = $user_query->results;
+
+		$this->assertEquals( 5, count( $users ) );
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->assertSame( absint( $users[ $i ]->ID ), absint( $ep_users[ $i ]->ID ) );
+			$this->assertSame( $users[ $i ]->display_name, $ep_users[ $i ]->display_name );
+		}
+	}
 }

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -947,4 +947,36 @@ class TestUser extends BaseTestCase {
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'user1-author', $user_query->results[0]->user_login );
 	}
+
+	/**
+	 * Tests a single field in the fields parameters for user queries.
+	 */
+	public function testSingleUserFieldQuery() {
+		$this->createAndIndexUsers();
+
+		// First, get the IDs of the users.
+		$user_query = new \WP_User_Query(
+			[
+				'number' => 5,
+				'fields' => 'ID',
+			]
+		);
+
+		$this->assertEquals( 5, count( $user_query->results ) );
+
+		// This returns an array of strings, while EP returns ints.
+		$user_ids = array_map( 'absint', $user_query->results );
+
+		// Run the same query against EP to verify we're only getting
+		// user IDs.
+		$user_query = new \WP_User_Query(
+			[
+				'ep_integrate' => true,
+				'number'       => 5,
+				'fields'       => 'ID',
+			]
+		);
+
+		$this->assertSame( $user_ids, $user_query->results );
+	}
 }


### PR DESCRIPTION
### Description of the Change
- Added `testSanitizeCredentials()` to help me get up to speed on EP unit tests and additional examples to the development documentation.
- Updated `maybe_filter_query()` for WP_User_Query to handle a single field and multiple fields as an array.
- Added unit tests `testSingleUserFieldQuery()` and `testMultipleUserFieldsQuery()`

### Benefits
User queries with 'fields' will now work correctly.

### Possible Drawbacks
None

### Verification Process
Created unit tests for the updated functionality.

### Checklist:
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests passed.


### Applicable Issues
Fixes #1609 

### Changelog Entry
- Fixed bug where passing 'fields' to WP_User_Query was not returning the requested fields