### PR TITLE
Added action that fires after an invalid response from Elasticsearch

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -405,6 +405,17 @@ class Elasticsearch {
 			);
 		}
 
+		/**
+		 * Fires after invalid Elasticsearch query
+		 *
+		 * @hook ep_invalid_response
+		 * @param  {array} $request Remote request response
+		 * @param  {array} $query Prepared Elasticsearch query
+		 * @param  {array} $query_args Current WP Query arguments
+		 * @param  {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
+		 */
+		do_action( 'ep_invalid_response', $request, $query, $query_args, $query_object );
+
 		return false;
 	}
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Added an action that fires after an invalid response from Elasticsearch.

Props @hanifn
cc: @rinatkhaziev @nickdaugherty @pschoffer @netsuso @parkcityj

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

N/A
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Allows invalid responses from Elasticsearch to be handled.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

We needed a way to detect invalid Elasticsearch responses. After applying this PR, we could apply logging and other measures to keep a handle on things.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Added ep_invalid_response action. Props @hanifn
<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
