### PR TITLE
Adds filterable arguments to WP_Filesystem() call (addresses #1972)

### DIFF
--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -217,7 +217,16 @@ class Documents extends Feature {
 
 		$post_args['attachments'] = [];
 
-		if ( ! WP_Filesystem() ) {
+		/**
+		 * Filters the arguments passed to WP_Filesystem()
+		 *
+		 * @hook ep_filesystem_args
+		 * @param  {boolean} False (default value)
+		 * @return {array|false} Array of args, or false if none
+		 */
+		$filesystem_args = apply_filters( 'ep_filesystem_args', false );
+
+		if ( ! WP_Filesystem( $filesystem_args ) ) {
 			return $post_args;
 		}
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->
Added a filterable `$filesystem_args` argument to allow for non-standard WordPress filesystem setups.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->
No alternate designs considered.

### Benefits

<!-- What benefits will be realized by the code change? -->
Allows the WP filesystem to open documents and index their contents properly on installations where the WP_Filesystem() defaults are insufficient (eg, SSH2-based access).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->
Without the filesystem args:
- Reindex documents
- Search for a string unique to a PDF uploaded to the site
- Search fails

With the filesystem args:
- Reindex the documents
- Search for a string unique to a PDF uploaded to the site
- Search finds the PDF

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
I don't believe this will adversely affect other uses of `WP_Filesystem()` in the code.

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
* Added `$filesystem_args` to the Document feature
* Added `ep_filesystem_args` filter
