### PR TITLE
Limit Protected Content Post Types

### DIFF
--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -68,6 +68,30 @@ class ProtectedContent extends Feature {
 			unset( $pc_post_types['nav_menu_item'] );
 		}
 
+		if ( ! empty( $pc_post_types['revision'] ) ) {
+			unset( $pc_post_types['revision'] );
+		}
+
+		if ( ! empty( $pc_post_types['custom_css'] ) ) {
+			unset( $pc_post_types['custom_css'] );
+		}
+
+		if ( ! empty( $pc_post_types['customize_changeset'] ) ) {
+			unset( $pc_post_types['customize_changeset'] );
+		}
+
+		if ( ! empty( $pc_post_types['oembed_cache'] ) ) {
+			unset( $pc_post_types['oembed_cache'] );
+		}
+
+		if ( ! empty( $pc_post_types['wp_block'] ) ) {
+			unset( $pc_post_types['wp_block'] );
+		}
+
+		if ( ! empty( $pc_post_types['user_request'] ) ) {
+			unset( $pc_post_types['user_request'] );
+		}
+
 		// Merge non public post types with any pre-filtered post_type
 		return array_merge( $post_types, $pc_post_types );
 	}

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -65,17 +65,12 @@ class SyncManager extends SyncManagerAbstract {
 		$indexable_post_statuses = $indexable->get_indexable_post_status();
 		$post_type               = get_post_type( $object_id );
 
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || 'revision' === $post_type ) {
-			// Bypass saving if doing autosave or post type is revision.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			// Bypass saving if doing autosave
 			return;
 		}
 
 		$post = get_post( $object_id );
-
-		// If the post is an auto-draft - let's abort.
-		if ( 'auto-draft' === $post->post_status ) {
-			return;
-		}
 
 		if ( in_array( $post->post_status, $indexable_post_statuses, true ) ) {
 			$indexable_post_types = $indexable->get_indexable_post_types();
@@ -134,7 +129,17 @@ class SyncManager extends SyncManagerAbstract {
 		 * @param  {int} $post_id ID of post
 		 * @return {boolean} New value
 		 */
-		if ( ( ! current_user_can( 'edit_post', $post_id ) && ! apply_filters( 'ep_sync_delete_permissions_bypass', false, $post_id ) ) || 'revision' === get_post_type( $post_id ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) && ! apply_filters( 'ep_sync_delete_permissions_bypass', false, $post_id ) ) {
+			return;
+		}
+
+		$indexable = Indexables::factory()->get( 'post' );
+		$post_type = get_post_type( $post_id );
+
+		$indexable_post_types = $indexable->get_indexable_post_types();
+
+		if ( ! in_array( $post_type, $indexable_post_types, true ) ) {
+			// If not an indexable post type, skip delete.
 			return;
 		}
 
@@ -159,8 +164,8 @@ class SyncManager extends SyncManagerAbstract {
 		$indexable = Indexables::factory()->get( 'post' );
 		$post_type = get_post_type( $post_id );
 
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || 'revision' === $post_type ) {
-			// Bypass saving if doing autosave or post type is revision.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			// Bypass saving if doing autosave
 			return;
 		}
 
@@ -180,11 +185,6 @@ class SyncManager extends SyncManagerAbstract {
 		}
 
 		$post = get_post( $post_id );
-
-		// If the post is an auto-draft - let's abort.
-		if ( 'auto-draft' === $post->post_status ) {
-			return;
-		}
 
 		$indexable_post_statuses = $indexable->get_indexable_post_status();
 


### PR DESCRIPTION
This change does a few things. First, it removes the following post types from indexed by Protected Content:

- revision
- oembed_cache
- custom_css
- user_request
- customize_changeset
- wp_block

While this does break backwards compatibility. Likely, no one is using this post types. They can still be indexed by filtering `ep_indexable_post_types`.

In the sync manager, we removed the `auto-draft` check since that status is not included in the indexable post statuses. We also add a post type check in the delete sync since we don't need to delete posts that aren't indexed based on post type. We also simplify some of the general sync check logic.

Replaces #1499 

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

