### PR TITLE
Rename first EP submenu item to Features

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -903,6 +903,15 @@ function action_admin_menu() {
 
 	add_submenu_page(
 		'elasticpress',
+		'ElasticPress ' . esc_html__( 'Features', 'elasticpress' ),
+		esc_html__( 'Features', 'elasticpress' ),
+		$capability,
+		'elasticpress',
+		__NAMESPACE__ . '\resolve_screen'
+	);
+
+	add_submenu_page(
+		'elasticpress',
 		'ElasticPress ' . esc_html__( 'Settings', 'elasticpress' ),
 		esc_html__( 'Settings', 'elasticpress' ),
 		$capability,


### PR DESCRIPTION
### Description of the Change

As advertised - instead of top-level ElasticPress menu being followed by another submenu item reading ElasticPress, that submenu item will read Features.

### Alternate Designs

n/a

### Benefits

Should make it easier to understand what that page is for specifically.

### Possible Drawbacks

Not seeing any.

### Verification Process

Checked in the admin, clicked to different pages and navigated back.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
