### PR TITLE
Fix input with different style

### DIFF
--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -142,7 +142,7 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 									 */
 									if ( apply_filters( 'ep_admin_show_credentials', true ) ) :
 										?>
-										<input <?php if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) : ?>disabled<?php endif; ?> type="" value="<?php echo esc_attr( $credentials['username'] ); ?>" name="ep_credentials[username]" id="ep_username">
+										<input <?php if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) : ?>disabled<?php endif; ?> type="text" value="<?php echo esc_attr( $credentials['username'] ); ?>" name="ep_credentials[username]" id="ep_username">
 									<?php endif ?>
 									<?php if ( defined( 'EP_CREDENTIALS' ) && EP_CREDENTIALS ) : ?>
 										<legend class="description"><?php esc_html_e( 'Your Subscription Username is set in wp-config.php', 'elasticpress' ); ?></legend>


### PR DESCRIPTION
### Description of the Change
Add missing input type in the Subscription Username's field.

Before change:
![image](https://user-images.githubusercontent.com/6010232/104961089-66e1ee00-59b4-11eb-83ed-51aafd9344ee.png)

After change:
![image](https://user-images.githubusercontent.com/6010232/104961072-5df11c80-59b4-11eb-9466-420ed6cca4ca.png)

### Alternate Designs

### Benefits

Input on the Settings page has the same style.

### Possible Drawbacks

### Verification Process

This has been tested manually.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes: #2035 

### Changelog Entry

Fixed input style on the Settings page.
