### PR TITLE
Add new filter to show or not ElasticPress Indexing option

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -51,12 +51,24 @@ function setup() {
 	add_action( 'ep_add_query_log', __NAMESPACE__ . '\log_version_query_error' );
 	add_filter( 'ep_analyzer_language', __NAMESPACE__ . '\use_language_in_setting', 10, 2 );
 	add_filter( 'wp_kses_allowed_html', __NAMESPACE__ . '\filter_allowed_html', 10, 2 );
-	add_filter( 'wpmu_blogs_columns', __NAMESPACE__ . '\filter_blogs_columns', 10, 1 );
-	add_action( 'manage_sites_custom_column', __NAMESPACE__ . '\add_blogs_column', 10, 2 );
 	add_action( 'manage_blogs_custom_column', __NAMESPACE__ . '\add_blogs_column', 10, 2 );
-	add_action( 'wp_ajax_ep_site_admin', __NAMESPACE__ . '\action_wp_ajax_ep_site_admin' );
-	add_action( 'wp_ajax_ep_site_admin', __NAMESPACE__ . '\action_wp_ajax_ep_site_admin' );
 	add_action( 'rest_api_init', __NAMESPACE__ . '\setup_endpoint' );
+
+	/**
+	 * Filter whether to show 'ElasticPress Indexing' option on Multisite in admin UI or not.
+	 *
+	 * @since  3.6.0
+	 * @hook ep_show_indexing_option_on_multisite
+	 * @param  {bool}  $show True to show.
+	 * @return {bool}  New value
+	 */
+	$show_indexing_option_on_multisite = apply_filters( 'ep_show_indexing_option_on_multisite', true );
+
+	if ( $show_indexing_option_on_multisite ) {
+		add_filter( 'wpmu_blogs_columns', __NAMESPACE__ . '\filter_blogs_columns', 10, 1 );
+		add_action( 'manage_sites_custom_column', __NAMESPACE__ . '\add_blogs_column', 10, 2 );
+		add_action( 'wp_ajax_ep_site_admin', __NAMESPACE__ . '\action_wp_ajax_ep_site_admin' );
+	}
 }
 
 /**


### PR DESCRIPTION
### Description of the Change

This change adds a new filter to show or not the ElasticPress Indexing option in the Sites screen (`wp-admin/network/sites.php`).

### Alternate Designs

### Benefits

### Possible Drawbacks

### Verification Process

This has been tested manually. Adding the code below is expected that the ElasitcPress Indexing option doesn't appear in the Sites screen.

```php
add_filter( 'ep_show_indexing_option_on_multisite', '__return_false' );
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes: #1893 

### Changelog Entry

Added the filter ep_show_indexing_option_on_multisite.
