### PR TITLE
Added decay function and score mode filters for weighting

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -460,12 +460,23 @@ class Search extends Feature {
 	public function weight_recent( $formatted_args, $args ) {
 		if ( ! empty( $args['s'] ) ) {
 			if ( $this->is_decaying_enabled() ) {
+				/**
+				 * Filter search date weighting scale
+				 *
+				 * @hook epwr_decay_function
+				 * @param  {string} $decay_function Current decay function
+				 * @param  {array} $formatted_args Formatted Elasticsearch arguments
+				 * @param  {array} $args WP_Query arguments
+				 * @return  {string} New decay function
+				 */
+				$decay_function = apply_filters( 'epwr_decay_function', 'exp', $formatted_args, $args );
+				
 				$date_score = array(
 					'function_score' => array(
 						'query'      => $formatted_args['query'],
 						'functions'  => array(
 							array(
-								'exp' => array(
+								$decay_function => array(
 									'post_date_gmt' => array(
 										/**
 										 * Filter search date weighting scale
@@ -501,7 +512,16 @@ class Search extends Feature {
 								),
 							),
 						),
-						'score_mode' => 'avg',
+						/**
+						 * Filter search date weighting score mode
+						 *
+						 * @hook epwr_score_mode
+						 * @param  {string} $score_mode Current score mode
+						 * @param  {array} $formatted_args Formatted Elasticsearch arguments
+						 * @param  {array} $args WP_Query arguments
+						 * @return  {string} New score mode
+						 */
+						'score_mode' => apply_filters( 'epwr_score_mode', 'avg', $formatted_args, $args ),
 						/**
 						 * Filter search date weighting boost mode
 						 *


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Added filters to allow setting the decay function and score mode for data weighting.

cc: @rinatkhaziev @nickdaugherty @pschoffer @netsuso @parkcityj
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

N/A
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Allows setting of the decay function and score mode via filters in addition to the others that were already there.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

We needed to change the decay function and score mode for specific queries. After applying this PR it was trivial to do.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Added filters for setting the decay function and score mode for date weighting.

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
