### PR TITLE
Add timeout filters for bulk_index and index_document

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -101,7 +101,7 @@ class Elasticsearch {
 		$request_args = array(
 			'body'     => $encoded_document,
 			'method'   => 'POST',
-			'timeout'  => 15,
+			'timeout'  => apply_filters( 'ep_index_document_timeout', 15 ),
 			'blocking' => $blocking,
 		);
 
@@ -802,7 +802,7 @@ class Elasticsearch {
 		$request_args = array(
 			'method'  => 'POST',
 			'body'    => $body,
-			'timeout' => 30,
+			'timeout' => apply_filters( 'ep_bulk_index_timeout', 30 ),
 		);
 
 		$request = $this->remote_request( $path, $request_args, [], 'bulk_index' );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Hi @tlovett1 ,

This PR is just to simply add a filter to modify the hardcoded timeout for the request for `bulk_index()` and `index_document()`.

The use case for this is for big documents (i.e a 20mb PDF). Without increasing the timeout of the request, they will simply not index.

We have had this problem in the past for a few elasticpress.io clients and currently there's one who is having this issue. Before, we had the `ep_bulk_index_post_request_args` filter but looks like that's no longer available. 

Perhaps the filter should be for the whole request args?

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

- Index large documents, without it, it is impossible 

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
Tested indexing a big PDF file (20mb) with and without the filter.
- How did you verify that all changed functionality works as expected?
The PDF file got indexed successfully using an elasticpress.io endpoint when the timeout was increased. It failed with the defaults. 
- How did you verify that the change has not introduced any regressions?
All documents were indexed correctly.

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
