### PR TITLE
Check if site is indexable before syncing

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -33,6 +33,10 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
+		if ( ! $this->can_index_site() ) {
+			return;
+		}
+
 		add_action( 'wp_insert_post', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'add_attachment', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'edit_attachment', array( $this, 'action_sync_on_update' ), 999, 3 );

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -31,6 +31,10 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
+		if ( ! $this->can_index_site() ) {
+			return;
+		}
+
 		add_action( 'created_term', [ $this, 'action_sync_on_update' ] );
 		add_action( 'edited_terms', [ $this, 'action_sync_on_update' ] );
 		add_action( 'added_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );

--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -144,6 +144,22 @@ abstract class SyncManager {
 	}
 
 	/**
+	 * Check if we can index content in the current blog
+	 *
+	 * @since 3.5
+	 * @return boolean
+	 */
+	public function can_index_site() {
+		if ( defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) {
+			$is_indexable = get_blog_option( get_current_blog_id(), 'ep_indexable', 'yes' );
+
+			return 'yes' === $is_indexable;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Determine whether syncing an indexable should take place.
 	 *
 	 * Returns true or false depending on the value of the WP_IMPORTING global.


### PR DESCRIPTION
This fixes a bug where when network activated non-indexable sites would still sync posts.