### PR TITLE
Improve mime type filtering

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -913,10 +913,12 @@ class Post extends Indexable {
 		 * @since 2.3
 		 */
 		if ( ! empty( $args['post_mime_type'] ) ) {
+			// Default list of mime types to an empty array.
+			$mime_types = array();
 			if ( is_string( $args['post_mime_type'] ) ) {
 				$mime_types = array_map( 'trim', explode( ',', $args['post_mime_type'] ) );
-			} else {
-				$mime_types = (array) $args['post_mime_type'];
+			} elseif ( is_array( $args['post_mime_type'] ) ) {
+				$mime_types = $args['post_mime_type'];
 			}
 			
 			// Collect fully qualified mime types here e.g. image/jpeg.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

As noted in issue #1604 the image block sends a mime type value of `image` through as an array which goes against the convention this part of the query filter relied on. This update makes the filter more agnostic, working with a single string (as `wp_post_mime_type_where()` does) or an array, plus it will then separate the values into full terms and prefixes.


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

This has the benefit of supporting almost any combination of values given in the `post_mime_type` argument and avoids the use of a `regexp` query which can be slower to run.

This fixes issue #1604

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

Searching media in the media modal opened from an image block in the block editor now returns results.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

- #1604 


### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

- Changed `post_mime_type` filtering to support more edge cases
