### PR TITLE
Fix category slug used when doing cat Tax Query with ID

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1000,7 +1000,8 @@ class Post extends Indexable {
 		$taxonomies = get_taxonomies( array(), 'objects' );
 
 		foreach ( $taxonomies as $tax_slug => $tax ) {
-			if ( $tax->query_var && ! empty( $args[ $tax->query_var ] ) ) {
+			// Exclude the category taxonomy from this check if we are performing a Tax Query as category_name will be set by core
+			if ( $tax->query_var && ! empty( $args[ $tax->query_var ] ) && 'category' !== $tax->name ) {
 				$args['tax_query'][] = array(
 					'taxonomy' => $tax_slug,
 					'terms'    => (array) $args[ $tax->query_var ],

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -6196,4 +6196,39 @@ class TestPost extends BaseTestCase {
 		$this->assertArrayHasKey( 'second', $return_prepare_date_terms );
 		$this->assertArrayHasKey( 'm', $return_prepare_date_terms );
 	}
+
+	/**
+	 * Test when we perform a Tax Query with Id's for the category taxonomy cat id is used and cat slug is not.
+	 *
+	 * @return void
+	 * @group  post
+	 */
+	public function testTaxQueryWithCategoryId() {
+		$cat = wp_create_category( 'test category' );
+
+		$query = new \WP_Query();
+
+		$post = new \ElasticPress\Indexable\Post\Post();
+
+		$args = $post->format_args(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'public',
+				'ep_integrate' => true,
+				'tax_query'    => array(
+					array(
+						'taxonomy' => 'category',
+						'terms'    => array( $cat ),
+						'field'    => 'term_id',
+						'operator' => 'in',
+					)
+				)
+			],
+			$query
+		);
+
+		$this->assertCount( 1, $args['post_filter']['bool']['must'][0]['bool']['must'] );
+		$this->assertArrayHasKey( 'terms.category.term_id', $args['post_filter']['bool']['must'][0]['bool']['must'][0]['terms'] );
+		$this->assertContains( $cat, $args['post_filter']['bool']['must'][0]['bool']['must'][0]['terms']['terms.category.term_id'] );
+	}
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixes #2242 

As WordPress core sets the category_name parameter when performing a Tax Query if you are doing an id's search, this conflicts with this check EP does here: https://github.com/10up/ElasticPress/blob/develop/includes/classes/Indexable/Post/Post.php#L1003

This problem only applies to the category taxonomy.


<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
