### PR TITLE
Allow filtering the HTML of Autosuggest items.

### DIFF
--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -265,7 +265,7 @@ function updateAutosuggestBox(options, input) {
 			</li>`;
 
 		if (typeof window.epAutosuggestItemHTMLFilter !== 'undefined') {
-			itemHTML = window.epAutosuggestItemHTMLFilter(itemHTML, options[i]);
+			itemHTML = window.epAutosuggestItemHTMLFilter(itemHTML, options[i], i);
 		}
 
 		itemString += itemHTML;

--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -242,7 +242,8 @@ function updateAutosuggestBox(options, input) {
 	// create markup for list items
 	// eslint-disable-next-line
 	for ( i = 0; resultsLimit > i; ++i ) {
-		const { text, url } = options[i];
+		const text = options[i]._source.post_title;
+		const url = options[i]._source.permalink;
 		const escapedText = escapeDoubleQuotes(text);
 
 		const searchParts = value.trim().split(' ');
@@ -437,22 +438,6 @@ function init() {
 		);
 	}
 
-	/**
-	 * Helper function to format search results for consumption
-	 * by the updateAutosuggestBox function
-	 *
-	 * @param {object} hits - results from ES
-	 * @returns {Array} formatted hits
-	 */
-	const formatSearchResults = (hits) => {
-		return hits.map((hit) => {
-			const text = hit._source.post_title;
-			const url = hit._source.permalink;
-
-			return { text, url };
-		});
-	};
-
 	// to be used by the handleUpDown function
 	// to keep track of the currently selected result
 	let currentIndex;
@@ -587,12 +572,11 @@ function init() {
 
 			if (response && response._shards && response._shards.successful > 0) {
 				const hits = checkForOrderedPosts(response.hits.hits, searchText);
-				const formattedResults = formatSearchResults(hits);
 
-				if (formattedResults.length === 0) {
+				if (hits.length === 0) {
 					hideAutosuggestBox();
 				} else {
-					updateAutosuggestBox(formattedResults, input);
+					updateAutosuggestBox(hits, input);
 				}
 			} else {
 				hideAutosuggestBox();

--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -258,11 +258,17 @@ function updateAutosuggestBox(options, input) {
 			);
 		}
 
-		itemString += `<li class="autosuggest-item" role="option" aria-selected="false" id="autosuggest-option-${i}">
+		let itemHTML = `<li class="autosuggest-item" role="option" aria-selected="false" id="autosuggest-option-${i}">
 				<a href="${url}" class="autosuggest-link" data-search="${escapedText}" data-url="${url}"  tabindex="-1">
 					${resultsText}
 				</a>
 			</li>`;
+
+		if (typeof window.epAutosuggestItemHTMLFilter !== 'undefined') {
+			itemHTML = window.epAutosuggestItemHTMLFilter(itemHTML, options[i]);
+		}
+
+		itemString += itemHTML;
 	}
 
 	// append list items to the list

--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -209,7 +209,7 @@ async function esSearch(query, searchTerm) {
 /**
  * Update the auto suggest box with new options or hide if none
  *
- * @param {Array} options - formatted results
+ * @param {Array} options - search results
  * @param {string} input - search string
  * @returns {boolean} return true
  */

--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -266,7 +266,7 @@ function updateAutosuggestBox(options, input) {
 			</li>`;
 
 		if (typeof window.epAutosuggestItemHTMLFilter !== 'undefined') {
-			itemHTML = window.epAutosuggestItemHTMLFilter(itemHTML, options[i], i);
+			itemHTML = window.epAutosuggestItemHTMLFilter(itemHTML, options[i], i, value);
 		}
 
 		itemString += itemHTML;


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Applies a `epAutosuggestItemHTMLFilter()` function to autosuggest items to allow filtering the HTML of autosuggest results.

### Alternate Designs

In this implementation the filter callback only receives the option object as the second argument, and the option index as the third argument. These can be used to reconstruct the original HTML, or a variation of it, if desired. This means that a custom filter would need to implement any required escaping, as well as highlighting.

An alternative approach could be to also pass the pre-processed escaped text and highlighted results text as arguments to the callback. 

The appropriate approach would depend on how much hand holding we want to do.

### Benefits

Developers can provide their own HTML for autosuggest result items.

### Possible Drawbacks

The potential for autosuggest results to break if future changes are made to the HTML of results that are not reflected in the HTML that may have been applied by a filter.

### Verification Process

- Check out this branch.
- Run `npm run build`.
- In a theme or plugin, define a `window.epAutosuggestItemHTMLFilter()` JavaScript function that returns some HTML.
- Start typing in a search field. The autosuggest results should use the HTML returned by our `epAutosuggestItemHTMLFilter()` function.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#2143
#2128 

### Changelog Entry

Added the ability to filter the HTML of autosuggest results by defining a `window.epAutosuggestItemHTMLFilter()` function in JavaScript.
  
<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
