### PR TITLE
Fix for https://github.com/10up/ElasticPress/issues/2065

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1358,7 +1358,7 @@ class Post extends Indexable {
 		}
 
 		if ( isset( $args['offset'] ) ) {
-			$formatted_args['from'] = $args['offset'];
+			$formatted_args['from'] = (int) $args['offset'];
 		}
 
 		if ( isset( $args['paged'] ) && $args['paged'] > 1 ) {


### PR DESCRIPTION
### Description of the Change

This is a fix for bug https://github.com/10up/ElasticPress/issues/2065. The 'from' statement in the query is an empty string when it needs to be an int. Line 1361 needs to have the value cast as an int to convert the empty string to a 0.

### Benefits

Some themes appear to not be handling the 'offset' correctly and are passing an empty string (which fools the isset check). The empty string is making its way to ES, which causes a break as it's invalid. Casting the empty string to an int converts it to a 0 which is valid in ES.

### Possible Drawbacks

N/A

### Verification Process

Tested this on a live site using this theme: https://themeforest.net/item/newspaper/5489609

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

- number_format_exception fix for 'from' statement caused by some themes.
