### PR TITLE
fixed not correct generating elastic queries for taxonomies

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1416,7 +1416,12 @@ class Post extends Indexable {
 			$single_tax_query = $tax_queries;
 			if ( ! empty( $single_tax_query['taxonomy'] ) ) {
 				$terms = isset( $single_tax_query['terms'] ) ? (array) $single_tax_query['terms'] : array();
-				$field = ( ! empty( $single_tax_query['field'] ) ) ? $single_tax_query['field'] : 'term_id';
+
+				if ( ! empty( $single_tax_query['field'] ) && 'id' !== $single_tax_query['field'] ) {
+					$field = $single_tax_query['field'];
+				} else {
+					$field = 'term_id';
+				}
 
 				if ( 'name' === $field ) {
 					$field = 'name.raw';


### PR DESCRIPTION
**Describe the bug**
For Custom Taxonomies elasticpress is generating not correct query.

**Steps to Reproduce**
If we want use Custom Taxonomy for our query, we fill $args for wp_query and we get next generated query for elastic:
```
{
  "from": 0,
  "size": 40,
  "query": {
    "match_all": {
      "boost": 1
    }
  },
  "post_filter": {
    "bool": {
      "must": [
        {
          "bool": {
            "should": [
              {
                "terms": {
                  "terms.cutom_tax_name.id": [
                    11111
                  ]
                }
              }
            ]
          }
        },

        {
          "terms": {
            "post_type.raw": [
              "post"
            ]
          }
        },
        {
          "term": {
            "post_status": "publish"
          }
        }
      ]
    }
  }
}
```
And elastic by this query not found some posts, because code formatting terms  `terrms.cutom_tax_name.id` has error. We need use `term_id` instead `id`, because in elastic we field stored under the name `term_id`

**Expected behavior**
<!-- A clear and concise description of what you expected to happen. -->

**Screenshots**
<!-- If applicable, add screenshots to help explain your problem. -->

**Environment information**
 - Browser and version: <!-- [e.g. Firefox 65.0.1, Chrome 73.0.3683.75, Safari 12.0.3] -->
 - WordPress version:  5.3.2
- ElasticPress version 3.4.1
   </details>

**Additional context**
<!-- Add any other context about the problem here. -->
