### PR TITLE
New Feature: search with boolean operators

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -153,6 +153,10 @@ function register_indexable_posts() {
 	Features::factory()->register_feature(
 		new Feature\SearchOrdering\SearchOrdering()
 	);
+
+	Features::factory()->register_feature(
+		new Feature\BooleanSearchOperators\BooleanSearchOperators()
+	);
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\register_indexable_posts' );
 

--- a/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
+++ b/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
@@ -73,7 +73,7 @@ class BooleanSearchOperators extends Feature {
 		}
 
 		if ( true === $query->query_vars['ep_integrate'] &&
-			 ( $this->is_active() || true === $query->query_vars['ep_boolean_operators'] ) ) {
+			( $this->is_active() || true === $query->query_vars['ep_boolean_operators'] ) ) {
 
 			\add_filter( 'ep_formatted_args_query', [ $this, 'replace_query_if_boolean' ], 999, 4 );
 		}
@@ -171,9 +171,9 @@ class BooleanSearchOperators extends Feature {
 				$search_text = \str_replace( array( ' AND ', ' OR ', ' NOT ' ), array( ' +', ' | ', ' -' ), $search_text );
 			} else {
 				$flags = explode( '|', $simple_query['simple_query_string']['flags'] );
-				$ops = array( 'AND', 'OR', 'NOT' );
+				$ops   = array( 'AND', 'OR', 'NOT' );
 
-				foreach( $ops as $flag ) {
+				foreach ( $ops as $flag ) {
 					if ( \in_array( $flag, $flags, true ) ) {
 						switch ( $flag ) {
 							case 'AND':

--- a/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
+++ b/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
@@ -62,7 +62,7 @@ class BooleanSearchOperators extends Feature {
 	 *
 	 * @hook   ep_elasticpress_enabled
 	 *
-	 * @param  {bool} $enabled Whether to integrate with Elasticsearch or not
+	 * @param  {bool}     $enabled Whether to integrate with Elasticsearch or not
 	 * @param  {WP_Query} $query WP_Query to evaluate
 	 *
 	 * @return bool
@@ -93,22 +93,132 @@ class BooleanSearchOperators extends Feature {
 	 *
 	 * @return array
 	 */
-	public function replace_query_if_boolean( $query, $args, $search_text, $search_fields ) {
+	public function replace_query_if_boolean( $query, $query_vars, $search_text, $search_fields ) {
 
 		if ( $this->query_uses_boolean_operators( $search_text ) ) {
-			$search_text = \str_replace( array( ' AND ', ' OR ', ' NOT ' ), array( ' +', ' | ', ' -' ), $search_text );
 
-			$simple_query_string = array(
+			$simple_query = array(
 				'simple_query_string' => array(
-					'query'                               => $search_text,
-					'fields'                              => \apply_filters( 'ep_boolean_operators_fields', $search_fields ),
-					'default_operator'                    => \apply_filters( 'ep_boolean_operators_default', 'OR' ),
-					'flags'                               => \apply_filters( 'ep_boolean_operators_flags', 'ALL' ),
-					'auto_generate_synonyms_phrase_query' => \apply_filters( 'ep_boolean_operators_generate_synonyms', true ),
+
+					/**
+					 * Filter the fields to use in boolean operator searches
+					 *
+					 * @hook    ep_boolean_operators_fields
+					 *
+					 * @param   {array} $search_fields
+					 * @param   {array}  $query_vars    Query variables
+					 * @param   {string} $search_text   Search text modified to replace tokens
+					 * @param   {array}  $search_fields Search fields
+					 * @param   {array}  $query         The original query
+					 *
+					 * @return  {array} New fields
+					 */
+					'fields'                              => \apply_filters( 'ep_boolean_operators_fields', $search_fields, $query_vars, $search_text, $query ),
+
+					/**
+					 * Filter the default boolean operator
+					 * Valid values: OR, AND
+					 *
+					 * @hook    ep_boolean_operators_default
+					 *
+					 * @param   {string} $default
+					 * @param   {array}  $query_vars    Query variables
+					 * @param   {string} $search_text   Search text modified to replace tokens
+					 * @param   {array}  $search_fields Search fields
+					 * @param   {array}  $query         The original query
+					 *
+					 * @return  {string} New operator
+					 */
+					'default_operator'                    => \apply_filters( 'ep_boolean_operators_default', 'OR', $query_vars, $search_text, $search_fields, $query ),
+
+					/**
+					 * Filter allowed boolean operators.
+					 * Valid flags: ALL, AND, ESCAPE, FUZZY, NEAR, NONE, NOT, OR, PHRASE, PRECEDENCE, PREFIX, SLOP, WHITESPACE
+					 * Must return a string with a single flag or use pipe separators, e.g.: 'OR|AND|PREFIX'
+					 *
+					 * @hook    ep_boolean_operators_flags
+					 *
+					 * @param   {string} $flags
+					 * @param   {array}  $query_vars    Query variables
+					 * @param   {string} $search_text   Search text modified to replace tokens
+					 * @param   {array}  $search_fields Search fields
+					 * @param   {array}  $query         The original query
+					 *
+					 * @return  {string} New flags
+					 */
+					'flags'                               => \apply_filters( 'ep_boolean_operators_flags', 'ALL', $query_vars, $search_text, $search_fields, $query ),
+
+					/**
+					 * Filter automatic synonym generation for boolean operators queries
+					 *
+					 * @hook    ep_boolean_operators_generate_synonyms
+					 *
+					 * @param   {bool} $auto_generate_synonyms
+					 * @param   {array}  $query_vars    Query variables
+					 * @param   {string} $search_text   Search text modified to replace tokens
+					 * @param   {array}  $search_fields Search fields
+					 * @param   {array}  $query         The original query
+					 *
+					 * @return  {bool} New fuzziness
+					 */
+					'auto_generate_synonyms_phrase_query' => \apply_filters( 'ep_boolean_operators_generate_synonyms', true, $query_vars, $search_text, $search_fields, $query ),
 				),
 			);
 
-			return \apply_filters( 'ep_boolean_operators_query_args', $simple_query_string, $args, $search_text, $search_fields, $query );
+			$original_text = $search_text;
+
+			if ( 'ALL' === $simple_query['simple_query_string']['flags'] ) {
+				$search_text = \str_replace( array( ' AND ', ' OR ', ' NOT ' ), array( ' +', ' | ', ' -' ), $search_text );
+			} else {
+				$flags = explode( '|', $simple_query['simple_query_string']['flags'] );
+				$ops = array( 'AND', 'OR', 'NOT' );
+
+				foreach( $ops as $flag ) {
+					if ( \in_array( $flag, $flags, true ) ) {
+						switch ( $flag ) {
+							case 'AND':
+								$search_text = \str_replace( " $flag ", ' +', $search_text );
+								break;
+							case 'OR':
+								$search_text = \str_replace( " $flag ", ' | ', $search_text );
+								break;
+							case 'NOT':
+								$search_text = \str_replace( " $flag ", ' -', $search_text );
+								break;
+						}
+					}
+				}
+			}
+
+			/**
+			 * Filter the search text to use in boolean operator queries
+			 *
+			 * @hook    ep_boolean_operators_search_text
+			 *
+			 * @param   {string} $search_text   Search text modified to replace tokens
+			 * @param   {string} $original_text The original search text
+			 * @param   {array}  $query_vars    Query variables
+			 * @param   {array}  $search_fields Search fields
+			 * @param   {array}  $query         The original query
+			 *
+			 * @return  {string} New search text
+			 */
+			$simple_query['simple_query_string']['query'] = \apply_filters( 'ep_boolean_operators_search_text', $search_text, $original_text, $query_vars, $search_fields, $query );
+
+			/**
+			 * Filter formatted Elasticsearch simple query string query (only contains query part)
+			 *
+			 * @hook   ep_boolean_operators_query_args
+			 *
+			 * @param  {array}  $simple_query  Current query
+			 * @param  {array}  $query_vars    Query variables
+			 * @param  {string} $search_text   Search text modified to replace tokens
+			 * @param  {array}  $search_fields Search fields
+			 * @param  {array}  $query         The original query
+			 *
+			 * @return {array} New query
+			 */
+			return \apply_filters( 'ep_boolean_operators_query_args', $simple_query, $query_vars, $search_text, $search_fields, $query );
 		}
 
 		return $query;
@@ -193,13 +303,16 @@ class BooleanSearchOperators extends Feature {
 		<p><?php esc_html_e( 'Allows users to search using the following boolean operators:', 'elasticpress' ); ?></p>
 		<ul>
 			<li>
-				<code>+</code> or <code>AND</code> <?php esc_html_e( 'signifies AND operation. eg.: modern +art, modern AND art', 'elasticpress' ); ?>
+				<code>+</code> or
+				<code>AND</code> <?php esc_html_e( 'signifies AND operation. eg.: modern +art, modern AND art', 'elasticpress' ); ?>
 			</li>
 			<li>
-				<code>|</code> or <code>OR</code> <?php esc_html_e( 'signifies OR operation. eg.: modern | art, modern OR art', 'elasticpress' ); ?>
+				<code>|</code> or
+				<code>OR</code> <?php esc_html_e( 'signifies OR operation. eg.: modern | art, modern OR art', 'elasticpress' ); ?>
 			</li>
 			<li>
-				<code>-</code> or <code>NOT</code> <?php esc_html_e( 'signifies NOT operation. eg.: modern -art, modern NOT art', 'elasticpress' ); ?>
+				<code>-</code> or
+				<code>NOT</code> <?php esc_html_e( 'signifies NOT operation. eg.: modern -art, modern NOT art', 'elasticpress' ); ?>
 			</li>
 			<li>
 				<code>"</code> <?php esc_html_e( 'wraps characters to signify a phrase. eg.: "modern art"', 'elasticpress' ); ?>

--- a/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
+++ b/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Boolean Search Operators Feature
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPress\Feature\BooleanSearchOperators;
+
+use ElasticPress\Feature;
+use ElasticPress\FeatureRequirementsStatus as FeatureRequirementsStatus;
+use ElasticPress\Features;
+use ElasticPress\Indexable\Post\Post;
+use ElasticPress\Indexables;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Boolean Search Feature
+ *
+ * @package ElasticPress\Feature\BooleanSearch
+ */
+class BooleanSearchOperators extends Feature {
+
+	/**
+	 * Initialize feature setting it's config
+	 */
+	public function __construct() {
+		$this->slug = 'booleansearchoperators';
+
+		$this->title = esc_html__( 'Boolean Search Operators', 'elasticpress' );
+
+		$this->requires_install_reindex = false;
+		$this->default_settings         = [
+				'active' => false,
+		];
+
+		parent::__construct();
+	}
+
+	/**
+	 * Setup Feature Functionality
+	 */
+	public function setup() {
+		/** Features Class @var Features $features */
+		$features = Features::factory();
+
+		/** Search Feature @var Feature\Search\Search $search */
+		$search = $features->get_registered_feature( 'search' );
+
+		if ( ! $search->is_active() && $this->is_active() ) {
+			$features->deactivate_feature( $this->slug );
+
+			return false;
+		}
+
+		add_filter( 'ep_elasticpress_enabled', [ $this, 'integrate_boolean_search_operators' ], 10, 2 );
+	}
+
+	public function integrate_boolean_search_operators( $enabled, $query ) {
+		if ( ! $enabled ) {
+			return;
+		}
+
+		if ( true === $query->query_vars['ep_integrate'] &&
+			 ( $this->is_active() || true === $query->query_vars['ep_boolean_search'] ) ) {
+
+			\add_filter( 'ep_formatted_args_query', [ $this, 'format_boolean_query_args' ], 999, 4 );
+		}
+	}
+
+	public function format_boolean_query_args( $query, $args, $search_text, $search_fields ) {
+		$boolean_query = array(
+			'simple_query_string' => array(
+				'query'            => $search_text,
+				'fields'           => $search_fields,
+				'default_operator' => \apply_filters( 'ep_boolean_operators_default', 'OR' ),
+			),
+		);
+
+		return $boolean_query;
+	}
+
+	/**
+	 * Returns requirements status of feature
+	 *
+	 * Requires the search feature to be activated
+	 *
+	 * @return FeatureRequirementsStatus
+	 */
+	public function requirements_status() {
+		/** Features Class @var Features $features */
+		$features = Features::factory();
+
+		/** Search Feature @var Feature\Search\Search $search */
+		$search = $features->get_registered_feature( 'search' );
+
+		if ( ! $search->is_active() ) {
+			return new FeatureRequirementsStatus( 2, esc_html__( 'This feature requires the "Post Search" feature to be enabled', 'elasticpress' ) );
+		}
+
+		return parent::requirements_status();
+	}
+
+	/**
+	 * Output feature box summary
+	 */
+	public function output_feature_box_summary() {
+		?>
+		<p><?php esc_html_e( 'Use boolean operators for search queries', 'elasticpress' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Output feature box long
+	 */
+	public function output_feature_box_long() {
+		?>
+		<p><?php esc_html_e( 'Allows users to search using boolean operators: +, |, -, "", *, (), ~#', 'elasticpress' ); ?></p>
+		<?php
+	}
+}

--- a/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
+++ b/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
@@ -32,7 +32,7 @@ class BooleanSearchOperators extends Feature {
 
 		$this->requires_install_reindex = false;
 		$this->default_settings         = [
-				'active' => false,
+			'active' => false,
 		];
 
 		parent::__construct();
@@ -72,13 +72,15 @@ class BooleanSearchOperators extends Feature {
 	public function format_boolean_query_args( $query, $args, $search_text, $search_fields ) {
 		$boolean_query = array(
 			'simple_query_string' => array(
-				'query'            => $search_text,
-				'fields'           => \apply_filters( 'ep_boolean_operators_fields', $search_fields ),
-				'default_operator' => \apply_filters( 'ep_boolean_operators_default', 'OR' ),
+				'query'                               => $search_text,
+				'fields'                              => \apply_filters( 'ep_boolean_operators_fields', $search_fields ),
+				'default_operator'                    => \apply_filters( 'ep_boolean_operators_default', 'OR' ),
+				'flags'                               => \apply_filters( 'ep_boolean_operators_flags', 'ALL' ),
+				'auto_generate_synonyms_phrase_query' => \apply_filters( 'ep_boolean_operators_generate_synonyms', true ),
 			),
 		);
 
-		return $boolean_query;
+		return \apply_filters( 'ep_boolean_operators_query_args', $boolean_query, $args, $search_text, $search_fields, $query );
 	}
 
 	/**

--- a/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
+++ b/includes/classes/Feature/BooleanSearchOperators/BooleanSearchOperators.php
@@ -8,10 +8,8 @@
 namespace ElasticPress\Feature\BooleanSearchOperators;
 
 use ElasticPress\Feature;
-use ElasticPress\FeatureRequirementsStatus as FeatureRequirementsStatus;
+use ElasticPress\FeatureRequirementsStatus;
 use ElasticPress\Features;
-use ElasticPress\Indexable\Post\Post;
-use ElasticPress\Indexables;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -28,7 +26,7 @@ class BooleanSearchOperators extends Feature {
 	 * Initialize feature setting it's config
 	 */
 	public function __construct() {
-		$this->slug = 'booleansearchoperators';
+		$this->slug = 'boolean_search_operators';
 
 		$this->title = esc_html__( 'Boolean Search Operators', 'elasticpress' );
 
@@ -75,7 +73,7 @@ class BooleanSearchOperators extends Feature {
 		$boolean_query = array(
 			'simple_query_string' => array(
 				'query'            => $search_text,
-				'fields'           => $search_fields,
+				'fields'           => \apply_filters( 'ep_boolean_operators_fields', $search_fields ),
 				'default_operator' => \apply_filters( 'ep_boolean_operators_default', 'OR' ),
 			),
 		);


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Introduces a new feature to allow using Boolean Search Operators such as `+ | - () * ~N` in search queries.

This is an optional feature and should be disabled when first introduced. Users can opt-in to the feature globally using the ElasticPress Features dashboard, or on individual queries by setting `$wp_query->ep_boolean_operators = true`.

When activated, the feature hooks into `ep_formatted_args_query` and replaces the default `multi_match` queries with Elasticsearch native [`simple_query_string` queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html).

#### Syntax 
- \+ signifies AND operation
- | signifies OR operation
- \- negates a single token
- \" wraps a number of tokens to signify a phrase for searching
- \* at the end of a term signifies a prefix query
- ( and ) signify precedence
- ~N after a word signifies edit distance (fuzziness)
- ~N after a phrase signifies slop amount

To use one of these characters literally, escape it with a preceding backslash (\).

This implementation also detects the use of uppercase `AND`, `OR` and `NOT` queries and replaces them with their proper counterparts: `+`, `|` and `-` when preparing the ES query. If no boolean operators are found in the search text, the feature is not activated and the query continues as a regular ElasticPress query.

### Benefits

<!-- What benefits will be realized by the code change? -->

`simple_query_string` queries are transformed internally into `match_phrase` queries. This allows for easier control of phrase matches using "google-like" queries (such as using quotes for phrases), as well as for more "academic-like" queries to be used in museums, libraries, or just to allow more control, while still allowing for the power of `match` queries to find partial results, fuzziness and slop, among other features.

Includes direct filters to change the most important top-level parameters as well as a catch-all filter allowing the query to be freely modified.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None. This feature is opt-in and will be inactive unless explicitly required.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

Fixes: #2039 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Added: Feature - Search with Boolean Operators
