### PR TITLE
Expanded indexable post unit test coverage

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1523,9 +1523,13 @@ class Post extends Indexable {
 	 * @return string The sanitized 'order' query variable.
 	 */
 	protected function parse_order( $order ) {
+		// Core will always set sort order to DESC for any invalid value,
+		// so we can't do any automated testing of this function.
+		// @codeCoverageIgnoreStart
 		if ( ! is_string( $order ) || empty( $order ) ) {
 			return 'desc';
 		}
+		// @codeCoverageIgnoreEnd
 
 		if ( 'ASC' === strtoupper( $order ) ) {
 			return 'asc';

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1370,10 +1370,6 @@ class Post extends Indexable {
 		 */
 		$formatted_args = apply_filters( 'ep_post_formatted_args', $formatted_args, $args, $wp_query );
 
-		// TOOD remove these.
-		// echo PHP_EOL;
-		// echo wp_json_encode( $formatted_args );
-
 		return $formatted_args;
 	}
 

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1175,7 +1175,7 @@ class Post extends Indexable {
 
 		if ( false !== $sticky_posts
 			&& is_home()
-			&& in_array( $args['ignore_sticky_posts'], array( 'false', 0 ), true ) ) {
+			&& in_array( $args['ignore_sticky_posts'], array( 'false', 0, false ), true ) ) {
 			$new_sort = [
 				[
 					'_score' => [

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -718,42 +718,44 @@ class Post extends Indexable {
 		 */
 
 		// Find root level taxonomies.
-		switch ( $args ) {
-			case ! empty( $args['category_name'] ):
-				$args['tax_query'][] = array(
-					'taxonomy' => 'category',
-					'terms'    => array( $args['category_name'] ),
-					'field'    => 'slug',
-				);
-				break;
-			case ! empty( $args['cat'] ):
-				$args['tax_query'][] = array(
-					'taxonomy' => 'category',
-					'terms'    => array( $args['cat'] ),
-					'field'    => 'id',
-				);
-				break;
-			case ! empty( $args['tag'] ):
-				$args['tax_query'][] = array(
-					'taxonomy' => 'post_tag',
-					'terms'    => array( $args['tag'] ),
-					'field'    => 'slug',
-				);
-				break;
-			case ! empty( $args['tag__and'] ):
-				$args['tax_query'][] = array(
-					'taxonomy' => 'post_tag',
-					'terms'    => $args['tag__and'],
-					'field'    => 'term_id',
-				);
-				break;
-			case ! empty( $args['tag_id'] ) && ! is_array( $args['tag_id'] ):
-				$args['tax_query'][] = array(
-					'taxonomy' => 'post_tag',
-					'terms'    => $args['tag_id'],
-					'field'    => 'term_id',
-				);
-				break;
+		if ( isset( $args['category_name'] ) && ! empty( $args['category_name'] ) ) {
+			$args['tax_query'][] = array(
+				'taxonomy' => 'category',
+				'terms'    => array( $args['category_name'] ),
+				'field'    => 'slug',
+			);
+		}
+
+		if ( isset( $args['cat'] ) && ! empty( $args['cat'] ) ) {
+			$args['tax_query'][] = array(
+				'taxonomy' => 'category',
+				'terms'    => array( $args['cat'] ),
+				'field'    => 'id',
+			);
+		}
+
+		if ( isset( $args['tag'] ) && ! empty( $args['tag'] ) ) {
+			$args['tax_query'][] = array(
+				'taxonomy' => 'post_tag',
+				'terms'    => array( $args['tag'] ),
+				'field'    => 'slug',
+			);
+		}
+
+		if ( isset( $args['tag__and'] ) && ! empty( $args['tag__and'] ) ) {
+			$args['tax_query'][] = array(
+				'taxonomy' => 'post_tag',
+				'terms'    => $args['tag__and'],
+				'field'    => 'term_id',
+			);
+		}
+
+		if ( isset( $args['tag_id'] ) && ! empty( $args['tag_id'] ) && ! is_array( $args['tag_id'] ) ) {
+			$args['tax_query'][] = array(
+				'taxonomy' => 'post_tag',
+				'terms'    => $args['tag_id'],
+				'field'    => 'term_id',
+			);
 		}
 
 		/**

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -762,8 +762,8 @@ class Post extends Indexable {
 			if ( $has_tag__and ) {
 
 				$args['tax_query'] = array_map(
-					function( $tax_query ) {
-						if ( 'post_tag' === $tax_query ) {
+					function( $tax_query ) use ( $args ) {
+						if ( isset( $tax_query['taxonomy'] ) && 'post_tag' === $tax_query['taxonomy'] && ! in_array( $args['tag_id'], $tax_query['terms'] ) ) {
 							$tax_query['terms'][] = $args['tag_id'];
 						}
 
@@ -771,7 +771,6 @@ class Post extends Indexable {
 					},
 					$args['tax_query']
 				);
-
 			} else {
 				$args['tax_query'][] = array(
 					'taxonomy' => 'post_tag',

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -14,7 +14,9 @@ use \WP_Query as WP_Query;
 use \WP_User as WP_User;
 
 if ( ! defined( 'ABSPATH' ) ) {
+	// @codeCoverageIgnoreStart
 	exit; // Exit if accessed directly.
+	// @codeCoverageIgnoreEnd
 }
 
 /**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5134,4 +5134,34 @@ class TestPost extends BaseTestCase {
 		$this->assertContains( 'pending', $statuses );
 		$this->assertContains( 'private', $statuses );
 	}
+
+	/**
+	 * Tests fields in format_args().
+	 *
+	 * @return void
+	 * @group post
+	 */
+	public function testFormatArgsFields() {
+
+		$post = new \ElasticPress\Indexable\Post\Post();
+
+		$args = $post->format_args(
+			[
+				'fields' => 'ids',
+			],
+			new \WP_Query()
+		);
+
+		$this->assertContains( 'post_id', $args['_source']['include'] );
+
+		$args = $post->format_args(
+			[
+				'fields' => 'id=>parent',
+			],
+			new \WP_Query()
+		);
+
+		$this->assertContains( 'post_id', $args['_source']['include'] );
+		$this->assertContains( 'post_parent', $args['_source']['include'] );
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5042,4 +5042,35 @@ class TestPost extends BaseTestCase {
 
 		$this->assertSame( 'image/jpeg', $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'][0] );
 	}
+
+	/**
+	 * Tests author in format_args().
+	 *
+	 * @return void
+	 * @group post
+	 */
+	public function testFormatArgsAuthor() {
+
+		$post = new \ElasticPress\Indexable\Post\Post();
+
+		$query = new \WP_Query();
+
+		$args = $post->format_args(
+			[
+				'author' => 123,
+			],
+			$query
+		);
+
+		$this->assertSame( 123, $args['post_filter']['bool']['must'][0]['term']['post_author.id'] );
+
+		$args = $post->format_args(
+			[
+				'author_name' => 'Bacon Ipsum',
+			],
+			$query
+		);
+
+		$this->assertSame( 'Bacon Ipsum', $args['post_filter']['bool']['must'][0]['term']['post_author.display_name'] );
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4229,7 +4229,9 @@ class TestPost extends BaseTestCase {
 
 		$this->assertTrue( is_array( $filter ) );
 		$this->assertCount( 1, $filter );
-		$this->assertSame( 'and', array_key_first( $filter ) );
+
+		$keys = array_keys( $filter );
+		$this->assertSame( 'and', $keys[0] );
 	}
 
 	/**
@@ -4966,7 +4968,7 @@ class TestPost extends BaseTestCase {
 
 		$must_terms = $args['post_filter']['bool']['must'][0]['bool']['must'];
 
-		$this->assertSame( 123, $must_terms[0]['terms']['terms.category.id'][0] );
+		$this->assertSame( 123, $must_terms[0]['terms']['terms.category.term_id'][0] );
 		$this->assertSame( 'tag-slug', $must_terms[1]['terms']['terms.post_tag.slug'][0] );
 		$this->assertSame( 'post-tag-slug', $must_terms[2]['terms']['terms.post_tag.slug'][0] );
 	}

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5211,4 +5211,67 @@ class TestPost extends BaseTestCase {
 
 		$this->assertSame( 'terms.post_type', $args['aggs']['aggregation_name']['terms']['field'] );
 	}
+
+	/**
+	 * Tests additional order by parameters in parse_orderby().
+	 *
+	 * @return void
+	 * @group post
+	 */
+	public function testParseOrderBy() {
+
+		// Post type.
+		$query_args = [
+			'ep_integrate' => true,
+			'orderby'      => 'type',
+			'order'        => 'asc',
+		];
+
+		$assert_callback = function( $args ) {
+
+			$this->assertArrayHasKey( 'post_type.raw', $args['sort'][0] );
+			$this->assertSame( 'asc', $args['sort'][0]['post_type.raw']['order'] );
+
+			return $args;
+		};
+
+		// We need to run tests inside a callback because parse_orderby()
+		// is a protected function.
+		add_filter( 'ep_formatted_args', $assert_callback );
+		$query = new \WP_Query( $query_args );
+		remove_filter( 'ep_formatted_args', $assert_callback );
+
+		// Post modified.
+		$query_args['orderby'] = 'modified';
+
+		$assert_callback = function( $args ) {
+
+			$this->assertArrayHasKey( 'post_modified', $args['sort'][0] );
+			$this->assertSame( 'asc', $args['sort'][0]['post_modified']['order'] );
+
+			return $args;
+		};
+
+		// Run the tests.
+		add_filter( 'ep_formatted_args', $assert_callback );
+		$query = new \WP_Query( $query_args );
+		remove_filter( 'ep_formatted_args', $assert_callback );
+
+		// Meta value.
+		$query_args['orderby']  = 'meta_value';
+		$query_args['meta_key'] = 'custom_meta_key';
+
+		$assert_callback = function( $args ) {
+
+			$this->assertArrayHasKey( 'meta.custom_meta_key.raw', $args['sort'][0] );
+			$this->assertSame( 'asc', $args['sort'][0]['meta.custom_meta_key.raw']['order'] );
+
+			return $args;
+		};
+
+		// Run the tests.
+		add_filter( 'ep_formatted_args', $assert_callback );
+		$query = new \WP_Query( $query_args );
+		remove_filter( 'ep_formatted_args', $assert_callback );
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5109,4 +5109,29 @@ class TestPost extends BaseTestCase {
 		$this->assertContains( $sticky_post_id, $args['query']['function_score']['functions'][0]->filter['terms']['_id'] );
 		$this->assertSame( 20, $args['query']['function_score']['functions'][0]->weight );
 	}
+
+	/**
+	 * Tests post statuses for admin in format_args().
+	 *
+	 * @return void
+	 * @group post
+	 */
+	public function testFormatArgsAdminPostStatuses() {
+
+		set_current_screen( 'edit.php' );
+		$this->assertTrue( is_admin() );
+
+		$post = new \ElasticPress\Indexable\Post\Post();
+
+		// This will include statuses besides publish.
+		$args = $post->format_args( [ ], new \WP_Query() );
+
+		$statuses = $args['post_filter']['bool']['must'][1]['terms']['post_status'];
+
+		$this->assertContains( 'publish', $statuses );
+		$this->assertContains( 'future', $statuses );
+		$this->assertContains( 'draft', $statuses );
+		$this->assertContains( 'pending', $statuses );
+		$this->assertContains( 'private', $statuses );
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5345,6 +5345,7 @@ class TestPost extends BaseTestCase {
 	 * Tests additional logic in put_mapping().
 	 *
 	 * @return void
+	 * @group post
 	 */
 	public function testPutMapping() {
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -153,6 +153,8 @@ class TestPost extends BaseTestCase {
 				'ep_integrate'   => true,
 				'posts_per_page' => 1,
 				'offset'         => 1,
+				'order'          => 'ASC',
+				'orderby'        => 'title',
 			)
 		);
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5273,5 +5273,22 @@ class TestPost extends BaseTestCase {
 		add_filter( 'ep_formatted_args', $assert_callback );
 		$query = new \WP_Query( $query_args );
 		remove_filter( 'ep_formatted_args', $assert_callback );
+
+		// Meta value number.
+		$query_args['orderby']  = 'meta_value_num';
+		$query_args['meta_key'] = 'custom_price';
+
+		$assert_callback = function( $args ) {
+
+			$this->assertArrayHasKey( 'meta.custom_price.long', $args['sort'][0] );
+			$this->assertSame( 'asc', $args['sort'][0]['meta.custom_price.long']['order'] );
+
+			return $args;
+		};
+
+		// Run the tests.
+		add_filter( 'ep_formatted_args', $assert_callback );
+		$query = new \WP_Query( $query_args );
+		remove_filter( 'ep_formatted_args', $assert_callback );
 	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4726,6 +4726,13 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
 
+		// Verify we're only getting the posts we requested.
+		$post_names = wp_list_pluck( $query->posts, 'post_name' );
+
+		$this->assertContains( get_post_field( 'post_name', $post_id_1 ), $post_names );
+		$this->assertContains( get_post_field( 'post_name', $post_id_2 ), $post_names );
+		$this->assertNotContains( get_post_field( 'post_name', $post_id_3 ), $post_names );
+
 		$args = array(
 			's'         => 'findme',
 			'post_type' => 'post',
@@ -4932,12 +4939,12 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
-	 * Tests fallback code inside format_args.
+	 * Tests additional code inside format_args.
 	 *
 	 * @return void
 	 * @group post
 	 */
-	public function testFormatArgsFallbacks() {
+	public function testFormatArgs() {
 
 		$post = new \ElasticPress\Indexable\Post\Post();
 
@@ -4952,8 +4959,6 @@ class TestPost extends BaseTestCase {
 			],
 			$query
 		);
-
-		echo wp_json_encode( $args, JSON_PRETTY_PRINT );
 
 		$this->assertSame( $posts_per_page, $args['size'] );
 


### PR DESCRIPTION
### Expanded Post unit test coverage
* Increased the code coverage on the \ElasticPress\Indexable\Post class to 100%
* Fixed a bug where both `cat` and `tag` parameters in the root WP_Query args would only pass one of those values to ES.
* Added the `false` bool value to an `ignore_sticky_posts` array check to match the strict type comparison it is doing.

### Benefits

Improved unit tests and bug fixes

### Possible Drawbacks

None

### Verification Process

Verified all existing unit tests passed and added new unit tests to verify the bug fixes.

### Checklist:
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests passed.

### Applicable Issues

#1718 

### Changelog Entry
* Fixed a bug where both `cat` and `tag` parameters in the root WP_Query args would only pass one of those values to ES.
* Added the `false` bool value to an `ignore_sticky_posts` array check to match the strict type comparison it is doing.
