### PR TITLE
Unit Test Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
         - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
         - sudo service elasticsearch restart
       before_script:
+        - composer self-update --1
         - composer install
         - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
         - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
         - composer run-script test-single-site
       before_install:
         - composer self-update --1
+        - composer --version
         - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION-amd64.deb
         - sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION-amd64.deb
         - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
         - composer run-script test
         - composer run-script test-single-site
       before_install:
+        - composer self-update --1
         - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION-amd64.deb
         - sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION-amd64.deb
         - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
@@ -37,7 +38,6 @@ jobs:
         - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
         - sudo service elasticsearch restart
       before_script:
-        - composer self-update --1
         - composer install
         - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
         - sleep 10

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -470,7 +470,6 @@ class Search extends Feature {
 				 * @return  {string} New decay function
 				 */
 				$decay_function = apply_filters( 'epwr_decay_function', 'exp', $formatted_args, $args );
-				
 				$date_score = array(
 					'function_score' => array(
 						'query'      => $formatted_args['query'],

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -323,9 +323,9 @@ abstract class Indexable {
 		 * @hook ep_after_bulk_index
 		 * @param {array} $object_ids List of object ids attempted to be indexed
 		 * @param {string} $slug Current indexable slug
-		 * @param {array|bool} $return Result of the Elasticsearch query. False on error.
+		 * @param {array|bool} $result Result of the Elasticsearch query. False on error.
 		 */
-		do_action( 'ep_after_bulk_index', $object_ids, $this->slug, $return );
+		do_action( 'ep_after_bulk_index', $object_ids, $this->slug, $result );
 
 		return $result;
 	}

--- a/tests/php/features/TestSearch.php
+++ b/tests/php/features/TestSearch.php
@@ -147,7 +147,9 @@ class TestSearch extends BaseTestCase {
 		);
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_filter( 'ep_formatted_args', array( $this, 'catch_ep_formatted_args' ) );
+		$this->assertTrue( ElasticPress\Features::factory()->get_registered_feature( 'search' )->is_decaying_enabled() );
+
+		add_filter( 'ep_formatted_args', array( $this, 'catch_ep_formatted_args' ), 20 );
 		$query = new \WP_Query(
 			array(
 				's' => 'test',

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -85,11 +85,9 @@ class TestSynonyms extends BaseTestCase {
 
 		$synonyms = $instance->get_synonyms();
 
-		echo json_encode( $synonyms, JSON_PRETTY_PRINT );
-
 		$this->assertNotEmpty( $synonyms );
 		$this->assertContains( 'sneakers, tennis shoes, trainers, runners', $synonyms );
-		$this->assertContains( 'shoes =&gt; sneaker, sandal, boots, high heels', $synonyms );
+		$this->assertContains( 'shoes => sneaker, sandal, boots, high heels', $synonyms );
 	}
 
 	public function testValidateSynonyms() {

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -85,6 +85,8 @@ class TestSynonyms extends BaseTestCase {
 
 		$synonyms = $instance->get_synonyms();
 
+		echo json_encode( $synonyms, JSON_PRETTY_PRINT );
+
 		$this->assertNotEmpty( $synonyms );
 		$this->assertContains( 'sneakers, tennis shoes, trainers, runners', $synonyms );
 		$this->assertContains( 'shoes =&gt; sneaker, sandal, boots, high heels', $synonyms );

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -85,7 +85,16 @@ class TestSynonyms extends BaseTestCase {
 
 		$synonyms = $instance->get_synonyms();
 
-		var_dump( $synonyms );
+
+		// For some reason, the greater-than gets encoded during the multi-site
+		// tests but not the single-site tests. This updates the encoding so
+		// they both match. See https://travis-ci.com/github/petenelson/ElasticPress/jobs/470254351.
+		$synonyms = array_map(
+			function ( $synonym ) {
+				return str_replace( '>', '&gt;', $synonym );
+			},
+			$synonyms
+		);
 
 		$this->assertNotEmpty( $synonyms );
 		$this->assertContains( 'sneakers, tennis shoes, trainers, runners', $synonyms );

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -89,7 +89,7 @@ class TestSynonyms extends BaseTestCase {
 
 		$this->assertNotEmpty( $synonyms );
 		$this->assertContains( 'sneakers, tennis shoes, trainers, runners', $synonyms );
-		$this->assertContains( 'shoes => sneaker, sandal, boots, high heels', $synonyms );
+		$this->assertContains( 'shoes =&gt; sneaker, sandal, boots, high heels', $synonyms );
 	}
 
 	public function testValidateSynonyms() {

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -85,6 +85,8 @@ class TestSynonyms extends BaseTestCase {
 
 		$synonyms = $instance->get_synonyms();
 
+		var_dump( $synonyms );
+
 		$this->assertNotEmpty( $synonyms );
 		$this->assertContains( 'sneakers, tennis shoes, trainers, runners', $synonyms );
 		$this->assertContains( 'shoes => sneaker, sandal, boots, high heels', $synonyms );

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -8,7 +8,7 @@
 namespace ElasticPressTest;
 
 use ElasticPress;
-use ElasticPress\Feature\Synonyms\Synonyms;
+use ElasticPress\Feature\Search\Synonyms;
 
 /**
  * Document test class
@@ -60,26 +60,9 @@ class TestSynonyms extends BaseTestCase {
 	public function testConstructor() {
 		$instance = $this->getFeature();
 
-		$this->assertEquals( $instance->slug, 'synonyms' );
-		$this->assertTrue( $instance->requires_install_reindex );
-	}
-
-	public function testOutputFeatureBoxSummary() {
-		$instance = $this->getFeature();
-
-		ob_start();
-		$instance->output_feature_box_summary();
-
-		$this->assertContains( 'Add synonyms to your searches.', ob_get_clean() );
-	}
-
-	public function testOutputFeatureBoxLong() {
-		$instance = $this->getFeature();
-
-		ob_start();
-		$instance->output_feature_box_long();
-
-		$this->assertContains( 'Create a custom synonym filter', ob_get_clean() );
+		$this->assertSame( 'ep_synonyms_filter', $instance->filter_name );
+		$this->assertIsArray( $instance->affected_indices );
+		$this->assertContains( 'post', $instance->affected_indices );
 	}
 
 	public function testGetSynonymPostId() {

--- a/tests/php/includes/classes/BaseTestCase.php
+++ b/tests/php/includes/classes/BaseTestCase.php
@@ -111,4 +111,13 @@ class BaseTestCase extends WP_UnitTestCase {
 	public function is_network_activate() {
 		return defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK;
 	}
+
+	/**
+	 * Filter hook to set the search algorithm to 3.4.
+	 *
+	 * @return string
+	 */
+	public function set_algorithm_34() {
+		return '3.4';
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -2007,6 +2007,9 @@ class TestPost extends BaseTestCase {
 	 * @group post
 	 */
 	public function testSearchPostDateOrderbyQuery() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		Functions\create_and_sync_post( array( 'post_title' => 'ordertesr' ) );
 		sleep( 3 );
 
@@ -2030,6 +2033,8 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 'Ordertest 222', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertest 111', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertesr', $query->posts[2]->post_title );
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -1468,6 +1468,9 @@ class TestPost extends BaseTestCase {
 	 * @group post
 	 */
 	public function testSearchAuthorQuery() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		$user_id = $this->factory->user->create(
 			array(
 				'user_login' => 'john',
@@ -1500,6 +1503,8 @@ class TestPost extends BaseTestCase {
 
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -2134,6 +2134,9 @@ class TestPost extends BaseTestCase {
 	 * @group post
 	 */
 	public function testSearchRelevanceOrderbyQuery() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		Functions\create_and_sync_post();
 		Functions\create_and_sync_post( array( 'post_title' => 'ordertet' ) );
 		Functions\create_and_sync_post( array( 'post_title' => 'ordertest' ) );
@@ -2151,6 +2154,8 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertest', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertet', $query->posts[1]->post_title );
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -2190,6 +2195,9 @@ class TestPost extends BaseTestCase {
 	 * @group post
 	 */
 	public function testSearchDefaultOrderbyQuery() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		Functions\create_and_sync_post();
 		Functions\create_and_sync_post( array( 'post_title' => 'Ordertet' ) );
 		Functions\create_and_sync_post( array( 'post_title' => 'ordertest' ) );
@@ -2206,6 +2214,8 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertest', $query->posts[0]->post_title );
 		$this->assertEquals( 'Ordertet', $query->posts[1]->post_title );
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -2227,6 +2227,9 @@ class TestPost extends BaseTestCase {
 	 * @group post
 	 */
 	public function testSearchDefaultOrderbyASCOrderQuery() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		Functions\create_and_sync_post();
 		Functions\create_and_sync_post( array( 'post_title' => 'Ordertest' ) );
 		Functions\create_and_sync_post( array( 'post_title' => 'ordertestt' ) );
@@ -2244,6 +2247,8 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertestt', $query->posts[0]->post_title );
 		$this->assertEquals( 'Ordertest', $query->posts[1]->post_title );
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -2075,6 +2075,9 @@ class TestPost extends BaseTestCase {
 	 * @group post
 	 */
 	public function testSearchRelevanceOrderbyQueryAdvanced() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		$posts = array();
 
 		$posts[5] = Functions\create_and_sync_post( array( 'post_title' => 'ordertet with even more lorem ipsum to make a longer field' ) );
@@ -2120,6 +2123,8 @@ class TestPost extends BaseTestCase {
 
 			$i++;
 		}
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -1044,6 +1044,9 @@ class TestPostMultisite extends BaseTestCase {
 	 * @group testMultipleTests
 	 */
 	public function testSearchTaxQuery() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		$sites = ElasticPress\Utils\get_sites();
 
 		if ( ! is_multisite() ) {
@@ -1091,6 +1094,8 @@ class TestPostMultisite extends BaseTestCase {
 		$this->assertSame( 2, $query->found_posts );
 
 		$this->cleanUpSites( $sites );
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -1100,6 +1100,9 @@ class TestPostMultisite extends BaseTestCase {
 	 * @group testMultipleTests
 	 */
 	public function testSearchAuthorQuery() {
+
+		add_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
+
 		$sites = ElasticPress\Utils\get_sites();
 
 		if ( ! is_multisite() ) {
@@ -1154,6 +1157,8 @@ class TestPostMultisite extends BaseTestCase {
 		$this->assertSame( 2, $query->found_posts );
 
 		$this->cleanUpSites( $sites );
+
+		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Fixes some code to pass existing unit tests, updated some broken unit tests, and applies the 3.4 algorithm filter to other unit tests to allow them to start passing. Note: This contains some changes that were done as part of the [Composer V1 pull request](https://github.com/10up/ElasticPress/pull/2022)

### Benefits

Allows unit tests to start passing again

### Possible Drawbacks

This does not contain new unit tests to cover ElasticPress 3.5 updates.

### Verification Process

Updated unit tests are now passing: https://travis-ci.com/github/petenelson/ElasticPress/jobs/470265557

### Checklist:

- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.

### Changelog Entry

* Fixes some code to pass existing unit tests, updated some broken unit tests, and applies the 3.4 algorithm filter to other unit tests to allow them to start passing.