### PR TITLE
Fix/issue 1502 index health dashboard indexes

### DIFF
--- a/includes/classes/Stats.php
+++ b/includes/classes/Stats.php
@@ -9,6 +9,7 @@
 namespace ElasticPress;
 
 use ElasticPress\Utils as Utils;
+use ElasticPress\Indexables as Indexables;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -121,6 +122,11 @@ class Stats {
 		}
 
 		$indices = $this->remote_request_helper( '_cat/indices?format=json' );
+
+		if ( is_multisite() && true !== EP_IS_NETWORK ) {
+			$current_site_indice = Indexables::factory()->get( 'post' )->get_index_name( get_current_blog_id() );
+			$indices = wp_list_filter( $indices, array( 'index' => $current_site_indice ) );
+		}
 
 		if ( ! empty( $indices ) ) {
 			foreach ( $indices as  $index ) {


### PR DESCRIPTION
<!--
### Requirements
When running a multisite or multiple indexes within the same ElasticSearch instance the new index health point will show all indexes and not just the relevant indexes.
Steps to Reproduce
• Install in a multisite from develop branch.
• Activate plugin with same credentials/endpoint on at least two sites
• Go to index-health on either site and you will see both indexes listed in index list/documents
-->

### Description of the Change

<!--
Updated queries for _stats and _cat/indices/  to query only current site's indice data when on a multisite and the plugin is not activated networkwide.
-->


### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- After the fix, 
- I set up a multisite of 3 sites
- Activated the plugin individually on each site and indexed.
- Visited the health stats page and the results were as expected.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

