### PR TITLE
Expanded DateQuery test coverage

### DIFF
--- a/includes/classes/Indexable/Post/DateQuery.php
+++ b/includes/classes/Indexable/Post/DateQuery.php
@@ -70,9 +70,7 @@ class DateQuery extends WP_Date_Query {
 					$clause_filter = $this->get_es_filter_for_clause( $clause, $query );
 
 					$filter_count = count( $clause_filter );
-					if ( ! $filter_count ) {
-						$filter_chunks['filters'][] = '';
-					} else {
+					if ( $filter_count ) {
 						$filter_chunks['filters'][] = $clause_filter;
 					}
 

--- a/includes/classes/Indexable/Post/DateQuery.php
+++ b/includes/classes/Indexable/Post/DateQuery.php
@@ -11,7 +11,9 @@ namespace ElasticPress\Indexable\Post;
 use \WP_Date_Query as WP_Date_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
+	// @codeCoverageIgnoreStart
 	exit; // Exit if accessed directly.
+	// @codeCoverageIgnoreEnd
 }
 
 /**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4210,6 +4210,29 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Tests the fallback code for filters and relations.
+	 *
+	 * @group post
+	 */
+	public function testDateQueryFiltersRelation() {
+
+		$date_query = new \ElasticPress\Indexable\Post\DateQuery(
+			[
+				'relation' => '',
+				[
+					'year' => 0,
+				],
+			]
+		);
+
+		$filter = $date_query->get_es_filter();
+
+		$this->assertTrue( is_array( $filter ) );
+		$this->assertCount( 1, $filter );
+		$this->assertSame( 'and', array_key_first( $filter ) );
+	}
+
+	/**
 	 * Test a date query with BETWEEN comparison
 	 *
 	 * @group post

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4233,6 +4233,92 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Tests additional code for validate_date_values() and simple_es_date_filter().
+	 *
+	 * @group post
+	 */
+	public function testDateQueryValidateDateValues() {
+
+		$date_query = new \ElasticPress\Indexable\Post\DateQuery( [] );
+
+		$this->assertFalse( $date_query->validate_date_values() );
+
+		$valid = $date_query->validate_date_values(
+			[
+				'after' => [ '2020' ],
+			]
+		);
+
+		$this->assertTrue( $valid );
+
+		$valid = $date_query->validate_date_values(
+			[
+				'year' => [ '2019', '2020' ],
+			]
+		);
+
+		$this->assertTrue( $valid );
+
+		$results = \ElasticPress\Indexable\Post\DateQuery::simple_es_date_filter(
+			[
+				'w' => 10,
+			]
+		);
+
+		$this->assertTrue( is_array( $results ) );
+		$this->assertSame( 10, $results['bool']['must'][0]['term']['date_terms.week'] );
+	}
+
+	/**
+	 * Tests invalid dates for validate_date_values().
+	 *
+	 * @group post
+	 */
+	public function testDateQueryValidateDateDoingItWrong() {
+
+		$this->setExpectedIncorrectUsage( 'ElasticPress\Indexable\Post\DateQuery' );
+
+		$date_query = new \ElasticPress\Indexable\Post\DateQuery( [] );
+
+		$valid = $date_query->validate_date_values(
+			[
+				'compare' => 'BETWEEN',
+				'month'   => [ 0, 1 ],
+			]
+		);
+
+		$this->assertFalse( $valid );
+
+		$valid = $date_query->validate_date_values(
+			[
+				'compare' => 'BETWEEN',
+				'month'   => [ 13, 14 ],
+			]
+		);
+
+		$this->assertFalse( $valid );
+
+		$valid = $date_query->validate_date_values(
+			[
+				'month' => '2',
+				'day'   => '30',
+				'year'  => '2020',
+			]
+		);
+
+		$this->assertFalse( $valid );
+
+		$valid = $date_query->validate_date_values(
+			[
+				'month' => '2',
+				'day'   => '30',
+			]
+		);
+
+		$this->assertFalse( $valid );
+	}
+
+	/**
 	 * Test a date query with BETWEEN comparison
 	 *
 	 * @group post
@@ -4335,9 +4421,58 @@ class TestPost extends BaseTestCase {
 			),
 		);
 
+		$date_query = new \ElasticPress\Indexable\Post\DateQuery(
+			[
+				'w' => 10,
+			]
+		);
+
+		$filter = $date_query->get_es_filter();
+
+		$this->assertTrue( is_array( $filter ) );
+		$this->assertSame( 10, $filter['and']['bool']['must'][0]['term']['date_terms.week'] );
+
 		$query = new \WP_Query( $args );
 		$this->assertEquals( $query->post_count, 4 );
 		$this->assertEquals( $query->found_posts, 4 );
+
+		$date_query = new \ElasticPress\Indexable\Post\DateQuery(
+			[
+				'monthnum' => 1,
+				'compare'  => '!=',
+			]
+		);
+
+		$filter = $date_query->get_es_filter();
+
+		$this->assertTrue( is_array( $filter ) );
+		$this->assertSame( 1, $filter['and']['bool']['must_not'][0]['term']['date_terms.month'] );
+
+		$date_query = new \ElasticPress\Indexable\Post\DateQuery(
+			[
+				'monthnum' => [ 1, 2 ],
+				'compare'  => 'IN',
+			]
+		);
+
+		$filter = $date_query->get_es_filter();
+
+		$this->assertTrue( is_array( $filter ) );
+		$this->assertSame( 1, $filter['and']['bool']['should'][0]['term']['date_terms.month'] );
+		$this->assertSame( 2, $filter['and']['bool']['should'][1]['term']['date_terms.month'] );
+
+		$date_query = new \ElasticPress\Indexable\Post\DateQuery(
+			[
+				'monthnum' => [ 1, 2 ],
+				'compare'  => 'NOT IN',
+			]
+		);
+
+		$filter = $date_query->get_es_filter();
+
+		$this->assertTrue( is_array( $filter ) );
+		$this->assertSame( 1, $filter['and']['bool']['must_not'][0]['term']['date_terms.month'] );
+		$this->assertSame( 2, $filter['and']['bool']['must_not'][1]['term']['date_terms.month'] );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
Expanded DateQuery tests to reach 100% coverage.

### Benefits
Improved unit tests

### Possible Drawbacks
None

### Checklist:
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [ ] All new and existing tests passed.

`testStickyPostsExcludedOnNotHome` may be an existing test that is failing.

### Applicable Issues
None

### Changelog Entry
* Expanded DateQuery test coverage
