### PR TITLE
[WIP] Create new flag for destructive reindex

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -491,7 +491,7 @@ class Command extends WP_CLI_Command {
 	 */
 	public function delete_transient_on_int( $signal_no ) {
 		if ( SIGINT === $signal_no ) {
-			$this->delete_transient();
+			$this->remove_indexing_flags();
 			WP_CLI::log( esc_html__( 'Indexing cleaned up.', 'elasticpress' ) );
 			exit;
 		}
@@ -572,7 +572,7 @@ class Command extends WP_CLI_Command {
 
 			// Right now setup is just the put_mapping command, as this also deletes the index(s) first.
 			if ( ! $this->put_mapping_helper( $args, $assoc_args ) ) {
-				$this->delete_transient();
+				$this->remove_indexing_flags();
 
 				exit( 1 );
 			}
@@ -615,7 +615,7 @@ class Command extends WP_CLI_Command {
 					WP_CLI::log( sprintf( esc_html__( 'Number of %1$s indexed on site %2$d: %3$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['plural'] ) ), $site['blog_id'], $result['synced'] ) );
 
 					if ( ! empty( $result['errors'] ) ) {
-						$this->delete_transient();
+						$this->remove_indexing_flags();
 
 						WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors on site %2$d: %3$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $site['blog_id'], $result['errors'] ) );
 					}
@@ -644,7 +644,7 @@ class Command extends WP_CLI_Command {
 				WP_CLI::log( sprintf( esc_html__( 'Number of %1$s indexed: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['plural'] ) ), $result['synced'] ) );
 
 				if ( ! empty( $result['errors'] ) ) {
-					$this->delete_transient();
+					$this->remove_indexing_flags();
 
 					WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
 				}
@@ -684,7 +684,7 @@ class Command extends WP_CLI_Command {
 				WP_CLI::log( sprintf( esc_html__( 'Number of %1$s indexed: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['plural'] ) ), $result['synced'] ) );
 
 				if ( ! empty( $result['errors'] ) ) {
-					$this->delete_transient();
+					$this->remove_indexing_flags();
 
 					WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
 				}
@@ -693,7 +693,7 @@ class Command extends WP_CLI_Command {
 
 		WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Total time elapsed: ', 'elasticpress' ) . '%N' . timer_stop() ) );
 
-		$this->delete_transient();
+		$this->remove_indexing_flags();
 
 		WP_CLI::success( esc_html__( 'Done!', 'elasticpress' ) );
 	}
@@ -854,7 +854,7 @@ class Command extends WP_CLI_Command {
 								do_action( 'ep_cli_' . $indexable->slug . '_bulk_index', $objects, $response );
 
 								if ( is_wp_error( $response ) ) {
-									$this->delete_transient();
+									$this->remove_indexing_flags();
 
 									if ( $show_errors ) {
 										if ( ! empty( $failed_objects ) ) {
@@ -1157,16 +1157,18 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete transient that indicates indexing is occuring
+	 * Delete transient and flag that indicate indexing is occuring
 	 *
 	 * @since 3.1
 	 */
-	private function delete_transient() {
+	private function remove_indexing_flags() {
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			delete_site_transient( 'ep_wpcli_sync' );
 		} else {
 			delete_transient( 'ep_wpcli_sync' );
 		}
+
+		Utils\unset_recreating_index_flag();
 	}
 
 	/**
@@ -1178,7 +1180,7 @@ class Command extends WP_CLI_Command {
 	 * @since      3.4
 	 */
 	public function clear_index() {
-		$this->delete_transient();
+		$this->remove_indexing_flags();
 
 		WP_CLI::success( esc_html__( 'Index cleared.', 'elasticpress' ) );
 	}

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -725,6 +725,8 @@ class Elasticsearch {
 		// 200 means the delete was successful
 		// 404 means the index was non-existent, but we should still pass this through as we will occasionally want to delete an already deleted index
 		if ( ! is_wp_error( $request ) && ( 200 === wp_remote_retrieve_response_code( $request ) || 404 === wp_remote_retrieve_response_code( $request ) ) ) {
+			Utils\set_recreating_index_flag();
+
 			$response_body = wp_remote_retrieve_body( $request );
 
 			return json_decode( $response_body );

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -35,7 +35,7 @@ class QueryIntegration {
 	 */
 	public function __construct() {
 		// Ensure that we are currently allowing ElasticPress to override the normal WP_Query
-		if ( Utils\is_indexing() ) {
+		if ( Utils\is_recreating_index() ) {
 			return;
 		}
 

--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -28,7 +28,7 @@ class QueryIntegration {
 	 */
 	public function __construct() {
 		// Check if we are currently indexing
-		if ( Utils\is_indexing() ) {
+		if ( Utils\is_recreating_index() ) {
 			return;
 		}
 

--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -28,7 +28,7 @@ class QueryIntegration {
 	 */
 	public function __construct() {
 		// Ensure that we are currently allowing ElasticPress to override the normal WP_Query
-		if ( Utils\is_indexing() ) {
+		if ( Utils\is_recreating_index() ) {
 			return;
 		}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -168,6 +168,60 @@ function is_indexing() {
 }
 
 /**
+ * Set the flag for destructive reindexes.
+ *
+ * @since  3.5
+ * @return void
+ */
+function set_recreating_index_flag() {
+	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+		update_site_option( 'ep_mapping_sync', true );
+	} else {
+		update_option( 'ep_mapping_sync', true );
+	}
+}
+
+/**
+ * Remove the flag for destructive reindexes.
+ *
+ * @since  3.5
+ * @return void
+ */
+function unset_recreating_index_flag() {
+	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+		update_site_option( 'ep_mapping_sync', false );
+	} else {
+		update_option( 'ep_mapping_sync', false );
+	}
+}
+
+/**
+ * Determine if ElasticPress is in the middle of a destructive reindex.
+ * A reindex is considered destructive if all mappings were deleted and all indexes
+ * are being recreated.
+ *
+ * @since  3.5
+ * @return boolean
+ */
+function is_recreating_index() {
+	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+		$mapping_sync = get_site_option( 'ep_mapping_sync', false );
+	} else {
+		$mapping_sync = get_option( 'ep_mapping_sync', false );
+	}
+
+	/**
+	 * Filter whether a destructive reindex is occurring.
+	 *
+	 * @since  3.5
+	 * @hook ep_is_recreating_index
+	 * @param  {bool} $recreating_index True for full reindexing
+	 * @return {bool} New recreating_index value
+	 */
+	return apply_filters( 'ep_is_recreating_index', (bool) $mapping_sync );
+}
+
+/**
  * Check if wpcli indexing is occurring
  *
  * @since  3.0

--- a/uninstall.php
+++ b/uninstall.php
@@ -62,6 +62,8 @@ class EP_Uninstaller {
 		delete_option( 'ep_host' );
 		delete_site_option( 'ep_index_meta' );
 		delete_option( 'ep_index_meta' );
+		delete_site_option( 'ep_mapping_sync' );
+		delete_option( 'ep_mapping_sync' );
 		delete_site_option( 'ep_feature_settings' );
 		delete_option( 'ep_feature_settings' );
 		delete_site_option( 'ep_version' );


### PR DESCRIPTION
### Description of the Change

This PR addresses the changes described in #1668.
In summary:
- It creates a new wp_option called `ep_mapping_sync`;
- It creates three new functions in the `Utils` namespace, to control and test the new flag: `set_recreating_index_flag()`, `unset_recreating_index_flag()`, and `is_recreating_index()`;
- `QueryIntegration` classes now rely on `is_recreating_index()` to check if ES should be used.
- The flag is set every time an index is deleted by the `Elasticsearch` class.
- [WIP] The flag is unset when everything is reindexed.

### Benefits

While soft reindexing, i.e., without wiping everything and reconstructing from the ground, users will still be able to use ES.

### Possible Drawbacks

Although I'm trying to make it as safe as possible, we will probably want to pay special attention to scenarios where the flag isn't set.

### Verification Process

- Run `wp elasticpress index` and check if ES is being used
- Run `wp elasticpress index --setup` and check if ES is *not* being used

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#1668

### Changelog Entry

Changed the function used to check whether queries should be run on ES or not.
