### PR TITLE
Allow custom queries in painless scripting language

### DIFF
--- a/docs/indexables.md
+++ b/docs/indexables.md
@@ -94,6 +94,7 @@ ElasticPress integrates with `WP_Query` if the `ep_integrate` parameter is passe
     ) );
     ```
 * ```custom_query``` (*string*)
+
     ```custom_query``` allows the user to write a custom query in the painless scripting language [https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html](https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html).
     ```php 
           $args['custom_query'][] = "doc['meta.birthday'].value.getMonthValue() == 3";

--- a/docs/indexables.md
+++ b/docs/indexables.md
@@ -96,7 +96,7 @@ ElasticPress integrates with `WP_Query` if the `ep_integrate` parameter is passe
 * ```custom_query``` (*string*)
     ```custom_query``` allows the user to write a custom query in the painless scripting language [https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html](https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html).
     ```php 
-          $args['custom_query'][] = "doc['meta.birthday'].value.getMonthValue() == 3";`
+          $args['custom_query'][] = "doc['meta.birthday'].value.getMonthValue() == 3";
     ```      
     
 * ```date_query``` (*array*)

--- a/docs/indexables.md
+++ b/docs/indexables.md
@@ -93,7 +93,9 @@ ElasticPress integrates with `WP_Query` if the `ep_integrate` parameter is passe
         'day'   => 1,
     ) );
     ```
-
+* ```custom_query``` (*string*)
+    ```custom_query``` allows the user to write a custom query in the painless scripting language (https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html)[https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html]. For example `doc['meta.birthday'].value.getMonthValue() == 3` 
+    
 * ```date_query``` (*array*)
 
     ```date_query``` accepts an array of keys and values (array|string|int) to find posts created on

--- a/docs/indexables.md
+++ b/docs/indexables.md
@@ -94,7 +94,10 @@ ElasticPress integrates with `WP_Query` if the `ep_integrate` parameter is passe
     ) );
     ```
 * ```custom_query``` (*string*)
-    ```custom_query``` allows the user to write a custom query in the painless scripting language [https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html](https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html). For example `doc['meta.birthday'].value.getMonthValue() == 3` 
+    ```custom_query``` allows the user to write a custom query in the painless scripting language [https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html](https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html).
+    ```php 
+          $args['custom_query'][] = "doc['meta.birthday'].value.getMonthValue() == 3";`
+    ```      
     
 * ```date_query``` (*array*)
 

--- a/docs/indexables.md
+++ b/docs/indexables.md
@@ -94,7 +94,7 @@ ElasticPress integrates with `WP_Query` if the `ep_integrate` parameter is passe
     ) );
     ```
 * ```custom_query``` (*string*)
-    ```custom_query``` allows the user to write a custom query in the painless scripting language (https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html)[https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html]. For example `doc['meta.birthday'].value.getMonthValue() == 3` 
+    ```custom_query``` allows the user to write a custom query in the painless scripting language [https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html](https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html). For example `doc['meta.birthday'].value.getMonthValue() == 3` 
     
 * ```date_query``` (*array*)
 

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1233,10 +1233,10 @@ class Post extends Indexable {
 					'bool' => array(
 						'filter' => array(
 							'script' => array(
-								'script' => array( 
+								'script' => array(
 									'source' => $custom_query,
-									'lang' => 'painless',
-								)
+									'lang'   => 'painless',
+								),
 							),
 						),
 					),

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1228,14 +1228,14 @@ class Post extends Indexable {
 		}
 
 		if ( ! empty( $args['custom_query'] ) ) {
-			foreach($args['custom_query'] as $customQuery){
+			foreach ( $args['custom_query'] as $custom_query ) {
 				$filter['bool']['must'][] = array(
-					"bool" => array(
-						"filter" => array(
+					'bool' => array(
+						'filter' => array(
 							'script' => array(
 								'script' => array( 
-									"source" => $customQuery,
-									"lang" => "painless"
+									'source' => $custom_query,
+									'lang' => 'painless',
 								)
 							),
 						),
@@ -1243,8 +1243,6 @@ class Post extends Indexable {
 				);
 			}
 		}
-
-
 
 		/**
 		 * Like WP_Query in search context, if no post_status is specified we default to "any". To

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1227,6 +1227,25 @@ class Post extends Indexable {
 			$use_filters = true;
 		}
 
+		if ( ! empty( $args['custom_query'] ) ) {
+			foreach($args['custom_query'] as $customQuery){
+				$filter['bool']['must'][] = array(
+					"bool" => array(
+						"filter" => array(
+							'script' => array(
+								'script' => array( 
+									"source" => $customQuery,
+									"lang" => "painless"
+								)
+							),
+						),
+					),
+				);
+			}
+		}
+
+
+
 		/**
 		 * Like WP_Query in search context, if no post_status is specified we default to "any". To
 		 * be safe you should ALWAYS specify the post_status parameter UNLIKE with WP_Query.


### PR DESCRIPTION
This allows the user to write a custom query in the painless scripting language https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html. 

For example, to search for a post by meta.birthday for all people born in March, you can use the following code:

`$args['custom_query'][] = "doc['meta.birthday'].value.getMonthValue() == 3";`