### PR TITLE
CLI: "wp elasticpress list-features" fix

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -136,9 +136,11 @@ class Command extends WP_CLI_Command {
 			}
 			WP_CLI::line( esc_html__( 'Active features:', 'elasticpress' ) );
 
-			foreach ( $features as $key => $feature ) {
-				if ( $feature['active'] ) {
-					WP_CLI::line( $key );
+			foreach ( array_keys( $features ) as $feature_slug ) {
+				$feature = Features::factory()->get_registered_feature( $feature_slug );
+
+				if ( $feature->is_active() ) {
+					WP_CLI::line( $feature_slug );
 				}
 			}
 		} else {


### PR DESCRIPTION
### Description of the Change

Use the feature object instance to test if a feature is active or not. Right now we are using the raw value of the `ep_feature_settings` (site_)option and so bypassing the `ep_feature_active` filter. The code is this PR uses the feature instance and its `is_active` method.

### Alternate Designs

We could use an `apply_filters` call but we wouldn't be able to pass the third argument (the object instance).

### Benefits

Right results for WP-CLI `wp elasticpress list-features` calls.

### Possible Drawbacks

n/a

### Verification Process

I've used
```
add_filter( 'ep_feature_active', '__return_false' );
```
and
```
add_filter(
	'ep_feature_active',
	function( $is_active, $feature_settings, $feature ) {
		if ( 'related_posts' === $feature->slug ) {
			$is_active = false;
		}
		return $is_active;
	},
	10,
	3
);
```
to test.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #1765 

### Changelog Entry

- Fixed the list of active features displayed by the `wp elasticpress list-features` WP-CLI command.