### PR TITLE
bugfix: current_user_can check in Feature/SearchOrdering

### DIFF
--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -444,7 +444,7 @@ class SearchOrdering extends Feature {
 			return;
 		}
 
-		if ( ! current_user_can( 'edit_post', $post ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Requirements

none

### Description of the Change

`current_user_can` should only be passed simple strings/integer not complete objects.


### Alternate Designs

---

### Benefits

---

### Possible Drawbacks

---

### Verification Process

Found the Solution here:
https://wordpress.org/support/topic/object-of-class-wp_post-could-not-be-converted-to-string/


Tested in newest ElasticPress und WordPress Version.

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.


### Applicable Issues

none

### Changelog Entry

Fixed: Creating Custom Results with Feature "Sortable" enabled, could throw an error
