### PR TITLE
EP Requests: Don't retry if is non-blocking request

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -924,9 +924,10 @@ class Elasticsearch {
 
 			$request_response_code = (int) wp_remote_retrieve_response_code( $request );
 
-			$is_valid_res = ( $request_response_code >= 200 && $request_response_code <= 299 );
+			$is_valid_res            = ( $request_response_code >= 200 && $request_response_code <= 299 );
+			$is_non_blocking_request = ( 0 === $request_response_code );
 
-			if ( false === $request || is_wp_error( $request ) || ! $is_valid_res ) {
+			if ( false === $request || is_wp_error( $request ) || ( ! $is_valid_res && ! $is_non_blocking_request ) ) {
 				$failures++;
 
 				/**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

As related in #1740, non-blocking requests return empty bodies and response codes and that is interpreted as an error by ElasticPress, that retries the query. This PR aims to avoid that behavior, simply avoiding a retry if the response code is 0.

### Alternate Designs

As non-blocking requests will fail async, I don't think we have much choice here.

### Benefits

Stop EP from doing unnecessary requests.

### Possible Drawbacks

none

### Verification Process

1. Set a plugin with 
```
add_filter(
	'ep_max_remote_request_tries',
	function( $num ) {
		return 5;
	}
);
```
2. Added this to the `Elasticsearch::remote_request()`
```
error_log( $failures . ' / ' . apply_filters( 'ep_max_remote_request_tries', 1, $path, $args ) . ' / ' . $request_response_code );
```
3. Saved a post as Draft and
4. Read logs.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1740 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
