### PR TITLE
Fix doc for get-cluster-indexes and get-indexes

### DIFF
--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -45,10 +45,10 @@ The following WP-CLI commands are supported by ElasticPress:
 
 * `wp elasticpress status`
 
-* `wp elasticpress get_indexes`
+* `wp elasticpress get-indexes`
 
   Get all index names as json.
 
-* `wp elasticpress get_cluster_indexes`
+* `wp elasticpress get-cluster-indexes`
 
   Return all indexes from the cluster as json.


### PR DESCRIPTION
The [cli commands documentation](http://10up.github.io/ElasticPress/tutorial-wp-cli.html) for `get-cluster-indexes` and `get-indexes` is incorrect, it uses underscores in stead of dashes.

