### PR TITLE
Add aria-labels and title attributes to icon hyperlinks in the header toolbar

### DIFF
--- a/includes/partials/header.php
+++ b/includes/partials/header.php
@@ -22,14 +22,14 @@ $base_url = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ? admin_url( 'networ
 	<div class="icons">
 		<span class="sync-status"></span>
 		<?php if ( in_array( Screen::factory()->get_current_screen(), [ 'dashboard', 'settings', 'health' ], true ) ) : ?>
-			<a class="dashicons pause-sync dashicons-controls-pause"></a>
-			<a class="dashicons resume-sync dashicons-controls-play"></a>
-			<a class="dashicons cancel-sync dashicons-no"></a>
+			<a class="dashicons pause-sync dashicons-controls-pause" title="<?php esc_html_e( 'Pause Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Pause Sync', 'elasticpress' ); ?>"></a>
+			<a class="dashicons resume-sync dashicons-controls-play" title ="<?php esc_html_e( 'Resume Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Resume Sync', 'elasticpress' ); ?>"></a>
+			<a class="dashicons cancel-sync dashicons-no" title="<?php esc_html_e( 'Cancel Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Cancel Sync', 'elasticpress' ); ?>"></a>
 			<?php if ( Elasticsearch::factory()->get_elasticsearch_version() && defined( 'EP_DASHBOARD_SYNC' ) && EP_DASHBOARD_SYNC ) : ?>
-				<a class="dashicons start-sync dashicons-update"></a>
+				<a class="dashicons start-sync dashicons-update" title="<?php esc_html_e( 'Start Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Start Sync', 'elasticpress' ); ?>"></a>
 			<?php endif; ?>
 		<?php endif; ?>
-		<a href="<?php echo esc_url( $base_url . 'elasticpress-settings' ); ?>" class="dashicons dashicons-admin-generic"></a>
+		<a href="<?php echo esc_url( $base_url . 'elasticpress-settings' ); ?>" class="dashicons dashicons-admin-generic" title="<?php esc_html_e( 'Settings', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Settings', 'elasticpress' ); ?>"></a>
 	</div>
 
 	<div class="progress-bar"></div>

--- a/includes/partials/header.php
+++ b/includes/partials/header.php
@@ -22,14 +22,14 @@ $base_url = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ? admin_url( 'networ
 	<div class="icons">
 		<span class="sync-status"></span>
 		<?php if ( in_array( Screen::factory()->get_current_screen(), [ 'dashboard', 'settings', 'health' ], true ) ) : ?>
-			<a class="dashicons pause-sync dashicons-controls-pause" title="<?php esc_html_e( 'Pause Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Pause Sync', 'elasticpress' ); ?>"></a>
-			<a class="dashicons resume-sync dashicons-controls-play" title ="<?php esc_html_e( 'Resume Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Resume Sync', 'elasticpress' ); ?>"></a>
-			<a class="dashicons cancel-sync dashicons-no" title="<?php esc_html_e( 'Cancel Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Cancel Sync', 'elasticpress' ); ?>"></a>
+			<a class="dashicons pause-sync dashicons-controls-pause" title="<?php esc_attr_e( 'Pause Sync', 'elasticpress' ); ?>" aria-label="<?php esc_attr_e( 'Pause Sync', 'elasticpress' ); ?>"></a>
+			<a class="dashicons resume-sync dashicons-controls-play" title ="<?php esc_attr_e( 'Resume Sync', 'elasticpress' ); ?>" aria-label="<?php esc_attr_e( 'Resume Sync', 'elasticpress' ); ?>"></a>
+			<a class="dashicons cancel-sync dashicons-no" title="<?php esc_attr_e( 'Cancel Sync', 'elasticpress' ); ?>" aria-label="<?php esc_attr_e( 'Cancel Sync', 'elasticpress' ); ?>"></a>
 			<?php if ( Elasticsearch::factory()->get_elasticsearch_version() && defined( 'EP_DASHBOARD_SYNC' ) && EP_DASHBOARD_SYNC ) : ?>
-				<a class="dashicons start-sync dashicons-update" title="<?php esc_html_e( 'Start Sync', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Start Sync', 'elasticpress' ); ?>"></a>
+				<a class="dashicons start-sync dashicons-update" title="<?php esc_attr_e( 'Start Sync', 'elasticpress' ); ?>" aria-label="<?php esc_attr_e( 'Start Sync', 'elasticpress' ); ?>"></a>
 			<?php endif; ?>
 		<?php endif; ?>
-		<a href="<?php echo esc_url( $base_url . 'elasticpress-settings' ); ?>" class="dashicons dashicons-admin-generic" title="<?php esc_html_e( 'Settings', 'elasticpress' ); ?>" aria-label="<?php esc_html_e( 'Settings', 'elasticpress' ); ?>"></a>
+		<a href="<?php echo esc_url( $base_url . 'elasticpress-settings' ); ?>" class="dashicons dashicons-admin-generic" title="<?php esc_attr_e( 'Settings', 'elasticpress' ); ?>" aria-label="<?php esc_attr_e( 'Settings', 'elasticpress' ); ?>"></a>
 	</div>
 
 	<div class="progress-bar"></div>


### PR DESCRIPTION
### Description of the Change

Issue #2286 

### Alternate Designs

This was the least intrusive option. The second option would be tooltips on each icon which would require additional javascript. The third option would be to add a text label just below the icon which probably involves some sort of design change and sign-off.

### Benefits

1. Screen readers will be able to identify the links
2. New users will understand the icon's function before selecting it

### Verification Process

To verify, I went to the wp-admin dashboard for the plugin and hovered over each icon to see the title attribute.

Also ran `composer run lint-fix` in my editor to make sure my code formatting was correct.

### Checklist:

- [X ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Add title attributes and aria-labels to each icon hyperlink in the header toolbar
