### PR TITLE
Added Prepare User meta data filter

### DIFF
--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -856,11 +856,7 @@ class User extends Indexable {
 		$prepared_roles = [];
 
 		foreach ( $sites as $site ) {
-			$maybe_in_array_roles = get_user_meta( $user_id, $wpdb->get_blog_prefix( $site['blog_id'] ) . 'capabilities', true );
-			
-			$roles = is_array($maybe_in_array_roles) 
-				? $maybe_in_array_roles 
-				: array( $maybe_in_array_roles );
+			$roles = (array) get_user_meta( $user_id, $wpdb->get_blog_prefix( $site['blog_id'] ) . 'capabilities', true );
 
 			if ( ! empty( $roles ) ) {
 				$prepared_roles[ (int) $site['blog_id'] ] = [

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -398,7 +398,7 @@ class User extends Indexable {
 			 * search columns into search_fields. search_fields overwrites search_columns.
 			 */
 			if ( ! empty( $search_fields ) ) {
-				$prepared_search_fields = [];
+				$_med_search_fields = [];
 
 				// WP_User_Query uses shortened column names so we need to expand those.
 				if ( ! empty( $search_fields['login'] ) ) {
@@ -876,7 +876,15 @@ class User extends Indexable {
 	 * @return array
 	 */
 	public function prepare_meta( $user_id ) {
-		$meta = (array) get_user_meta( $user_id );
+		/**
+		 * Filter pre-prepare meta for a user
+		 *
+		 * @hook ep_prepare_user_meta_data
+		 * @param  {array} $meta Meta data
+		 * @param  {int} $user_id User ID
+		 * @return  {array} New meta
+		 */
+		$meta = apply_filters( 'ep_prepare_user_meta_data', (array)get_user_meta( $user_id ), $user_id );
 
 		if ( empty( $meta ) ) {
 			/**

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -856,7 +856,11 @@ class User extends Indexable {
 		$prepared_roles = [];
 
 		foreach ( $sites as $site ) {
-			$roles = get_user_meta( $user_id, $wpdb->get_blog_prefix( $site['blog_id'] ) . 'capabilities', true );
+			$maybe_in_array_roles = get_user_meta( $user_id, $wpdb->get_blog_prefix( $site['blog_id'] ) . 'capabilities', true );
+			
+			$roles = is_array($maybe_in_array_roles) 
+				? $maybe_in_array_roles 
+				: array( $maybe_in_array_roles );
 
 			if ( ! empty( $roles ) ) {
 				$prepared_roles[ (int) $site['blog_id'] ] = [

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -398,7 +398,7 @@ class User extends Indexable {
 			 * search columns into search_fields. search_fields overwrites search_columns.
 			 */
 			if ( ! empty( $search_fields ) ) {
-				$_med_search_fields = [];
+				$prepared_search_fields = [];
 
 				// WP_User_Query uses shortened column names so we need to expand those.
 				if ( ! empty( $search_fields['login'] ) ) {


### PR DESCRIPTION
<!--

### Description of the Change

Added new filter `ep_prepare_user_meta_data` to mirror the`ep_prepare_meta_data` in the Post Indexable. Nothing major here, but more for consistency and because our team will use it :)

### Alternate Designs

Use the "same" filter style as on the Post indexable

### Benefits

Filter the user meta before any operation is done

### Possible Drawbacks

None

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

Working with it locally, all works fine :)

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

### Changelog Entry

Added new filter `ep_prepare_user_meta_data` to mirror the`ep_prepare_meta_data` in the Post Indexable
