### PR TITLE
Add default value to parameter $context in the function use_language_in_setting

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -997,7 +997,7 @@ function action_admin_menu() {
  * @param string $context  The context where the function is running.
  * @return string          The updated language.
  */
-function use_language_in_setting( $language = 'english', $context ) {
+function use_language_in_setting( $language = 'english', $context = '' ) {
 	// Get the currently set language.
 	$ep_language = Utils\get_language();
 


### PR DESCRIPTION
### Description of the Change

In PHP 8, an [optional parameter should not be followed by a required one](https://www.php.net/manual/en/functions.arguments.php). This change adds a default value to parameter `$context` in the function `use_language_in_setting` to support PHP 8 but without changing the signature of the function.  

### Alternate Designs

### Benefits

Support PHP 8.

### Possible Drawbacks

### Verification Process

This has been tested manually.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes: #1980 

### Changelog Entry

Fixed PHP 8 support.
