### PR TITLE
fix: save weighting settings based on post_type

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -332,16 +332,20 @@ class Weighting {
 			}
 		}
 
-		if ( ! empty( $_POST['weighting'] ) ) {
-			foreach ( $_POST['weighting'] as $post_type => $post_type_weighting ) {
-				// This also ensures the string is safe, since this would return false otherwise
-				if ( ! post_type_exists( $post_type ) ) {
-					continue;
-				}
+		$search     = Features::factory()->get_registered_feature( 'search' );
+		$post_types = $search->get_searchable_post_types();
 
-				$new_config[ $post_type ] = array();
+		foreach ( $post_types as $post_type ) {
+			// This also ensures the string is safe, since this would return false otherwise
+			if ( ! post_type_exists( $post_type ) ) {
+				continue;
+			}
 
-				foreach ( $post_type_weighting as $weighting_field => $weighting_values ) {
+			/** override default post_type settings while saving */
+			$new_config[ $post_type ] = array();
+
+			if ( isset( $_POST['weighting'][ $post_type ] ) ) {
+				foreach ( $_POST['weighting'][ $post_type ] as $weighting_field => $weighting_values ) {
 					$new_config[ $post_type ][ sanitize_text_field( $weighting_field ) ] = [
 						'weight'  => isset( $weighting_values['weight'] ) ? intval( $weighting_values['weight'] ) : 0,
 						'enabled' => isset( $weighting_values['enabled'] ) && 'on' === $weighting_values['enabled'] ? true : false,

--- a/tests/php/features/TestWeighting.php
+++ b/tests/php/features/TestWeighting.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Test weighting sub-feature
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+/**
+ * Weighting test class
+ */
+class TestWeighting extends BaseTestCase {
+
+	/**
+	 * Setup each test.
+	 *
+	 * @since 3.4.1
+	 */
+	public function setUp() {
+		global $wpdb;
+		parent::setUp();
+		$wpdb->suppress_errors();
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $admin_id );
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->sync_queue = [];
+
+		$this->setup_test_post_type();
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+	}
+
+	/**
+	 * Clean up after each test. Reset our mocks
+	 *
+	 * @since 2.1
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		// make sure no one attached to this
+		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
+		$this->fired_actions = array();
+		$this->get_weighting_feature()->save_weighting_configuration( [ 'weighting' => [] ] );
+
+	}
+
+
+	/**
+	 * Test searchable post_types exist after configuration change
+	 */
+	function testWeightablePostType() {
+		$search = ElasticPress\Features::factory()->get_registered_feature( 'search' );
+
+		$searchable_post_types = $search->get_searchable_post_types();
+
+		$weighting_settings = [
+			'weighting' => [
+				'post' => [
+					'post_title' => [
+						'enabled' => 'on',
+						'weight'  => 1
+					]
+				],
+			]
+		];
+
+		$this->get_weighting_feature()->save_weighting_configuration( $weighting_settings );
+
+		$weighting_configuration = $this->get_weighting_feature()->get_weighting_configuration();
+
+		$this->assertEquals( count( $searchable_post_types ), count( array_keys( $weighting_configuration ) ) );
+
+		$this->assertFalse( in_array( 'ep_test_not_public', array_keys( $weighting_configuration ), true ) );
+
+	}
+
+	/**
+	 * Test settings toggle
+	 */
+	public function testWeightingConfiguration() {
+
+		$weighting_ep_test = $this->get_weighting_feature()->get_post_type_default_settings( 'ep_test' );
+		$this->assertTrue( $weighting_ep_test['post_title']['enabled'] );
+
+		$weighting_configuration = $this->get_weighting_feature()->get_weighting_configuration();
+		$this->assertEmpty( $weighting_configuration );
+
+		$weighting_settings = [
+			'weighting' => [
+				'post' => [
+					'post_title' => [
+						'enabled' => 'on',
+						'weight'  => 1
+					]
+				],
+			]
+		];
+
+		// enable post_title weighting
+		$this->get_weighting_feature()->save_weighting_configuration( $weighting_settings );
+		$weighting_configuration = $this->get_weighting_feature()->get_weighting_configuration();
+		$this->assertTrue( $weighting_configuration['post']['post_title']['enabled'] );
+		$this->assertEquals( 1, $weighting_configuration['post']['post_title']['weight'] );
+
+		// disable post_title weighting
+		$weighting_settings['weighting']['post']['post_title']['enabled'] = '';
+		$this->get_weighting_feature()->save_weighting_configuration( $weighting_settings );
+		$weighting_configuration = $this->get_weighting_feature()->get_weighting_configuration();
+		$this->assertFalse( $weighting_configuration['post']['post_title']['enabled'] );
+
+	}
+
+	/**
+	 * @return weighting sub-feature
+	 */
+	public function get_weighting_feature() {
+		$search = ElasticPress\Features::factory()->get_registered_feature( 'search' );
+
+		return $search->weighting;
+	}
+
+}


### PR DESCRIPTION
### Description of the Change

Save weighting settings for each searchable post type,  regardless of `$_POST['weighting']`

The Weighting Engine doesn't store the default weighting settings for a post_type in `elasticpress_weighting`. So it fails when all options are disabled at once. Because it can't save the options when `$_POST['weighting'][$post_type]` is not in place.

### Verification Process

1) Register a custom post type. E.g:
```
function epdev_custom_post_type()
{
	register_post_type('ep_test',
		array(
			'labels'      => array(
				'name'          => __('Tests'),
				'singular_name' => __('Test'),
			),
			'public'      => true,
			'has_archive' => true,
			'rewrite'     => array( 'slug' => 'ep-test' ), 
		)
	);
}
add_action('init', 'epdev_custom_post_type');
```

2) Disable all weighting options for `Test` post_type
3) See the changes are not saving
4) checkout `fix/weighting-engine-checkbox` and repeat the same steps for verification

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Applicable Issues

#1686
