### PR TITLE
Add filter to bypass the Delete/Update Term permission check in SyncManager

### DIFF
--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -55,8 +55,18 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
-		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			return;
+		/**
+		 * Filter whether to skip the permissions check on editing a term
+		 *
+		 * @param  {bool} $bypass True to bypass
+		 * @param  {int} $term_id ID of term
+		 * @return {boolean} New value
+		 */
+		if ( ! apply_filters( 'ep_sync_insert_term_permissions_bypass', false, $term_id ) ) {
+			if ( ! current_user_can( 'edit_term', $term_id ) && ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) ) {
+				// Bypass saving if user does not have access to edit term and we're not in a cron process.
+				return;
+			}
 		}
 
 		if ( apply_filters( 'ep_term_sync_kill', false, $term_id ) ) {
@@ -74,8 +84,18 @@ class SyncManager extends SyncManagerAbstract {
 		$hierarchy = array_merge( $ancestors, $children );
 
 		foreach ( $hierarchy as $hierarchy_term_id ) {
-			if ( ! current_user_can( 'edit_term', $hierarchy_term_id ) ) {
-				return;
+			/**
+			 * Filter whether to skip the permissions check on editing a term
+			 *
+			 * @param  {bool} $bypass True to bypass
+			 * @param  {int} $hierarchy_term_id ID of term
+			 * @return {boolean} New value
+			 */
+			if ( ! apply_filters( 'ep_sync_insert_term_permissions_bypass', false, $hierarchy_term_id ) ) {
+				if ( ! current_user_can( 'edit_term', $hierarchy_term_id ) && ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) ) {
+					// Bypass saving if user does not have access to edit term and we're not in a cron process.
+					return;
+				}
 			}
 
 			if ( apply_filters( 'ep_term_sync_kill', false, $hierarchy_term_id ) ) {

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -166,7 +166,14 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
-		if ( ! current_user_can( 'delete_term', $term_id ) ) {
+		/**
+		 * Filter whether to skip the permissions check on deleting a term
+		 *
+		 * @param  {bool} $bypass True to bypass
+		 * @param  {int} $term_id ID of term
+		 * @return {boolean} New value
+		 */
+		if ( ! current_user_can( 'delete_term', $term_id ) && ! apply_filters( 'ep_sync_delete_term_permissions_bypass', false, $term_id ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description of the Change

This change will add a hook to override the permission check when deleting/updating terms. This feature already exists in the Post SyncManager when [deleting](https://github.com/10up/ElasticPress/blob/develop/includes/classes/Indexable/Post/SyncManager.php#L168) and [updating](https://github.com/10up/ElasticPress/blob/develop/includes/classes/Indexable/Post/SyncManager.php#L228).

### Alternate Designs

This code will mirror how it's currently done in the Post SyncManager but the code could be expanded to include the `DOING_CRON` conditions in the delete action for both term and post so the logic is more similar. It could be argued to be outside this scope since the current/initial PR suggestion will simply add opt-in features whereas adding CRON conditions changes default behavior.

### Benefits

Allows developers to bypass the user permission check for operations that happens outside logged in environments (CLI etc).

### Possible Drawbacks

Could allow for developers to create their own "vulnerability" so others can delete/updating terms without user permission but is not inherently true by default. I'm guessing this is not something you're too worried about (like me) since it already exists in the Post SyncManager. 

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
Tested it locally and running it in production.

- How did you verify that all changed functionality works as expected?
Tested it locally and running it in production.

- How did you verify that the change has not introduced any regressions?
It's a new filter/hook that do not exist anywhere else so there should not be any regression by design unless the hook name have been used before.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Added filter to bypass user permission check before deleting/updating terms from index.

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
