### PR TITLE
Feature/improve credential storage

### DIFF
--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -132,8 +132,23 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 									<label for="ep_username"><?php esc_html_e( 'Subscription Username', 'elasticpress' ); ?></label>
 								</th>
 								<td>
-									<input type="text" value="<?php echo esc_attr( $credentials['username'] ); ?>" name="ep_credentials[username]" id="ep_username">
-									<legend class="description"><?php esc_html_e( 'Plug in your subscription username here.', 'elasticpress' ); ?></legend>
+									<?php
+									/**
+									 * Filter whether to show epio credentials fields in admin UI or not
+									 *
+									 * @hook ep_admin_show_credentials
+									 * @param  {boolean} $show True to show
+									 * @return {boolean} New value
+									 */
+									if ( apply_filters( 'ep_admin_show_credentials', true ) ) :
+										?>
+										<input <?php if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) : ?>disabled<?php endif; ?> type="" value="<?php echo esc_attr( $credentials['username'] ); ?>" name="ep_credentials[username]" id="ep_username">
+									<?php endif ?>
+									<?php if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) : ?>
+										<legend class="description"><?php esc_html_e( 'Your Subscription Username is set in wp-config.php', 'elasticpress' ); ?></legend>
+									<?php else : ?>
+										<legend class="description"><?php esc_html_e( 'Plug in your subscription username here.', 'elasticpress' ); ?></legend>
+									<?php endif; ?>
 								</td>
 							</tr>
 
@@ -141,8 +156,23 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 								<th scope="row">
 									<label for="ep_token"><?php esc_html_e( 'Subscription Token', 'elasticpress' ); ?></label></th>
 								<td>
-									<input type="text" value="<?php echo esc_attr( $credentials['token'] ); ?>" name="ep_credentials[token]" id="ep_token">
-									<legend class="description"><?php esc_html_e( 'Plug in your subscription token here.', 'elasticpress' ); ?></legend>
+									<?php
+									/**
+									 * Filter whether to show epio credentials fields in admin UI or not
+									 *
+									 * @hook ep_admin_show_credentials
+									 * @param  {boolean} $show True to show
+									 * @return {boolean} New value
+									 */
+									if ( apply_filters( 'ep_admin_show_credentials', true ) ) :
+										?>
+										<input <?php if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) : ?>disabled<?php endif; ?> type="text" value="<?php echo esc_attr( $credentials['token'] ); ?>" name="ep_credentials[token]" id="ep_token">
+									<?php endif ?>
+									<?php if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) : ?>
+										<legend class="description"><?php esc_html_e( 'Your Subscription Token is set in wp-config.php', 'elasticpress' ); ?></legend>
+									<?php else : ?>
+										<legend class="description"><?php esc_html_e( 'Plug in your subscription token here.', 'elasticpress' ); ?></legend>
+									<?php endif; ?>
 								</td>
 							</tr>
 						<?php endif; ?>

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -19,7 +19,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array
  */
 function get_epio_credentials() {
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK && is_epio() ) {
+	if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) {
+		$raw_credentials = explode( ':', EP_CREDENTIALS );
+		if ( is_array( $raw_credentials ) && 2 === count( $raw_credentials ) ) {
+			$credentials = array(
+				'username' => $raw_credentials[0],
+				'token'    => $raw_credentials[1],
+			);
+		}
+		$credentials = sanitize_credentials( $credentials );
+	} elseif ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK && is_epio() ) {
 		$credentials = sanitize_credentials( get_site_option( 'ep_credentials', false ) );
 	} elseif ( is_epio() ) {
 		$credentials = sanitize_credentials( get_option( 'ep_credentials', false ) );


### PR DESCRIPTION
### Description of the Change

This implements an EP_CREDENTIALS constant to store elasticpress.io credentials outside of the WordPress database. The current change utilizes a colon delimited username:token pair in a single constant to reflect usage in ep shield and other areas in which the username and token are simply concatenated with a colon for implementation. In addition, this extends the ability to hide and other language enhancements to the credentials form in the same manner as has been done for EP_HOST and EP_INSTALL_PREFIX.

### Alternate Designs

As a follow-up, we would eventually like to see hiding of fields and other config items available via PHP constant however, this will allow us to implement elasticpress.io accounts on user sites using a consistent configuration format for all required configuration items.

### Benefits

This will allow us to implement elasticpress.io accounts on user sites using a consistent configuration format for all required configuration items.

### Possible Drawbacks

This probably doesn't go far enough. For example, hiding these same configuration variables via constant would be ideal however, this would require changes to established precedent already implemented in EP_HOST and EP_INSTALL_PREFIX. 

### Verification Process

Automated and manual testing has been included to verify correct operation of the new configuration inputs.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

https://github.com/10up/ElasticPress/issues/1818

### Changelog Entry

* [Feature] Implement EP_CREDENTIALS constant to store credentials in a _username:token_ format.
