### PR TITLE
Force composer to v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
         - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
         - sudo service elasticsearch restart
       before_script:
+        - composer self-update --1
         - composer install
         - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
         - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,12 @@ jobs:
     - script: if [ -n "$AWS_ACCESS_KEY" ]; then bash run-wpacceptance.sh; fi
       name: "WP Acceptance Test"
       before_script:
+        - composer self-update --1
         - composer install
         - npm install
         - if [ -n "$AWS_ACCESS_KEY" ]; then ./vendor/bin/wpsnapshots configure 10up --aws_key=$AWS_ACCESS_KEY --aws_secret=$SECRET_ACCESS_KEY --user_name=Travis --user_email=travis@10up.com; fi
     - script: composer run-script lint
       name: "Linting"
       before_script:
+        - composer self-update --1
         - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
         - composer run-script test-single-site
       before_install:
         - composer self-update --1
+        - composer --version
         - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION-amd64.deb
         - sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION-amd64.deb
         - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
         - composer run-script test
         - composer run-script test-single-site
       before_install:
+        - composer self-update --1
         - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION-amd64.deb
         - sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION-amd64.deb
         - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
@@ -37,7 +38,6 @@ jobs:
         - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
         - sudo service elasticsearch restart
       before_script:
-        - composer self-update --1
         - composer install
         - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
         - sleep 10


### PR DESCRIPTION
### Description of the Change
Unit tests are currently unable to run due to [Composer v2](https://travis-ci.org/github/10up/ElasticPress/jobs/753550203#L270) being used in the CI process. This is causing `composer install` to fail. Adding `composer self-update --1` forces Composer to use v1 and allows the `composer install` to work and unit tests to run.

### Possible Drawbacks

Eventually this change can be reverted once all the affected packages are updated to support Composer v2.

### Verification Process
Verified via CI: https://travis-ci.com/github/petenelson/ElasticPress/jobs/469862924
Some of the unit tests themselves are failing, but this update now allows the unit tests to run.

### Checklist:

- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Changelog Entry

* Force Composer v1 for Travis CI unit tests 
