### PR TITLE
Added action to edited_term to sync posts when a term is edited

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -49,7 +49,102 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'updated_post_meta', array( $this, 'action_queue_meta_sync' ), 10, 4 );
 		add_action( 'added_post_meta', array( $this, 'action_queue_meta_sync' ), 10, 4 );
 		add_action( 'deleted_post_meta', array( $this, 'action_queue_meta_sync' ), 10, 4 );
+		add_action( 'edited_term', array( $this, 'action_edited_term' ), 10, 3 );
 		add_action( 'wp_initialize_site', array( $this, 'action_create_blog_index' ) );
+	}
+
+	/**
+	 * When a term is updated, re-index all posts attached to that term
+	 *
+	 * @param  int    $term_id Term id.
+	 * @param  int    $tt_id Term Taxonomy id.
+	 * @param  string $taxonomy Taxonomy name.
+	 * @since  3.5
+	 */
+	public function action_edited_term( $term_id, $tt_id, $taxonomy ) {
+		global $wpdb;
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			// Bypass saving if doing autosave
+			return;
+		}
+
+		/**
+		 *  Filter to allow skipping this action in case of custom handling
+		 *
+		 *  @hook ep_skip_action_edited_term
+		 *  @param {bool} $skip Current value of whether to skip running action_edited_term or not
+		 *  @return {bool}  New value of whether to skip running action_edited_term or not
+		 */
+		if ( apply_filters( 'ep_skip_action_edited_term', false, $term_id, $tt_id, $taxonomy ) ) {
+			return;
+		}
+
+		// Find ID of all attached posts (query lifted from wp_delete_term())
+		$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $tt_id ) );
+
+		if ( ! count( $object_ids ) ) {
+			return;
+		}
+
+		$indexable = Indexables::factory()->get( 'post' );
+
+		// Add all of them to the queue
+		foreach ( $object_ids as $post_id ) {
+			$post_type = get_post_type( $post_id );
+
+			$post = get_post( $post_id );
+
+			// If post not found, skip to the next iteration
+			if ( ! is_object( $post ) ) {
+				continue;
+			}
+
+			$indexable_post_statuses = $indexable->get_indexable_post_status();
+
+			if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
+				return;
+			}
+
+			// Only re-index if the taxonomy is indexed for this post
+			$indexable_taxonomies = $indexable->get_indexable_post_taxonomies( $post );
+
+			$indexable_taxonomy_names = wp_list_pluck( $indexable_taxonomies, 'name' );
+
+			if ( ! in_array( $taxonomy, $indexable_taxonomy_names, true ) ) {
+				return;
+			}
+
+			$indexable_post_types = $indexable->get_indexable_post_types();
+
+			if ( in_array( $post_type, $indexable_post_types, true ) ) {
+				/**
+				 * Fire before post is queued for syncing
+				 *
+				 * @hook ep_sync_on_edited_term
+				 * @param  {int} $post_id ID of post
+				 * @param  {int} $term_id ID of the term that was edited
+				 * @param  {int} $tt_id Taxonomy Term ID of the term that was edited
+				 * @param  {int} $taxonomy Taxonomy of the term that was edited
+				 */
+				do_action( 'ep_sync_on_edited_term', $post_id, $term_id, $tt_id, $taxonomy );
+
+				/**
+				 * Filter to kill post sync
+				 *
+				 * @hook ep_post_sync_kill
+				 * @param {bool} $skip True meanas kill sync for post
+				 * @param  {int} $object_id ID of post
+				 * @param  {int} $object_id ID of post
+				 * @return {boolean} New value
+				 */
+				if ( apply_filters( 'ep_post_sync_kill', false, $post_id, $post_id ) ) {
+					return;
+				}
+
+				$this->add_to_queue( $post_id );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

When a term is edited, all related posts should be re-indexed. This is very important when it comes to term-based queries which happen pretty regularly on our platform.

Filters for skipping this process have also been added since at large affected-post counts, things tend to fail. We handle these occurrences in a separate queue system that asynchronously processes indexing jobs.

Props @nickdaugherty
cc @rinatkhaziev @pschoffer @netsuso @parkcityj
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

We didn't consider any other designs.

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Post data remains consistent with the database which keeps queries returning expected results.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

The default behaviour is problematic when there are a lot of posts affected. We only do this behaviour for 10k or less posts and offload any indexing with counts above that to be processed asynchronously.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

We noticed data inconsistencies when comparing posts from the DB against posts from ES when editing terms. After applying these changes, the index and the DB were consistent.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Added queuing of affected posts on term change. Props @nickdaugherty

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
