### PR TITLE
Bump PHP version for PHPUnit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Set PHP version
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.2'
+        php-version: '7.4'
         coverage: none
         tools: composer:v1
 


### PR DESCRIPTION
### Description of the Change

This is an attempt to fix the ` Warning:  mysqli_real_connect(): The server requested authentication method unknown to the client [caching_sha2_password] in /tmp/wordpress/wp-includes/wp-db.php on line 1653` error, like https://github.com/10up/ElasticPress/runs/2122309836