### PR TITLE
Autosuggest: don't enqueue scripts if EP is indexing

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -322,6 +322,10 @@ class Autosuggest extends Feature {
 	 * @since  2.4
 	 */
 	public function enqueue_scripts() {
+		if ( Utils\is_indexing() ) {
+			return;
+		}
+
 		$host         = Utils\get_host();
 		$endpoint_url = false;
 		$settings     = $this->get_settings();


### PR DESCRIPTION
### Description of the Change

As stated in #2126, enqueueing Autosuggest scripts on the frontend while EP is indexing makes the autosuggest query to be empty, generating a `TypeError: t.replace is not a function` error. This PR adds a check, completely avoiding autosuggest to enqueue anything while EP is indexing.

### Verification Process

Manual. Indexing with --nobulk and checking.

### Applicable Issues

Fixes #2126 

### Changelog Entry

- Autosuggest JavaScript is not loaded anymore when ElasticPress is indexing the content.