### PR TITLE
Facet: Empty term which is selected is not clickable to unselect

### DIFF
--- a/assets/css/facets.css
+++ b/assets/css/facets.css
@@ -11,12 +11,12 @@
 	display: none;
 }
 
-.widget_ep-facet .empty-term {
+.widget_ep-facet .empty-term:not(.selected) {
 	position: relative;
 	opacity: .5;
 }
 
-.widget_ep-facet .empty-term:after {
+.widget_ep-facet .empty-term:not(.selected):after {
 	z-index: 2;
 	content: ' ';
 	display: block;


### PR DESCRIPTION
If an empty term is selected at the same time, it should still been clickable to unselect the term

### Description of the Change

If a term in the Facet search is selected but empty, its not clickable and you can't unselect the term. This checks if the empty-term is selected and does not apply the empty-term class

### Alternate Designs

The opacity could still be applies to make clear, that there is no search result with this term

### Benefits

I created a quick search form which does not use the facet widget and there is no check if there are enough search results. In the second step, you can use the facet widgets

### Possible Drawbacks



### Verification Process

Cheched the CSS

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues


### Changelog Entry

