### PR TITLE
Bugfix/1938 facets get terms wp error

### DIFF
--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -99,9 +99,9 @@ class Widget extends WP_Widget {
 		);
 
 		/**
-		 * No terms!
+		 * Terms validity check
 		 */
-		if ( 0 === $terms || is_wp_error( $terms ) ) {
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
 			return;
 		}
 

--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -101,7 +101,7 @@ class Widget extends WP_Widget {
 		/**
 		 * No terms!
 		 */
-		if ( 0 === $terms ) {
+		if ( 0 === $terms || is_wp_error( $terms ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description of the Change

added is_wp_error() check to get_terms() result in the Widgets Facets.

Since [get_terms()](https://developer.wordpress.org/reference/functions/get_terms/
) may return a WP_Error object, adding the control will avoid exceptions in case the result of get_terms is an error.

### Verification Process
The bug was replicated, fixed and tested locally, using the Facets Widget.
It is a simple and "straightforward change".

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/ElasticPress/issues/1988

### Changelog Entry

Bug fixes:
* Fix php exception when get_terms() returns a WP_Error object in the Facets Widget.