### PR TITLE
WP-CLI: Add terms to status and stats

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1046,8 +1046,14 @@ class Command extends WP_CLI_Command {
 
 		$sites = ( is_multisite() ) ? Utils\get_sites() : array( 'blog_id' => get_current_blog_id() );
 
+		$term_indexable = Indexables::factory()->get( 'term' );
+
 		foreach ( $sites as $site ) {
 			$index_names[] = Indexables::factory()->get( 'post' )->get_index_name( $site['blog_id'] );
+
+			if ( ! empty( $term_indexable ) ) {
+				$index_names[] = $term_indexable->get_index_name( $site['blog_id'] );
+			}
 		}
 
 		$user_indexable = Indexables::factory()->get( 'user' );
@@ -1085,8 +1091,15 @@ class Command extends WP_CLI_Command {
 
 		$sites = ( is_multisite() ) ? Utils\get_sites() : array( 'blog_id' => get_current_blog_id() );
 
+		$post_indexable = Indexables::factory()->get( 'post' );
+		$term_indexable = Indexables::factory()->get( 'term' );
+
 		foreach ( $sites as $site ) {
-			$index_names[] = Indexables::factory()->get( 'post' )->get_index_name( $site['blog_id'] );
+			$index_names[] = $post_indexable->get_index_name( $site['blog_id'] );
+
+			if ( ! empty( $term_indexable ) ) {
+				$index_names[] = $term_indexable->get_index_name( $site['blog_id'] );
+			}
 		}
 
 		$user_indexable = Indexables::factory()->get( 'user' );
@@ -1105,31 +1118,19 @@ class Command extends WP_CLI_Command {
 		$body = json_decode( wp_remote_retrieve_body( $request ), true );
 
 		foreach ( $sites as $site ) {
-			$current_index = Indexables::factory()->get( 'post' )->get_index_name( $site['blog_id'] );
+			$current_index = $post_indexable->get_index_name( $site['blog_id'] );
 
-			if ( isset( $body['indices'][ $current_index ] ) ) {
-				WP_CLI::log( '====== Stats for: ' . $current_index . ' ======' );
-				WP_CLI::log( 'Documents:  ' . $body['indices'][ $current_index ]['primaries']['docs']['count'] );
-				WP_CLI::log( 'Index Size: ' . size_format( $body['indices'][ $current_index ]['primaries']['store']['size_in_bytes'], 2 ) );
-				WP_CLI::log( 'Index Size (including replicas): ' . size_format( $body['indices'][ $current_index ]['total']['store']['size_in_bytes'], 2 ) );
-				WP_CLI::log( '====== End Stats ======' );
-			} else {
-				WP_CLI::warning( $current_index . ' is not currently indexed.' );
+			$this->render_stats( $current_index, $body );
+
+			if ( $term_indexable ) {
+				$this->render_stats( $term_indexable->get_index_name( $site['blog_id'] ), $body );
 			}
 		}
 
 		if ( ! empty( $user_indexable ) ) {
 			$user_index = $user_indexable->get_index_name();
 
-			if ( isset( $body['indices'][ $user_index ] ) ) {
-				WP_CLI::log( '====== Stats for: ' . $user_index . ' ======' );
-				WP_CLI::log( 'Documents:  ' . $body['indices'][ $user_index ]['primaries']['docs']['count'] );
-				WP_CLI::log( 'Index Size: ' . size_format( $body['indices'][ $user_index ]['primaries']['store']['size_in_bytes'], 2 ) );
-				WP_CLI::log( 'Index Size (including replicas): ' . size_format( $body['indices'][ $user_index ]['total']['store']['size_in_bytes'], 2 ) );
-				WP_CLI::log( '====== End Stats ======' );
-			} else {
-				WP_CLI::warning( $user_index . ' is not currently indexed.' );
-			}
+			$this->render_stats( $user_index, $body );
 		}
 	}
 
@@ -1586,4 +1587,23 @@ class Command extends WP_CLI_Command {
 		return $should_interrupt_sync ? (bool) $should_interrupt_sync : null;
 	}
 
+	/**
+	 * Utilitary function to render Stats for a given index.
+	 *
+	 * @since 3.5.6
+	 * @param string $current_index The index name.
+	 * @param array  $body          The response body.
+	 * @return void
+	 */
+	protected function render_stats( $current_index, $body ) {
+		if ( isset( $body['indices'][ $current_index ] ) ) {
+			WP_CLI::log( '====== Stats for: ' . $current_index . ' ======' );
+			WP_CLI::log( 'Documents:  ' . $body['indices'][ $current_index ]['primaries']['docs']['count'] );
+			WP_CLI::log( 'Index Size: ' . size_format( $body['indices'][ $current_index ]['primaries']['store']['size_in_bytes'], 2 ) );
+			WP_CLI::log( 'Index Size (including replicas): ' . size_format( $body['indices'][ $current_index ]['total']['store']['size_in_bytes'], 2 ) );
+			WP_CLI::log( '====== End Stats ======' );
+		} else {
+			WP_CLI::warning( $current_index . ' is not currently indexed.' );
+		}
+	}
 }


### PR DESCRIPTION
### Description of the Change

Add terms indexes to the status and stats WP-CLI commands.