### PR TITLE
Don't activate Protected Content by default when using EP.io

### DIFF
--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -219,10 +219,9 @@ class ProtectedContent extends Feature {
 	 * @return FeatureRequirementsStatus
 	 */
 	public function requirements_status() {
-		$status = new FeatureRequirementsStatus( 0 );
+		$status = new FeatureRequirementsStatus( 1 );
 
 		if ( ! Utils\is_epio() ) {
-			$status->code    = 1;
 			$status->message = __( "You aren't using <a href='https://elasticpress.io'>ElasticPress.io</a> so we can't be sure your Elasticsearch instance is secure.", 'elasticpress' );
 		}
 


### PR DESCRIPTION
### Description of the Change

As stated in ##2123, the Protected Content feature should never be auto-activated even when using ElasticPress.io.
### Alternate Designs

### Verification Process

1. Deleted site options
2. Made the change in the code
3. Setup the plugin using EP.io
4. The feature was not activated.

### Applicable Issues

Fixes #2123

### Changelog Entry

- The Protected Content feature isn't auto-activated when using ElasticPress.io anymore
