### PR TITLE
Fix post_mime_type argument

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -998,7 +998,10 @@ class Post extends Indexable {
 				$args_post_mime_type = [];
 
 				foreach ( $args['post_mime_type'] as $mime_type ) {
-					// check if matches the MIME type pattern: type/subtype
+					/**
+					 * check if matches the MIME type pattern: type/subtype and
+					 * leave an empty string as posts, pages and CPTs don't have a MIME type
+					 */
 					if ( preg_match( '/^[-._a-z0-9]+\/[-._a-z0-9]+$/i', $mime_type ) || empty( $mime_type ) ) {
 						$args_post_mime_type[] = $mime_type;
 					} else {

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -999,7 +999,7 @@ class Post extends Indexable {
 
 				foreach ( $args['post_mime_type'] as $mime_type ) {
 					// check if matches the MIME type pattern: type/subtype
-					if ( preg_match( '/^[-._a-z0-9]+\/[-._a-z0-9]+$/i', $mime_type ) ) {
+					if ( preg_match( '/^[-._a-z0-9]+\/[-._a-z0-9]+$/i', $mime_type ) || empty( $mime_type ) ) {
 						$args_post_mime_type[] = $mime_type;
 					} else {
 						$filtered_mime_type_by_type = wp_match_mime_types( $mime_type, wp_get_mime_types() );

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -994,9 +994,23 @@ class Post extends Indexable {
 		 */
 		if ( ! empty( $args['post_mime_type'] ) ) {
 			if ( is_array( $args['post_mime_type'] ) ) {
+
+				$args_post_mime_type = [];
+
+				foreach ( $args['post_mime_type'] as $mime_type ) {
+					// check if matches the MIME type pattern: type/subtype
+					if ( preg_match( '/^[-._a-z0-9]+\/[-._a-z0-9]+$/i', $mime_type ) ) {
+						$args_post_mime_type[] = $mime_type;
+					} else {
+						$filtered_mime_type_by_type = wp_match_mime_types( $mime_type, wp_get_mime_types() );
+
+						$args_post_mime_type = array_merge( $args_post_mime_type, $filtered_mime_type_by_type[ $mime_type ] );
+					}
+				}
+
 				$filter['bool']['must'][] = array(
 					'terms' => array(
-						'post_mime_type' => (array) $args['post_mime_type'],
+						'post_mime_type' => $args_post_mime_type,
 					),
 				);
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -3950,24 +3950,31 @@ class TestPost extends BaseTestCase {
 	 * @since 2.3
 	 */
 	public function testPostMimeTypeQuery() {
-		Functions\create_and_sync_post(
+		$attachment_id_1_jpeg = Functions\create_and_sync_post(
 			array(
 				'post_type'      => 'attachment',
 				'post_mime_type' => 'image/jpeg',
 				'post_status'    => 'inherit',
 			)
 		);
-		Functions\create_and_sync_post(
+		$attachment_id_2_jpeg = Functions\create_and_sync_post(
 			array(
 				'post_type'      => 'attachment',
 				'post_mime_type' => 'image/jpeg',
 				'post_status'    => 'inherit',
 			)
 		);
-		Functions\create_and_sync_post(
+		$attachment_id_3_pdf = Functions\create_and_sync_post(
 			array(
 				'post_type'      => 'attachment',
 				'post_mime_type' => 'application/pdf',
+				'post_status'    => 'inherit',
+			)
+		);
+		$attachment_id_4_png = Functions\create_and_sync_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/png',
 				'post_status'    => 'inherit',
 			)
 		);
@@ -3983,7 +3990,13 @@ class TestPost extends BaseTestCase {
 
 		$query = new \WP_Query( $args );
 
-		$this->assertEquals( 2, $query->post_count );
+		$attachment_names = wp_list_pluck( $query->posts, 'post_name' );
+
+		$this->assertEquals( 3, $query->post_count );
+
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_1_jpeg ), $attachment_names );
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_2_jpeg ), $attachment_names );
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_4_png ), $attachment_names );
 
 		$args = array(
 			'ep_integrate'   => true,
@@ -3997,7 +4010,51 @@ class TestPost extends BaseTestCase {
 
 		$query = new \WP_Query( $args );
 
+		$attachment_names = wp_list_pluck( $query->posts, 'post_name' );
+
 		$this->assertEquals( 3, $query->found_posts );
+
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_1_jpeg ), $attachment_names );
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_2_jpeg ), $attachment_names );
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_3_pdf ), $attachment_names );
+
+		$args = array(
+			'ep_integrate'   => true,
+			'post_mime_type' => array(
+				'image',
+				'application/pdf',
+			),
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+		);
+
+		$query = new \WP_Query( $args );
+
+		$attachment_names = wp_list_pluck( $query->posts, 'post_name' );
+
+		$this->assertEquals( 4, $query->found_posts );
+
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_1_jpeg ), $attachment_names );
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_2_jpeg ), $attachment_names );
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_3_pdf ), $attachment_names );
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_4_png ), $attachment_names );
+
+		$args = array(
+			'ep_integrate'   => true,
+			'post_mime_type' => array(
+				'image/png',
+			),
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+		);
+
+		$query = new \WP_Query( $args );
+
+		$attachment_names = wp_list_pluck( $query->posts, 'post_name' );
+
+		$this->assertEquals( 1, $query->found_posts );
+
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_4_png ), $attachment_names );
 	}
 
 	/**
@@ -5254,7 +5311,49 @@ class TestPost extends BaseTestCase {
 			$query
 		);
 
+		$this->assertCount( 1, $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] );
 		$this->assertSame( 'image/jpeg', $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'][0] );
+
+		$args = $post->format_args(
+			[
+				'post_mime_type' => [ 'image/jpeg', 'application/pdf' ],
+			],
+			$query
+		);
+
+		$this->assertCount( 2, $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] );
+		$this->assertContains( 'image/jpeg', $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] );
+		$this->assertContains( 'application/pdf', $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] );
+
+		$args = $post->format_args(
+			[
+				'post_mime_type' => [ 'image' ],
+			],
+			$query
+		);
+
+		$this->assertGreaterThan( 1, count( $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] ) );
+		$this->assertContains( 'image/jpeg', $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] );
+
+		$args = $post->format_args(
+			[
+				'post_mime_type' => [ 'image', 'application/pdf' ],
+			],
+			$query
+		);
+
+		$this->assertGreaterThan( 2, count( $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] ) );
+		$this->assertContains( 'image/jpeg', $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] );
+		$this->assertContains( 'application/pdf', $args['post_filter']['bool']['must'][0]['terms']['post_mime_type'] );
+
+		$args = $post->format_args(
+			[
+				'post_mime_type' => [],
+			],
+			$query
+		);
+
+		$this->assertArrayNotHasKey( 'terms', $args['post_filter']['bool']['must'][0] );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4000,6 +4000,21 @@ class TestPost extends BaseTestCase {
 
 		$args = array(
 			'ep_integrate'   => true,
+			'post_mime_type' => 'image/png',
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+		);
+
+		$query = new \WP_Query( $args );
+
+		$attachment_names = wp_list_pluck( $query->posts, 'post_name' );
+
+		$this->assertEquals( 1, $query->post_count );
+
+		$this->assertContains( get_post_field( 'post_name', $attachment_id_4_png ), $attachment_names );
+
+		$args = array(
+			'ep_integrate'   => true,
 			'post_mime_type' => array(
 				'image/jpeg',
 				'application/pdf',


### PR DESCRIPTION
### Description of the Change

This change updates the plugin to handle `post_mime_type` argument when it has an array with a MIME type without the subtype i.e `image` instead of `image/png`.

### Alternate Designs

### Benefits

It's possible to search images when using the Gutenberg editor or Web Stories plugin.

### Possible Drawbacks

### Verification Process

1. Enable document indexing
2. Enable admin and AJAX via `ep_admin_wp_query_integration` and `ep_ajax_wp_query_integration`
3. Edit a post with the block editor
4. Add a new image block to bring up the media modal
5. Use the search bar to search for an image
6. See the image

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes: #1604 #2206

### Changelog Entry

Fixed post_mime_type argument issue when it has an array with a MIME type without the subtype
<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
