### PR TITLE
Allow searches for variation SKU in admin interface

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -705,7 +705,7 @@ class WooCommerce extends Feature {
 	 * @since TBD
 	 *
 	 * @param array $post_args Post arguments.
-	 * @param int $post_id Post ID.
+	 * @param int   $post_id Post ID.
 	 *
 	 * @return array
 	 */
@@ -1008,7 +1008,7 @@ class WooCommerce extends Feature {
 	 * @since TBD
 	 *
 	 * @param array $post_args Post arguments.
-	 * @param int $post_id Post ID.
+	 * @param int   $post_id Post ID.
 	 *
 	 * @return array
 	 */
@@ -1065,7 +1065,7 @@ class WooCommerce extends Feature {
 	 */
 	public function admin_variations_skus_search( $search_fields, $args ) {
 		global $pagenow;
-		if ( ! is_array( $search_fields ) || 'edit.php' != $pagenow || empty( $args['post_type'] ) || 'product' !== $args['post_type'] || empty( $args['s'] ) ) {
+		if ( ! is_array( $search_fields ) || 'edit.php' !== $pagenow || empty( $args['post_type'] ) || 'product' !== $args['post_type'] || empty( $args['s'] ) ) {
 			return $search_fields;
 		}
 


### PR DESCRIPTION
### Description of the Change

This is a proof of concept of handling searching by products variations SKU and returning parent product (#781) and is a refactored version of https://github.com/10up/ElasticPress/pull/941 since it got closed due to major code changes in 3.0.

The point of this is to be able to search for a variation sku and then get the parent product in the admin interface (this is a default feature in WooCommerce).

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

I created a new variable product with a couple of variants. These all have a new `__wc_ep_variations_skus` meta value in Elasticsearch.
The value of `__wc_ep_variations_skus` is being updated when the parent product is updating which is the core logic of the PR but the value have also been tested to update when a variation is being deleted through the admin interface without pressing the "Update" button for the parent product and the value have also been tested to update when using the variation _Save Changes_ button below variations in the interface (hence; not the "Update parent post button")

I have also tested that the admin product overview list changes only affect the mentioned list by test other overview lists (like Orders, Pages, Posts) and on the front-end when Elasticsearch is enabled.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document. **This file no longer exists**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
https://github.com/10up/ElasticPress/issues/781

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
WC Enhancement: add variation sku as a searchable field and apply it on the product overview list.