### PR TITLE
Fix incorrect titles page

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -151,7 +151,7 @@ class Synonyms {
 	public function admin_menu() {
 		add_submenu_page(
 			'elasticpress',
-			esc_html__( 'Synonyms', 'elasticpress' ),
+			'ElasticPress ' . esc_html__( 'Synonyms', 'elasticpress' ),
 			esc_html__( 'Synonyms', 'elasticpress' ),
 			'manage_options',
 			'elasticpress-synonyms',

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -151,7 +151,7 @@ class Synonyms {
 	public function admin_menu() {
 		add_submenu_page(
 			'elasticpress',
-			'ElasticPress ' . esc_html__( 'Synonyms', 'elasticpress' ),
+			esc_html__( 'ElasticPress Synonyms', 'elasticpress' ),
 			esc_html__( 'Synonyms', 'elasticpress' ),
 			'manage_options',
 			'elasticpress-synonyms',

--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -174,7 +174,7 @@ class Weighting {
 	public function add_weighting_submenu_page() {
 		add_submenu_page(
 			'elasticpress',
-			'ElasticPress ' . esc_html__( 'Search Fields & Weighting', 'elasticpress' ),
+			esc_html__( 'ElasticPress Search Fields & Weighting', 'elasticpress' ),
 			esc_html__( 'Search Fields & Weighting', 'elasticpress' ),
 			'manage_options',
 			'elasticpress-weighting',

--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -172,7 +172,14 @@ class Weighting {
 	 * Adds the submenu page for controlling weighting
 	 */
 	public function add_weighting_submenu_page() {
-		add_submenu_page( 'elasticpress', __( 'Search Fields & Weighting', 'elasticpress' ), __( 'Search Fields & Weighting', 'elasticpress' ), 'manage_options', 'elasticpress-weighting', [ $this, 'render_settings_page' ] );
+		add_submenu_page(
+			'elasticpress',
+			'ElasticPress ' . esc_html__( 'Search Fields & Weighting', 'elasticpress' ),
+			esc_html__( 'Search Fields & Weighting', 'elasticpress' ),
+			'manage_options',
+			'elasticpress-weighting',
+			[ $this, 'render_settings_page' ]
+		);
 	}
 
 	/**

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -858,7 +858,7 @@ class SearchOrdering extends Feature {
 	 */
 	public function update_page_title( $admin_title, $title ) {
 		if ( $this->title === $title ) {
-			return __( 'ElasticPress Custom Search Results' );
+			return __( 'ElasticPress Custom Search Results', 'elasticpress' );
 		}
 
 		return $admin_title;

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -82,6 +82,7 @@ class SearchOrdering extends Feature {
 		add_filter( 'enter_title_here', [ $this, 'filter_enter_title_here' ] );
 		add_filter( 'manage_' . self::POST_TYPE_NAME . '_posts_columns', [ $this, 'filter_column_names' ] );
 		add_filter( 'post_updated_messages', [ $this, 'filter_updated_messages' ] );
+		add_filter( 'admin_title', [ $this, 'update_page_title' ], 10, 2 );
 
 		// Deals with trashing/untrashing/deleting
 		add_action( 'wp_trash_post', [ $this, 'handle_post_trash' ] );
@@ -209,7 +210,13 @@ class SearchOrdering extends Feature {
 	 * Adds the search ordering to the admin menu
 	 */
 	public function admin_menu() {
-		add_submenu_page( 'elasticpress', esc_html__( 'Custom Results', 'elasticpress' ), esc_html__( 'Custom Results', 'elasticpress' ), 'manage_options', 'edit.php?post_type=' . self::POST_TYPE_NAME );
+		add_submenu_page(
+			'elasticpress',
+			esc_html__( 'Custom Results', 'elasticpress' ),
+			esc_html__( 'Custom Results', 'elasticpress' ),
+			'manage_options',
+			'edit.php?post_type=' . self::POST_TYPE_NAME
+		);
 	}
 
 	/**
@@ -839,6 +846,22 @@ class SearchOrdering extends Feature {
 		wp_cache_delete( $post_id, self::TAXONOMY_NAME . '_relationships' );
 
 		return $result;
+	}
+
+	/**
+	 * Update the page title to keep the consistency through the plugin
+	 *
+	 * @param string $admin_title The page title, with extra context added
+	 * @param string $title The original page title
+	 *
+	 * @return string Updated the page title
+	 */
+	public function update_page_title( $admin_title, $title ) {
+		if ( $this->title === $title ) {
+			return 'ElasticPress ' . $admin_title;
+		}
+
+		return $admin_title;
 	}
 
 }

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -858,7 +858,7 @@ class SearchOrdering extends Feature {
 	 */
 	public function update_page_title( $admin_title, $title ) {
 		if ( $this->title === $title ) {
-			return 'ElasticPress ' . $admin_title;
+			return __( 'ElasticPress Custom Search Results' );
 		}
 
 		return $admin_title;

--- a/includes/classes/Screen.php
+++ b/includes/classes/Screen.php
@@ -74,6 +74,14 @@ class Screen {
 				if ( ! isset( $_GET['install_complete'] ) && ( true === $install_status || isset( $_GET['do_sync'] ) ) ) {
 					$this->screen = 'highlighting';
 				}
+			} elseif ( 'elasticpress-weighting' === $_GET['page'] ) {
+				if ( ! isset( $_GET['install_complete'] ) && ( true === $install_status || isset( $_GET['do_sync'] ) ) ) {
+					$this->screen = 'weighting';
+				}
+			} elseif ( 'elasticpress-synonyms' === $_GET['page'] ) {
+				if ( ! isset( $_GET['install_complete'] ) && ( true === $install_status || isset( $_GET['do_sync'] ) ) ) {
+					$this->screen = 'synonyms';
+				}
 			}
 		}
 	}

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -931,7 +931,7 @@ function action_admin_menu() {
 
 	add_submenu_page(
 		'elasticpress',
-		'ElasticPress ' . esc_html__( 'Features', 'elasticpress' ),
+		esc_html__( 'ElasticPress Features', 'elasticpress' ),
 		esc_html__( 'Features', 'elasticpress' ),
 		$capability,
 		'elasticpress',
@@ -940,7 +940,7 @@ function action_admin_menu() {
 
 	add_submenu_page(
 		'elasticpress',
-		'ElasticPress ' . esc_html__( 'Settings', 'elasticpress' ),
+		esc_html__( 'ElasticPress Settings', 'elasticpress' ),
 		esc_html__( 'Settings', 'elasticpress' ),
 		$capability,
 		'elasticpress-settings',
@@ -949,7 +949,7 @@ function action_admin_menu() {
 
 	add_submenu_page(
 		'elasticpress',
-		'ElasticPress ' . esc_html__( 'Index Health', 'elasticpress' ),
+		esc_html__( 'ElasticPress Index Health', 'elasticpress' ),
 		esc_html__( 'Index Health', 'elasticpress' ),
 		$capability,
 		'elasticpress-health',

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -725,7 +725,7 @@ function action_admin_enqueue_dashboard_scripts() {
 		wp_localize_script( 'ep_admin_sites_scripts', 'epsa', $data );
 	}
 
-	if ( in_array( Screen::factory()->get_current_screen(), [ 'dashboard', 'settings', 'install', 'health', 'highlighting' ], true ) ) {
+	if ( in_array( Screen::factory()->get_current_screen(), [ 'dashboard', 'settings', 'install', 'health', 'highlighting', 'weighting', 'synonyms' ], true ) ) {
 		wp_enqueue_style( 'ep_admin_styles', EP_URL . 'dist/css/dashboard-styles.min.css', [], EP_VERSION );
 	}
 


### PR DESCRIPTION
### Description of the Change

Some pages are showing an incorrect or inconsistent title page. This change updates the title pages to follow the pattern "ElasticPress PAGE_NAME".

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Keeping consistency through the plugin.

### Possible Drawbacks

n/a

### Verification Process

This has been tested manually.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#2009

### Changelog Entry

Fixed inconsistent title pages.