### PR TITLE
Terms indexable updates

### DIFF
--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -220,7 +220,7 @@ class QueryIntegration {
 				}
 			}
 
-			$term->elasticsearch = true; // Super useful for debugging
+			$term->elasticsearch = true; // Super useful for debugging.
 
 			if ( $term ) {
 				$new_terms[] = $term;

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -829,7 +829,7 @@ class Term extends Indexable {
 				);
 			} elseif ( 'description' === $orderby ) {
 				$sort[] = array(
-					'description.raw' => array(
+					'description.sortable' => array(
 						'order' => $order,
 					),
 				);

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -805,7 +805,7 @@ class Term extends Indexable {
 		if ( ! empty( $orderby ) ) {
 			if ( 'name' === $orderby ) {
 				$sort[] = array(
-					'name.raw' => array(
+					'name.sortable' => array(
 						'order' => $order,
 					),
 				);

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -510,6 +510,8 @@ class Term extends Indexable {
 
 		if ( version_compare( $es_version, '5.0', '<' ) ) {
 			$mapping_file = 'pre-5-0.php';
+		} elseif ( version_compare( $es_version, '7.0', '>=' ) ) {
+			$mapping_file = '7-0.php';
 		}
 
 		$mapping = require apply_filters( 'ep_term_mapping_file', __DIR__ . '/../../../mappings/term/' . $mapping_file );

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -88,16 +88,9 @@ class Term extends Indexable {
 		 * Support `order` and `orderby` query vars
 		 */
 
-		// Set sort order, default is 'asc'.
+		// Set sort order, default is 'ASC'.
 		if ( ! empty( $query_vars['order'] ) ) {
 			$order = $this->parse_order( $query_vars['order'] );
-		} else {
-			$order = 'asc';
-		}
-
-		// Default sort by name
-		if ( empty( $query_vars['orderby'] ) ) {
-			$query_vars['orderby'] = 'name';
 		}
 
 		// Set sort type.

--- a/includes/mappings/term/7-0.php
+++ b/includes/mappings/term/7-0.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Elasticsearch mapping for terms
+ *
+ * @since   3.1
+ * @package elasticpress
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+return [
+	'settings' => [
+		'index.mapping.total_fields.limit' => apply_filters( 'ep_term_total_field_limit', 5000 ),
+		'index.max_result_window'          => apply_filters( 'ep_term_max_result_window', 1000000 ),
+
+		/**
+		 * Filter Elasticsearch term maximum shingle difference
+		 *
+		 * @hook ep_max_shingle_diff
+		 * @param  {int} $number Max difference
+		 * @return {int} New number
+		 */
+		'index.max_shingle_diff'           => apply_filters( 'ep_term_max_shingle_diff', 8 ),
+
+		'analysis'                         => [
+			'analyzer'   => [
+				'default'          => [
+					'tokenizer' => 'standard',
+					'filter'    => [ 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
+					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
+				],
+				'shingle_analyzer' => [
+					'type'      => 'custom',
+					'tokenizer' => 'standard',
+					'filter'    => [ 'lowercase', 'shingle_filter' ],
+				],
+				'ewp_lowercase'    => [
+					'type'      => 'custom',
+					'tokenizer' => 'keyword',
+					'filter'    => [ 'lowercase' ],
+				],
+			],
+			'filter'     => [
+				'shingle_filter'     => [
+					'type'             => 'shingle',
+					'min_shingle_size' => 2,
+					'max_shingle_size' => 5,
+				],
+				'ewp_word_delimiter' => [
+					'type'              => 'word_delimiter',
+					'preserve_original' => true,
+				],
+				'ewp_snowball'       => [
+					'type'     => 'snowball',
+					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
+				],
+				'edge_ngram'         => [
+					'side'     => 'front',
+					'max_gram' => 10,
+					'min_gram' => 3,
+					'type'     => 'edgeNGram',
+				],
+			],
+			'normalizer' => [
+				'lowerasciinormalizer' => [
+					'type'   => 'custom',
+					'filter' => [ 'lowercase', 'asciifolding' ],
+				],
+			],
+		],
+	],
+	'mappings' => [
+		'date_detection'    => false,
+		'dynamic_templates' => [
+			[
+				'template_meta_types' => [
+					'path_match' => 'meta.*',
+					'mapping'    => [
+						'type'       => 'object',
+						'path'       => 'full',
+						'properties' => [
+							'value'    => [
+								'type'   => 'text',
+								'fields' => [
+									'sortable' => [
+										'type'         => 'keyword',
+										'ignore_above' => 10922,
+										'normalizer'   => 'lowerasciinormalizer',
+									],
+									'raw'      => [
+										'type'         => 'keyword',
+										'ignore_above' => 10922,
+									],
+								],
+							],
+							'raw'      => [ /* Left for backwards compat */
+								'type'         => 'keyword',
+								'ignore_above' => 10922,
+							],
+							'long'     => [
+								'type' => 'long',
+							],
+							'double'   => [
+								'type' => 'double',
+							],
+							'boolean'  => [
+								'type' => 'boolean',
+							],
+							'date'     => [
+								'type'   => 'date',
+								'format' => 'yyyy-MM-dd',
+							],
+							'datetime' => [
+								'type'   => 'date',
+								'format' => 'yyyy-MM-dd HH:mm:ss',
+							],
+							'time'     => [
+								'type'   => 'date',
+								'format' => 'HH:mm:ss',
+							],
+						],
+					],
+				],
+			],
+		],
+
+		'properties'        => [
+			'term_id'          => [
+				'type' => 'long',
+			],
+			'ID'               => [
+				'type' => 'long',
+			],
+			'name'             => [
+				'type'   => 'text',
+				'fields' => [
+					'name' => [
+						'type' => 'text',
+					],
+					'sortable' => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+						'normalizer'   => 'lowerasciinormalizer',
+					],
+					'raw'  => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+					],
+				],
+			],
+			'slug'             => [
+				'type'   => 'text',
+				'fields' => [
+					'name' => [
+						'type' => 'text',
+					],
+					'raw'  => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+					],
+				],
+			],
+			'term_group'       => [
+				'type' => 'long',
+			],
+			'term_taxonomy_id' => [
+				'type' => 'long',
+			],
+			'taxonomy'         => [
+				'type'   => 'text',
+				'fields' => [
+					'description' => [
+						'type' => 'text',
+					],
+					'raw'         => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+					],
+				],
+			],
+			'description'      => [
+				'type'   => 'text',
+				'fields' => [
+					'description' => [
+						'type' => 'text',
+					],
+					'sortable' => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+						'normalizer'   => 'lowerasciinormalizer',
+					],
+					'raw'         => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+					],
+				],
+			],
+			'parent'           => [
+				'type' => 'long',
+			],
+			'count'            => [
+				'type' => 'long',
+			],
+			'meta'             => [
+				'type' => 'object',
+			],
+			'hierarchy'        => [
+				'type' => 'object',
+			],
+			'object_ids'       => [
+				'type' => 'object',
+			],
+		],
+	],
+];

--- a/includes/mappings/term/initial.php
+++ b/includes/mappings/term/initial.php
@@ -14,21 +14,11 @@ return [
 	'settings' => [
 		'index.mapping.total_fields.limit' => apply_filters( 'ep_term_total_field_limit', 5000 ),
 		'index.max_result_window'          => apply_filters( 'ep_term_max_result_window', 1000000 ),
-
-		/**
-		 * Filter Elasticsearch term maximum shingle difference
-		 *
-		 * @hook ep_max_shingle_diff
-		 * @param  {int} $number Max difference
-		 * @return {int} New number
-		 */
-		'index.max_shingle_diff'           => apply_filters( 'ep_term_max_shingle_diff', 8 ),
-
 		'analysis'                         => [
 			'analyzer'   => [
 				'default'          => [
 					'tokenizer' => 'standard',
-					'filter'    => [ 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
+					'filter'    => [ 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'shingle_analyzer' => [
@@ -72,145 +62,139 @@ return [
 		],
 	],
 	'mappings' => [
-		'date_detection'    => false,
-		'dynamic_templates' => [
-			[
-				'template_meta_types' => [
-					'path_match' => 'meta.*',
-					'mapping'    => [
-						'type'       => 'object',
-						'path'       => 'full',
-						'properties' => [
-							'value'    => [
-								'type'   => 'text',
-								'fields' => [
-									'sortable' => [
-										'type'         => 'keyword',
-										'ignore_above' => 10922,
-										'normalizer'   => 'lowerasciinormalizer',
-									],
-									'raw'      => [
-										'type'         => 'keyword',
-										'ignore_above' => 10922,
+		'term' => [
+			'date_detection'    => false,
+			'dynamic_templates' => [
+				[
+					'template_meta_types' => [
+						'path_match' => 'meta.*',
+						'mapping'    => [
+							'type'       => 'object',
+							'path'       => 'full',
+							'properties' => [
+								'value'    => [
+									'type'   => 'text',
+									'fields' => [
+										'sortable' => [
+											'type'         => 'keyword',
+											'ignore_above' => 10922,
+											'normalizer'   => 'lowerasciinormalizer',
+										],
+										'raw'      => [
+											'type'         => 'keyword',
+											'ignore_above' => 10922,
+										],
 									],
 								],
-							],
-							'raw'      => [ /* Left for backwards compat */
-								'type'         => 'keyword',
-								'ignore_above' => 10922,
-							],
-							'long'     => [
-								'type' => 'long',
-							],
-							'double'   => [
-								'type' => 'double',
-							],
-							'boolean'  => [
-								'type' => 'boolean',
-							],
-							'date'     => [
-								'type'   => 'date',
-								'format' => 'yyyy-MM-dd',
-							],
-							'datetime' => [
-								'type'   => 'date',
-								'format' => 'yyyy-MM-dd HH:mm:ss',
-							],
-							'time'     => [
-								'type'   => 'date',
-								'format' => 'HH:mm:ss',
+								'raw'      => [ /* Left for backwards compat */
+									'type'         => 'keyword',
+									'ignore_above' => 10922,
+								],
+								'long'     => [
+									'type' => 'long',
+								],
+								'double'   => [
+									'type' => 'double',
+								],
+								'boolean'  => [
+									'type' => 'boolean',
+								],
+								'date'     => [
+									'type'   => 'date',
+									'format' => 'yyyy-MM-dd',
+								],
+								'datetime' => [
+									'type'   => 'date',
+									'format' => 'yyyy-MM-dd HH:mm:ss',
+								],
+								'time'     => [
+									'type'   => 'date',
+									'format' => 'HH:mm:ss',
+								],
 							],
 						],
 					],
 				],
 			],
-		],
-
-		'properties'        => [
-			'term_id'          => [
-				'type' => 'long',
+			'_all'              => [
+				'analyzer' => 'simple',
 			],
-			'ID'               => [
-				'type' => 'long',
-			],
-			'name'             => [
-				'type'   => 'text',
-				'fields' => [
-					'name' => [
-						'type' => 'text',
-					],
-					'sortable' => [
-						'type'         => 'keyword',
-						'ignore_above' => 10922,
-						'normalizer'   => 'lowerasciinormalizer',
-					],
-					'raw'  => [
-						'type'         => 'keyword',
-						'ignore_above' => 10922,
+			'properties'        => [
+				'term_id'          => [
+					'type' => 'long',
+				],
+				'ID'               => [
+					'type' => 'long',
+				],
+				'name'             => [
+					'type'   => 'text',
+					'fields' => [
+						'name' => [
+							'type' => 'text',
+						],
+						'raw'  => [
+							'type'         => 'keyword',
+							'ignore_above' => 10922,
+						],
 					],
 				],
-			],
-			'slug'             => [
-				'type'   => 'text',
-				'fields' => [
-					'name' => [
-						'type' => 'text',
-					],
-					'raw'  => [
-						'type'         => 'keyword',
-						'ignore_above' => 10922,
-					],
-				],
-			],
-			'term_group'       => [
-				'type' => 'long',
-			],
-			'term_taxonomy_id' => [
-				'type' => 'long',
-			],
-			'taxonomy'         => [
-				'type'   => 'text',
-				'fields' => [
-					'description' => [
-						'type' => 'text',
-					],
-					'raw'         => [
-						'type'         => 'keyword',
-						'ignore_above' => 10922,
+				'slug'             => [
+					'type'   => 'text',
+					'fields' => [
+						'name' => [
+							'type' => 'text',
+						],
+						'raw'  => [
+							'type'         => 'keyword',
+							'ignore_above' => 10922,
+						],
 					],
 				],
-			],
-			'description'      => [
-				'type'   => 'text',
-				'fields' => [
-					'description' => [
-						'type' => 'text',
-					],
-					'sortable' => [
-						'type'         => 'keyword',
-						'ignore_above' => 10922,
-						'normalizer'   => 'lowerasciinormalizer',
-					],
-					'raw'         => [
-						'type'         => 'keyword',
-						'ignore_above' => 10922,
+				'term_group'       => [
+					'type' => 'long',
+				],
+				'term_taxonomy_id' => [
+					'type' => 'long',
+				],
+				'taxonomy'         => [
+					'type'   => 'text',
+					'fields' => [
+						'description' => [
+							'type' => 'text',
+						],
+						'raw'         => [
+							'type'         => 'keyword',
+							'ignore_above' => 10922,
+						],
 					],
 				],
-			],
-			'parent'           => [
-				'type' => 'long',
-			],
-			'count'            => [
-				'type' => 'long',
-			],
-			'meta'             => [
-				'type' => 'object',
-			],
-			'hierarchy'        => [
-				'type' => 'object',
-			],
-			'object_ids'       => [
-				'type' => 'object',
+				'description'      => [
+					'type'   => 'text',
+					'fields' => [
+						'description' => [
+							'type' => 'text',
+						],
+						'raw'         => [
+							'type'         => 'keyword',
+							'ignore_above' => 10922,
+						],
+					],
+				],
+				'parent'           => [
+					'type' => 'long',
+				],
+				'count'            => [
+					'type' => 'long',
+				],
+				'meta'             => [
+					'type' => 'object',
+				],
+				'hierarchy'        => [
+					'type' => 'object',
+				],
+				'object_ids'       => [
+					'type' => 'object',
+				],
 			],
 		],
 	],

--- a/includes/mappings/term/initial.php
+++ b/includes/mappings/term/initial.php
@@ -139,6 +139,11 @@ return [
 					'name' => [
 						'type' => 'text',
 					],
+					'sortable' => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+						'normalizer'   => 'lowerasciinormalizer',
+					],
 					'raw'  => [
 						'type'         => 'keyword',
 						'ignore_above' => 10922,

--- a/includes/mappings/term/initial.php
+++ b/includes/mappings/term/initial.php
@@ -14,11 +14,21 @@ return [
 	'settings' => [
 		'index.mapping.total_fields.limit' => apply_filters( 'ep_term_total_field_limit', 5000 ),
 		'index.max_result_window'          => apply_filters( 'ep_term_max_result_window', 1000000 ),
+
+		/**
+		 * Filter Elasticsearch term maximum shingle difference
+		 *
+		 * @hook ep_max_shingle_diff
+		 * @param  {int} $number Max difference
+		 * @return {int} New number
+		 */
+		'index.max_shingle_diff'           => apply_filters( 'ep_term_max_shingle_diff', 8 ),
+
 		'analysis'                         => [
 			'analyzer'   => [
 				'default'          => [
 					'tokenizer' => 'standard',
-					'filter'    => [ 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
+					'filter'    => [ 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'shingle_analyzer' => [
@@ -62,139 +72,135 @@ return [
 		],
 	],
 	'mappings' => [
-		'term' => [
-			'date_detection'    => false,
-			'dynamic_templates' => [
-				[
-					'template_meta_types' => [
-						'path_match' => 'meta.*',
-						'mapping'    => [
-							'type'       => 'object',
-							'path'       => 'full',
-							'properties' => [
-								'value'    => [
-									'type'   => 'text',
-									'fields' => [
-										'sortable' => [
-											'type'         => 'keyword',
-											'ignore_above' => 10922,
-											'normalizer'   => 'lowerasciinormalizer',
-										],
-										'raw'      => [
-											'type'         => 'keyword',
-											'ignore_above' => 10922,
-										],
+		'date_detection'    => false,
+		'dynamic_templates' => [
+			[
+				'template_meta_types' => [
+					'path_match' => 'meta.*',
+					'mapping'    => [
+						'type'       => 'object',
+						'path'       => 'full',
+						'properties' => [
+							'value'    => [
+								'type'   => 'text',
+								'fields' => [
+									'sortable' => [
+										'type'         => 'keyword',
+										'ignore_above' => 10922,
+										'normalizer'   => 'lowerasciinormalizer',
+									],
+									'raw'      => [
+										'type'         => 'keyword',
+										'ignore_above' => 10922,
 									],
 								],
-								'raw'      => [ /* Left for backwards compat */
-									'type'         => 'keyword',
-									'ignore_above' => 10922,
-								],
-								'long'     => [
-									'type' => 'long',
-								],
-								'double'   => [
-									'type' => 'double',
-								],
-								'boolean'  => [
-									'type' => 'boolean',
-								],
-								'date'     => [
-									'type'   => 'date',
-									'format' => 'yyyy-MM-dd',
-								],
-								'datetime' => [
-									'type'   => 'date',
-									'format' => 'yyyy-MM-dd HH:mm:ss',
-								],
-								'time'     => [
-									'type'   => 'date',
-									'format' => 'HH:mm:ss',
-								],
+							],
+							'raw'      => [ /* Left for backwards compat */
+								'type'         => 'keyword',
+								'ignore_above' => 10922,
+							],
+							'long'     => [
+								'type' => 'long',
+							],
+							'double'   => [
+								'type' => 'double',
+							],
+							'boolean'  => [
+								'type' => 'boolean',
+							],
+							'date'     => [
+								'type'   => 'date',
+								'format' => 'yyyy-MM-dd',
+							],
+							'datetime' => [
+								'type'   => 'date',
+								'format' => 'yyyy-MM-dd HH:mm:ss',
+							],
+							'time'     => [
+								'type'   => 'date',
+								'format' => 'HH:mm:ss',
 							],
 						],
 					],
 				],
 			],
-			'_all'              => [
-				'analyzer' => 'simple',
+		],
+
+		'properties'        => [
+			'term_id'          => [
+				'type' => 'long',
 			],
-			'properties'        => [
-				'term_id'          => [
-					'type' => 'long',
-				],
-				'ID'               => [
-					'type' => 'long',
-				],
-				'name'             => [
-					'type'   => 'text',
-					'fields' => [
-						'name' => [
-							'type' => 'text',
-						],
-						'raw'  => [
-							'type'         => 'keyword',
-							'ignore_above' => 10922,
-						],
+			'ID'               => [
+				'type' => 'long',
+			],
+			'name'             => [
+				'type'   => 'text',
+				'fields' => [
+					'name' => [
+						'type' => 'text',
+					],
+					'raw'  => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
 					],
 				],
-				'slug'             => [
-					'type'   => 'text',
-					'fields' => [
-						'name' => [
-							'type' => 'text',
-						],
-						'raw'  => [
-							'type'         => 'keyword',
-							'ignore_above' => 10922,
-						],
+			],
+			'slug'             => [
+				'type'   => 'text',
+				'fields' => [
+					'name' => [
+						'type' => 'text',
+					],
+					'raw'  => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
 					],
 				],
-				'term_group'       => [
-					'type' => 'long',
-				],
-				'term_taxonomy_id' => [
-					'type' => 'long',
-				],
-				'taxonomy'         => [
-					'type'   => 'text',
-					'fields' => [
-						'description' => [
-							'type' => 'text',
-						],
-						'raw'         => [
-							'type'         => 'keyword',
-							'ignore_above' => 10922,
-						],
+			],
+			'term_group'       => [
+				'type' => 'long',
+			],
+			'term_taxonomy_id' => [
+				'type' => 'long',
+			],
+			'taxonomy'         => [
+				'type'   => 'text',
+				'fields' => [
+					'description' => [
+						'type' => 'text',
+					],
+					'raw'         => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
 					],
 				],
-				'description'      => [
-					'type'   => 'text',
-					'fields' => [
-						'description' => [
-							'type' => 'text',
-						],
-						'raw'         => [
-							'type'         => 'keyword',
-							'ignore_above' => 10922,
-						],
+			],
+			'description'      => [
+				'type'   => 'text',
+				'fields' => [
+					'description' => [
+						'type' => 'text',
+					],
+					'raw'         => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
 					],
 				],
-				'parent'           => [
-					'type' => 'long',
-				],
-				'count'            => [
-					'type' => 'long',
-				],
-				'meta'             => [
-					'type' => 'object',
-				],
-				'hierarchy'        => [
-					'type' => 'object',
-				],
-				'object_ids'       => [
-					'type' => 'object',
-				],
+			],
+			'parent'           => [
+				'type' => 'long',
+			],
+			'count'            => [
+				'type' => 'long',
+			],
+			'meta'             => [
+				'type' => 'object',
+			],
+			'hierarchy'        => [
+				'type' => 'object',
+			],
+			'object_ids'       => [
+				'type' => 'object',
 			],
 		],
 	],

--- a/includes/mappings/term/initial.php
+++ b/includes/mappings/term/initial.php
@@ -186,6 +186,11 @@ return [
 					'description' => [
 						'type' => 'text',
 					],
+					'sortable' => [
+						'type'         => 'keyword',
+						'ignore_above' => 10922,
+						'normalizer'   => 'lowerasciinormalizer',
+					],
 					'raw'         => [
 						'type'         => 'keyword',
 						'ignore_above' => 10922,

--- a/tests/php/includes/functions.php
+++ b/tests/php/includes/functions.php
@@ -109,6 +109,7 @@ function create_and_sync_user( $user_args = array(), $user_meta = array() ) {
 function create_and_sync_term( $slug, $name, $description, $taxonomy, $posts = [], $parent = null ) {
 	$args = [
 		'slug' => $slug,
+		'description' => $description,
 	];
 
 	if ( ! empty( $parent ) ) {

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -378,9 +378,10 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -388,10 +389,11 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'order'      => 'desc',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'order'        => 'desc',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -411,10 +413,11 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'orderby'    => 'slug',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'orderby'      => 'slug',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -422,11 +425,12 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'order'      => 'desc',
-				'orderby'    => 'slug',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'order'        => 'desc',
+				'orderby'      => 'slug',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -448,10 +452,11 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'orderby'    => 'description',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'orderby'      => 'description',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -468,11 +473,12 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'order'      => 'desc',
-				'orderby'    => 'description',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'order'        => 'desc',
+				'orderby'      => 'description',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -499,10 +505,11 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'orderby'    => 'term_id',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'orderby'      => 'term_id',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -510,11 +517,12 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'order'      => 'desc',
-				'orderby'    => 'term_id',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'order'        => 'desc',
+				'orderby'      => 'term_id',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -532,10 +540,11 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'orderby'    => 'id',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'orderby'      => 'id',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -543,11 +552,12 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'order'      => 'desc',
-				'orderby'    => 'id',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'order'        => 'desc',
+				'orderby'      => 'id',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -579,10 +589,11 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'orderby'    => 'parent',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'orderby'      => 'parent',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -601,11 +612,12 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'hide_empty' => false,
-				'taxonomy'   => 'post_tag',
-				'order'      => 'desc',
-				'orderby'    => 'parent',
+				'number'       => 10,
+				'hide_empty'   => false,
+				'taxonomy'     => 'post_tag',
+				'order'        => 'desc',
+				'orderby'      => 'parent',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -634,9 +646,10 @@ class TestTerm extends BaseTestCase {
 
 		$post = wp_insert_post(
 			[
-				'post_title'  => 'Test',
-				'post_status' => 'publish',
-				'post_type'   => 'post',
+				'post_title'   => 'Test',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'ep_integrate' => true,
 			]
 		);
 
@@ -646,9 +659,10 @@ class TestTerm extends BaseTestCase {
 
 		$term_query = new \WP_Term_Query(
 			[
-				'number'     => 10,
-				'taxonomy'   => 'post_tag',
-				'hide_empty' => true,
+				'number'       => 10,
+				'taxonomy'     => 'post_tag',
+				'hide_empty'   => true,
+				'ep_integrate' => true,
 			]
 		);
 

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -297,9 +297,9 @@ class TestTerm extends BaseTestCase {
 
 		$this->assertTrue( is_array( $term ) );
 
-		$this->markTestIncomplete(
-			"The 'get' parameter is not currently working."
-		);
+		ElasticPress\Indexables::factory()->get( 'term' )->index( $term['term_id'], true );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
 		// First, verify this with default functionality.
 		$term_query = new \WP_Term_Query(

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -190,7 +190,7 @@ class TestTerm extends BaseTestCase {
 	public function testBasicTermQuery() {
 		$this->createAndIndexTerms();
 
-		// First try without ES and make sure everything is right
+		// First try without ES and make sure everything is right.
 		$term_query = new \WP_Term_Query(
 			[
 				'number'     => 10,
@@ -205,8 +205,7 @@ class TestTerm extends BaseTestCase {
 
 		$this->assertEquals( 4, count( $term_query->terms ) );
 
-		// Now try with Elasticsearch
-
+		// Now try with Elasticsearch.
 		$term_query = new \WP_Term_Query(
 			[
 				'ep_integrate' => true,
@@ -488,7 +487,7 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		// Remove empty parents
+		// Remove empty parents.
 		foreach ( $term_query->terms as $key => $term_value ) {
 			if ( empty( $term_value->parent ) ) {
 				unset( $term_query->terms[ $key ] );
@@ -509,7 +508,7 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		// Remove empty parents
+		// Remove empty parents.
 		foreach ( $term_query->terms as $key => $term_value ) {
 			if ( empty( $term_value->parent ) ) {
 				unset( $term_query->terms[ $key ] );

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -692,13 +692,13 @@ class TestTerm extends BaseTestCase {
 	/**
 	 * Tests prepare_document function.
 	 *
-	 * @return void
+	 * @since 3.4
+	 * @group term
 	 */
 	public function testPrepareDocument() {
 
 		$results = ElasticPress\Indexables::factory()->get( 'term' )->prepare_document( 0 );
 
 		$this->assertFalse( $results );
-
 	}
 }

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -415,7 +415,11 @@ class TestTerm extends BaseTestCase {
 	public function testTermQueryOrderSlug() {
 		$this->createAndIndexTerms();
 
-		$term = wp_insert_term( 'ff', 'post_tag', [ 'slug' => 'aaa' ] );
+		$term_id = Functions\create_and_sync_term( 'aaa', 'aaa', '', 'post_tag' );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$this->assertGreaterThan( 0, $term_id );
 
 		$term_query = new \WP_Term_Query(
 			[
@@ -427,7 +431,9 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertEquals( $term['term_id'], $term_query->terms[0]->term_id );
+		$this->assertSame( 5, count( $term_query->terms ) );
+
+		$this->assertEquals( $term_id, $term_query->terms[0]->term_id );
 
 		$term_query = new \WP_Term_Query(
 			[
@@ -440,7 +446,7 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertEquals( $term['term_id'], $term_query->terms[ count( $term_query->terms ) - 1 ]->term_id );
+		$this->assertEquals( $term_id, $term_query->terms[ count( $term_query->terms ) - 1 ]->term_id );
 	}
 
 	/**
@@ -452,9 +458,13 @@ class TestTerm extends BaseTestCase {
 	public function testTermQueryOrderDescription() {
 		$this->createAndIndexTerms();
 
-		$term = wp_insert_term( 'ff', 'post_tag', [ 'description' => 'aaa' ] );
+		$term_id_1 = Functions\create_and_sync_term( 'ff', 'ff', 'aaa', 'post_tag' );
+		$term_id_2 = Functions\create_and_sync_term( 'yff', 'ff', 'bbb', 'post_tag' );
 
-		$term_2 = wp_insert_term( 'yff', 'post_tag', [ 'description' => 'bbb' ] );
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$this->assertGreaterThan( 0, $term_id_1 );
+		$this->assertGreaterThan( 0, $term_id_2 );
 
 		$term_query = new \WP_Term_Query(
 			[
@@ -475,7 +485,9 @@ class TestTerm extends BaseTestCase {
 
 		$term_query->terms = array_values( $term_query->terms );
 
-		$this->assertEquals( $term['term_id'], $term_query->terms[0]->term_id );
+		$this->assertSame( 6, count( $term_query->terms ) );
+
+		$this->assertEquals( $term_id_1, $term_query->terms[0]->term_id );
 
 		$term_query = new \WP_Term_Query(
 			[
@@ -497,7 +509,9 @@ class TestTerm extends BaseTestCase {
 
 		$term_query->terms = array_values( $term_query->terms );
 
-		$this->assertEquals( $term['term_id'], $term_query->terms[ count( $term_query->terms ) - 1 ]->term_id );
+		$this->assertSame( 6, count( $term_query->terms ) );
+
+		$this->assertEquals( $term_id_1, $term_query->terms[ count( $term_query->terms ) - 1 ]->term_id );
 	}
 
 	/**


### PR DESCRIPTION
* Updated term mapping for ES 7.0
** Removed `standard` as a filter https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#standard-filter-removed
** Added `index.max_shingle_diff`
** Removed `term` as one of the levels in the mapping array to match the levels of the mapping array for posts.
* Fixed testTermQueryOrderParent()