### PR TITLE
Add root taxonomies to tax_query only when query_var is set

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -742,6 +742,14 @@ class Post extends Indexable {
 			);
 		}
 
+		if ( isset( $args['post_tag'] ) && ! empty( $args['post_tag'] ) ) {
+			$args['tax_query'][] = array(
+				'taxonomy' => 'post_tag',
+				'terms'    => array( $args['post_tag'] ),
+				'field'    => 'slug',
+			);
+		}
+
 		$has_tag__and = false;
 
 		if ( isset( $args['tag__and'] ) && ! empty( $args['tag__and'] ) ) {
@@ -783,7 +791,8 @@ class Post extends Indexable {
 		/**
 		 * Try to find other taxonomies set in the root of WP_Query
 		 *
-		 * @since  3.4
+		 * @since 3.4
+		 * @since 3.4.2 Test taxonomies with their query_var value.
 		 */
 		$taxonomies = get_taxonomies( array(), 'objects' );
 

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -785,17 +785,13 @@ class Post extends Indexable {
 		 *
 		 * @since  3.4
 		 */
-		$taxonomies = get_taxonomies();
+		$taxonomies = get_taxonomies( array(), 'objects' );
 
-		foreach ( $taxonomies as $tax_slug ) {
-			if ( 'ep_custom_result' === $tax_slug ) {
-				continue;
-			}
-
-			if ( ! empty( $args[ $tax_slug ] ) ) {
+		foreach ( $taxonomies as $tax_slug => $tax ) {
+			if ( $tax->query_var && ! empty( $args[ $tax->query_var ] ) ) {
 				$args['tax_query'][] = array(
 					'taxonomy' => $tax_slug,
-					'terms'    => (array) $args[ $tax_slug ],
+					'terms'    => (array) $args[ $tax->query_var ],
 					'field'    => 'slug',
 				);
 			}


### PR DESCRIPTION
### Description of the Change

This PR aims to improve WP_Query root taxonomies detection. Instead of checking if a taxonomy slug is an argument of the query, it checks for the taxonomy `query_var` value, mimicking what WordPress core does [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-query.php#L1114):

```
foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy => $t ) {
	if ( 'post_tag' == $taxonomy ) {
		continue;   // Handled further down in the $q['tag'] block
	}

	if ( $t->query_var && ! empty( $q[ $t->query_var ] ) ) {
		...
	}
}
```
(`$taxonomy` is the slug, `$t->query_var` the query_var).

### Alternate Designs

### Benefits

Although it won't completely solve the problem stated in #1727, it can at least reduce it. Also, we'd be better aligned with the strategy adopted by WP core.

### Possible Drawbacks


### Verification Process

Created the taxonomy as said in #1727 and with the code in PR it works.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1727

### Changelog Entry


