### PR TITLE
Switched from errors to warnings in index command

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -627,7 +627,7 @@ class Command extends WP_CLI_Command {
 					if ( ! empty( $result['errors'] ) ) {
 						$this->delete_transient();
 
-						WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors on site %2$d: %3$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $site['blog_id'], $result['errors'] ) );
+						WP_CLI::warning( sprintf( esc_html__( 'Number of %1$s index errors on site %2$d: %3$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $site['blog_id'], $result['errors'] ) );
 					}
 				}
 
@@ -658,7 +658,7 @@ class Command extends WP_CLI_Command {
 				if ( ! empty( $result['errors'] ) ) {
 					$this->delete_transient();
 
-					WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
+					WP_CLI::warning( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
 				}
 			}
 
@@ -702,7 +702,7 @@ class Command extends WP_CLI_Command {
 				if ( ! empty( $result['errors'] ) ) {
 					$this->delete_transient();
 
-					WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
+					WP_CLI::warning( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
 				}
 			}
 		}
@@ -895,7 +895,8 @@ class Command extends WP_CLI_Command {
 										}
 									}
 
-									WP_CLI::error( implode( "\n", $response->get_error_messages() ) );
+									WP_CLI::warning( implode( "\n", $response->get_error_messages() ) );
+									continue;
 								}
 
 								if ( isset( $response['errors'] ) && true === $response['errors'] ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Switched from WPCLI errors to WPCLI warnings in commands. This is because `WP_CLI::error` stops execution which means that the retry functionality during indexing doesn't work as expected.

Props @rinatkhaziev
cc: @nickdaugherty @pschoffer @netsuso @parkcityj
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

N/A
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Retry functionality starts working as expected.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Execution no longer stops when an error in encountered during indexing via WPCLI.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

We were having indexing operations not retrying when they should have. After applying this PR, the retry functionality worked as expected.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Changed errors to warnings in index command to allow retry functionality to work as intended. Props @rinatkhaziev
<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
