### PR TITLE
[WP Acceptance] Create a mu-plugins folder first

### DIFF
--- a/wpacceptance.json
+++ b/wpacceptance.json
@@ -13,6 +13,6 @@
     "snapshot_id": "4e38780a2545d8325df2008391666a2f",
     "before_scripts" : [
       "mv tests/wpa/test-plugins/* ../",
-      "mv tests/wpa/test-mu-plugins/* ../../mu-plugins/"
+      "mkdir -p ../../mu-plugins/ && mv tests/wpa/test-mu-plugins/* ../../mu-plugins/"
     ]
 }


### PR DESCRIPTION
### Description of the Change

This PR changes one of the before_scripts commands, creating the mu-plugins before moving anything into it.

### Alternate Designs

n/a

### Benefits

Possibility of adding mu-plugins without error. This is especially useful to run WP Acceptance tests against other servers.

### Possible Drawbacks

n/a

### Verification Process

Changed and run it a couple of times with --show_browser (to check which server was being used).

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Applicable Issues

n/a

### Changelog Entry

