### PR TITLE
Add support to 'NOT LIKE' operator for meta_query

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -541,7 +541,7 @@ abstract class Indexable {
 					$meta_key_path = 'meta.' . $single_meta_query['key'];
 				} elseif ( in_array( $compare, array( '=', '!=' ), true ) && ! $type ) {
 					$meta_key_path = 'meta.' . $single_meta_query['key'] . '.raw';
-				} elseif ( 'like' === $compare ) {
+				} elseif ( in_array( $compare, array( 'like', 'not like' ), true ) ) {
 					$meta_key_path = 'meta.' . $single_meta_query['key'] . '.value';
 				} elseif ( $type && isset( $meta_query_type_mapping[ $type ] ) ) {
 					// Map specific meta field types to different Elasticsearch core types
@@ -719,6 +719,21 @@ abstract class Indexable {
 							$terms_obj = array(
 								'match_phrase' => array(
 									$meta_key_path => $single_meta_query['value'],
+								),
+							);
+						}
+						break;
+					case 'not like':
+						if ( isset( $single_meta_query['value'] ) ) {
+							$terms_obj = array(
+								'bool' => array(
+									'must_not' => array(
+										array(
+											'match_phrase' => array(
+												$meta_key_path => $single_meta_query['value'],
+											),
+										),
+									),
 								),
 							);
 						}


### PR DESCRIPTION
### Description of the Change

This change adds support to NOT LIKE operator for meta_query. 

### Alternate Designs

### Benefits

Adds a new way to filter posts.

### Possible Drawbacks

### Verification Process

This has been tested manually adding a custom field using [ACF](https://wordpress.org/plugins/advanced-custom-fields/) and querying with the operator NOT LIKE.

1. Adds a check box field with the options red, green, and blue;
2. Set this field in some posts;
3. Query using NOT LIKE 

```php
$args = array(
	'ep_integrate' => true,
	'meta_query'   => array(
		array(
			'key'     => 'checks',
			'value'   => 'red',
			'compare' => 'NOT LIKE',
		),
	),
);

$the_query = new WP_Query( $args );
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes: #2015 

### Changelog Entry

Added support to NOT LIKE operator for meta_query
