### PR TITLE
Facets: Create a new "ep_facet_search_get_terms_args" filter

### DIFF
--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -77,9 +77,24 @@ class Widget extends WP_Widget {
 		 * Get all the terms so we know if we should output the widget
 		 */
 		$terms = get_terms(
-			array(
-				'taxonomy'   => $taxonomy,
-				'hide_empty' => true,
+			/**
+			 * Filter arguments passed to get_terms() while getting all possible terms for the facet widget.
+			 *
+			 * @since  3.5.x
+			 * @hook ep_facet_search_get_terms_args
+			 * @param  {array} $query Weighting query
+			 * @param  {string} $post_type Post type
+			 * @param  {array} $args WP Query arguments
+			 * @return  {array} New query
+			 */
+			apply_filters(
+				'ep_facet_search_get_terms_args',
+				[
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => true,
+				],
+				$args,
+				$instance
 			)
 		);
 


### PR DESCRIPTION
### Description of the Change

This PR introduces a new `ep_facet_search_get_terms_args` filter to the `get_terms()` call we have inside the Facets widget.

With this, developers will be able to easily tweak that function call. It can be useful, for example, to exclude some unwanted terms like "Uncategorized". The code would be something like:

```
add_filter(
	'ep_facet_search_get_terms_args',
	function( $args ) {
		$args['exclude_tree'] = [ 1 ];

		return $args;
	}
);
```

### Alternate Designs

Open to suggestions.

### Benefits

Explained above.

### Possible Drawbacks

n/a

### Verification Process

I've added the filter and tested the snippet above.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

Added the "ep_facet_search_get_terms_args" filter, making it possible to change the get_terms() call inside the Facets widget.
