### PR TITLE
Add GitHub Action to auto-close non-responsive `reporter feedback` issues after 3 days

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,30 @@
+name: No Response
+
+# **What it does**: Closes issues where the original author doesn't respond to a request for information.
+# **Why we have it**: To remove the need for maintainers to remember to check back on issues periodically to see if contributors have responded.
+# **Who does it impact**: Everyone that works on docs or docs-internal.
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          closeComment: >
+            This issue has been automatically closed because there has been no response
+            to our request for more information from the original author. With only the
+            information that is currently in the issue, we don't have enough information
+            to take action. Please reach out if you have or find the answers we need so
+            that we can investigate further. See [this blog post on bug reports and the
+            importance of repro steps](https://www.lee-dohm.com/2015/01/04/writing-good-bug-reports/)
+            for more information about the kind of information that may be helpful.
+          daysUntilClose: 3 # Number of days of inactivity before an Issue is closed for lack of response
+          responseRequiredLabel: "reporter feedback" # Label indicating that a response from the original author is required

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -18,13 +18,13 @@ jobs:
       - uses: lee-dohm/no-response@v0.5.0
         with:
           token: ${{ github.token }}
+          daysUntilClose: 3 # Number of days of inactivity before an Issue is closed for lack of response
+          responseRequiredLabel: "reporter feedback" # Label indicating that a response from the original author is required
           closeComment: >
             This issue has been automatically closed because there has been no response
-            to our request for more information from the original author. With only the
+            to our request for more information. With only the
             information that is currently in the issue, we don't have enough information
             to take action. Please reach out if you have or find the answers we need so
             that we can investigate further. See [this blog post on bug reports and the
             importance of repro steps](https://www.lee-dohm.com/2015/01/04/writing-good-bug-reports/)
             for more information about the kind of information that may be helpful.
-          daysUntilClose: 3 # Number of days of inactivity before an Issue is closed for lack of response
-          responseRequiredLabel: "reporter feedback" # Label indicating that a response from the original author is required


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds a new GitHub Action that checks issues with the `reporter feedback` label and if there's no response in 3 days will auto-close the issue.

### Alternate Designs

Keep as-is with no automation or adjust the schedule this runs, the days to wait until closing, and/or the closing comment.

### Benefits

No longer have to check the `reporter feedback` label weekly to see which items can be closed.

### Possible Drawbacks

No identified.

### Verification Process

This is current running on https://github.com/desktop/desktop/blob/development/.github/no-response.yml && https://github.com/github/docs/blob/6d7b73256f86778cd0e0045d54a6e9acea128ce6/.github/workflows/no-response.yaml and is well-documented at https://github.com/lee-dohm/no-response so I'm fairly comfortable this will work.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

```
### Added
- Project automation via GitHub Action (props to the magnificent @jeffpaul).
```