### PR TITLE
Exclude password protected posts from search

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -521,6 +521,16 @@ class Post extends Indexable {
 		 */
 		$meta = apply_filters( 'ep_prepare_meta_data', (array) get_post_meta( $post->ID ), $post );
 
+		/**
+		 * Make sure that proper post meta is being saved for
+		 * password protected posts.
+		 * 
+		 * @since 3.4.2
+		 */
+		if ( ! empty( $post->post_password ) ) {	
+			$meta['password_protected'] = true;	
+		}
+
 		if ( empty( $meta ) ) {
 			/**
 			 * Filter final list of prepared meta.
@@ -956,6 +966,24 @@ class Post extends Indexable {
 		}
 
 		$meta_queries = [];
+
+		/**
+		 * Make sure that for non-admin users we don't display
+		 * password protected posts in search results.
+		 * 
+		 * @hook ep_search_password_protected
+		 * @param  {bool} $not_is_admin Default value returned by !is_admin()
+		 * @return  {bool} Display or not password protected posts in search results
+		 * 
+		 * @since 3.4.2
+		 */
+		if ( apply_filter( 'ep_search_password_protected', ! is_admin()) ) {
+			$meta_queries[] = array(
+				'key'     => 'password_protected',
+				'value'   => true,
+				'compare' => '!=',
+			);
+		}
 
 		/**
 		 * Support meta_key


### PR DESCRIPTION
### Description of the Change
The problem we faced was the display of password-protected posts in the search results. Upon further investigation we were not able to hide password-protected posts via any existing hooks. Looking at past issues, we found this one: #1083 which had a PR: #1094 that was reverted at a later time. Upon testing the PR we managed to successfully hide posts from search results using it hence I am re-opening the PR with an additional hook to be able to show posts regardless of admin status if one might want that.
 
### Alternate Designs
We attempted to hide password-protected posts from the search results (which is default WP behavior) via existing hooks with no success.

### Benefits
Hide password-protected posts from search results. This behavior can be disabled via the included hook.

### Possible Drawbacks
None of which I can tell so far.

### Verification Process
Upon implementing this code on our test and production sites, we re-run the indexing process and then tested the default WP search results in the front-end of the site using different keywords that we knew previously returned password-protected posts.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues
None so far.

### Changelog Entry
Add support for hiding password-protected posts from search-results. Props @allan23 (#1094)
Add filter hook so you can still display password-protected posts from search-results. @cristianuibar