### PR TITLE
Update before_scripts in wpacceptance.json

### DIFF
--- a/wpacceptance.json
+++ b/wpacceptance.json
@@ -13,6 +13,6 @@
     "snapshot_id": "4e38780a2545d8325df2008391666a2f",
     "before_scripts" : [
       "mv tests/wpa/test-plugins/* ../",
-      "mv tests/wpa/test-mu-plugins ../../mu-plugins"
+      "mv tests/wpa/test-mu-plugins/* ../../mu-plugins/"
     ]
 }


### PR DESCRIPTION
### Description of the Change

Update the script to copy the test-mu-plugins folder content to reflect the same that happens with the normal plugins folder.

I'm setting the EP credentials in a mu-plugin and got this error:
`Before script returned a non-zero exit code: mv tests/wpa/test-mu-plugins ../../mu-plugins`

After making the change proposed in this PR it worked.

### Alternate Designs

n/a

### Benefits

We can easily run tests against external services like EP.io.

### Possible Drawbacks

n/a

### Verification Process

1. Create a mu-plugin inside the `/tests/wpa/test-mu-plugins` folder
2. Set EP_INDEX_PREFIX, ES_SHIELD, and EP_HOST inside of it
3. Run tests
4. See the `Before script returned a non-zero exit code: mv tests/wpa/test-mu-plugins ../../mu-plugins` message
5. Apply the changes
6. The error doesn't happen

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
