### PR TITLE
Avoids undefined variable notice

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -831,6 +831,7 @@ class Elasticsearch {
 			'timeout' => 30,
 		];
 
+		$closed = false;
 		if ( $close_first ) {
 			$closed = $this->close_index( $index );
 		}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Avoids `Undefined variable: closed` by defining the variable preemptively.

### Alternate Designs

`n/a` - it is a kinda simple solution so not sure of different approaches.

### Benefits

No notice

### Possible Drawbacks

`n/a`

### Verification Process

Ran on our dev-environment... the notice is gone

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [`n/a`] My change requires a change to the documentation.
- [`n/a`] I have updated the documentation accordingly.
- [`n/a`] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes https://github.com/10up/ElasticPress/issues/2155

### Changelog Entry

Fixed `Undefined variable: closed` notice in `update_index_settings`. 
