### PR TITLE
Facets: Check if $agg['buckets'] really exists

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -346,6 +346,10 @@ class Facets extends Feature {
 						continue;
 					}
 
+					if ( ! is_array( $agg ) || empty( $agg['buckets'] ) ) {
+						continue;
+					}
+
 					$GLOBALS['ep_facet_aggs'][ $key ] = [];
 
 					foreach ( $agg['buckets'] as $bucket ) {


### PR DESCRIPTION
### Description of the Change

Although I could not reproduce the problem stated in #1938, this PR adds a check before iterating over the aggregation buckets.

### Applicable Issues

fixes #1938

### Changelog Entry

Add an extra check in the iteration over the aggregations.
