### PR TITLE
(fix): reset queue after delete post

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -8,8 +8,8 @@
 
 namespace ElasticPress\Indexable\Post;
 
-use ElasticPress\Indexables as Indexables;
 use ElasticPress\Elasticsearch as Elasticsearch;
+use ElasticPress\Indexables as Indexables;
 use ElasticPress\SyncManager as SyncManagerAbstract;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -164,6 +164,12 @@ class SyncManager extends SyncManagerAbstract {
 		do_action( 'ep_delete_post', $post_id );
 
 		Indexables::factory()->get( 'post' )->delete( $post_id, false );
+
+        /**
+		 * Make sure to reset sync queue in case an shutdown happens before a redirect
+		 * when a redirect has already been triggered.
+		 */
+		$this->sync_queue = [];
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

#1827 issues that deleting a post from the admin view, does not delete the post from ES, but rather, changes the post_status to `trash`.

### Benefits

By resetting the `sync_queue`, no more actions will be handled, after the `wp_redirect` kicks in.

### Possible Drawbacks

Cannot run phpunit, as I'm running in Docker, and don't have svn and such locally installed.

### Verification Process
According to the screenshots from #1827, deleting a post from admin view, does not delete the post/document in ES (but changes the post_status of that document to `trash`.
After apply my patch, the deleted document is not found in ES anymore.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Code could have unintended impact on other parts of the plugin.

### Changelog Entry

Added: reset `sync_queue` after deleting post.