### PR TITLE
Update PHP Version info (5.4 -> 5.6)

### DIFF
--- a/.github/hookdoc-tmpl/README.md
+++ b/.github/hookdoc-tmpl/README.md
@@ -2,9 +2,9 @@
 
 ElasticPress, a fast and flexible search and query engine for WordPress, enables WordPress to find or “query” relevant content extremely fast through a variety of highly customizable features. WordPress out-of-the-box struggles to analyze content relevancy and can be very slow. ElasticPress supercharges your WordPress website making for happier users and administrators. The plugin even contains features for popular plugins.
 
-**ElasticPress 3.0:** ElasticPress 3.0 contains major changes from 2.x including a rewrite of the feature registration API and PHP 5.4+ features. If you have problems upgrading, please create an issue.
+**ElasticPress 3.0:** ElasticPress 3.0 contains major changes from 2.x including a rewrite of the feature registration API and PHP 5.4+ features. If you have problems upgrading, please create an issue. The minimum PHP version for ElasticPress 3.6.2 is 5.6.
 
-**Please note:** master is the stable branch on GitHub.
+**Please note:** currently, `master` is the stable branch on GitHub. The upcoming ElasticPress 3.7.0 release will remove built assets from the `develop` branch, will replace `master` with `trunk`, will build a stable release version including built assets into a `stable` branch, and will include a build script should you want to build assets from a branch.
 
 **Upgrade Notice:** Versions 1.6.1, 1.6.2, 1.7, 1.8, 2.1, 2.1.2, 2.2, 2.7, 3.0, 3.1, and 3.3 require re-syncing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased]
 
+## [3.6.2] - TBD
+
+**Note that the upcoming ElasticPress 3.7.0 release will remove built assets from the `develop` branch, will replace `master` with `trunk`, will build a stable release version including built assets into a `stable` branch, and will include a build script should you want to build assets from a branch.**  As such, please plan to update any references you have from `master` to either `stable` or `trunk` depending on whether you require built assets or not.
+
+This version bumps official support to PHP 5.6+. Minimum PHP version for ElasticPress 3.7.0 will be 7.0+.
+
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [3.6.1] - 2021-07-15
 **Note that the upcoming ElasticPress 3.7.0 release will remove built assets from the `develop` branch, will replace `master` with `trunk`, will build a stable release version including built assets into a `stable` branch, and will include a build script should you want to build assets from a branch.**  As such, please plan to update any references you have from `master` to either `stable` or `trunk` depending on whether you require built assets or not.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ElasticPress has an in depth documentation site. [Visit the docs ☞](http://10u
 
 * [Elasticsearch](https://www.elastic.co) 5.0+ **ElasticSearch max version supported: 7.9**
 * [WordPress](http://wordpress.org) 3.7.1+
-* [PHP](https://php.net/) 5.4+
+* [PHP](https://php.net/) 5.6+
 
 ## React Components
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 * [Elasticsearch](https://www.elastic.co) 5.0+ **ElasticSearch max version supported: 7.9**
 * [WordPress](http://wordpress.org) 3.7.1+
-* [PHP](https://php.net/) 5.4+
+* [PHP](https://php.net/) 5.6+
 * A properly configured web server with object caching is highly recommended.
 
 ## Install Steps

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -5,7 +5,7 @@
  * Description:       A fast and flexible search and query engine for WordPress.
  * Version:           3.6.1
  * Requires at least: 3.7.1
- * Requires PHP:      5.4
+ * Requires PHP:      5.6
  * Author:            10up
  * Author URI:        http://10up.com
  * License:           GPL v2 or later


### PR DESCRIPTION
### Description of the Change

This PR updates all references to the minimum PHP version required by the plugin.

### Applicable Issues

Closes #2292

### Changelog Entry

Changed: Minimum supported version of PHP bumped to 5.6.