### PR TITLE
Fix: WP Acceptance tests and Page Crashed errors tolerance

### DIFF
--- a/run-wpacceptance.sh
+++ b/run-wpacceptance.sh
@@ -126,7 +126,7 @@ for i in $(seq 1 $ATTEMPTS); do
     TOTAL_ERRORS_COUNT=$(echo "${SUMMARY}" | grep '✘' | wc -l )
 
     # Get the Page Crashed errors
-    PAGE_CRASHED_ERRORS=$(echo "${SUMMARY}" | grep -Pzo '✘(.|\n)*?Page crashed' | tr '\0' '\n' | grep '✘' )
+    PAGE_CRASHED_ERRORS=$(echo "${SUMMARY}" | grep -Pzo '✘([^✘☢])*?Page crashed' | tr '\0' '\n' | grep '✘' )
     PAGE_CRASHED_ERRORS_COUNT=$(echo "${PAGE_CRASHED_ERRORS}" | wc -l )
 
     if [ $TOTAL_ERRORS_COUNT -gt $PAGE_CRASHED_ERRORS_COUNT ]; then


### PR DESCRIPTION
### Description of the Change

This PR changes the regex used to get Page Crashed errors from WP Acceptance tests.

### Applicable Issues

Closes #2311

### Changelog Entry

Fixed: WP Acceptance tests and Page Crashed errors