### PR TITLE
Add a default permission_callback to all of our custom REST routes

### DIFF
--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -159,9 +159,10 @@ class RelatedPosts extends Feature {
 			'wp/v2',
 			'/posts/(?P<id>[0-9]+)/related',
 			[
-				'methods'  => 'GET',
-				'callback' => [ $this, 'output_endpoint' ],
-				'args'     => [
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'output_endpoint' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'id'     => [
 						'description' => 'Post ID.',
 						'type'        => 'numeric',

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -638,9 +638,10 @@ class SearchOrdering extends Feature {
 			'elasticpress/v1',
 			'pointer_search',
 			[
-				'methods'  => 'GET',
-				'callback' => [ $this, 'handle_pointer_search' ],
-				'args'     => [
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'handle_pointer_search' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					's' => [
 						'validate_callback' => function ( $param ) {
 							return ! empty( $param );
@@ -655,9 +656,10 @@ class SearchOrdering extends Feature {
 			'elasticpress/v1',
 			'pointer_preview',
 			[
-				'methods'  => 'GET',
-				'callback' => [ $this, 'handle_pointer_preview' ],
-				'args'     => [
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'handle_pointer_preview' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					's' => [
 						'validate_callback' => function ( $param ) {
 							return ! empty( $param );


### PR DESCRIPTION
### Description of the Change

Adds a `permission_callback` parameter to all of our `register_rest_route` calls. This was previously not required but in WordPress 5.5, this will now throw a PHP notice if debug is on and this parameter isn't passed. Because we currently aren't doing any sort of permission check, we utilize the `__return_true` function here, which will always return true.

### Alternate Designs

None

### Benefits

Removes PHP notices in WordPress 5.5+ when debug is on

### Possible Drawbacks

None

### Verification Process

With debug on and prior to any changes, tested out the plugin locally. Saw that I was getting 3 PHP notices. After this fix, tested again and didn't get any PHP notices

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #1867