### PR TITLE
check constant definition first

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -107,7 +107,7 @@ class Command extends WP_CLI_Command {
 			WP_CLI::error( esc_html__( 'No feature with that slug is registered', 'elasticpress' ) );
 		}
 
-		if ( EP_IS_NETWORK ) {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			$active_features = get_site_option( 'ep_feature_settings', [] );
 		} else {
 			$active_features = get_option( 'ep_feature_settings', [] );
@@ -136,7 +136,7 @@ class Command extends WP_CLI_Command {
 	public function list_features( $args, $assoc_args ) {
 
 		if ( empty( $assoc_args['all'] ) ) {
-			if ( EP_IS_NETWORK ) {
+			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 				$features = get_site_option( 'ep_feature_settings', [] );
 			} else {
 				$features = get_option( 'ep_feature_settings', [] );
@@ -555,7 +555,7 @@ class Command extends WP_CLI_Command {
 		 */
 		do_action( 'ep_wp_cli_pre_index', $args, $assoc_args );
 
-		if ( EP_IS_NETWORK ) {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			$this->is_network_transient = true;
 			set_site_transient( 'ep_wpcli_sync', true, $this->transient_expiration );
 		} else {
@@ -565,7 +565,7 @@ class Command extends WP_CLI_Command {
 		timer_start();
 
 		// This clears away dashboard notifications.
-		if ( EP_IS_NETWORK ) {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			update_site_option( 'ep_last_sync', time() );
 			delete_site_option( 'ep_need_upgrade_sync' );
 			delete_site_option( 'ep_feature_auto_activated_sync' );
@@ -1138,7 +1138,7 @@ class Command extends WP_CLI_Command {
 	 */
 	private function index_occurring() {
 
-		if ( EP_IS_NETWORK ) {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			$dashboard_syncing = get_site_option( 'ep_index_meta' );
 			$wpcli_syncing     = get_site_transient( 'ep_wpcli_sync' );
 		} else {


### PR DESCRIPTION
### Description of the Change

@tlovett1 - It seems the changes in 79d49e944043aa5647ad68f261509d1732d3a897  (#1647) causing a regression when the plugin is not network-wide activated. 

(Alternatively, we can set `define( 'EP_IS_NETWORK', $network_activated );` by removing if statement for making sure the constant defined)

### Testing

To test, all CLI functions should be tested with and without network-wide as well as network activated and not network activated.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

