### PR TITLE
uninstall.php: Change the EP_FILE const to its value

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -39,7 +39,7 @@ class EP_Uninstaller {
 		}
 
 		// Not uninstalling this plugin.
-		if ( dirname( WP_UNINSTALL_PLUGIN ) !== dirname( EP_FILE ) ) {
+		if ( dirname( WP_UNINSTALL_PLUGIN ) !== dirname( plugin_basename( __FILE__ ) ) ) {
 			$this->exit_uninstaller();
 		}
 


### PR DESCRIPTION
### Description of the Change

As per #1760, this PR changes the unset EP_FILE in the uninstall.php file to the value it has in the main file.

During the uninstall process, the magic file [uninstall.php](https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/#method-2-uninstall-php) is called but the main plugin file is not. With that, the EP_FILE constant is not set and the `( dirname( WP_UNINSTALL_PLUGIN ) !== dirname( EP_FILE ) )` comparison fails. As the uninstall.php is always placed in the plugin's root, it is safe to replace that constant with  `plugin_basename( __FILE__ )`.

### Alternate Designs

We could set the constant in that file too but that is not necessary, as it won't be used anywhere else.

### Benefits

It will be possible to uninstall the plugin via WP Dashboard and WP-CLI.

### Possible Drawbacks

None.

### Verification Process

I've installed the plugin, tried to uninstall it via WP Dashboard and WP-CLI and could not. With the change introduced in this PR it was possible.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #1760

### Changelog Entry

Fixed the plugin uninstall script.
