### PR TITLE
Add the `ep_highlight_should_add_clause` filter

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -229,7 +229,7 @@ class Search extends Feature {
 		 * @param  {array} $fields Highlighting fields
 		 * @param  {array} $formatted_args array
 		 * @param  {array} $args WP_Query args
-		 * @return  {string} New Highlighting fields
+		 * @return  {array} New Highlighting fields
 		 */
 		$fields_to_highlight = apply_filters(
 			'ep_highlighting_fields',


### PR DESCRIPTION
### Description of the Change

This PR adds a new `ep_highlight_should_add_clause` filter to let developers decide where the `highlight` clause should be added to the ES query.

### Alternate Designs

n/a

### Benefits

Developers can use highlight in AJAX and REST requests, for example.

### Possible Drawbacks

n/a

### Verification Process

1. Added the code
2. Tested if everything worked as before
3. Added `add_filter( 'ep_highlight_should_add_clause', '__return_true' );` to a mu-plugin
4. Visited https://ep-352.test/wp-json/wp/v2/posts?search=lorem and saw <mark> tags

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

Fixes #2051

### Changelog Entry

Add a new filter to let developers decide where the `highlight` clause should be added to the ES query
