### PR TITLE
CLI Index Refactor

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -833,7 +833,7 @@ class Command extends WP_CLI_Command {
 						 * @param  {int} $object_id Object ID
 						 * @return {bool} New value
 						 */
-						if ( apply_filters( 'ep_' . $indexable->slug . '_index_kill', false, $object_id ) ) {
+						if ( apply_filters( 'ep_' . $indexable->slug . '_index_kill', false, $object->ID ) ) {
 							$killed_object_count++;
 						} else {
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -917,7 +917,7 @@ class Command extends WP_CLI_Command {
 
 		}
 
-		if ( $show_errors ) {
+		if ( $show_errors && ! empty( $failed_objects ) ) {
 			$this->output_index_errors( $failed_objects, $indexable );
 		}
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -25,29 +25,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * CLI Commands for ElasticPress
  */
 class Command extends WP_CLI_Command {
-	/**
-	 * Holds the objects that will be bulk indexed.
-	 *
-	 * @since 0.9
-	 * @var  array
-	 */
-	private $objects = [];
-
-	/**
-	 * Holds all of the objects that failed to index during a bulk index.
-	 *
-	 * @since 0.9
-	 * @var  array
-	 */
-	private $failed_objects = [];
-
-	/**
-	 * Holds error messages for individual objects that failed to index (assuming they're available).
-	 *
-	 * @since 1.7
-	 * @var  array
-	 */
-	private $failed_objects_message = [];
 
 	/**
 	 * Holds whether it's network transient or not

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1148,9 +1148,9 @@ class Command extends WP_CLI_Command {
 		$host = Utils\get_host();
 
 		if ( empty( $host ) ) {
-			WP_CLI::error( esc_html__( 'An index is already occuring. Try again later.', 'elasticpress' ) );
+			WP_CLI::error( esc_html__( 'Elasticsearch host is not set.', 'elasticpress' ) );
 		} elseif ( ! Elasticsearch::factory()->get_elasticsearch_version( true ) ) {
-			WP_CLI::error( esc_html__( 'An index is already occuring. Try again later.', 'elasticpress' ) );
+			WP_CLI::error( esc_html__( 'Could not connect to Elasticsearch.', 'elasticpress' ) );
 		}
 	}
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -844,7 +844,7 @@ class Command extends WP_CLI_Command {
 						}
 
 						// If we have hit the trigger, initiate the bulk request.
-						if ( ! empty( $objects ) && ( count( $objects ) + $killed_object_count ) >= absint( $bulk_trigger ) ) {
+						if ( ! empty( $objects ) && ( count( $objects ) + $killed_object_count ) >= absint( count( $query['objects'] ) ) ) {
 							$index_objects = $objects;
 
 							$this->reset_transient();


### PR DESCRIPTION
This PR refactors and greatly simplifies how CLI indexing occurs. It removes some confusion recursion. It also adds a CLI flag `--show-errors` which will force the indexing command to output errors for bulk as well as no bulk indexing. I have a feeling this might fix some of the bugs currently being reported.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
