### PR TITLE
Update/gh actions

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/actions-wordpress/dotorg-plugin-asset-update@master
+      uses: 10up/action-wordpress-plugin-asset-update@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -10,9 +10,8 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: WordPress Plugin Deploy
-      uses: 10up/actions-wordpress/dotorg-plugin-deploy@master
+      uses: 10up/action-wordpress-plugin-deploy@stable
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: elasticpress


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR updates the deploy and asset update actions from the old umbrella repo to the individual repos where the actions currently reside.

### Alternate Designs

We may also want to look into replacing [Travis](https://github.com/10up/ElasticPress/blob/develop/.travis.yml) with out new [testing](https://github.com/10up/classifai/blob/develop/.github/workflows/test.yml) and [linting](https://github.com/10up/classifai/blob/develop/.github/workflows/lint.yml) actions as GitHub Actions run much quicker than Travis and allow us to jettison the Travis costs.  If that's desired, then we can update this PR to make those changes as well, just let me know!

### Benefits

Ensures that ElasticPress benefits from updates to our GitHub Actions versus being stuck on an old actions version.

### Possible Drawbacks

none identified.

### Verification Process

Several other plugins already use the newer actions, though the next deploys will further certify that for ElasticPress.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

n/a