### PR TITLE
Update mappings

### DIFF
--- a/includes/mappings/comment/7-0.php
+++ b/includes/mappings/comment/7-0.php
@@ -112,7 +112,7 @@ return [
 					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
-					'type'     => 'edgeNGram',
+					'type'     => 'edge_ngram',
 				],
 			],
 			'normalizer' => [
@@ -131,7 +131,6 @@ return [
 					'path_match' => 'meta.*',
 					'mapping'    => [
 						'type'       => 'object',
-						'path'       => 'full',
 						'properties' => [
 							'value'    => [
 								'type'   => 'text',

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -113,7 +113,7 @@ return array(
 					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
-					'type'     => 'edgeNGram',
+					'type'     => 'edge_ngram',
 				),
 			),
 			'normalizer' => array(
@@ -135,7 +135,6 @@ return array(
 					'path_match' => 'post_meta.*',
 					'mapping'    => array(
 						'type'   => 'text',
-						'path'   => 'full',
 						'fields' => array(
 							'{name}' => array(
 								'type' => 'text',
@@ -153,7 +152,6 @@ return array(
 					'path_match' => 'meta.*',
 					'mapping'    => array(
 						'type'       => 'object',
-						'path'       => 'full',
 						'properties' => array(
 							'value'    => array(
 								'type'   => 'text',
@@ -203,7 +201,6 @@ return array(
 					'path_match' => 'terms.*',
 					'mapping'    => array(
 						'type'       => 'object',
-						'path'       => 'full',
 						'properties' => array(
 							'name'             => array(
 								'type'   => 'text',

--- a/includes/mappings/term/7-0.php
+++ b/includes/mappings/term/7-0.php
@@ -60,7 +60,7 @@ return [
 					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
-					'type'     => 'edgeNGram',
+					'type'     => 'edge_ngram',
 				],
 			],
 			'normalizer' => [
@@ -79,7 +79,6 @@ return [
 					'path_match' => 'meta.*',
 					'mapping'    => [
 						'type'       => 'object',
-						'path'       => 'full',
 						'properties' => [
 							'value'    => [
 								'type'   => 'text',

--- a/includes/mappings/user/7-0.php
+++ b/includes/mappings/user/7-0.php
@@ -112,7 +112,7 @@ return array(
 					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
-					'type'     => 'edgeNGram',
+					'type'     => 'edge_ngram',
 				),
 			),
 			'normalizer' => array(
@@ -131,7 +131,6 @@ return array(
 					'path_match' => 'meta.*',
 					'mapping'    => array(
 						'type'       => 'object',
-						'path'       => 'full',
 						'properties' => array(
 							'value'    => array(
 								'type'   => 'text',
@@ -181,7 +180,6 @@ return array(
 					'path_match' => 'capabilities.*',
 					'mapping'    => array(
 						'type'       => 'object',
-						'path'       => 'full',
 						'properties' => array(
 							'roles' => array(
 								'type' => 'keyword',


### PR DESCRIPTION
### Description of the Change

When applying mappings we get following warnings on ES - 7.8.0

```
Warning: 299 Elasticsearch-7.8.0-757314695644ea9a1dc2fecd26d1a43856725e65 &quot;The [edgeNGram] token filter name is deprecated and will be removed in a future version. Please change the filter name to [edge_ngram] instead.&quot; in /wp/wp-content/mu-plugins/search/includes/classes/class-search.php on line 765 [$ /usr/local/bin/wp vip-search index --setup] [wp-content/mu-plugins/search/includes/classes/class-search.php:765 trigger_error(), wp-includes/class-wp-hook.php:292 Automattic\VIP\Search\Search->filter__ep_do_intercept_request(), wp-includes/plugin.php:212 WP_Hook->apply_filters(), wp-content/mu-plugins/search/elasticpress/includes/classes/Elasticsearch.php:1155 apply_filters('ep_do_intercept_request'), wp-content/mu-plugins/search/elasticpress/includes/classes/Elasticsearch.php:785 ElasticPress\Elasticsearch->remote_request(), wp-content/mu-plugins/search/elasticpress/includes/classes/Indexable/Post/Post.php:247 ElasticPress\Elasticsearch->put_mapping(), wp-content/mu-plugins/search/elasticpress/includes/classes/Command.php:263 ElasticPress\Indexable\Post\Post->put_mapping(), wp-content/mu-plugins/search/elasticpress/includes/classes/Command.php:619 ElasticPress\Command->put_mapping_helper(), ElasticPress\Command->index(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:399 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/class-wp-cli.php:1391 WP_CLI\Runner->run_command(), wp-content/mu-plugins/search/includes/classes/commands/class-corecommand.php:198 WP_CLI::run_command(), Automattic\VIP\Search\Commands\CoreCommand->index(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:399 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:422 WP_CLI\Runner->run_command(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1194 WP_CLI\Runner->run_command_and_exit(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23 WP_CLI\Runner->start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:77 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:11 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
Warning: 299 Elasticsearch-7.8.0-757314695644ea9a1dc2fecd26d1a43856725e65 &quot;dynamic template [template_meta_types] has invalid content [{\&quot;path_match\&quot;:\&quot;meta.*\&quot;,\&quot;mapping\&quot;:{\&quot;path\&quot;:\&quot;full\&quot;,\&quot;properties\&quot;:{\&quot;date\&quot;:{\&quot;format\&quot;:\&quot;yyyy-MM-dd\&quot;,\&quot;type\&quot;:\&quot;date\&quot;},\&quot;datetime\&quot;:{\&quot;format\&quot;:\&quot;yyyy-MM-dd HH:mm:ss\&quot;,\&quot;type\&quot;:\&quot;date\&quot;},\&quot;boolean\&quot;:{\&quot;type\&quot;:\&quot;boolean\&quot;},\&quot;double\&quot;:{\&quot;type\&quot;:\&quot;double\&quot;},\&quot;raw\&quot;:{\&quot;ignore_above\&quot;:10922,\&quot;type\&quot;:\&quot;keyword\&quot;},\&quot;time\&quot;:{\&quot;format\&quot;:\&quot;HH:mm:ss\&quot;,\&quot;type\&quot;:\&quot;date\&quot;},\&quot;value\&quot;:{\&quot;type\&quot;:\&quot;text\&quot;,\&quot;fields\&quot;:{\&quot;raw\&quot;:{\&quot;ignore_above\&quot;:10922,\&quot;type\&quot;:\&quot;keyword\&quot;},\&quot;sortable\&quot;:{\&quot;normalizer\&quot;:\&quot;lowerasciinormalizer\&quot;,\&quot;ignore_above\&quot;:10922,\&quot;type\&quot;:\&quot;keyword\&quot;}}},\&quot;long\&quot;:{\&quot;type\&quot;:\&quot;long\&quot;}},\&quot;type\&quot;:\&quot;object\&quot;}}], caused by [Unused mapping attributes [{path=full}]]&quot; in /wp/wp-content/mu-plugins/search/includes/classes/class-search.php on line 765 [$ /usr/local/bin/wp vip-search index --setup] [wp-content/mu-plugins/search/includes/classes/class-search.php:765 trigger_error(), wp-includes/class-wp-hook.php:292 Automattic\VIP\Search\Search->filter__ep_do_intercept_request(), wp-includes/plugin.php:212 WP_Hook->apply_filters(), wp-content/mu-plugins/search/elasticpress/includes/classes/Elasticsearch.php:1155 apply_filters('ep_do_intercept_request'), wp-content/mu-plugins/search/elasticpress/includes/classes/Elasticsearch.php:785 ElasticPress\Elasticsearch->remote_request(), wp-content/mu-plugins/search/elasticpress/includes/classes/Indexable/Post/Post.php:247 ElasticPress\Elasticsearch->put_mapping(), wp-content/mu-plugins/search/elasticpress/includes/classes/Command.php:263 ElasticPress\Indexable\Post\Post->put_mapping(), wp-content/mu-plugins/search/elasticpress/includes/classes/Command.php:619 ElasticPress\Command->put_mapping_helper(), ElasticPress\Command->index(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:399 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/class-wp-cli.php:1391 WP_CLI\Runner->run_command(), wp-content/mu-plugins/search/includes/classes/commands/class-corecommand.php:198 WP_CLI::run_command(), Automattic\VIP\Search\Commands\CoreCommand->index(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:399 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:422 WP_CLI\Runner->run_command(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1194 WP_CLI\Runner->run_command_and_exit(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23 WP_CLI\Runner->start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:77 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:11 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
Warning: 299 Elasticsearch-7.8.0-757314695644ea9a1dc2fecd26d1a43856725e65 &quot;dynamic template [template_terms] has invalid content [{\&quot;path_match\&quot;:\&quot;terms.*\&quot;,\&quot;mapping\&quot;:{\&quot;path\&quot;:\&quot;full\&quot;,\&quot;properties\&quot;:{\&quot;parent\&quot;:{\&quot;type\&quot;:\&quot;long\&quot;},\&quot;name\&quot;:{\&quot;type\&quot;:\&quot;text\&quot;,\&quot;fields\&quot;:{\&quot;raw\&quot;:{\&quot;type\&quot;:\&quot;keyword\&quot;},\&quot;sortable\&quot;:{\&quot;normalizer\&quot;:\&quot;lowerasciinormalizer\&quot;,\&quot;type\&quot;:\&quot;keyword\&quot;}}},\&quot;term_taxonomy_id\&quot;:{\&quot;type\&quot;:\&quot;long\&quot;},\&quot;term_order\&quot;:{\&quot;type\&quot;:\&quot;long\&quot;},\&quot;term_id\&quot;:{\&quot;type\&quot;:\&quot;long\&quot;},\&quot;facet\&quot;:{\&quot;type\&quot;:\&quot;keyword\&quot;},\&quot;slug\&quot;:{\&quot;type\&quot;:\&quot;keyword\&quot;}},\&quot;type\&quot;:\&quot;object\&quot;}}], caused by [Unused mapping attributes [{path=full}]]&quot; in /wp/wp-content/mu-plugins/search/includes/classes/class-search.php on line 765 [$ /usr/local/bin/wp vip-search index --setup] [wp-content/mu-plugins/search/includes/classes/class-search.php:765 trigger_error(), wp-includes/class-wp-hook.php:292 Automattic\VIP\Search\Search->filter__ep_do_intercept_request(), wp-includes/plugin.php:212 WP_Hook->apply_filters(), wp-content/mu-plugins/search/elasticpress/includes/classes/Elasticsearch.php:1155 apply_filters('ep_do_intercept_request'), wp-content/mu-plugins/search/elasticpress/includes/classes/Elasticsearch.php:785 ElasticPress\Elasticsearch->remote_request(), wp-content/mu-plugins/search/elasticpress/includes/classes/Indexable/Post/Post.php:247 ElasticPress\Elasticsearch->put_mapping(), wp-content/mu-plugins/search/elasticpress/includes/classes/Command.php:263 ElasticPress\Indexable\Post\Post->put_mapping(), wp-content/mu-plugins/search/elasticpress/includes/classes/Command.php:619 ElasticPress\Command->put_mapping_helper(), ElasticPress\Command->index(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:399 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/class-wp-cli.php:1391 WP_CLI\Runner->run_command(), wp-content/mu-plugins/search/includes/classes/commands/class-corecommand.php:198 WP_CLI::run_command(), Automattic\VIP\Search\Commands\CoreCommand->index(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100 call_user_func(), WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491 call_user_func(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:399 WP_CLI\Dispatcher\Subcommand->invoke(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:422 WP_CLI\Runner->run_command(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1194 WP_CLI\Runner->run_command_and_exit(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23 WP_CLI\Runner->start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:77 WP_CLI\Bootstrap\LaunchRunner->process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:11 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
```

These changes are addressing the issues by:
* renaming `edgeNGram` (deprecated) -> `edge_ngram`  (which is [supported](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/analysis-edgengram-tokenfilter.html) at least in all 7.x versions)
* dropping unknown attribute `path` under mapping in dynamic_templates

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
