### PR TITLE
Disable dashboard sync AJAX callback if EP_DASHBOARD_SYNC is set to false.

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -370,7 +370,7 @@ function action_wp_ajax_ep_notice_dismiss() {
  * @since  2.1
  */
 function action_wp_ajax_ep_index() {
-	if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) ) {
+	if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) || ! EP_DASHBOARD_SYNC ) {
 		wp_send_json_error();
 		exit;
 	}
@@ -670,7 +670,7 @@ function action_wp_ajax_ep_index() {
  * @since  2.1
  */
 function action_wp_ajax_ep_cancel_index() {
-	if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) ) {
+	if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) || ! EP_DASHBOARD_SYNC ) {
 		wp_send_json_error();
 		exit;
 	}


### PR DESCRIPTION

### Description of the Change

See https://github.com/10up/ElasticPress/issues/1914

This fix disabled sync AJAX callback if EP_DASHBOARD_SYNC is set to false.
Currently the constats only remove the sync buttons.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Properly disable the dashboard sync feature.

### Possible Drawbacks

Possible confusion from user trying to sync via dashboard.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
