### PR TITLE
Weighting inside admin

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -565,7 +565,7 @@ class Weighting {
 		 */
 		$weight_config = apply_filters( 'ep_weighting_configuration_for_search', $weight_config, $args );
 
-		if ( Utils\is_integrated_request( 'weighting' ) && ! empty( $args['s'] ) ) {
+		if ( Utils\is_integrated_request( 'weighting', [ 'public' ] ) && ! empty( $args['s'] ) ) {
 			/*
 			 * This section splits up the single query clause for all post types into separate nested clauses (one for each post type)
 			 * which then get combined into one result set. By having separate clauses for each post type, we can then


### PR DESCRIPTION
### Description of the Change

This is a follow-up of #2267. Even with Protected Content enabled, weighting should be applied only on the front end.

Developers wanting to change that behavior can use this snippet:
```
add_filter(
	'ep_is_integrated_request',
	function( $is_integrated, $context ) {
		return ( 'weighting' === $context ) ? true : $is_integrated;
	},
	10,
	2
);
```