### PR TITLE
WP-CLI commands to get and set the search algorithm version

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1434,6 +1434,61 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Set the algorithm version.
+	 *
+	 * @synopsis [--version=<version>] [--default]
+	 * @subcommand set-algorithm-version
+	 *
+	 * @since       3.5.4
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function set_search_algorithm_version( $args, $assoc_args ) {
+		if ( empty( $assoc_args['version'] ) && ! isset( $assoc_args['default'] ) ) {
+			WP_CLI::error( esc_html__( 'This command expects a version number or the --default flag.', 'elasticpress' ) );
+		}
+
+		if ( ! empty( $assoc_args['default'] ) ) {
+			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+				delete_site_option( 'ep_search_algorithm_version' );
+			} else {
+				delete_option( 'ep_search_algorithm_version' );
+			}
+		} else {
+			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+				update_site_option( 'ep_search_algorithm_version', $assoc_args['version'] );
+			} else {
+				update_option( 'ep_search_algorithm_version', $assoc_args['version'], false );
+			}
+		}
+
+		WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );
+	}
+
+	/**
+	 * Get the algorithm version.
+	 *
+	 * @subcommand get-algorithm-version
+	 *
+	 * @since       3.5.4
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_search_algorithm_version( $args, $assoc_args ) {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$value = get_site_option( 'ep_search_algorithm_version', '' );
+		} else {
+			$value = get_option( 'ep_search_algorithm_version', '' );
+		}
+
+		if ( empty( $value ) ) {
+			WP_CLI::line( 'default' );
+		} else {
+			WP_CLI::line( $value );
+		}
+	}
+
+	/**
 	 * Custom get_transient to WP-CLI env.
 	 *
 	 * We are using the direct SQL query instead of

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1436,6 +1436,10 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Set the algorithm version.
 	 *
+	 * Set the algorithm version through the `ep_search_algorithm_version` option,
+	 * that will be used by the filter with same name.
+	 * Delete the option if `--default` is passed.
+	 *
 	 * @synopsis [--version=<version>] [--default]
 	 * @subcommand set-algorithm-version
 	 *
@@ -1467,6 +1471,9 @@ class Command extends WP_CLI_Command {
 
 	/**
 	 * Get the algorithm version.
+	 *
+	 * Get the value of the `ep_search_algorithm_version` option, or
+	 * `default` if empty.
 	 *
 	 * @subcommand get-algorithm-version
 	 *

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1086,7 +1086,22 @@ class Post extends Indexable {
 		 */
 		$search_fields = apply_filters( 'ep_search_fields', $search_fields, $args );
 
-		$search_algorithm_version = apply_filters( 'ep_search_algorithm_version', '3.5' );
+		$default_algorithm_version = '3.5';
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$search_algorithm_version_option = get_site_option( 'ep_search_algorithm_version', $default_algorithm_version );
+		} else {
+			$search_algorithm_version_option = get_option( 'ep_search_algorithm_version', $default_algorithm_version );
+		}
+
+		/**
+		 * Filter the algorithm version to be used.
+		 *
+		 * @since  3.5
+		 * @hook ep_search_algorithm_version
+		 * @param  {string} $search_algorithm_version Algorithm version.
+		 * @return  {string} New algorithm version
+		 */
+		$search_algorithm_version = apply_filters( 'ep_search_algorithm_version', $search_algorithm_version_option );
 
 		$search_text = ( ! empty( $args['s'] ) ) ? $args['s'] : '';
 


### PR DESCRIPTION
### Description of the Change

This PR adds two new WP-CLI commands:

- `wp elasticpress set-algorithm-version [--version=<version>] [--default]`

- `wp elasticpress get-algorithm-version`

It also adds a PHP docblock for the `ep_search_algorithm_version` filter.

### Benefits

Users will be able to change the search algorithm version without PHP code.

### Changelog Entry

Add the new `set-algorithm-version` and `get-algorithm-version` WP-CLI commands.
