### PR TITLE
Changes in mapping version determination

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -288,58 +288,7 @@ class Post extends Indexable {
 			return false;
 		}
 
-		$version = 'unknown';
-
-		if ( isset( $mapping[ $index ]['mappings']['post']['_meta']['mapping_version'] ) ) {
-			$version = $mapping[ $index ]['mappings']['post']['_meta']['mapping_version'];
-		} elseif ( isset( $mapping[ $index ]['mappings']['_meta']['mapping_version'] ) ) {
-			$version = $mapping[ $index ]['mappings']['_meta']['mapping_version'];
-		}
-
-		// mapping does not have meta value set - use legacy detection
-		if ( 'unknown' === $version ) {
-
-			// check for pre-5-0 mapping
-			if ( isset( $mapping[ $index ]['mappings']['post']['properties']['post_name']['fields']['raw']['ignore_above'] ) ) {
-				$val = $mapping[ $index ]['mappings']['post']['properties']['post_name']['fields']['raw']['ignore_above'];
-				if ( ! $val || 10922 !== $val ) {
-					$version = 'pre-5-0.php';
-				} elseif ( $val && 10922 === $val ) {
-					$version = 'not-pre-5-0';
-				}
-			}
-
-			// check for 5-0 mapping
-			if ( 'not-pre-5-0' === $version ) {
-				if ( isset( $mapping[ $index ]['mappings']['post']['properties']['post_content_filtered']['fields'] ) ) {
-					$version = '5-0.php';
-				} else {
-					$version = 'not-5-0';
-				}
-			}
-
-			// check for 5-2 mapping
-			if ( 'not-5-0' === $version ) {
-				if ( isset( $mapping[ $index ]['mappings']['post']['_all'] ) ) {
-					$version = '5-2.php';
-				} else {
-					$version = 'not-5-2';
-				}
-			}
-
-			// check for 7-0 mapping
-			if ( 'not-5-2' === $version ) {
-				if ( isset( $mapping[ $index ]['settings']['index.max_shingle_diff'] ) ) {
-					$version = '7-0.php';
-				} else {
-					$version = 'not-7-0';
-				}
-			}
-
-			if ( preg_match( '/^not-.*/', $version ) ) {
-				$version = 'unknown';
-			}
-		}
+		$version = $this->determine_mapping_version_based_on_existing( $mapping, $index );
 
 		/**
 		 * Filter the mapping version for posts.
@@ -2005,5 +1954,80 @@ class Post extends Indexable {
 		}
 
 		return $orderbys;
+	}
+
+	/**
+	 * Given a mapping content, try to determine the version used.
+	 *
+	 * @since 3.6.3
+	 *
+	 * @param array  $mapping Mapping content.
+	 * @param string $index   Index name
+	 * @return string         Version of the mapping being used.
+	 */
+	protected function determine_mapping_version_based_on_existing( $mapping, $index ) {
+		if ( isset( $mapping[ $index ]['mappings']['post']['_meta']['mapping_version'] ) ) {
+			return $mapping[ $index ]['mappings']['post']['_meta']['mapping_version'];
+		}
+		if ( isset( $mapping[ $index ]['mappings']['_meta']['mapping_version'] ) ) {
+			return $mapping[ $index ]['mappings']['_meta']['mapping_version'];
+		}
+
+		/**
+		 * Check for 7-0 mapping.
+		 * If mapping has a `post` type, it can't be ES 7, as mapping types were removed in that release.
+		 *
+		 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html
+		 */
+		if ( ! isset( $mapping[ $index ]['mappings']['post'] ) ) {
+			return '7-0.php';
+		}
+
+		$post_mapping = $mapping[ $index ]['mappings']['post'];
+
+		/**
+		 * Starting at this point, our tests rely on the post_title.fields.sortable field.
+		 * As this field is present in all our mappings, if this field is not present in
+		 * the mapping, this is a custom mapping.
+		 *
+		 * To have this code working with custom mappings, use the `ep_post_mapping_version_determined` filter.
+		 */
+		if ( ! isset( $post_mapping['properties']['post_title']['fields']['sortable'] ) ) {
+			return 'unknown';
+		}
+
+		$post_title_sortable = $post_mapping['properties']['post_title']['fields']['sortable'];
+
+		/**
+		 * Check for 5-2 mapping.
+		 * Normalizers on keyword fields were only made available in ES 5.2
+		 *
+		 * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.2/release-notes-5.2.0.html
+		 */
+		if ( isset( $post_title_sortable['normalizer'] ) ) {
+			return '5-2.php';
+		}
+
+		/**
+		 * Check for 5-0 mapping.
+		 * `keyword` fields were only made available in ES 5.0
+		 *
+		 * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/release-notes-5.0.0.html
+		 */
+		if ( 'keyword' === $post_title_sortable['type'] ) {
+			return '5-0.php';
+		}
+
+		/**
+		 * Check for pre-5-0 mapping.
+		 * `string` fields were deprecated in ES 5.0 in favor of text/keyword
+		 *
+		 * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/release-notes-5.0.0.html
+		 */
+		if ( 'string' === $post_title_sortable['type'] ) {
+			return 'pre-5-0.php';
+		}
+
+		return 'unknown';
 	}
 }


### PR DESCRIPTION
### Description of the Change

This PR splits `Post::determine_mapping_version()` in two different methods, so we can:
1. Early return if a version is already determined
2. Keep the `ep_post_mapping_version_determined` filter being executed at the end of the process.

It also fixes the check for ES 7.

### Applicable Issues

Closes #2332 
Closes #2331

### Changelog Entry

- Fixed: Mapping version determination does not send false positives for ES 7 anymore.
