### PR TITLE
Start of InstantSearch feature. Saving a template to EP.io.

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -153,6 +153,10 @@ function register_indexable_posts() {
 	Features::factory()->register_feature(
 		new Feature\SearchOrdering\SearchOrdering()
 	);
+
+	Features::factory()->register_feature(
+		new Feature\InstantSearch\InstantSearch()
+	);
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\register_indexable_posts' );
 

--- a/includes/classes/Feature/InstantSearch/InstantSearch.php
+++ b/includes/classes/Feature/InstantSearch/InstantSearch.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Instant Search feature
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPress\Feature\InstantSearch;
+
+use ElasticPress\Elasticsearch as Elasticsearch;
+use ElasticPress\Feature as Feature;
+use ElasticPress\Features as Features;
+use ElasticPress\Indexables as Indexables;
+use ElasticPress\Utils as Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Instant Search feature class.
+ *
+ * @since 3.7.0
+ */
+class InstantSearch extends Feature {
+	/**
+	 * Elasticsearch query template.
+	 *
+	 * @var array
+	 */
+	protected $search_template = [];
+
+	/**
+	 * Initialize feature.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->slug = 'instant-search';
+
+		$this->title = esc_html__( 'Instant Search', 'elasticpress' );
+
+		$this->requires_install_reindex = false;
+
+		$this->default_settings = [];
+
+		parent::__construct();
+	}
+
+	/**
+	 * Output feature box summary.
+	 *
+	 * @return void
+	 */
+	public function output_feature_box_summary() {
+		// TODO Short feature description.
+	}
+
+	/**
+	 * Output feature box long.
+	 *
+	 * @return void
+	 */
+	public function output_feature_box_long() {
+		// TODO Detailed feature description.
+	}
+
+	/**
+	 * Setup feature functionality.
+	 *
+	 * @return void
+	 */
+	public function setup() {
+		add_filter( 'ep_saved_weighting_configuration', [ $this, 'epio_send_search_template' ] );
+		add_filter( 'ep_pre_dashboard_index', [ $this, 'epio_send_search_template' ] );
+		add_filter( 'ep_wp_cli_pre_index', [ $this, 'epio_send_search_template' ] );
+	}
+
+	/**
+	 * Send the search template to EP.io.
+	 *
+	 * @return void
+	 */
+	public function epio_send_search_template() {
+		if ( ! Utils\is_epio() ) {
+			return;
+		}
+
+		$endpoint = Indexables::factory()->get( 'post' )->get_index_name() . '/search-template';
+		$response = Elasticsearch::factory()->remote_request(
+			$endpoint,
+			[
+				'blocking' => false,
+				'body'     => $this->get_search_template(),
+				'method'   => 'PUT',
+			]
+		);
+	}
+
+	/**
+	 * Generate a search template.
+	 *
+	 * A search template is the JSON for an Elasticsearch query with a
+	 * placeholder search term. The template is sent to EP.io where it's used
+	 * to make Elasticsearch queries using search terms sent from the front
+	 * end.
+	 *
+	 * @return string The search template JSON.
+	 */
+	public function get_search_template() {
+		$placeholder = '{{ep_placeholder}}';
+		$post_type   = Features::factory()->get_registered_feature( 'search' )->get_searchable_post_types();
+		$post_status = get_post_stati(
+			[
+				'public'              => true,
+				'exclude_from_search' => false,
+			]
+		);
+
+		add_filter( 'ep_intercept_remote_request', '__return_true' );
+		add_filter( 'ep_do_intercept_request', [ $this, 'intercept_search_request' ], 10, 4 );
+		add_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request' ], 10, 2 );
+		add_filter( 'posts_pre_query', '__return_empty_array', 100, 1 );
+
+		$query = new \WP_Query(
+			[
+				'post_type'    => $post_type,
+				'post_status'  => array_values( $post_status ),
+				's'            => $placeholder,
+				'ep_integrate' => true,
+			]
+		);
+
+		remove_filter( 'posts_pre_query', '__return_empty_array', 100 );
+		remove_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request' ], 10, 2 );
+		remove_filter( 'ep_do_intercept_request', [ $this, 'intercept_search_request' ], 10 );
+		remove_filter( 'ep_intercept_remote_request', '__return_true' );
+
+		return $this->search_template;
+	}
+
+	/**
+	 * Return true if a given feature is supported by instant search.
+	 *
+	 * Applied as a filter on Utils\is_integrated_request() so that features
+	 * are enabled for the query that is used to generate the search template,
+	 * regardless of the request type. This avoids the need to send a request
+	 * to the front end.
+	 *
+	 * @param bool   $is_integrated Whether queries for the request will be
+	 *                              integrated.
+	 * @param string $context       Context for the original check. Usually the
+	 *                              slug of the feature doing the check.
+	 * @return bool True if the check is for a feature supported by instant
+	 *              search.
+	 */
+	public function is_integrated_request( $is_integrated, $context ) {
+		$supported_contexts = [
+			'autosuggest',
+			'documents',
+			'search',
+			'weighting',
+			'woocommerce',
+		];
+
+		if ( in_array( $context, $supported_contexts, true ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Store intercepted request value and return (cached) request result
+	 *
+	 * @param object $response Response
+	 * @param array  $query Query
+	 * @param array  $args WP_Query Argument array
+	 * @param int    $failures Count of failures in request loop
+	 * @return object $response Response
+	 */
+	public function intercept_search_request( $response, $query = [], $args = [], $failures = 0 ) {
+		$this->search_template = $query['args']['body'];
+
+		return wp_remote_request( $query['url'], $args );
+	}
+}


### PR DESCRIPTION
### Description of the Change

Adds the beginnings of an Instant Search feature. This PR adds the Feature class for the feature, as well as the generation of an Elasticsearch query template. This template is sent to EP.io to be used as the template for searches made by requests to an API that will power the Instant Search front-end.

### Alternate Designs

There has been discussion of whether multiple search templates should be supported. This version does not support multiple templates. If multiple templates are going to be supported, I thing discussion needs to be had over what the user or developer experience of using multiple templates would be. I don't think it will be particularly straightforward, but perhaps this PR can be used to kickstart that conversation.

### Verification Process

When this branch is checked out, _Instant Search_ should be visible in _ElasticPress > Features_, with just the option to _Enable_ or _Disable_. When enabled, and when connected to the EP.io development environment with the appropriate branch checked out, the following actions should trigger a search template to be saved for the user's Posts index:

- Starting an index via the Dashboard.
- Starting an index via WP CLI.
- Saving the weighting configuration.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
