### PR TITLE
Fix: field [include] deprecation

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1320,7 +1320,7 @@ class Post extends Indexable {
 			switch ( $args['fields'] ) {
 				case 'ids':
 					$formatted_args['_source'] = array(
-						'include' => array(
+						'includes' => array(
 							'post_id',
 						),
 					);
@@ -1328,7 +1328,7 @@ class Post extends Indexable {
 
 				case 'id=>parent':
 					$formatted_args['_source'] = array(
-						'include' => array(
+						'includes' => array(
 							'post_id',
 							'post_parent',
 						),

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -491,7 +491,7 @@ class Term extends Indexable {
 			switch ( $query_vars['fields'] ) {
 				case 'ids':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 						],
 					];
@@ -499,7 +499,7 @@ class Term extends Indexable {
 
 				case 'id=>name':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 							'name',
 						],
@@ -508,7 +508,7 @@ class Term extends Indexable {
 
 				case 'id=>parent':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 							'parent',
 						],
@@ -517,7 +517,7 @@ class Term extends Indexable {
 
 				case 'id=>slug':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 							'slug',
 						],
@@ -526,14 +526,14 @@ class Term extends Indexable {
 
 				case 'names':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'name',
 						],
 					];
 					break;
 				case 'tt_ids':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_taxonomy_id',
 						],
 					];

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -215,7 +215,7 @@ class User extends Indexable {
 		 */
 		if ( isset( $query_vars['fields'] ) && 'all' !== $query_vars['fields'] && 'all_with_meta' !== $query_vars['fields'] ) {
 			$formatted_args['_source'] = [
-				'include' => (array) $query_vars['fields'],
+				'includes' => (array) $query_vars['fields'],
 			];
 		}
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5089,7 +5089,7 @@ class TestPost extends BaseTestCase {
 		// Create a sticky post.
 		$sticky_post_id = Functions\create_and_sync_post();
 		stick_post( $sticky_post_id );
-	
+
 		$sticky_posts = get_option( 'sticky_posts' );
 		$this->assertNotEmpty( $sticky_posts );
 
@@ -5153,7 +5153,7 @@ class TestPost extends BaseTestCase {
 			new \WP_Query()
 		);
 
-		$this->assertContains( 'post_id', $args['_source']['include'] );
+		$this->assertContains( 'post_id', $args['_source']['includes'] );
 
 		$args = $post->format_args(
 			[
@@ -5162,8 +5162,8 @@ class TestPost extends BaseTestCase {
 			new \WP_Query()
 		);
 
-		$this->assertContains( 'post_id', $args['_source']['include'] );
-		$this->assertContains( 'post_parent', $args['_source']['include'] );
+		$this->assertContains( 'post_id', $args['_source']['includes'] );
+		$this->assertContains( 'post_parent', $args['_source']['includes'] );
 	}
 
 	/**

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1107,7 +1107,7 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 'term_id', $args['_source']['include'][0] );
+		$this->assertSame( 'term_id', $args['_source']['includes'][0] );
 
 		$args = $term->format_args(
 			[
@@ -1115,8 +1115,8 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 'term_id', $args['_source']['include'][0] );
-		$this->assertSame( 'name', $args['_source']['include'][1] );
+		$this->assertSame( 'term_id', $args['_source']['includes'][0] );
+		$this->assertSame( 'name', $args['_source']['includes'][1] );
 
 		$args = $term->format_args(
 			[
@@ -1124,8 +1124,8 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 'term_id', $args['_source']['include'][0] );
-		$this->assertSame( 'parent', $args['_source']['include'][1] );
+		$this->assertSame( 'term_id', $args['_source']['includes'][0] );
+		$this->assertSame( 'parent', $args['_source']['includes'][1] );
 
 		$args = $term->format_args(
 			[
@@ -1133,8 +1133,8 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 'term_id', $args['_source']['include'][0] );
-		$this->assertSame( 'slug', $args['_source']['include'][1] );
+		$this->assertSame( 'term_id', $args['_source']['includes'][0] );
+		$this->assertSame( 'slug', $args['_source']['includes'][1] );
 
 		$args = $term->format_args(
 			[
@@ -1142,7 +1142,7 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 'term_taxonomy_id', $args['_source']['include'][0] );
+		$this->assertSame( 'term_taxonomy_id', $args['_source']['includes'][0] );
 
 		$args = $term->format_args(
 			[
@@ -1150,7 +1150,7 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 'name', $args['_source']['include'][0] );
+		$this->assertSame( 'name', $args['_source']['includes'][0] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Change `_source_include` to `_source_includes` to prevent deprecation warning.


### Verification Process
1. On the `develop` branch, create and excute a user query with `fields`:
```
	$users = new WP_User_Query( array(
		'search'        => 'admin',
		'search_fields' => array( 'display_name' ),
		'fields'        => array( 'ID', 'display_name' ),
		'ep_integrate'  => true
	) );
```
2. Check the log of elasticsearch, see `Deprecated field [include] used, expected [includes] instead`.
3. Check out this PR, run the query again.
4. Check the log again, don't see new deprecation logs.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Closes #1769
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
