### PR TITLE
Feature: Track CLI index in a headless fashion

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1294,6 +1294,27 @@ class Command extends WP_CLI_Command {
 
 	}
 
+	/**
+	 * Returns a JSON array with the results of the last CLI sync (if present) of an empty array.
+	 *
+	 * @synopsis [--clear]
+	 * @subcommand get-last-cli-sync
+	 *
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_last_cli_sync( $args, $assoc_args ) {
+
+		$last_sync = get_site_option( 'ep_last_cli_index', array() );
+
+		if ( isset( $assoc_args['clear'] ) ) {
+			delete_site_option( 'ep_last_cli_index' );
+		}
+
+		WP_CLI::line( wp_json_encode( $last_sync ) );
+
+	}
+
 
 	/**
 	 * maybe change Elastic host on the fly

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1295,15 +1295,15 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Returns a JSON array with the results of the last CLI sync (if present) of an empty array.
+	 * Returns a JSON array with the results of the last CLI index (if present) of an empty array.
 	 *
 	 * @synopsis [--clear]
-	 * @subcommand get-last-cli-sync
+	 * @subcommand get-last-cli-index
 	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
-	public function get_last_cli_sync( $args, $assoc_args ) {
+	public function get_last_cli_index( $args, $assoc_args ) {
 
 		$last_sync = get_site_option( 'ep_last_cli_index', array() );
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -708,7 +708,7 @@ class Command extends WP_CLI_Command {
 		$index_results = array(
 			'total'        => $total_indexable,
 			'synced'       => $total_indexed,
-			'end_time_gmt' => current_time( 'timestamp', true ),
+			'end_time_gmt' => time(),
 			'total_time'   => (float) $index_time,
 			'errors'       => $index_errors,
 		);
@@ -930,7 +930,7 @@ class Command extends WP_CLI_Command {
 			}
 
 			$query_args['offset'] += $per_page;
-			$total_indexable      = (int) $query['total_objects'];
+			$total_indexable       = (int) $query['total_objects'];
 
 			usleep( 500 );
 
@@ -946,9 +946,9 @@ class Command extends WP_CLI_Command {
 		wp_reset_postdata();
 
 		return [
-			'total'  		=> $total_indexable,
-			'synced' 		=> $synced,
-			'errors' 		=> count( $failed_objects ),
+			'total'         => $total_indexable,
+			'synced'        => $synced,
+			'errors'        => count( $failed_objects ),
 			'error_details' => $this->output_index_errors( $failed_objects, $indexable, false ),
 		];
 	}
@@ -958,7 +958,7 @@ class Command extends WP_CLI_Command {
 	 *
 	 * @param  array     $errors Error array
 	 * @param  Indexable $indexable Index indexable
-	 * @param bool		 $output True to print output.
+	 * @param  bool      $output True to print output
 	 *
 	 * @return array Array of error messages for furthur logging.
 	 * @since 3.4
@@ -969,7 +969,7 @@ class Command extends WP_CLI_Command {
 
 		foreach ( $errors as $object_id => $error ) {
 
-			$error_array[$object_id] = array(
+			$error_array[ $object_id ] = array(
 				$indexable->labels['singular'],
 				$error['type'],
 				$error['reason'],
@@ -1273,7 +1273,7 @@ class Command extends WP_CLI_Command {
 
 			if ( $dashboard_syncing ) {
 
-				$index_status['method']   = 'web';
+				$index_status['method']        = 'web';
 				$index_status['items_indexed'] = $dashboard_syncing['offset'];
 				$index_status['total_items']   = $dashboard_syncing['found_items'];
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1244,9 +1244,9 @@ class Command extends WP_CLI_Command {
 	 * items_indexed | integer | Total number of items indexed
 	 * total_items | integer | Total number of items indexed or -1 if not yet determined
 	 *
-	 * @subcommand get-index-status
+	 * @subcommand get-indexing-status
 	 */
-	public function get_index_status() {
+	public function get_indexing_status() {
 
 		$index_status = array(
 			'indexing'      => false,

--- a/tests/wpa/WpCliTest.php
+++ b/tests/wpa/WpCliTest.php
@@ -321,4 +321,14 @@ class WpCliTest extends TestBase {
 
 		$this->assertStringContainsString( 'Index Size', $cli_result );
 	}
+
+	/**
+	 * @testdox If user runs wp elasticpress get-index-status command, it should return a string indicating the index is not running.
+	*/
+	public function testGetIndexStatusCommand() {
+
+		$cli_result = $this->runCommand( 'wp elasticpress get-index-status' )['stdout'];
+
+		$this->assertStringContainsString( '{"indexing":false,"method":"none","items_indexed":0,"total_items":-1}', $cli_result );
+	}
 }

--- a/tests/wpa/WpCliTest.php
+++ b/tests/wpa/WpCliTest.php
@@ -333,21 +333,21 @@ class WpCliTest extends TestBase {
 	}
 
 	/**
-	 * @testdox If user runs wp elasticpress get-last-cli-sync command, it should return a string indicating with the appropriate fields.
+	 * @testdox If user runs wp elasticpress get-last-cli-index command, it should return a string indicating with the appropriate fields.
 	*/
-	public function testGetLastCLISyncCommand() {
+	public function testGetLastCLIIndexCommand() {
 
-		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-cync' )['stdout'];
+		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-index' )['stdout'];
 
 		$this->assertStringContainsString( '[]', $cli_result );
 
 		$this->runCommand( 'wp elasticpress index' );
 
-		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-cync --clear' )['stdout'];
+		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-index --clear' )['stdout'];
 
 		$this->assertStringContainsString( '"total_time"', $cli_result );
 
-		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-cync --clear' )['stdout'];
+		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-index --clear' )['stdout'];
 
 		$this->assertStringContainsString( '[]', $cli_result );
 	}

--- a/tests/wpa/WpCliTest.php
+++ b/tests/wpa/WpCliTest.php
@@ -325,9 +325,9 @@ class WpCliTest extends TestBase {
 	/**
 	 * @testdox If user runs wp elasticpress get-index-status command, it should return a string indicating the index is not running.
 	*/
-	public function testGetIndexStatusCommand() {
+	public function testGetIndexingStatusCommand() {
 
-		$cli_result = $this->runCommand( 'wp elasticpress get-index-status' )['stdout'];
+		$cli_result = $this->runCommand( 'wp elasticpress get-indexing-status' )['stdout'];
 
 		$this->assertStringContainsString( '{"indexing":false,"method":"none","items_indexed":0,"total_items":-1}', $cli_result );
 	}

--- a/tests/wpa/WpCliTest.php
+++ b/tests/wpa/WpCliTest.php
@@ -331,4 +331,24 @@ class WpCliTest extends TestBase {
 
 		$this->assertStringContainsString( '{"indexing":false,"method":"none","items_indexed":0,"total_items":-1}', $cli_result );
 	}
+
+	/**
+	 * @testdox If user runs wp elasticpress get-last-cli-sync command, it should return a string indicating with the appropriate fields.
+	*/
+	public function testGetLastCLISyncCommand() {
+
+		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-cync' )['stdout'];
+
+		$this->assertStringContainsString( '[]', $cli_result );
+
+		$this->runCommand( 'wp elasticpress index' );
+
+		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-cync --clear' )['stdout'];
+
+		$this->assertStringContainsString( '"total_time"', $cli_result );
+
+		$cli_result = $this->runCommand( 'wp elasticpress get-last-cli-cync --clear' )['stdout'];
+
+		$this->assertStringContainsString( '[]', $cli_result );
+	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -80,6 +80,8 @@ class EP_Uninstaller {
 		delete_site_option( 'ep_hide_intro_shown_notice' );
 		delete_option( 'ep_skip_install' );
 		delete_site_option( 'ep_skip_install' );
+		delete_option( 'ep_last_cli_index' );
+		delete_site_option( 'ep_last_cli_index' );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

This PR adds the following two commands as well as necessary data structures and acceptance tests to determine index status on an index started via an automated session.

`wp elasticpress get-index-status`

Returns the following:

```{"indexing":false,"method":"none","items_indexed":0,"total_items":-1}```

`wp elasticpress get-last-cli-index [--clear]` The optional clear flag will clear the saved status from the database

Returns an empty json array or the following:

```{"total":2006,"synced":2006,"end_time_gmt":1602177690,"total_time":24.418,"errors":[]}```

### Alternate Designs

After an analysis of existing commands and endpoints there wasn't another method we could find existing that would serve the purpose. We are open to further suggestions.

### Benefits

This would allow an automated system handling the plugin at scale to accurately determine the status and results of an indexing operation. In addition, it will allow support folks at any level to better diagnose and help troubleshoot any issues that might arise during a sync.

### Possible Drawbacks

It make use of extra database and cache calls that will minimally effect performance. 

### Verification Process

Appropriate acceptance testing was added to verify the commands work as intended.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1911

### Changelog Entry

* Feature: Added get-index-status cli command
* Feature: Added get-last-cli-index cli command