### PR TITLE
Dont make product categories facetable when woo feature is not active

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -9,6 +9,7 @@
 namespace ElasticPress\Feature\Facets;
 
 use ElasticPress\Feature as Feature;
+use ElasticPress\Features as Features;
 use ElasticPress\Utils as Utils;
 use ElasticPress\FeatureRequirementsStatus as FeatureRequirementsStatus;
 use ElasticPress\Indexables as Indexables;
@@ -198,6 +199,12 @@ class Facets extends Feature {
 		$ep_integrate = $query->get( 'ep_integrate', null );
 
 		if ( false === $ep_integrate ) {
+			return false;
+		}
+
+		$woocommerce = Features::factory()->get_registered_feature( 'woocommerce' );
+
+		if ( ! $woocommerce->is_active() && ( function_exists( 'is_product_category' ) && is_product_category() ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Description of the Change

Skip facet query on product category archives when the WooCommerce feature is not active. These changes prevent breaking the query.

fixes #1662

### Benefits

Fixing product category pages

### Verification Process

- deactivate EP Woo feature
- activate EP Facets feature
- visit WooCommerce product category
- see the results

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1662

