### PR TITLE
added conditional + filter to allow for additional control within do_weighting()

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -519,11 +519,16 @@ class Weighting {
 	public function do_weighting( $formatted_args, $args ) {
 
 		/**
-		 * If search fields is set on the query, we should use those instead of the weighting, since the query was
-		 * overridden by some custom code
+		 * Force the weightings to be utilized but bypassing the inner conditional (which might cause a return)
 		 */
-		if ( isset( $args['search_fields'] ) && ! empty( $args['search_fields'] ) ) {
-			return $formatted_args;
+		if ( apply_filters( 'ep_weighting_check_search_fields', true, $formatted_args, $args ) ) {
+			/**
+			 * If search fields is set on the query, we should use those instead of the weighting, since the query was
+			 * overridden by some custom code
+			 */
+			if ( isset( $args['search_fields'] ) && ! empty( $args['search_fields'] ) ) {
+				return $formatted_args;
+			}
 		}
 
 		$weight_config = $this->get_weighting_configuration();


### PR DESCRIPTION
### Description of the Change

This PR is a proposed solution to the bug reported here:

Issue 2001 - [Weighting and WooCommerce](https://github.com/10up/ElasticPress/issues/2001)

### Alternate Designs

The proposed selected for its simplcity.

### Benefits

More control of when / when not the weighting will be used in the search query. Currently, for example, WC product searches are not weighted (even though there are weight settings under EP's Search Fields & Weighting). 

### Possible Drawbacks

Nothing obvious comes to mind. 

### Verification Process

Used the filter to pass over the conditional that was returning WC products (i.e., weights weren't used). 


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Added filter 'ep_weighting_check_search_fields' in Weighting.php's method: do_weighting() 
