### PR TITLE
Fix docs for the ep_formatted_args filter

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1420,7 +1420,7 @@ class Post extends Indexable {
 		/**
 		 * Filter formatted Elasticsearch [ost ]query (entire query)
 		 *
-		 * @hook ep_formatted_args_query
+		 * @hook ep_formatted_args
 		 * @param {array} $formatted_args Formatted Elasticsearch query
 		 * @param {array} $query_vars Query variables
 		 * @param {array} $query Query part


### PR DESCRIPTION
As the docblock for the `ep_formatted_args` filter is wrongly mentioning `ep_formatted_args_query`, we currently don't have a http://10up.github.io/ElasticPress/ep_formatted_args.html generated.