### PR TITLE
Update the default boost_mode from sum to multiply

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -520,7 +520,7 @@ class Search extends Feature {
 								 * @param  {array} $args WP_Query arguments
 								 * @return  {string} New weight
 								 */
-								'weight' => apply_filters( 'epwr_weight', 1, $formatted_args, $args ),
+								'weight' => apply_filters( 'epwr_weight', 0.001, $formatted_args, $args ),
 							),
 						),
 						/**
@@ -532,7 +532,7 @@ class Search extends Feature {
 						 * @param  {array} $args WP_Query arguments
 						 * @return  {string} New score mode
 						 */
-						'score_mode' => apply_filters( 'epwr_score_mode', 'avg', $formatted_args, $args ),
+						'score_mode' => apply_filters( 'epwr_score_mode', 'sum', $formatted_args, $args ),
 						/**
 						 * Filter search date weighting boost mode
 						 *

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -514,6 +514,7 @@ class Search extends Feature {
 								/**
 								 * Filter search date weight
 								 *
+								 * @since 3.5.6
 								 * @hook epwr_weight
 								 * @param  {string} $weight Current weight
 								 * @param  {array} $formatted_args Formatted Elasticsearch arguments

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -536,7 +536,6 @@ class Search extends Feature {
 						/**
 						 * Filter search date weighting boost mode
 						 *
-						 * @since  3.5.6
 						 * @hook epwr_boost_mode
 						 * @param  {string} $boost_mode Current boost mode
 						 * @param  {array} $formatted_args Formatted Elasticsearch arguments

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -530,7 +530,7 @@ class Search extends Feature {
 						 * @param  {array} $args WP_Query arguments
 						 * @return  {string} New boost mode
 						 */
-						'boost_mode' => apply_filters( 'epwr_boost_mode', 'sum', $formatted_args, $args ),
+						'boost_mode' => apply_filters( 'epwr_boost_mode', 'multiply', $formatted_args, $args ),
 					),
 				);
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -510,6 +510,18 @@ class Search extends Feature {
 									),
 								),
 							),
+							array(
+								/**
+								 * Filter search date weight
+								 *
+								 * @hook epwr_weight
+								 * @param  {string} $weight Current weight
+								 * @param  {array} $formatted_args Formatted Elasticsearch arguments
+								 * @param  {array} $args WP_Query arguments
+								 * @return  {string} New weight
+								 */
+								'weight' => apply_filters( 'epwr_weight', 1, $formatted_args, $args ),
+							),
 						),
 						/**
 						 * Filter search date weighting score mode

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -536,6 +536,7 @@ class Search extends Feature {
 						/**
 						 * Filter search date weighting boost mode
 						 *
+						 * @since  3.5.6
 						 * @hook epwr_boost_mode
 						 * @param  {string} $boost_mode Current boost mode
 						 * @param  {array} $formatted_args Formatted Elasticsearch arguments


### PR DESCRIPTION
### Description of the Change

This change updates the default `boost_mode` from `sum` to `multiply`. Using `sum` achieves a smaller effect on decaying old content. So old content can still surface at the top of the search results.

### Alternate Designs

### Benefits

Old content turns less relevant in search.

### Possible Drawbacks

### Verification Process

1. Creating posts with a date range between 2009 and 2021.
2. Searched for a term that is common in posts from 2009 and 2021
3. The posts from 2021 are at the top of the search.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes: #2042 

### Changelog Entry

Change the default boost_mode to multiply.
