### PR TITLE
Remove elasticpress_synonyms_post_id option

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -769,7 +769,8 @@ class Synonyms {
 			[
 				'post_content' => $this->example_synonym_list(),
 				'post_type'    => self::POST_TYPE_NAME,
-			]
+			],
+			true
 		);
 	}
 
@@ -791,7 +792,8 @@ class Synonyms {
 				'ID'           => $synonym_post_id,
 				'post_content' => $content,
 				'post_type'    => self::POST_TYPE_NAME,
-			]
+			],
+			true
 		);
 	}
 }

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -780,9 +780,15 @@ class Synonyms {
 	 * @return int|WP_Error
 	 */
 	private function update_synonym_post( $content ) {
+		$synonym_post_id = $this->get_synonym_post_id();
+
+		if ( ! $synonym_post_id ) {
+			return $synonym_post_id;
+		}
+
 		return wp_insert_post(
 			[
-				'ID'           => $this->get_synonym_post_id(),
+				'ID'           => $synonym_post_id,
 				'post_content' => $content,
 				'post_type'    => self::POST_TYPE_NAME,
 			]

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -127,27 +127,8 @@ class Upgrades {
 	 * change it to the correct one.
 	 */
 	public function upgrade_3_5_3() {
-		$synonyms_post_id = get_option( 'elasticpress_synonyms_post_id', '' );
-
-		if ( ! $synonyms_post_id ) {
-			delete_option( 'elasticpress_synonyms_post_id' );
-
-			return;
-		}
-
-		$synonyms_post = get_post( $synonyms_post_id );
-
-		if ( ! $synonyms_post ) {
-			delete_option( 'elasticpress_synonyms_post_id' );
-
-			return;
-		}
-
-		if ( 'ep-synonym' !== $synonyms_post->post_type ) {
-			$synonyms_post->post_type = 'ep-synonym';
-
-			wp_update_post( $synonyms_post );
-		}
+		delete_option( 'elasticpress_synonyms_post_id' );
+		delete_site_option( 'elasticpress_synonyms_post_id' );
 	}
 
 	/**

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -49,8 +49,6 @@ class TestSynonyms extends BaseTestCase {
 		// make sure no one attached to this
 		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
-		delete_option( 'elasticpress_synonyms_post_id' );
-		delete_site_option( 'elasticpress_synonyms_post_id' );
 	}
 
 	public function getFeature() {


### PR DESCRIPTION
### Description of the Change

This change refactors the `get_synonym_post_id` function to remove the dependence of `elasticpress_synonyms_post_id` option.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Verification Process

This has been tested manually.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

### Changelog Entry
