### PR TITLE
Autosuggest: Helper function to delete cached query

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1282,6 +1282,15 @@ class Command extends WP_CLI_Command {
 	public function clear_index() {
 		$this->delete_transient();
 
+		/**
+		 * Fires after the CLI `clear-index` command is executed.
+		 *
+		 * @hook ep_cli_clear_index
+		 *
+		 * @since 3.5.5
+		 */
+		do_action( 'ep_cli_clear_index' );
+
 		WP_CLI::success( esc_html__( 'Index cleared.', 'elasticpress' ) );
 	}
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1280,16 +1280,25 @@ class Command extends WP_CLI_Command {
 	 * @since      3.4
 	 */
 	public function clear_index() {
+		/**
+		 * Fires before the CLI `clear-index` command is executed.
+		 *
+		 * @hook ep_cli_before_clear_index
+		 *
+		 * @since 3.5.5
+		 */
+		do_action( 'ep_cli_before_clear_index' );
+
 		$this->delete_transient();
 
 		/**
 		 * Fires after the CLI `clear-index` command is executed.
 		 *
-		 * @hook ep_cli_clear_index
+		 * @hook ep_cli_after_clear_index
 		 *
 		 * @since 3.5.5
 		 */
-		do_action( 'ep_cli_clear_index' );
+		do_action( 'ep_cli_after_clear_index' );
 
 		WP_CLI::success( esc_html__( 'Index cleared.', 'elasticpress' ) );
 	}
@@ -1468,6 +1477,17 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function set_search_algorithm_version( $args, $assoc_args ) {
+		/**
+		 * Fires before the algorithm version is changed via WP-CLI.
+		 *
+		 * @hook ep_cli_before_set_search_algorithm_version
+		 * @param  {array} $args CLI command position args
+		 * @param {array} $assoc_args CLI command associative args
+		 *
+		 * @since 3.5.5
+		 */
+		do_action( 'ep_cli_before_set_search_algorithm_version', $args, $assoc_args );
+
 		if ( empty( $assoc_args['version'] ) && ! isset( $assoc_args['default'] ) ) {
 			WP_CLI::error( esc_html__( 'This command expects a version number or the --default flag.', 'elasticpress' ) );
 		}
@@ -1489,13 +1509,13 @@ class Command extends WP_CLI_Command {
 		/**
 		 * Fires after the algorithm version is changed via WP-CLI.
 		 *
-		 * @hook ep_cli_put_mapping
+		 * @hook ep_cli_after_set_search_algorithm_version
 		 * @param  {array} $args CLI command position args
 		 * @param {array} $assoc_args CLI command associative args
 		 *
 		 * @since 3.5.5
 		 */
-		do_action( 'ep_cli_set_search_algorithm_version', $args, $assoc_args );
+		do_action( 'ep_cli_after_set_search_algorithm_version', $args, $assoc_args );
 
 		WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );
 	}

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -752,6 +752,17 @@ class Command extends WP_CLI_Command {
 			update_option( 'ep_last_cli_index', $index_results, false );
 		}
 
+		/**
+		 * Fires after executing a CLI index
+		 *
+		 * @hook ep_wp_cli_after_index
+		 * @param  {array} $args CLI command position args
+		 * @param {array} $assoc_args CLI command associative args
+		 *
+		 * @since 3.5.5
+		 */
+		do_action( 'ep_wp_cli_after_index', $args, $assoc_args );
+
 		WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Total time elapsed: ', 'elasticpress' ) . '%N' . $index_time ) );
 
 		$this->delete_transient();
@@ -1465,6 +1476,17 @@ class Command extends WP_CLI_Command {
 				update_option( 'ep_search_algorithm_version', $assoc_args['version'], false );
 			}
 		}
+
+		/**
+		 * Fires after the algorithm version is changed via WP-CLI.
+		 *
+		 * @hook ep_cli_put_mapping
+		 * @param  {array} $args CLI command position args
+		 * @param {array} $assoc_args CLI command associative args
+		 *
+		 * @since 3.5.5
+		 */
+		do_action( 'ep_cli_set_search_algorithm_version', $args, $assoc_args );
 
 		WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );
 	}

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -92,11 +92,11 @@ class Autosuggest extends Feature {
 		add_filter( 'ep_wp_cli_pre_index', [ $this, 'epio_send_autosuggest_public_request' ] );
 		add_filter( 'debug_information', [ $this, 'epio_autosuggest_health_check_info' ] );
 
-		add_action( 'ep_cli_set_search_algorithm_version', [ $this, 'delete_cached_query' ] );
+		add_action( 'ep_cli_before_set_search_algorithm_version', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_after_dashboard_index', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_after_update_feature', [ $this, 'delete_cached_query' ] );
-		add_action( 'ep_cli_clear_index', [ $this, 'delete_cached_query' ] );
+		add_action( 'ep_cli_after_clear_index', [ $this, 'delete_cached_query' ] );
 	}
 
 	/**

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -92,7 +92,7 @@ class Autosuggest extends Feature {
 		add_filter( 'ep_wp_cli_pre_index', [ $this, 'epio_send_autosuggest_public_request' ] );
 		add_filter( 'debug_information', [ $this, 'epio_autosuggest_health_check_info' ] );
 
-		add_action( 'ep_cli_before_set_search_algorithm_version', [ $this, 'delete_cached_query' ] );
+		add_action( 'ep_cli_after_set_search_algorithm_version', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_after_dashboard_index', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_after_update_feature', [ $this, 'delete_cached_query' ] );

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -91,6 +91,11 @@ class Autosuggest extends Feature {
 		add_filter( 'ep_pre_dashboard_index', [ $this, 'epio_send_autosuggest_public_request' ] );
 		add_filter( 'ep_wp_cli_pre_index', [ $this, 'epio_send_autosuggest_public_request' ] );
 		add_filter( 'debug_information', [ $this, 'epio_autosuggest_health_check_info' ] );
+
+		add_action( 'ep_cli_set_search_algorithm_version', [ $this, 'delete_cached_query' ] );
+		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_cached_query' ] );
+		add_action( 'ep_after_dashboard_index', [ $this, 'delete_cached_query' ] );
+		add_action( 'ep_after_update_feature', [ $this, 'delete_cached_query' ] );
 	}
 
 	/**
@@ -562,11 +567,26 @@ class Autosuggest extends Feature {
 				if ( isset( $request->http_response ) && isset( $request->http_response->body ) ) {
 					$request->http_response->body = '';
 				}
-				set_transient( $cache_key, $request, 300 );
+				set_transient( $cache_key, $request, 5 * MINUTE_IN_SECONDS );
 			}
 		}
 
 		return $request;
+	}
+
+	/**
+	 * Delete the cached query for autosuggest.
+	 *
+	 * @since 3.5.5
+	 */
+	public function delete_cached_query() {
+		global $wp_object_cache;
+		if ( wp_using_ext_object_cache() ) {
+			// Delete the entire group.
+			unset( $wp_object_cache->cache['ep_autosuggest'] );
+		} else {
+			delete_transient( 'ep_autosuggest_query_request_cache' );
+		}
 	}
 
 	/**

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -96,6 +96,7 @@ class Autosuggest extends Feature {
 		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_after_dashboard_index', [ $this, 'delete_cached_query' ] );
 		add_action( 'ep_after_update_feature', [ $this, 'delete_cached_query' ] );
+		add_action( 'ep_cli_clear_index', [ $this, 'delete_cached_query' ] );
 	}
 
 	/**

--- a/includes/classes/Features.php
+++ b/includes/classes/Features.php
@@ -153,6 +153,23 @@ class Features {
 			$feature->post_activation();
 		}
 
+		/**
+		 * Fires after activating, inactivating, or just updating a feature.
+		 *
+		 * @hook ep_after_update_feature
+		 * @param  {string} $feature Feature slug
+		 * @param  {array} $settings Feature settings
+		 * @param  {array} $data Feature activation data
+		 *
+		 * @since 3.5.5
+		 */
+		do_action(
+			'ep_after_update_feature',
+			$slug,
+			$settings,
+			$data
+		);
+
 		return $data;
 	}
 

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -662,6 +662,14 @@ function action_wp_ajax_ep_index() {
 
 						$indexable_object->create_network_alias( $indexes );
 					}
+
+						/**
+						 * Fires after executing a reindex via Dashboard
+						 *
+						 * @since  3.5.5
+						 * @hook ep_after_dashboard_index
+						 */
+						do_action( 'ep_after_dashboard_index' );
 				} else {
 					$index_meta['offset'] = (int) $query['total_objects'];
 				}
@@ -669,6 +677,9 @@ function action_wp_ajax_ep_index() {
 				$index_meta['offset'] = (int) $query['total_objects'];
 
 				delete_option( 'ep_index_meta' );
+
+				/* This action is documented in this file */
+				do_action( 'ep_after_dashboard_index' );
 			}
 		}
 	} else {


### PR DESCRIPTION
### Description of the Change

This PR fixes the problem outlined in #2104. It also adds some new actions:

- ep_wp_cli_after_index
- ep_after_dashboard_index
- ep_cli_before_set_search_algorithm_version
- ep_cli_after_set_search_algorithm_version
- ep_after_update_feature
- ep_cli_before_clear_index
- ep_cli_after_clear_index

### Applicable Issues

Closes #2104 

### Changelog Entry

- Add new actions: ep_wp_cli_after_index, ep_after_dashboard_index, ep_cli_before_set_search_algorithm_version, ep_cli_after_set_search_algorithm_version, ep_after_update_feature, ep_cli_before_clear_index, and ep_cli_after_clear_index