### PR TITLE
Fix #1496 Multisite check to pause EP requests when indexing is running

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -578,7 +578,7 @@ class Command extends WP_CLI_Command {
 		 */
 		do_action( 'ep_wp_cli_pre_index', $args, $assoc_args );
 
-		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
+		if ( isset( $assoc_args['network-wide'] ) || is_multisite() ) {
 			$this->is_network_transient = true;
 			set_site_transient( 'ep_wpcli_sync', true, $this->transient_expiration );
 		} else {
@@ -588,7 +588,7 @@ class Command extends WP_CLI_Command {
 		timer_start();
 
 		// This clears away dashboard notifications.
-		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
+		if ( isset( $assoc_args['network-wide'] ) || is_multisite() ) {
 			update_site_option( 'ep_last_sync', time() );
 			delete_site_option( 'ep_need_upgrade_sync' );
 			delete_site_option( 'ep_feature_auto_activated_sync' );


### PR DESCRIPTION
### Description of the Change

This PR fixes issue #1496. ElasticPress requests on a subsite of multisite network do not pause when indexing is running on the site with global `--url` WP CLI parameter.

### Alternate Designs

None

### Benefits

A few multisite checks to pause EP requests when indexing is running on a subsite.

### Possible Drawbacks

EP will be able to facilitate multisite requests without specifying `--network-wide` parameter for indexing.

### Verification Process

I verified the solution using the following steps:
- Network activate the plugin
- Ran `wp elasticpress index --url=subsite`
- While the indexing was running, I performed a search operation on the subsite and confirmed with `Debug Bar ElasticPress` plugin that EP was not running for this search.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #1496 

### Changelog Entry

- Updated multisite check for indexing operation for the indexing subcommand of EP CLI.