### PR TITLE
Add missing options and transients to be removed on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -56,6 +56,7 @@ class EP_Uninstaller {
 	 * @return void
 	 */
 	protected static function clean_options() {
+		global $wpdb;
 
 		// Delete options.
 		delete_site_option( 'ep_host' );
@@ -128,6 +129,33 @@ class EP_Uninstaller {
 		delete_transient( 'ep_autosuggest_query_request_cache' );
 		delete_site_transient( 'ep_related_posts_' );
 		delete_transient( 'ep_related_posts_' );
+
+		// Delete ep_related_posts_* transients
+		if ( is_plugin_active_for_network( 'elasticpress/elasticpress.php' ) ) {
+			$sites = get_sites();
+
+			foreach ( $sites as $site ) {
+				switch_to_blog( $site->blog_id );
+
+				$related_posts_transients = $wpdb->get_col( "SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'" );
+
+				foreach ( $related_posts_transients as $related_posts_transient ) {
+					$related_posts_transient = str_replace( '_transient_', '', $related_posts_transient );
+					delete_site_transient( $related_posts_transient );
+					delete_transient( $related_posts_transient );
+				}
+
+				restore_current_blog();
+			}
+		} else {
+			$related_posts_transients = $wpdb->get_col( "SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'" );
+
+			foreach ( $related_posts_transients as $related_posts_transient ) {
+				$related_posts_transient = str_replace( '_transient_', '', $related_posts_transient );
+				delete_site_transient( $related_posts_transient );
+				delete_transient( $related_posts_transient );
+			}
+		}
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -149,80 +149,47 @@ class EP_Uninstaller {
 		} else {
 			// Delete options.
 			delete_option( 'ep_host' );
-			delete_site_option( 'ep_index_meta' );
 			delete_option( 'ep_index_meta' );
-			delete_site_option( 'ep_feature_settings' );
 			delete_option( 'ep_feature_settings' );
-			delete_site_option( 'ep_version' );
 			delete_option( 'ep_version' );
 			delete_option( 'ep_intro_shown' );
-			delete_site_option( 'ep_intro_shown' );
 			delete_option( 'ep_last_sync' );
-			delete_site_option( 'ep_last_sync' );
 			delete_option( 'ep_need_upgrade_sync' );
-			delete_site_option( 'ep_need_upgrade_sync' );
 			delete_option( 'ep_feature_requirement_statuses' );
-			delete_site_option( 'ep_feature_requirement_statuses' );
 			delete_option( 'ep_feature_auto_activated_sync' );
-			delete_site_option( 'ep_feature_auto_activated_sync' );
 			delete_option( 'ep_hide_intro_shown_notice' );
-			delete_site_option( 'ep_hide_intro_shown_notice' );
 			delete_option( 'ep_skip_install' );
-			delete_site_option( 'ep_skip_install' );
 			delete_option( 'ep_last_cli_index' );
-			delete_site_option( 'ep_last_cli_index' );
 			delete_option( 'ep_credentials' );
-			delete_site_option( 'ep_credentials' );
 			delete_option( 'ep_prefix' );
-			delete_site_option( 'ep_prefix' );
 			delete_option( 'ep_language' );
-			delete_site_option( 'ep_language' );
 			delete_option( 'ep_bulk_setting' );
-			delete_site_option( 'ep_bulk_setting' );
 
 			// Delete admin notices options
-			delete_site_option( 'ep_hide_host_error_notice' );
 			delete_option( 'ep_hide_host_error_notice' );
-			delete_site_option( 'ep_hide_es_below_compat_notice' );
 			delete_option( 'ep_hide_es_below_compat_notice' );
-			delete_site_option( 'ep_hide_es_above_compat_notice' );
 			delete_option( 'ep_hide_es_above_compat_notice' );
-			delete_site_option( 'ep_hide_need_setup_notice' );
 			delete_option( 'ep_hide_need_setup_notice' );
-			delete_site_option( 'ep_hide_no_sync_notice' );
 			delete_option( 'ep_hide_no_sync_notice' );
-			delete_site_option( 'ep_hide_upgrade_sync_notice' );
 			delete_option( 'ep_hide_upgrade_sync_notice' );
-			delete_site_option( 'ep_hide_auto_activate_sync_notice' );
 			delete_option( 'ep_hide_auto_activate_sync_notice' );
-			delete_site_option( 'ep_hide_using_autosuggest_defaults_notice' );
 			delete_option( 'ep_hide_using_autosuggest_defaults_notice' );
-			delete_site_option( 'ep_hide_yellow_health_notice' );
 			delete_option( 'ep_hide_yellow_health_notice' );
 
 			// Delete transients
-			delete_site_transient( 'ep_es_info_response_code' );
 			delete_transient( 'ep_es_info_response_code' );
-			delete_site_transient( 'ep_es_info_response_error' );
 			delete_transient( 'ep_es_info_response_error' );
-			delete_site_transient( 'logging_ep_es_info' );
 			delete_transient( 'logging_ep_es_info' );
-			delete_site_transient( 'ep_wpcli_sync_interrupted' );
 			delete_transient( 'ep_wpcli_sync_interrupted' );
-			delete_site_transient( 'ep_wpcli_sync' );
 			delete_transient( 'ep_wpcli_sync' );
-			delete_site_transient( 'ep_es_info' );
 			delete_transient( 'ep_es_info' );
-			delete_site_transient( 'ep_autosuggest_query_request_cache' );
 			delete_transient( 'ep_autosuggest_query_request_cache' );
-			delete_site_transient( 'ep_related_posts_' );
 			delete_transient( 'ep_related_posts_' );
 
 			$related_posts_transients = $wpdb->get_col( "SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'" );
 
 			foreach ( $related_posts_transients as $related_posts_transient ) {
 				$related_posts_transient = str_replace( '_transient_', '', $related_posts_transient );
-				delete_site_transient( $related_posts_transient );
 				delete_transient( $related_posts_transient );
 			}
 		}

--- a/uninstall.php
+++ b/uninstall.php
@@ -133,8 +133,6 @@ class EP_Uninstaller {
 				delete_transient( 'ep_es_info' );
 				delete_site_transient( 'ep_autosuggest_query_request_cache' );
 				delete_transient( 'ep_autosuggest_query_request_cache' );
-				delete_site_transient( 'ep_related_posts_' );
-				delete_transient( 'ep_related_posts_' );
 
 				$related_posts_transients = $wpdb->get_col( "SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'" );
 
@@ -184,7 +182,6 @@ class EP_Uninstaller {
 			delete_transient( 'ep_wpcli_sync' );
 			delete_transient( 'ep_es_info' );
 			delete_transient( 'ep_autosuggest_query_request_cache' );
-			delete_transient( 'ep_related_posts_' );
 
 			$related_posts_transients = $wpdb->get_col( "SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'" );
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -112,22 +112,22 @@ class EP_Uninstaller {
 		delete_option( 'ep_hide_yellow_health_notice' );
 
 		// Delete transients
-		delete_site_transient('ep_es_info_response_code');
-		delete_transient('ep_es_info_response_code');
-		delete_site_transient('ep_es_info_response_error');
-		delete_transient('ep_es_info_response_error');
-		delete_site_transient('logging_ep_es_info');
-		delete_transient('logging_ep_es_info');
-		delete_site_transient('ep_wpcli_sync_interrupted');
-		delete_transient('ep_wpcli_sync_interrupted');
-		delete_site_transient('ep_wpcli_sync');
-		delete_transient('ep_wpcli_sync');
-		delete_site_transient('ep_es_info');
-		delete_transient('ep_es_info');
-		delete_site_transient('ep_autosuggest_query_request_cache');
-		delete_transient('ep_autosuggest_query_request_cache');
-		delete_site_transient('ep_related_posts_');
-		delete_transient('ep_related_posts_');
+		delete_site_transient( 'ep_es_info_response_code' );
+		delete_transient( 'ep_es_info_response_code' );
+		delete_site_transient( 'ep_es_info_response_error' );
+		delete_transient( 'ep_es_info_response_error' );
+		delete_site_transient( 'logging_ep_es_info' );
+		delete_transient( 'logging_ep_es_info' );
+		delete_site_transient( 'ep_wpcli_sync_interrupted' );
+		delete_transient( 'ep_wpcli_sync_interrupted' );
+		delete_site_transient( 'ep_wpcli_sync' );
+		delete_transient( 'ep_wpcli_sync' );
+		delete_site_transient( 'ep_es_info' );
+		delete_transient( 'ep_es_info' );
+		delete_site_transient( 'ep_autosuggest_query_request_cache' );
+		delete_transient( 'ep_autosuggest_query_request_cache' );
+		delete_site_transient( 'ep_related_posts_' );
+		delete_transient( 'ep_related_posts_' );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -58,84 +58,83 @@ class EP_Uninstaller {
 	protected static function clean_options() {
 		global $wpdb;
 
-		// Delete options.
-		delete_site_option( 'ep_host' );
-		delete_option( 'ep_host' );
-		delete_site_option( 'ep_index_meta' );
-		delete_option( 'ep_index_meta' );
-		delete_site_option( 'ep_feature_settings' );
-		delete_option( 'ep_feature_settings' );
-		delete_site_option( 'ep_version' );
-		delete_option( 'ep_version' );
-		delete_option( 'ep_intro_shown' );
-		delete_site_option( 'ep_intro_shown' );
-		delete_option( 'ep_last_sync' );
-		delete_site_option( 'ep_last_sync' );
-		delete_option( 'ep_need_upgrade_sync' );
-		delete_site_option( 'ep_need_upgrade_sync' );
-		delete_option( 'ep_feature_requirement_statuses' );
-		delete_site_option( 'ep_feature_requirement_statuses' );
-		delete_option( 'ep_feature_auto_activated_sync' );
-		delete_site_option( 'ep_feature_auto_activated_sync' );
-		delete_option( 'ep_hide_intro_shown_notice' );
-		delete_site_option( 'ep_hide_intro_shown_notice' );
-		delete_option( 'ep_skip_install' );
-		delete_site_option( 'ep_skip_install' );
-		delete_option( 'ep_last_cli_index' );
-		delete_site_option( 'ep_last_cli_index' );
-		delete_option( 'ep_credentials' );
-		delete_site_option( 'ep_credentials' );
-		delete_option( 'ep_prefix' );
-		delete_site_option( 'ep_prefix' );
-		delete_option( 'ep_language' );
-		delete_site_option( 'ep_language' );
-		delete_option( 'ep_bulk_setting' );
-		delete_site_option( 'ep_bulk_setting' );
-
-		// Delete admin notices options
-		delete_site_option( 'ep_hide_host_error_notice' );
-		delete_option( 'ep_hide_host_error_notice' );
-		delete_site_option( 'ep_hide_es_below_compat_notice' );
-		delete_option( 'ep_hide_es_below_compat_notice' );
-		delete_site_option( 'ep_hide_es_above_compat_notice' );
-		delete_option( 'ep_hide_es_above_compat_notice' );
-		delete_site_option( 'ep_hide_need_setup_notice' );
-		delete_option( 'ep_hide_need_setup_notice' );
-		delete_site_option( 'ep_hide_no_sync_notice' );
-		delete_option( 'ep_hide_no_sync_notice' );
-		delete_site_option( 'ep_hide_upgrade_sync_notice' );
-		delete_option( 'ep_hide_upgrade_sync_notice' );
-		delete_site_option( 'ep_hide_auto_activate_sync_notice' );
-		delete_option( 'ep_hide_auto_activate_sync_notice' );
-		delete_site_option( 'ep_hide_using_autosuggest_defaults_notice' );
-		delete_option( 'ep_hide_using_autosuggest_defaults_notice' );
-		delete_site_option( 'ep_hide_yellow_health_notice' );
-		delete_option( 'ep_hide_yellow_health_notice' );
-
-		// Delete transients
-		delete_site_transient( 'ep_es_info_response_code' );
-		delete_transient( 'ep_es_info_response_code' );
-		delete_site_transient( 'ep_es_info_response_error' );
-		delete_transient( 'ep_es_info_response_error' );
-		delete_site_transient( 'logging_ep_es_info' );
-		delete_transient( 'logging_ep_es_info' );
-		delete_site_transient( 'ep_wpcli_sync_interrupted' );
-		delete_transient( 'ep_wpcli_sync_interrupted' );
-		delete_site_transient( 'ep_wpcli_sync' );
-		delete_transient( 'ep_wpcli_sync' );
-		delete_site_transient( 'ep_es_info' );
-		delete_transient( 'ep_es_info' );
-		delete_site_transient( 'ep_autosuggest_query_request_cache' );
-		delete_transient( 'ep_autosuggest_query_request_cache' );
-		delete_site_transient( 'ep_related_posts_' );
-		delete_transient( 'ep_related_posts_' );
-
 		// Delete ep_related_posts_* transients
-		if ( is_plugin_active_for_network( 'elasticpress/elasticpress.php' ) ) {
+		if ( is_multisite() ) {
 			$sites = get_sites();
 
 			foreach ( $sites as $site ) {
 				switch_to_blog( $site->blog_id );
+
+				// Delete options.
+				delete_option( 'ep_host' );
+				delete_site_option( 'ep_index_meta' );
+				delete_option( 'ep_index_meta' );
+				delete_site_option( 'ep_feature_settings' );
+				delete_option( 'ep_feature_settings' );
+				delete_site_option( 'ep_version' );
+				delete_option( 'ep_version' );
+				delete_option( 'ep_intro_shown' );
+				delete_site_option( 'ep_intro_shown' );
+				delete_option( 'ep_last_sync' );
+				delete_site_option( 'ep_last_sync' );
+				delete_option( 'ep_need_upgrade_sync' );
+				delete_site_option( 'ep_need_upgrade_sync' );
+				delete_option( 'ep_feature_requirement_statuses' );
+				delete_site_option( 'ep_feature_requirement_statuses' );
+				delete_option( 'ep_feature_auto_activated_sync' );
+				delete_site_option( 'ep_feature_auto_activated_sync' );
+				delete_option( 'ep_hide_intro_shown_notice' );
+				delete_site_option( 'ep_hide_intro_shown_notice' );
+				delete_option( 'ep_skip_install' );
+				delete_site_option( 'ep_skip_install' );
+				delete_option( 'ep_last_cli_index' );
+				delete_site_option( 'ep_last_cli_index' );
+				delete_option( 'ep_credentials' );
+				delete_site_option( 'ep_credentials' );
+				delete_option( 'ep_prefix' );
+				delete_site_option( 'ep_prefix' );
+				delete_option( 'ep_language' );
+				delete_site_option( 'ep_language' );
+				delete_option( 'ep_bulk_setting' );
+				delete_site_option( 'ep_bulk_setting' );
+
+				// Delete admin notices options
+				delete_site_option( 'ep_hide_host_error_notice' );
+				delete_option( 'ep_hide_host_error_notice' );
+				delete_site_option( 'ep_hide_es_below_compat_notice' );
+				delete_option( 'ep_hide_es_below_compat_notice' );
+				delete_site_option( 'ep_hide_es_above_compat_notice' );
+				delete_option( 'ep_hide_es_above_compat_notice' );
+				delete_site_option( 'ep_hide_need_setup_notice' );
+				delete_option( 'ep_hide_need_setup_notice' );
+				delete_site_option( 'ep_hide_no_sync_notice' );
+				delete_option( 'ep_hide_no_sync_notice' );
+				delete_site_option( 'ep_hide_upgrade_sync_notice' );
+				delete_option( 'ep_hide_upgrade_sync_notice' );
+				delete_site_option( 'ep_hide_auto_activate_sync_notice' );
+				delete_option( 'ep_hide_auto_activate_sync_notice' );
+				delete_site_option( 'ep_hide_using_autosuggest_defaults_notice' );
+				delete_option( 'ep_hide_using_autosuggest_defaults_notice' );
+				delete_site_option( 'ep_hide_yellow_health_notice' );
+				delete_option( 'ep_hide_yellow_health_notice' );
+
+				// Delete transients
+				delete_site_transient( 'ep_es_info_response_code' );
+				delete_transient( 'ep_es_info_response_code' );
+				delete_site_transient( 'ep_es_info_response_error' );
+				delete_transient( 'ep_es_info_response_error' );
+				delete_site_transient( 'logging_ep_es_info' );
+				delete_transient( 'logging_ep_es_info' );
+				delete_site_transient( 'ep_wpcli_sync_interrupted' );
+				delete_transient( 'ep_wpcli_sync_interrupted' );
+				delete_site_transient( 'ep_wpcli_sync' );
+				delete_transient( 'ep_wpcli_sync' );
+				delete_site_transient( 'ep_es_info' );
+				delete_transient( 'ep_es_info' );
+				delete_site_transient( 'ep_autosuggest_query_request_cache' );
+				delete_transient( 'ep_autosuggest_query_request_cache' );
+				delete_site_transient( 'ep_related_posts_' );
+				delete_transient( 'ep_related_posts_' );
 
 				$related_posts_transients = $wpdb->get_col( "SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'" );
 
@@ -148,6 +147,77 @@ class EP_Uninstaller {
 				restore_current_blog();
 			}
 		} else {
+			// Delete options.
+			delete_option( 'ep_host' );
+			delete_site_option( 'ep_index_meta' );
+			delete_option( 'ep_index_meta' );
+			delete_site_option( 'ep_feature_settings' );
+			delete_option( 'ep_feature_settings' );
+			delete_site_option( 'ep_version' );
+			delete_option( 'ep_version' );
+			delete_option( 'ep_intro_shown' );
+			delete_site_option( 'ep_intro_shown' );
+			delete_option( 'ep_last_sync' );
+			delete_site_option( 'ep_last_sync' );
+			delete_option( 'ep_need_upgrade_sync' );
+			delete_site_option( 'ep_need_upgrade_sync' );
+			delete_option( 'ep_feature_requirement_statuses' );
+			delete_site_option( 'ep_feature_requirement_statuses' );
+			delete_option( 'ep_feature_auto_activated_sync' );
+			delete_site_option( 'ep_feature_auto_activated_sync' );
+			delete_option( 'ep_hide_intro_shown_notice' );
+			delete_site_option( 'ep_hide_intro_shown_notice' );
+			delete_option( 'ep_skip_install' );
+			delete_site_option( 'ep_skip_install' );
+			delete_option( 'ep_last_cli_index' );
+			delete_site_option( 'ep_last_cli_index' );
+			delete_option( 'ep_credentials' );
+			delete_site_option( 'ep_credentials' );
+			delete_option( 'ep_prefix' );
+			delete_site_option( 'ep_prefix' );
+			delete_option( 'ep_language' );
+			delete_site_option( 'ep_language' );
+			delete_option( 'ep_bulk_setting' );
+			delete_site_option( 'ep_bulk_setting' );
+
+			// Delete admin notices options
+			delete_site_option( 'ep_hide_host_error_notice' );
+			delete_option( 'ep_hide_host_error_notice' );
+			delete_site_option( 'ep_hide_es_below_compat_notice' );
+			delete_option( 'ep_hide_es_below_compat_notice' );
+			delete_site_option( 'ep_hide_es_above_compat_notice' );
+			delete_option( 'ep_hide_es_above_compat_notice' );
+			delete_site_option( 'ep_hide_need_setup_notice' );
+			delete_option( 'ep_hide_need_setup_notice' );
+			delete_site_option( 'ep_hide_no_sync_notice' );
+			delete_option( 'ep_hide_no_sync_notice' );
+			delete_site_option( 'ep_hide_upgrade_sync_notice' );
+			delete_option( 'ep_hide_upgrade_sync_notice' );
+			delete_site_option( 'ep_hide_auto_activate_sync_notice' );
+			delete_option( 'ep_hide_auto_activate_sync_notice' );
+			delete_site_option( 'ep_hide_using_autosuggest_defaults_notice' );
+			delete_option( 'ep_hide_using_autosuggest_defaults_notice' );
+			delete_site_option( 'ep_hide_yellow_health_notice' );
+			delete_option( 'ep_hide_yellow_health_notice' );
+
+			// Delete transients
+			delete_site_transient( 'ep_es_info_response_code' );
+			delete_transient( 'ep_es_info_response_code' );
+			delete_site_transient( 'ep_es_info_response_error' );
+			delete_transient( 'ep_es_info_response_error' );
+			delete_site_transient( 'logging_ep_es_info' );
+			delete_transient( 'logging_ep_es_info' );
+			delete_site_transient( 'ep_wpcli_sync_interrupted' );
+			delete_transient( 'ep_wpcli_sync_interrupted' );
+			delete_site_transient( 'ep_wpcli_sync' );
+			delete_transient( 'ep_wpcli_sync' );
+			delete_site_transient( 'ep_es_info' );
+			delete_transient( 'ep_es_info' );
+			delete_site_transient( 'ep_autosuggest_query_request_cache' );
+			delete_transient( 'ep_autosuggest_query_request_cache' );
+			delete_site_transient( 'ep_related_posts_' );
+			delete_transient( 'ep_related_posts_' );
+
 			$related_posts_transients = $wpdb->get_col( "SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'" );
 
 			foreach ( $related_posts_transients as $related_posts_transient ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -82,6 +82,52 @@ class EP_Uninstaller {
 		delete_site_option( 'ep_skip_install' );
 		delete_option( 'ep_last_cli_index' );
 		delete_site_option( 'ep_last_cli_index' );
+		delete_option( 'ep_credentials' );
+		delete_site_option( 'ep_credentials' );
+		delete_option( 'ep_prefix' );
+		delete_site_option( 'ep_prefix' );
+		delete_option( 'ep_language' );
+		delete_site_option( 'ep_language' );
+		delete_option( 'ep_bulk_setting' );
+		delete_site_option( 'ep_bulk_setting' );
+
+		// Delete admin notices options
+		delete_site_option( 'ep_hide_host_error_notice' );
+		delete_option( 'ep_hide_host_error_notice' );
+		delete_site_option( 'ep_hide_es_below_compat_notice' );
+		delete_option( 'ep_hide_es_below_compat_notice' );
+		delete_site_option( 'ep_hide_es_above_compat_notice' );
+		delete_option( 'ep_hide_es_above_compat_notice' );
+		delete_site_option( 'ep_hide_need_setup_notice' );
+		delete_option( 'ep_hide_need_setup_notice' );
+		delete_site_option( 'ep_hide_no_sync_notice' );
+		delete_option( 'ep_hide_no_sync_notice' );
+		delete_site_option( 'ep_hide_upgrade_sync_notice' );
+		delete_option( 'ep_hide_upgrade_sync_notice' );
+		delete_site_option( 'ep_hide_auto_activate_sync_notice' );
+		delete_option( 'ep_hide_auto_activate_sync_notice' );
+		delete_site_option( 'ep_hide_using_autosuggest_defaults_notice' );
+		delete_option( 'ep_hide_using_autosuggest_defaults_notice' );
+		delete_site_option( 'ep_hide_yellow_health_notice' );
+		delete_option( 'ep_hide_yellow_health_notice' );
+
+		// Delete transients
+		delete_site_transient('ep_es_info_response_code');
+		delete_transient('ep_es_info_response_code');
+		delete_site_transient('ep_es_info_response_error');
+		delete_transient('ep_es_info_response_error');
+		delete_site_transient('logging_ep_es_info');
+		delete_transient('logging_ep_es_info');
+		delete_site_transient('ep_wpcli_sync_interrupted');
+		delete_transient('ep_wpcli_sync_interrupted');
+		delete_site_transient('ep_wpcli_sync');
+		delete_transient('ep_wpcli_sync');
+		delete_site_transient('ep_es_info');
+		delete_transient('ep_es_info');
+		delete_site_transient('ep_autosuggest_query_request_cache');
+		delete_transient('ep_autosuggest_query_request_cache');
+		delete_site_transient('ep_related_posts_');
+		delete_transient('ep_related_posts_');
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Some options and transients are not removed after uninstalling the plugin. This change adds these missing options and transients to be removed on uninstall process.

### Alternate Designs

### Benefits

All options and transients are removed.

### Possible Drawbacks

### Verification Process

This has been tested manually.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes: #1953

### Changelog Entry

Fixed uninstall process to remove all options and transients.
