### PR TITLE
Fix admin notice on the Synonyms page

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -207,11 +207,9 @@ class Synonyms {
 			case 'error-update-index':
 				$message = __( 'There was a problem updating the index with your synonyms. If you have not indexed your data, please run an index.', 'elasticpress' );
 				break;
+			default:
+				$message = __( 'There was an error updating the synonym list.', 'elasticpress' );
 		}
-
-		$message = ( 'success' === $update )
-			? __( 'Successfully updated synonym filter.', 'elasticpress' )
-			: __( 'There was an error updating the synonym list.', 'elasticpress' );
 
 		printf(
 			'<div class="%1$s"><p>%2$s</p></div>',


### PR DESCRIPTION
### Description of the Change

When an error occurred in the Synonyms admin page, just the following message is showed: `There was an error updating the synonym list`. This happens because the message is overwritten in [line 212](https://github.com/10up/ElasticPress/blob/96d518f5cf0a803f27b4ccd4177238d73b09639e/includes/classes/Feature/Search/Synonyms.php#L212) (ElasticPress/includes/classes/Feature/Search/Synonyms.php).

This change removes the content of line 212 and adds a default message in the [switch/case](https://github.com/10up/ElasticPress/blob/develop/includes/classes/Feature/Search/Synonyms.php#L200). 

### Alternate Designs

### Benefits

Show a more specific message to error.

### Possible Drawbacks

n/a

### Verification Process

This has been tested manually on the Synonyms page with no indexed data.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#1941 

### Changelog Entry

Fixed admin notice on the Synonyms page
