### PR TITLE
Hide links to the Weighting and Synonyms Screens when in Multisite

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -377,9 +377,12 @@ class Search extends Feature {
 			</div>
 		</div>
 
-		<br class="clear">
-		<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=elasticpress-weighting' ) ); ?>"><?php esc_html_e( 'Advanced fields and weighting settings', 'elasticpress' ); ?></a></p>
-		<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=elasticpress-synonyms' ) ); ?>"><?php esc_html_e( 'Add synonyms to your post searches', 'elasticpress' ); ?></a></p>
+		<?php if ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) : ?>
+			<br class="clear">
+			<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=elasticpress-weighting' ) ); ?>"><?php esc_html_e( 'Advanced fields and weighting settings', 'elasticpress' ); ?></a></p>
+			<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=elasticpress-synonyms' ) ); ?>"><?php esc_html_e( 'Add synonyms to your post searches', 'elasticpress' ); ?></a></p>
+		<?php endif; ?>
+
 		<?php
 	}
 }


### PR DESCRIPTION
### Description of the Change

Hide links to the Weighting Screen and the Synonyms Screen inside the Post Search box when in Multisite.

![image](https://user-images.githubusercontent.com/184628/93810157-9c541600-fc24-11ea-90cc-b1c72ae25612.png)

### Alternate Designs

n/a

### Benefits

Remove links to pages the user should not access.

### Possible Drawbacks

n/a

### Verification Process

1. Created a MU site
2. Network activated EP
3. Clicked on links: both screens broken
4. Network deactivated EP
5. Activate EP per site
6. Clieck on links: screens look good

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1811 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
