### PR TITLE
Add clear-index command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 * Cast taxonomy slug to array in case it's already an array in `WP_Query`.
 * Remove unnecessary usage of `--network-wide` CLI paramter.
 * Add name, nickname, and display name to fields used for user search.
+* Add `clear-transient` WP CLI command.
 
 ## [3.3] - 2018-12-18
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -27,14 +27,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Command extends WP_CLI_Command {
 
 	/**
-	 * Holds whether it's network transient or not
-	 *
-	 * @since 2.1.1
-	 * @var  array
-	 */
-	private $is_network_transient = false;
-
-	/**
 	 * Holds time until transient expires
 	 *
 	 * @since 2.1.1
@@ -556,7 +548,6 @@ class Command extends WP_CLI_Command {
 		do_action( 'ep_wp_cli_pre_index', $args, $assoc_args );
 
 		if ( EP_IS_NETWORK ) {
-			$this->is_network_transient = true;
 			set_site_transient( 'ep_wpcli_sync', true, $this->transient_expiration );
 		} else {
 			set_transient( 'ep_wpcli_sync', true, $this->transient_expiration );
@@ -1157,7 +1148,7 @@ class Command extends WP_CLI_Command {
 	 * @since 2.2
 	 */
 	private function reset_transient() {
-		if ( $this->is_network_transient ) {
+		if ( EP_IS_NETWORK ) {
 			set_site_transient( 'ep_wpcli_sync', true, $this->transient_expiration );
 		} else {
 			set_transient( 'ep_wpcli_sync', true, $this->transient_expiration );
@@ -1170,11 +1161,23 @@ class Command extends WP_CLI_Command {
 	 * @since 3.1
 	 */
 	private function delete_transient() {
-		if ( $this->is_network_transient ) {
+		if ( EP_IS_NETWORK ) {
 			delete_site_transient( 'ep_wpcli_sync' );
 		} else {
 			delete_transient( 'ep_wpcli_sync' );
 		}
+	}
+
+	/**
+	 * If an index was stopped prematurely and won't start again, this will clear this
+	 * cached data such that a new index can start.
+	 *
+	 * @subcommand clear-index
+	 * @alias delete-transient
+	 * @since      3.4
+	 */
+	public function clear_index() {
+		$this->delete_transient();
 	}
 
 
@@ -1183,7 +1186,7 @@ class Command extends WP_CLI_Command {
 	 *
 	 * @param array $assoc_args Associative CLI args.
 	 *
-	 * @since 3.x
+	 * @since 3.4
 	 */
 	private function maybe_change_host( $assoc_args ) {
 		if ( isset( $assoc_args['ep-host'] ) ) {
@@ -1202,7 +1205,7 @@ class Command extends WP_CLI_Command {
 	 *
 	 * @param array $assoc_args Associative CLI args.
 	 *
-	 * @since 3.x
+	 * @since 3.4
 	 */
 	private function maybe_change_index_prefix( $assoc_args ) {
 		if ( isset( $assoc_args['ep-prefix'] ) ) {

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -509,7 +509,7 @@ class Command extends WP_CLI_Command {
 		global $wp_actions;
 
 		if ( ! function_exists( 'pcntl_signal' ) ) {
-			WP_CLI::warning( esc_html__( 'Function pcntl_signal not available. Make sure to run `wp transient delete ep_wpcli_sync` in case the process is killed.' ) );
+			WP_CLI::warning( esc_html__( 'Function pcntl_signal not available. Make sure to run `wp elasticpress clear-index` in case the process is killed.' ) );
 		} else {
 			declare( ticks = 1 );
 			pcntl_signal( SIGINT, [ $this, 'delete_transient_on_int' ] );

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1178,6 +1178,8 @@ class Command extends WP_CLI_Command {
 	 */
 	public function clear_index() {
 		$this->delete_transient();
+
+		WP_CLI::success( esc_html__( 'Index cleared.', 'elasticpress' ) );
 	}
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,7 @@ Please refer to [Github](https://github.com/10up/ElasticPress) for detailed usag
 * Cast taxonomy slug to array in case it's already an array in `WP_Query`.
 * Remove unnecessary usage of `--network-wide` CLI paramter.
 * Add name, nickname, and display name to fields used for user search.
+* Add `clear-transient` WP CLI command.
 
 = 3.3 =
 


### PR DESCRIPTION
Adds a simple `clear-index` CLI command to reset the index transient. This is a shortcut for `wp transient delete...`.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

