### PR TITLE
Post metadata: Just queue post if the meta changed is allowed

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -76,6 +76,11 @@ class SyncManager extends SyncManagerAbstract {
 
 		$post = get_post( $object_id );
 
+		$allowed_meta_to_be_indexed = $indexable->prepare_meta( $post );
+		if ( ! in_array( $meta_key, array_keys( $allowed_meta_to_be_indexed ), true ) ) {
+			return;
+		}
+
 		if ( in_array( $post->post_status, $indexable_post_statuses, true ) ) {
 			$indexable_post_types = $indexable->get_indexable_post_types();
 


### PR DESCRIPTION
### Description of the Change

As described in #1857, EP will trigger a sync every time any metadata is changed (including `_edit_lock` and any other). This PR aims to only sync when metadata that will really be stored in ES is changed.

To narrow down the allowed meta I'm using the `ElasticPress\Indexable\Post\Post::prepare_meta()` method, as it'll run all filters a dev would use: ep_prepare_meta_data, ep_prepared_post_meta, ep_prepare_meta_allowed_protected_keys, ep_prepare_meta_excluded_public_keys. ep_prepare_meta_whitelist_key, and ep_prepared_post_meta.

### Alternate Designs

We could avoid a ES sync just for `_edit_lock`.

### Benefits

Less requests made to the ES server.

### Possible Drawbacks

n/a

### Verification Process

I've looked at docker logs and made some `error_log()` calls. I've changed a default meta data (`my_test`) and also WooCommerce SKUs. Both were updated successfully.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1857

### Changelog Entry

- Fixed unnecessary requests to the ES server while saving posts.