### PR TITLE
Moved EP indexable posts class registration into a function that runs in the plugins_loaded action

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -83,60 +83,61 @@ if ( $network_activated ) {
 }
 
 /**
- * Sets up all the various EP classes.
+ * Sets up the indexable posts class.
  *
  * @return void
  */
-function ep_setup() {
-	global $wp_version;
-
+function register_indexable_posts() {
 	/**
 	 * Handle indexables
 	 */
 	Indexables::factory()->register( new Indexable\Post\Post() );
 
-	/**
-	 * Handle features
-	 */
-	Features::factory()->register_feature(
-		new Feature\Search\Search()
-	);
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\register_indexable_posts' );
 
-	Features::factory()->register_feature(
-		new Feature\ProtectedContent\ProtectedContent()
-	);
+global $wp_version;
 
-	Features::factory()->register_feature(
-		new Feature\Autosuggest\Autosuggest()
-	);
+/**
+ * Handle features
+ */
+Features::factory()->register_feature(
+	new Feature\Search\Search()
+);
 
-	Features::factory()->register_feature(
-		new Feature\RelatedPosts\RelatedPosts()
-	);
+Features::factory()->register_feature(
+	new Feature\ProtectedContent\ProtectedContent()
+);
 
-	Features::factory()->register_feature(
-		new Feature\WooCommerce\WooCommerce()
-	);
+Features::factory()->register_feature(
+	new Feature\Autosuggest\Autosuggest()
+);
 
-	Features::factory()->register_feature(
-		new Feature\Facets\Facets()
-	);
+Features::factory()->register_feature(
+	new Feature\RelatedPosts\RelatedPosts()
+);
 
-	Features::factory()->register_feature(
-		new Feature\Documents\Documents()
-	);
+Features::factory()->register_feature(
+	new Feature\WooCommerce\WooCommerce()
+);
 
-	if ( version_compare( $wp_version, '5.1', '>=' ) || 0 === stripos( $wp_version, '5.1-' ) ) {
-		Features::factory()->register_feature(
-			new Feature\Users\Users()
-		);
-	}
+Features::factory()->register_feature(
+	new Feature\Facets\Facets()
+);
 
+Features::factory()->register_feature(
+	new Feature\Documents\Documents()
+);
+
+if ( version_compare( $wp_version, '5.1', '>=' ) || 0 === stripos( $wp_version, '5.1-' ) ) {
 	Features::factory()->register_feature(
-		new Feature\SearchOrdering\SearchOrdering()
+		new Feature\Users\Users()
 	);
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\ep_setup' );
+
+Features::factory()->register_feature(
+	new Feature\SearchOrdering\SearchOrdering()
+);
 
 /**
  * Set the availability of dashboard sync functionality. Defaults to true (enabled).

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -82,53 +82,61 @@ if ( $network_activated ) {
 	define( 'EP_IS_NETWORK', true );
 }
 
-global $wp_version;
-
 /**
- * Handle indexables
+ * Sets up all the various EP classes.
+ *
+ * @return void
  */
-Indexables::factory()->register( new Indexable\Post\Post() );
+function ep_setup() {
+	global $wp_version;
 
-/**
- * Handle features
- */
-Features::factory()->register_feature(
-	new Feature\Search\Search()
-);
+	/**
+	 * Handle indexables
+	 */
+	Indexables::factory()->register( new Indexable\Post\Post() );
 
-Features::factory()->register_feature(
-	new Feature\ProtectedContent\ProtectedContent()
-);
-
-Features::factory()->register_feature(
-	new Feature\Autosuggest\Autosuggest()
-);
-
-Features::factory()->register_feature(
-	new Feature\RelatedPosts\RelatedPosts()
-);
-
-Features::factory()->register_feature(
-	new Feature\WooCommerce\WooCommerce()
-);
-
-Features::factory()->register_feature(
-	new Feature\Facets\Facets()
-);
-
-Features::factory()->register_feature(
-	new Feature\Documents\Documents()
-);
-
-if ( version_compare( $wp_version, '5.1', '>=' ) || 0 === stripos( $wp_version, '5.1-' ) ) {
+	/**
+	 * Handle features
+	 */
 	Features::factory()->register_feature(
-		new Feature\Users\Users()
+		new Feature\Search\Search()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\ProtectedContent\ProtectedContent()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\Autosuggest\Autosuggest()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\RelatedPosts\RelatedPosts()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\WooCommerce\WooCommerce()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\Facets\Facets()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\Documents\Documents()
+	);
+
+	if ( version_compare( $wp_version, '5.1', '>=' ) || 0 === stripos( $wp_version, '5.1-' ) ) {
+		Features::factory()->register_feature(
+			new Feature\Users\Users()
+		);
+	}
+
+	Features::factory()->register_feature(
+		new Feature\SearchOrdering\SearchOrdering()
 	);
 }
-
-Features::factory()->register_feature(
-	new Feature\SearchOrdering\SearchOrdering()
-);
+add_action( 'plugins_loaded', __NAMESPACE__ . '\ep_setup' );
 
 /**
  * Set the availability of dashboard sync functionality. Defaults to true (enabled).
@@ -181,7 +189,7 @@ function handle_upgrades() {
 		$last_sync = get_option( 'ep_last_sync', 'never' );
 	}
 
-	// No need to upgrade since we've never synced
+	// No need to upgrade since we've never synced.
 	if ( empty( $last_sync ) || 'never' === $last_sync ) {
 		return;
 	}

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -83,61 +83,60 @@ if ( $network_activated ) {
 }
 
 /**
- * Sets up the indexable posts class.
+ * Sets up the indexables and features.
  *
  * @return void
  */
 function register_indexable_posts() {
+	global $wp_version;
+
 	/**
 	 * Handle indexables
 	 */
 	Indexables::factory()->register( new Indexable\Post\Post() );
 
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\register_indexable_posts' );
-
-global $wp_version;
-
-/**
- * Handle features
- */
-Features::factory()->register_feature(
-	new Feature\Search\Search()
-);
-
-Features::factory()->register_feature(
-	new Feature\ProtectedContent\ProtectedContent()
-);
-
-Features::factory()->register_feature(
-	new Feature\Autosuggest\Autosuggest()
-);
-
-Features::factory()->register_feature(
-	new Feature\RelatedPosts\RelatedPosts()
-);
-
-Features::factory()->register_feature(
-	new Feature\WooCommerce\WooCommerce()
-);
-
-Features::factory()->register_feature(
-	new Feature\Facets\Facets()
-);
-
-Features::factory()->register_feature(
-	new Feature\Documents\Documents()
-);
-
-if ( version_compare( $wp_version, '5.1', '>=' ) || 0 === stripos( $wp_version, '5.1-' ) ) {
+	/**
+	 * Handle features
+	 */
 	Features::factory()->register_feature(
-		new Feature\Users\Users()
+		new Feature\Search\Search()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\ProtectedContent\ProtectedContent()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\Autosuggest\Autosuggest()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\RelatedPosts\RelatedPosts()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\WooCommerce\WooCommerce()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\Facets\Facets()
+	);
+
+	Features::factory()->register_feature(
+		new Feature\Documents\Documents()
+	);
+
+	if ( version_compare( $wp_version, '5.1', '>=' ) || 0 === stripos( $wp_version, '5.1-' ) ) {
+		Features::factory()->register_feature(
+			new Feature\Users\Users()
+		);
+	}
+
+	Features::factory()->register_feature(
+		new Feature\SearchOrdering\SearchOrdering()
 	);
 }
-
-Features::factory()->register_feature(
-	new Feature\SearchOrdering\SearchOrdering()
-);
+add_action( 'plugins_loaded', __NAMESPACE__ . '\register_indexable_posts' );
 
 /**
  * Set the availability of dashboard sync functionality. Defaults to true (enabled).

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -542,7 +542,7 @@ class Elasticsearch {
 		}
 
 		/**
-		 * Filter Elasticsearch response headers
+		 * Filter Elasticsearch request headers
 		 *
 		 * @hook ep_format_request_headers
 		 * @param {array} $headers Current headers

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4614,4 +4614,34 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
 	}
+
+	/**
+	 * Tests the http_request_args filter.
+	 *
+	 * @return void
+	 */
+	public function testHttpRequestArgsFilter() {
+		add_action( 'ep_sync_on_transition', array( $this, 'action_sync_on_transition' ), 10, 0 );
+
+		add_filter(
+			'http_request_args',
+			function( $args ) {
+				$args['headers']['x-my-value'] = '12345';
+				return $args;
+			}
+		);
+
+		add_filter(
+			'http_request_args',
+			function( $args ) {
+				$this->assertSame( '12345', $args['headers']['x-my-value'] );
+				return $args;
+			},
+			PHP_INT_MAX
+		);
+
+		$post_id = Functions\create_and_sync_post();
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+	}
 }


### PR DESCRIPTION
### Description of the Change
Moves the `Indexables::factory()->register( new Indexable\Post\Post() );` call into a `plugins_loaded` action.

### Alternate Designs
None.

### Benefits
The indexable post class make a call to Elasticsearch inside its constructor. Since this constructor is being called prior to any other plugins being loaded, any hooks/filters in the other plugins will not run.

### Possible Drawbacks
Possible breaking changes for existing plugins/themes that interact with EP, but the scope of this is unknown.

### Verification Process
Ran all of the existing unit tests locally, all passed.
```
root@350c654785b0:/var/www/html/wp-content/plugins/elasticpress# EP_HOST="http://elasticsearch:9200" ./vendor/bin/phpunit
Installing...
Installing network...
Running as multisite...
WordPress version 5.3.2
Elasticsearch version 7.5.1
Installing WooCommerce version 3.6.5 ...
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 7.5.12 by Sebastian Bergmann and contributors.

...............................................................  63 / 242 ( 26%)
............................................................... 126 / 242 ( 52%)
............................................................... 189 / 242 ( 78%)
.....................................................           242 / 242 (100%)

Time: 4.59 minutes, Memory: 86.25 MB

OK (242 tests, 797 assertions)
```

### Checklist:
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests passed.

### Applicable Issues
Fixes #1613 

### Changelog Entry
- Moved EP indexable posts class registration into a function that runs in the `plugins_loaded` action