### PR TITLE
Use date_Create that does not throw exception or warning

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -477,9 +477,9 @@ abstract class Indexable {
 		$meta_types['datetime'] = '1970-01-01 00:00:01';
 		$meta_types['time']     = '00:00:01';
 
-		try {
-			// is this is a recognizable date format?
-			$new_date  = new \DateTime( $meta_value, \wp_timezone() );
+		// is this is a recognizable date format?
+		$new_date  = date_create( $meta_value, \wp_timezone() );
+		if ( $new_date ) {
 			$timestamp = $new_date->getTimestamp();
 
 			// PHP allows DateTime to build dates with the non-existing year 0000, and this causes
@@ -490,9 +490,6 @@ abstract class Indexable {
 				$meta_types['datetime'] = $new_date->format( 'Y-m-d H:i:s' );
 				$meta_types['time']     = $new_date->format( 'H:i:s' );
 			}
-		} catch ( \Exception $e ) {
-			// if $meta_value is not a recognizable date format, DateTime will throw an exception,
-			// just catch it and move on.
 		}
 
 		return $meta_types;


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This is inspired by https://github.com/Automattic/ElasticPress/pull/113


It seems that `new \DateTime( $meta_value, \wp_timezone() );` throws not only exception but also a `E_WARNING` in certain cases.

There is the `date_create` alternative, that according to [manual](https://www.php.net/manual/en/function.date-create.php) is an alias. While testing it though, I found that, it returns false on failure and does **NOT** throw an exception or warning (as far as I can see).

There are already unittests covering this function that are passing and also testing on the local dev-environment results in good results.
### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Changed - Meta parsing tweak to avoid `E_WARNING`s