### PR TITLE
Fix catch_ep_formatted_args()

### DIFF
--- a/tests/php/features/TestSearch.php
+++ b/tests/php/features/TestSearch.php
@@ -241,6 +241,7 @@ class TestSearch extends BaseTestCase {
 	 */
 	public function catch_ep_formatted_args( $args ) {
 		$this->fired_actions['ep_formatted_args'] = $args;
+		return $args;
 	}
 
 	/**


### PR DESCRIPTION
This function should return $args, as it is used by a filter.