### PR TITLE
Terms: Use $query_vars['parent'] even when equals 0

### DIFF
--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -424,7 +424,7 @@ class Term extends Indexable {
 		/**
 		 * Support `parent` query var.
 		 */
-		if ( ! empty( $query_vars['parent'] ) ) {
+		if ( isset( $query_vars['parent'] ) ) {
 			$filter['bool']['must'][]['bool']['must'] = [
 				'term' => [
 					'parent' => (int) $query_vars['parent'],

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -424,7 +424,7 @@ class Term extends Indexable {
 		/**
 		 * Support `parent` query var.
 		 */
-		if ( isset( $query_vars['parent'] ) ) {
+		if ( isset( $query_vars['parent'] ) && '' !== $query_vars['parent'] ) {
 			$filter['bool']['must'][]['bool']['must'] = [
 				'term' => [
 					'parent' => (int) $query_vars['parent'],


### PR DESCRIPTION
### Description of the Change

Currently, we are using `if ( ! empty( $query_vars['parent'] ) ) {` which isn't true when `parent = 0`. This PR changes the test to use `isset()` instead.

### Applicable Issues

Closes #2232

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
