### PR TITLE
Update/delete taxanomy fix upstream

### DIFF
--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -40,6 +40,7 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'added_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'deleted_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'updated_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
+		add_action( 'pre_delete_term', [ $this, 'action_queue_children_sync' ] );
 		add_action( 'delete_term', [ $this, 'action_sync_on_delete' ] );
 		add_action( 'set_object_terms', [ $this, 'action_sync_on_object_update' ], 10, 2 );
 	}
@@ -177,6 +178,19 @@ class SyncManager extends SyncManagerAbstract {
 		}
 
 		Indexables::factory()->get( 'term' )->delete( $term_id, false );
+	}
+
+	/**
+	 * Enqueue sync of children terms in hierchy when deleting parent. Children terms will be reasigned to
+	 * a different parent and we want to reflect that change in ElasticSearch
+	 *
+	 * @param int $term_id Term ID.
+	 * @since 3.6.3
+	 */
+	public function action_queue_children_sync( $term_id ) {
+		if ( $this->kill_sync() ) {
+			return;
+		}
 
 		// Find all terms in the hierarchy so we resync those as well
 		$term      = get_term( $term_id );
@@ -185,12 +199,12 @@ class SyncManager extends SyncManagerAbstract {
 		$hierarchy = array_merge( $ancestors, $children );
 
 		foreach ( $hierarchy as $hierarchy_term_id ) {
-			if ( ! current_user_can( 'edit_term', $hierarchy_term_id ) ) {
+			if ( apply_filters( 'ep_term_sync_kill', false, $hierarchy_term_id ) ) {
 				return;
 			}
 
-			if ( apply_filters( 'ep_term_sync_kill', false, $hierarchy_term_id ) ) {
-				return;
+			if ( ! current_user_can( 'edit_term', $term_id ) && ! apply_filters( 'ep_sync_insert_permissions_bypass', false, $term_id, 'term' )  ) {
+				continue;
 			}
 
 			do_action( 'ep_sync_term_on_transition', $hierarchy_term_id );

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -203,7 +203,7 @@ class SyncManager extends SyncManagerAbstract {
 				return;
 			}
 
-			if ( ! current_user_can( 'edit_term', $term_id ) && ! apply_filters( 'ep_sync_insert_permissions_bypass', false, $term_id, 'term' )  ) {
+			if ( ! current_user_can( 'edit_term', $term_id ) && ! apply_filters( 'ep_sync_insert_permissions_bypass', false, $term_id, 'term' ) ) {
 				continue;
 			}
 


### PR DESCRIPTION

### Description of the Change

Deleting term needs to do 2 actions:
* Delete the term
* Reindex all the child terms

However, if the hook is invoked on `delete_term` the term is already deleted in WP by then. The operations needed to get the list of child terms then fails. 

This change switches the two actions into 2 hooks. On `pre_delete_term` which happens both before the term is deleted but also before the child terms were updated in WP already, we will enqueue child terms to sync queue. Then on `delete_term` (same as before) we will remove the term from ES.

The sync queue is then processed on shutdown, that is after the children terms were already updated with the correct parent.

Another change in this PR is adding the permission check bypass for CLI and cron on term resyncing.


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1) ` wp elasticpress activate-feature terms`
2)  `wp elasticpress index --setup`
3) Create some hierarchy of categories
4) Delete middle one `wp term delete category <ID of term that has children>

5) No errors
5) Term is deleted
5) Check that index is correctly showing the children of deleted term pointing to the parent of deleted term as their parent now



### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Fixes: Term deletion propagation to ElasticSearch
