### PR TITLE
Fix synonyms list update

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -250,7 +250,7 @@ class Synonyms {
 		if ( ! $this->synonym_post_id ) {
 			$this->synonym_post_id = get_option( 'elasticpress_synonyms_post_id', false );
 
-			if ( false === $this->synonym_post_id ) {
+			if ( false === $this->synonym_post_id || ! $this->synonym_post_exists( $this->synonym_post_id ) ) {
 				$post_id = wp_insert_post(
 					[
 						'post_title'   => __( 'Elasticpress Synonyms', 'elasticpress' ),
@@ -767,5 +767,15 @@ class Synonyms {
 			'value'   => trim( sanitize_text_field( $token ) ),
 			'primary' => $primary,
 		);
+	}
+
+	/**
+	 * Check if synonym post exists
+	 *
+	 * @param int $id The post id.
+	 * @return boolean
+	 */
+	private function synonym_post_exists( $id ) {
+		return is_string( get_post_status( $id ) );
 	}
 }

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -408,6 +408,7 @@ class Synonyms {
 				[
 					'ID'           => $this->get_synonym_post_id(),
 					'post_content' => $content,
+					'post_type'    => self::POST_TYPE_NAME,
 				]
 			);
 

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -45,6 +45,7 @@ class Upgrades {
 		 */
 		$routines = [
 			'3.5.2' => [ 'upgrade_3_5_2', 'init' ],
+			'3.5.3' => [ 'upgrade_3_5_3', 'init' ]
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ] );
@@ -117,6 +118,36 @@ class Upgrades {
 		);
 
 		update_option( 'elasticpress_weighting', $weighting_options );
+	}
+
+	/**
+	 * Upgrade routine of v3.5.3.
+	 *
+	 * Check if synonyms post has the correct post type, otherwise,
+	 * change it to the correct one.
+	 */
+	public function upgrade_3_5_3() {
+		$synonyms_post_id = get_option( 'elasticpress_synonyms_post_id', '' );
+
+		if ( ! $synonyms_post_id ) {
+			delete_option( 'elasticpress_synonyms_post_id' );
+
+			return;
+		}
+
+		$synonyms_post = get_post( $synonyms_post_id );
+
+		if ( ! $synonyms_post ) {
+			delete_option( 'elasticpress_synonyms_post_id' );
+
+			return;
+		}
+
+		if ( 'ep-synonym' !== $synonyms_post->post_type ) {
+			$synonyms_post->post_type = 'ep-synonym';
+
+			wp_update_post( $synonyms_post );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

The synonyms list is saved in a custom post type that is not accessible through the admin dashboard. However, when the synonyms list is updated, the post type is changed from `ep-synonym` to `post`. 

As a consequence, this post becomes available in the list of posts where can accidentally be deleted. If the post with the synonyms list is deleted, it's no possible to save a new one because the plugin references the deleted post and raises an error.

This change ensures that the custom post type doesn't change on the update and adds an upgrade routine to fix this problem.

### Alternate Designs

### Benefits

Users can add/update the synonyms list.

### Possible Drawbacks

### Verification Process

This has been tested manually.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes: #1941 

### Changelog Entry

Fixed on update the synonyms list.
