### PR TITLE
Facets widget: Move <div> outside ob_start()

### DIFF
--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -270,9 +270,9 @@ class Widget extends WP_Widget {
 					</div>
 				<?php endforeach; ?>
 			</div>
+			<?php $facet_html = ob_get_clean(); ?>
 		</div>
 		<?php
-		$facet_html = ob_get_clean();
 
 		// phpcs:disable
 		/**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR makes the HTML that is passed to the `ep_facet_search_widget` filter valid. This is required because `ob_start()` is started inside the `<div class="terms">` element but closing element is included in the `ob` result

### Benefits
The main benefit here is that it is valid/complete HTML that is being passed.
It is not necessarily a problem is the markup is only being manipulated with str_replace() or similar functions but HTML parsers like `DOMDocument()` will try to auto-correct broken markup and add/remove a `<div>` which will, in the end, cause broken markup

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
