### PR TITLE
Remove references to posts_by_query property

### DIFF
--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -236,8 +236,6 @@ class QueryIntegration {
 		 * No post types so bail
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
-			$this->posts_by_query[ spl_object_hash( $query ) ] = [];
-
 			return [];
 		}
 
@@ -337,8 +335,6 @@ class QueryIntegration {
 			 */
 			do_action( 'ep_wp_query_non_cached_search', $new_posts, $ep_query, $query );
 		}
-
-		$this->posts_by_query[ spl_object_hash( $query ) ] = $new_posts;
 
 		/**
 		 * Fires before returning posts from query


### PR DESCRIPTION
### Description of the Change

This change removes the references to `posts_by_query` property. This property was used by two functions that were removed by the commit [6d71e6c39f5bab11df49580ddcb813fef02ff9fc](https://github.com/10up/ElasticPress/commit/6d71e6c39f5bab11df49580ddcb813fef02ff9fc) 

### Alternate Designs

### Benefits

### Possible Drawbacks

### Verification Process

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes: #1762 

### Changelog Entry