### PR TITLE
[WooCommerce] Add Fields to the Weighting Dashboard

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -181,76 +181,19 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 /**
+ * Setup upgrades
+ */
+Upgrades::factory();
+
+/**
  * Handle upgrades. Certain version require a re-sync on upgrade.
+ * Deprecated in favor of `\ElasticPress\Upgrades::factory()`.
  *
  * @since  2.2
  */
 function handle_upgrades() {
-	if ( ! is_admin() || defined( 'DOING_AJAX' ) ) {
-		return;
-	}
-
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		$last_sync = get_site_option( 'ep_last_sync', 'never' );
-	} else {
-		$last_sync = get_option( 'ep_last_sync', 'never' );
-	}
-
-	// No need to upgrade since we've never synced.
-	if ( empty( $last_sync ) || 'never' === $last_sync ) {
-		return;
-	}
-
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		$old_version = get_site_option( 'ep_version', false );
-	} else {
-		$old_version = get_option( 'ep_version', false );
-	}
-
-	/**
-	 * Reindex if we cross a reindex version in the upgrade
-	 */
-	$reindex_versions = apply_filters(
-		'ep_reindex_versions',
-		array(
-			'2.2',
-			'2.3.1',
-			'2.4',
-			'2.5.1',
-			'2.6',
-			'2.7',
-			'3.0',
-			'3.1',
-			'3.3',
-			'3.4',
-		)
-	);
-
-	$need_upgrade_sync = false;
-
-	if ( false !== $old_version ) {
-		$last_reindex_version = $reindex_versions[ count( $reindex_versions ) - 1 ];
-
-		if ( -1 === version_compare( $old_version, $last_reindex_version ) && 0 <= version_compare( EP_VERSION, $last_reindex_version ) ) {
-			$need_upgrade_sync = true;
-		}
-	}
-
-	if ( $need_upgrade_sync ) {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			update_site_option( 'ep_need_upgrade_sync', true );
-		} else {
-			update_option( 'ep_need_upgrade_sync', true );
-		}
-	}
-
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		update_site_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
-	} else {
-		update_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
-	}
+	_deprecated_function( __CLASS__, '3.5.2', '\ElasticPress\Upgrades::factory()' );
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\handle_upgrades', 5 );
 
 /**
  * Load text domain and handle debugging

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -433,25 +433,6 @@ class WooCommerce extends Feature {
 					);
 
 					$query->set( 'search_fields', $search_fields );
-				} elseif ( 'product' === $post_type ) {
-					$search_fields = $query->get( 'search_fields', array( 'post_title', 'post_content', 'post_excerpt' ) );
-
-					// Remove author_name from this search.
-					$search_fields = $this->remove_author( $search_fields );
-
-					foreach ( $search_fields as $field_key => $field ) {
-						if ( 'author_name' === $field ) {
-							unset( $search_fields[ $field_key ] );
-						}
-					}
-
-					$search_fields['meta']       = ( ! empty( $search_fields['meta'] ) ) ? $search_fields['meta'] : [];
-					$search_fields['taxonomies'] = ( ! empty( $search_fields['taxonomies'] ) ) ? $search_fields['taxonomies'] : [];
-
-					$search_fields['meta']       = array_merge( $search_fields['meta'], array( '_sku' ) );
-					$search_fields['taxonomies'] = array_merge( $search_fields['taxonomies'], array( 'category', 'post_tag', 'product_tag', 'product_cat' ) );
-
-					$query->set( 'search_fields', $search_fields );
 				}
 			} else {
 				/**
@@ -718,6 +699,29 @@ class WooCommerce extends Feature {
 	}
 
 	/**
+	 * Add WooCommerce Fields to the Weighting Dashboard.
+	 *
+	 * @since 3.x
+	 *
+	 * @param array  $fields    Current weighting fields.
+	 * @param string $post_type Current post type.
+	 * @return array            New fields.
+	 */
+	public function add_product_attributes_to_weighting( $fields, $post_type ) {
+		if ( 'product' === $post_type ) {
+			unset( $fields['attributes']['children']['author_name'] );
+
+			$sku_key = 'meta._sku.value';
+
+			$fields['attributes']['children'][ $sku_key ] = array(
+				'key'   => $sku_key,
+				'label' => __( 'SKU', 'elasticpress' ),
+			);
+		}
+		return $fields;
+	}
+
+	/**
 	 * Add WC post type to autosuggest
 	 *
 	 * @param array $post_types Array of post types (e.g. post, page).
@@ -753,6 +757,7 @@ class WooCommerce extends Feature {
 			add_action( 'parse_query', [ $this, 'search_order' ], 11 );
 			add_filter( 'ep_term_suggest_post_type', [ $this, 'suggest_wc_add_post_type' ] );
 			add_filter( 'ep_facet_include_taxonomies', [ $this, 'add_product_attributes' ] );
+			add_filter( 'ep_weighting_fields_for_post_type', [ $this, 'add_product_attributes_to_weighting' ], 10, 2 );
 		}
 	}
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -433,6 +433,25 @@ class WooCommerce extends Feature {
 					);
 
 					$query->set( 'search_fields', $search_fields );
+				} elseif ( 'product' === $post_type && is_plugin_active_for_network( EP_FILE ) ) {
+					$search_fields = $query->get( 'search_fields', array( 'post_title', 'post_content', 'post_excerpt' ) );
+
+					// Remove author_name from this search.
+					$search_fields = $this->remove_author( $search_fields );
+
+					foreach ( $search_fields as $field_key => $field ) {
+						if ( 'author_name' === $field ) {
+							unset( $search_fields[ $field_key ] );
+						}
+					}
+
+					$search_fields['meta']       = ( ! empty( $search_fields['meta'] ) ) ? $search_fields['meta'] : [];
+					$search_fields['taxonomies'] = ( ! empty( $search_fields['taxonomies'] ) ) ? $search_fields['taxonomies'] : [];
+
+					$search_fields['meta']       = array_merge( $search_fields['meta'], array( '_sku' ) );
+					$search_fields['taxonomies'] = array_merge( $search_fields['taxonomies'], array( 'category', 'post_tag', 'product_tag', 'product_cat' ) );
+
+					$query->set( 'search_fields', $search_fields );
 				}
 			} else {
 				/**

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -728,7 +728,9 @@ class WooCommerce extends Feature {
 	 */
 	public function add_product_attributes_to_weighting( $fields, $post_type ) {
 		if ( 'product' === $post_type ) {
-			unset( $fields['attributes']['children']['author_name'] );
+			if ( ! empty( $fields['attributes']['children']['author_name'] ) ) {
+				unset( $fields['attributes']['children']['author_name'] );
+			}
 
 			$sku_key = 'meta._sku.value';
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -433,7 +433,7 @@ class WooCommerce extends Feature {
 					);
 
 					$query->set( 'search_fields', $search_fields );
-				} elseif ( 'product' === $post_type && is_plugin_active_for_network( EP_FILE ) ) {
+				} elseif ( 'product' === $post_type && defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 					$search_fields = $query->get( 'search_fields', array( 'post_title', 'post_content', 'post_excerpt' ) );
 
 					// Remove author_name from this search.

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -741,6 +741,29 @@ class WooCommerce extends Feature {
 	}
 
 	/**
+	 * Add WooCommerce Fields to the default values of the Weighting Dashboard.
+	 *
+	 * @since 3.x
+	 *
+	 * @param array  $defaults  Default values for the post type.
+	 * @param string $post_type Current post type.
+	 * @return array
+	 */
+	public function add_product_default_post_type_weights( $defaults, $post_type ) {
+		if ( 'product' === $post_type ) {
+			if ( ! empty( $defaults['author_name'] ) ) {
+				unset( $defaults['author_name'] );
+			}
+
+			$defaults['meta._sku.value'] = array(
+				'enabled' => true,
+				'weight'  => 1,
+			);
+		}
+		return $defaults;
+	}
+
+	/**
 	 * Add WC post type to autosuggest
 	 *
 	 * @param array $post_types Array of post types (e.g. post, page).
@@ -777,6 +800,7 @@ class WooCommerce extends Feature {
 			add_filter( 'ep_term_suggest_post_type', [ $this, 'suggest_wc_add_post_type' ] );
 			add_filter( 'ep_facet_include_taxonomies', [ $this, 'add_product_attributes' ] );
 			add_filter( 'ep_weighting_fields_for_post_type', [ $this, 'add_product_attributes_to_weighting' ], 10, 2 );
+			add_filter( 'ep_weighting_default_post_type_weights', [ $this, 'add_product_default_post_type_weights' ], 10, 2 );
 		}
 	}
 

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Handle upgrades.
+ *
+ * @since  3.x
+ * @package elasticpress
+ */
+
+namespace ElasticPress;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Upgrades
+ *
+ * @package ElasticPress
+ */
+class Upgrades {
+
+	/**
+	 * Store the version number before performing upgrades.
+	 * Set in the `setup()` method.
+	 *
+	 * @var null|string
+	 */
+	protected $old_version;
+
+	/**
+	 * Initialize class
+	 */
+	public function setup() {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$this->old_version = get_site_option( 'ep_version', false );
+		} else {
+			$this->old_version = get_option( 'ep_version', false );
+		}
+
+		/**
+		 * An array with the upgrades routines.
+		 * Indexes are the ElasticPress version and values
+		 * are an array with the method name and, if needed,
+		 * the action name where it should be hooked.
+		 */
+		$routines = [
+			'3.5.2' => [ 'upgrade_3_5_2', 'init' ],
+		];
+
+		array_walk( $routines, [ $this, 'run_upgrade_routine' ] );
+
+		/**
+		 * Check if a reindex is needed.
+		 */
+		add_action( 'plugins_loaded', [ $this, 'check_reindex_needed' ], 5 );
+
+		/**
+		 * Update the version number.
+		 * Note: if a upgrade routine method is hooked to some action,
+		 * this code will be executed *earlier* than the routine method.
+		 */
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			update_site_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
+		} else {
+			update_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
+		}
+	}
+
+	/**
+	 * Run the upgrade routine, if needed.
+	 *
+	 * @param array  $routine Array with the info about the method to call.
+	 *                        If needed to be run in an action, it'll contain the action name.
+	 * @param string $version The version number to be tested.
+	 */
+	protected function run_upgrade_routine( $routine, $version ) {
+		if ( version_compare( $this->old_version, $version, '<' ) ) {
+			$function_name = $routine[0];
+			$action_tag    = $routine[1];
+			$priority      = ( ! empty( $routine[2] ) ) ? $routine[2] : 10;
+			if ( $action_tag ) {
+				add_action( $action_tag, [ $this, $function_name ], $priority );
+			} else {
+				$this->$function_name();
+			}
+		}
+	}
+
+	/**
+	 * Upgrade routine of v3.5.2.
+	 *
+	 * If weighting options exist and the WooCommerce feature is enabled,
+	 * this method will enable the SKU field.
+	 */
+	public function upgrade_3_5_2() {
+		$weighting_options = get_option( 'elasticpress_weighting', [] );
+		if ( empty( $weighting_options ) ) {
+			return;
+		}
+
+		$woocommerce = Features::factory()->get_registered_feature( 'woocommerce' );
+		if ( ! $woocommerce->is_active() ) {
+			return;
+		}
+
+		if ( empty( $weighting_options['product'] ) ) {
+			return;
+		}
+
+		if ( ! empty( $weighting_options['product']['author_name'] ) ) {
+			unset( $weighting_options['product']['author_name'] );
+		}
+
+		$weighting_options['product']['meta._sku.value'] = array(
+			'enabled' => true,
+			'weight'  => 1,
+		);
+
+		update_option( 'elasticpress_weighting', $weighting_options );
+	}
+
+	/**
+	 * Check if a reindex is needed based on the version number.
+	 */
+	public function check_reindex_needed() {
+		if ( ! is_admin() || defined( 'DOING_AJAX' ) ) {
+			return;
+		}
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$last_sync = get_site_option( 'ep_last_sync', 'never' );
+		} else {
+			$last_sync = get_option( 'ep_last_sync', 'never' );
+		}
+
+		// No need to upgrade since we've never synced.
+		if ( empty( $last_sync ) || 'never' === $last_sync ) {
+			return;
+		}
+
+		/**
+		 * Reindex if we cross a reindex version in the upgrade
+		 */
+		$reindex_versions = apply_filters(
+			'ep_reindex_versions',
+			array(
+				'2.2',
+				'2.3.1',
+				'2.4',
+				'2.5.1',
+				'2.6',
+				'2.7',
+				'3.0',
+				'3.1',
+				'3.3',
+				'3.4',
+			)
+		);
+
+		$need_upgrade_sync = false;
+
+		if ( false !== $this->old_version ) {
+			$last_reindex_version = $reindex_versions[ count( $reindex_versions ) - 1 ];
+
+			if ( -1 === version_compare( $this->old_version, $last_reindex_version ) && 0 <= version_compare( EP_VERSION, $last_reindex_version ) ) {
+				$need_upgrade_sync = true;
+			}
+		}
+
+		if ( $need_upgrade_sync ) {
+			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+				update_site_option( 'ep_need_upgrade_sync', true );
+			} else {
+				update_option( 'ep_need_upgrade_sync', true );
+			}
+		}
+	}
+
+	/**
+	 * Return singleton instance of class
+	 *
+	 * @return self
+	 */
+	public static function factory() {
+		static $instance = false;
+
+		if ( ! $instance ) {
+			$instance = new self();
+			$instance->setup();
+		}
+
+		return $instance;
+	}
+}


### PR DESCRIPTION
### Description of the Change

As per #1722 , when we add the WooCommerce fields to the query via search_fields parameter, the weighting engine is completely ignored.

This PR aims to add WooCommerce fields to the _Manage Search Fields & Weighting_ Screen, giving the user the ability to enable or not WooCommerce fields and change their weights. This is a cleaner and more elegant approach than the one suggested on #1785 .

### Screenshot

This is how the _Product_ post type box looks like with the initial version of the PR:

![image](https://user-images.githubusercontent.com/184628/84509459-1aa23300-ac9a-11ea-8124-5be2564ed701.png)

Note the "SKU" field and the absence of the "Author", which is removed by the current code.

### Alternate Designs

### Benefits

Keep weighting functionality AND having WC fields.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I've checked the ES query in Debug Bar

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1722 

### Changelog Entry

Add WooCommerce fields to the _Manage Search Fields & Weighting_ Screen.
