### PR TITLE
Load scripts & styles only when they are really necessary

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -166,7 +166,7 @@ checked<?php endif; ?> value="any"><?php echo wp_kses_post( __( 'Show all conten
 	 * @since 2.5
 	 */
 	public function front_scripts() {
-		wp_enqueue_script(
+		wp_register_script(
 			'elasticpress-facets',
 			EP_URL . 'dist/js/facets.min.js',
 			[ 'jquery', 'underscore' ],
@@ -174,7 +174,7 @@ checked<?php endif; ?> value="any"><?php echo wp_kses_post( __( 'Show all conten
 			true
 		);
 
-		wp_enqueue_style(
+		wp_register_style(
 			'elasticpress-facets',
 			EP_URL . 'dist/css/facets.min.css',
 			[],

--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -261,6 +261,10 @@ class Widget extends WP_Widget {
 		</div>
 		<?php
 		$facet_html = ob_get_clean();
+		
+		// Enqueue Script & Styles
+		wp_enqueue_script( 'elasticpress-facets' );
+		wp_enqueue_style( 'elasticpress-facets' );
 
 		// phpcs:disable
 		// Allows developers to modify widget html


### PR DESCRIPTION
### Description of the Change

Use `wp_register_script` / `wp_register_style` to register (not enqueue script & styles) and only call `wp_enqueue_script` / `wp_enqueue_style` if the assets are really necessary.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Frontend performance improvement when the Facets Widget is only implemented on a few pages.

### Possible Drawbacks

No kown drawbacks

### Verification Process

Added a new Sidebar with a Facet Widget only visible on pages where ìs_search()` is `true` and checked if the scripts and styles are only loaded on these pages.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
