### PR TITLE
Add WooCommerce fields without overwriting weight config

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -553,7 +553,12 @@ class Weighting {
 
 			// grab the query and keep track of whether or not it is nested in a function score
 			$function_score = isset( $formatted_args['query']['function_score'] );
-			$query          = $function_score ? $formatted_args['query']['function_score']['query'] : $formatted_args['query'];
+			$query          = null;
+			if ( $function_score ) {
+				$query = $formatted_args['query']['function_score']['query'];
+			} elseif ( isset( $formatted_args['query'] ) ) {
+				$query = $formatted_args['query'];
+			}
 
 			foreach ( (array) $args['post_type'] as $post_type ) {
 				if ( false === $this->post_type_has_fields( $post_type, $args ) ) {

--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -633,4 +633,50 @@ class Weighting {
 
 		return $formatted_args;
 	}
+
+	/**
+	 * Add fields to the weighting configuration for search without overwriting existent fields.
+	 *
+	 * @since 3.x
+	 *
+	 * @param array  $weight_config Existent weighting configuration.
+	 * @param array  $search_fields Fields to be added.
+	 * @param string $post_type     Post type where the fields should be added.
+	 *
+	 * @return array Modified weighting configuration.
+	 */
+	public function add_weighted_fields( $weight_config, $search_fields, $post_type ) {
+		$product_config = ( isset( $weight_config[ $post_type ] ) ) ? $weight_config[ $post_type ] : array();
+		foreach ( $search_fields as $key => $search_field ) {
+			if ( is_integer( $key ) ) {
+				$this->set_weighted_field( $product_config, $search_field );
+			} else {
+				foreach ( $search_field as $sub_field ) {
+					if ( 'taxonomies' === $key ) {
+						$field_name = 'terms.' . $sub_field . '.name';
+					} else {
+						$field_name = $key . '.' . $sub_field . '.value';
+					}
+					$this->set_weighted_field( $product_config, $field_name );
+				}
+			}
+		}
+		$weight_config[ $post_type ] = $product_config;
+		return $weight_config;
+	}
+
+	/**
+	 * If it doesn't exist, add a single field to the weighting configuration array.
+	 *
+	 * @param array  $weighted_fields All fields set so far.
+	 * @param string $field_name      The new field name.
+	 */
+	protected function set_weighted_field( &$weighted_fields, $field_name ) {
+		if ( ! isset( $weighted_fields[ $field_name ] ) || ! $weighted_fields[ $field_name ]['enabled'] ) {
+			$weighted_fields[ $field_name ] = array(
+				'weight'  => 1,
+				'enabled' => true,
+			);
+		}
+	}
 }

--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -646,10 +646,10 @@ class Weighting {
 	 * @return array Modified weighting configuration.
 	 */
 	public function add_weighted_fields( $weight_config, $search_fields, $post_type ) {
-		$product_config = ( isset( $weight_config[ $post_type ] ) ) ? $weight_config[ $post_type ] : array();
+		$post_type_config = ( isset( $weight_config[ $post_type ] ) ) ? $weight_config[ $post_type ] : array();
 		foreach ( $search_fields as $key => $search_field ) {
 			if ( is_integer( $key ) ) {
-				$this->set_weighted_field( $product_config, $search_field );
+				$this->set_weighted_field( $post_type_config, $search_field );
 			} else {
 				foreach ( $search_field as $sub_field ) {
 					if ( 'taxonomies' === $key ) {
@@ -657,11 +657,11 @@ class Weighting {
 					} else {
 						$field_name = $key . '.' . $sub_field . '.value';
 					}
-					$this->set_weighted_field( $product_config, $field_name );
+					$this->set_weighted_field( $post_type_config, $field_name );
 				}
 			}
 		}
-		$weight_config[ $post_type ] = $product_config;
+		$weight_config[ $post_type ] = $post_type_config;
 		return $weight_config;
 	}
 


### PR DESCRIPTION
### Description of the Change

As per #1722 , when we add the WooCommerce fields to the query via `search_fields` parameter, the weighting engine is completely ignored. This PR aims to add the same fields but keeping the weighting config.

This PR also creates a method that tries to guess the best way to add a field to the query weighting config: `Weighting::add_weighted_fields()`

### Alternate Designs

### Benefits

Keep weighting functionality AND having WC fields.

### Possible Drawbacks

### Verification Process

I've checked the ES query in Debug Bar.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

#1722 

### Changelog Entry

Add WooCommerce fields to the query without removing weighting configurations.
