### PR TITLE
Add the `post_title.suggest` field when using the new algorithm

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -244,7 +244,18 @@ class Autosuggest extends Feature {
 				foreach ( $query['bool']['must'] as $q_index => $must_query ) {
 					if ( isset( $must_query['bool'] ) && isset( $must_query['bool']['should'] ) ) {
 						foreach ( $must_query['bool']['should'] as $index => $current_bool_should ) {
-							if ( isset( $current_bool_should['multi_match'] ) && isset( $current_bool_should['multi_match']['fuzziness'] ) && 0 !== $current_bool_should['multi_match']['fuzziness'] && isset( $current_bool_should['multi_match']['fields'] ) ) {
+							if (
+								isset( $current_bool_should['multi_match'] ) &&
+								isset( $current_bool_should['multi_match']['fields'] ) &&
+								(
+									isset( $current_bool_should['multi_match']['fuzziness'] ) &&
+									0 !== $current_bool_should['multi_match']['fuzziness']
+								) ||
+								(
+									isset( $current_bool_should['multi_match']['slop'] ) &&
+									0 !== $current_bool_should['multi_match']['slop']
+								)
+							) {
 								foreach ( $current_bool_should['multi_match']['fields'] as $key => $field ) {
 									foreach ( $ngram_fields as $plain_field => $ngram_field ) {
 										if ( preg_match( '/^(' . $plain_field . ')(\^(\d+))?$/', $field, $match ) ) {

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -248,12 +248,14 @@ class Autosuggest extends Feature {
 								isset( $current_bool_should['multi_match'] ) &&
 								isset( $current_bool_should['multi_match']['fields'] ) &&
 								(
-									isset( $current_bool_should['multi_match']['fuzziness'] ) &&
-									0 !== $current_bool_should['multi_match']['fuzziness']
-								) ||
-								(
-									isset( $current_bool_should['multi_match']['slop'] ) &&
-									0 !== $current_bool_should['multi_match']['slop']
+									(
+										isset( $current_bool_should['multi_match']['fuzziness'] ) &&
+										0 !== $current_bool_should['multi_match']['fuzziness']
+									) ||
+									(
+										isset( $current_bool_should['multi_match']['slop'] ) &&
+										0 !== $current_bool_should['multi_match']['slop']
+									)
 								)
 							) {
 								foreach ( $current_bool_should['multi_match']['fields'] as $key => $field ) {


### PR DESCRIPTION
### Description of the Change

For autosuggest, the current code just adds the `post_title.suggest` field to multi_match clauses that contain `fuzziness`. As the new algorithm uses `slop`, the ngram field isn't added to the query.

### Alternate Designs

We probably could test just for `! empty( $current_bool_should['multi_match']['fuzziness'] )` perhaps?

### Benefits

Partial matches for autosuggest working again.

### Possible Drawbacks

n/a

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
