### PR TITLE
Add the ep_query_send_ep_search_term_header filter

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -298,10 +298,13 @@ class Elasticsearch {
 		/**
 		 * Filter whether to send the EP-Search-Term header or not.
 		 *
+		 * @todo Evaluate if we should remove tests for is_admin() and empty post types.
+		 *
 		 * @since  3.5.2
 		 * @hook ep_query_send_ep_search_term_header
-		 * @param  {bool} $send_header True means send the EP-Search-Term header
-		 * @return {bool} New $send_header value
+		 * @param  {bool}  $send_header True means send the EP-Search-Term header
+		 * @param  {array} $query_args  WP query args
+		 * @return {bool}  New $send_header value
 		 */
 		$send_ep_search_term_header = apply_filters(
 			'ep_query_send_ep_search_term_header',
@@ -310,12 +313,13 @@ class Elasticsearch {
 				! empty( $query_args['s'] ) &&
 				! is_admin() &&
 				! isset( $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification
-			)
+			),
+			$query_args
 		);
 
 		// If needed, send the search term as a header to ES so the backend understands what a normal query looks like
 		if ( $send_ep_search_term_header ) {
-			$request_args['headers']['EP-Search-Term'] = $query_args['s'];
+			$request_args['headers']['EP-Search-Term'] = rawurlencode( $query_args['s'] );
 		}
 
 		$request = $this->remote_request( $path, $request_args, $query_args, 'query' );

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -295,8 +295,26 @@ class Elasticsearch {
 			),
 		);
 
-		// If search, send the search term as a header to ES so the backend understands what a normal query looks like
-		if ( isset( $query_args['s'] ) && (bool) $query_args['s'] && ! is_admin() && ! isset( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		/**
+		 * Filter whether to send the EP-Search-Term header or not.
+		 *
+		 * @since  3.5.2
+		 * @hook ep_query_send_ep_search_term_header
+		 * @param  {bool} $send_header True means send the EP-Search-Term header
+		 * @return {bool} New $send_header value
+		 */
+		$send_ep_search_term_header = apply_filters(
+			'ep_query_send_ep_search_term_header',
+			(
+				Utils\is_epio() &&
+				! empty( $query_args['s'] ) &&
+				! is_admin() &&
+				! isset( $_GET['post_type'] ) // phpcs:ignore WordPress.Security.NonceVerification
+			)
+		);
+
+		// If needed, send the search term as a header to ES so the backend understands what a normal query looks like
+		if ( $send_ep_search_term_header ) {
 			$request_args['headers']['EP-Search-Term'] = $query_args['s'];
 		}
 


### PR DESCRIPTION
### Description of the Change

This PR changes the way the plugin decides if the `EP-Search-Term` header should be sent or not. As it was designed to be used by ElasticPress.io, it now includes a test using `Utils\is_epio()`. The value of the header is now escaped too.

Also, it introduces the new `ep_query_send_ep_search_term_header` filter. Returning `false` to it will avoid the header from being sent.

For non-EP.io customers relying on that header, here is a snippet that can be used to bring it back:

```
add_filter(
	'ep_query_send_ep_search_term_header',
	function ( $old_value, $query_args ) {
		return ! empty( $query_args['s'] ) &&
			! is_admin() &&
			! isset( $_GET['post_type'] );
	},
	10,
	2
);
```

### Alternate Designs

n/a

### Benefits

Remove an unnecessary header for non-EP.io clients.

### Possible Drawbacks

People relying on that header will need to add that snippet.

### Verification Process

Installed Debug Bar and Debug Bar ElasticPress
Made a request using an EP.io endpoint (header is present)
Changed the return from Utils\ep_io() (header is not present)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#790 

### Changelog Entry

Send the EP-Search-Term just for ElasticPress.io clients.
