### PR TITLE
Add filters for easier search algorithm manipulation

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -433,7 +433,27 @@ class Weighting {
 							$field = 'post_author.display_name';
 						}
 
-						$fieldset['fields'][ $key ] = "{$field}^{$weight}";
+						/**
+						 * Filter fields and their weitghting as used in the Elasticsearch query.
+						 *
+						 * @hook ep_query_weighting_fields
+						 * @param  {string} $weighted_field The field and its weight as used in the ES query.
+						 * @param  {string} $field          Field name
+						 * @param  {string} $weight         Weight value
+						 * @param  {array}  $fieldset       Current subset of formatted ES args
+						 * @param  {array}  $weights        Weight configuration
+						 * @return  {array} New weighted field string
+						 *
+						 * @since  3.5.5
+						 */
+						$fieldset['fields'][ $key ] = apply_filters(
+							'ep_query_weighting_fields',
+							"{$field}^{$weight}",
+							$field,
+							$weight,
+							$fieldset,
+							$weights
+						);
 					}
 				} else {
 					// this handles removing post_author.login field added in Post::format_args() if author search field has being disabled

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1209,11 +1209,21 @@ class Post extends Indexable {
 			 * Filter formatted Elasticsearch post query (only contains query part)
 			 *
 			 * @hook ep_formatted_args_query
-			 * @param {array} $query Current query
-			 * @param {array} $query_vars Query variables
-			 * @return  {array} New query
+			 * @param {array}  $query         Current query
+			 * @param {array}  $query_vars    Query variables
+			 * @param {string} $search_text   Search text
+			 * @param {array}  $search_fields Search fields
+			 * @return {array} New query
+			 *
+			 * @since 3.5.5 $search_text and $search_fields parameters added.
 			 */
-			$formatted_args['query'] = apply_filters( 'ep_formatted_args_query', $query, $args );
+			$formatted_args['query'] = apply_filters(
+				'ep_formatted_args_query',
+				$query,
+				$args,
+				$search_text,
+				$search_fields
+			);
 		} elseif ( ! empty( $args['ep_match_all'] ) || ! empty( $args['ep_integrate'] ) ) {
 			$formatted_args['query']['match_all'] = array(
 				'boost' => 1,


### PR DESCRIPTION
### Description of the Change

As outlined in #2101, due to the way ElasticPress builds the query sent to Elasticsearch, quite often it's hard to manipulate it. This PR adds a new `ep_query_weighting_fields` filter and add two more parameters to `ep_formatted_args_query`.

### Possible usage

```
function set_precise_search( $query, $args, $search_text, $search_fields ) {
	if (
		! @isset( $query['bool']['should'][0]['multi_match']['fields'] ) ||
		! @isset( $query['bool']['should'][0]['multi_match']['query'] )
	) {
		// not the query we're looking for
		return $query;
	}

	$query = array(
		'bool' => array(
			'should' => array(
				array(
					'multi_match' => array(
						'query'  => $search_text,
						'type'   => 'phrase',
						'fields' => $search_fields,
						'boost'  => 5,
						'slop'   => 5,
					),
				),
				array(
					'multi_match' => array(
						'query'  => $search_text,
						'type'   => 'phrase',
						'fields' => $search_fields,
						'boost'  => 2,
						'slop'   => 12,
					),
				),
				array(
					'multi_match' => array(
						'query'       => $search_text,
						'type'        => 'cross_fields',
						'fields'      => $search_fields,
						'boost'       => 1,
						'analyzer'    => 'standard',
						'tie_breaker' => 0.5,
						'operator'    => 'and',
					),
				),
			),
		),
	);

	return $query;
}
add_filter( 'ep_formatted_args_query', 'set_precise_search', 10, 4 );

function adjust_weight_for_cross_fields( $weighted_field, $field, $weight, $fieldset, $weights ) {
	if ( 'cross_fields' === $fieldset['type'] ) {
		$weighted_field = "{$field}^1";
	}
	return $weighted_field;
}
add_filter( 'ep_query_weighting_fields', 'adjust_weight_for_cross_fields', 10, 5 );
```

### Applicable Issues

Closes #2101 

### Changelog Entry

- Add a new `ep_query_weighting_fields` filter
- Add two parameters to the `ep_formatted_args_query` filter.