### PR TITLE
Don't use timestamps that cause 5 digit years

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -427,7 +427,14 @@ abstract class Indexable {
 			$datetime = '1971-01-01 00:00:01';
 			$time     = '00:00:01';
 
-			if ( false !== $timestamp ) {
+			/**
+			 * Workaround for `strtotime` potentially producing valid timestamps that would result in 5 digit years
+			 * which DateTime::__construct() can't handle,
+			 * resulting in an 'Uncaught Error: Call to a member function getTimestamp() on bool' in date_i18n.
+			 *
+			 * This better be fixed by 9999-12-31 23:59:59
+			 */
+			if ( false !== $timestamp && 253402300799 > $timestamp ) {
 				$date     = date_i18n( 'Y-m-d', $timestamp );
 				$datetime = date_i18n( 'Y-m-d H:i:s', $timestamp );
 				$time     = date_i18n( 'H:i:s', $timestamp );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Workaround for `strtotime` potentially producing valid timestamps that would result in 5 digit years resulting in an `Uncaught Error: Call to a member function getTimestamp() on bool` in `date_i18n`.

Props @rinatkhaziev
cc: @nickdaugherty @pschoffer @netsuso @parkcityj

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

N/A
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Prevents errors from halting execution due to the way dates are handled in PHP.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

A site wouldn't index on a specific post. After applying this PR, it was indexed smoothly.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Fixed timestamp check to avoid creating dates with 5 digit years which currently results in errors. Props @rinatkhaziev
<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
