### PR TITLE
WP Acceptance Fixes

### DIFF
--- a/tests/wpa/BasicTest.php
+++ b/tests/wpa/BasicTest.php
@@ -27,29 +27,16 @@ class BasicTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 
 		$I->waitUntilElementContainsText( 'Sync complete', '.sync-status' );
 
-		try {
-			$I->moveTo( 'wp-admin/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-health' );
 
-			foreach ( $this->indexes as $index_name ) {
-				$I->seeText( $index_name );
-			}
-		} catch (\Throwable $th) {
-			// If failed for some other reason, it is a real failure.
-			if ( false === strpos( $th->getMessage(), 'Page crashed' ) ) {
-				throw $th;
-			}
-
-			$cli_result = $this->runCommand( 'wp elasticpress stats' )['stdout'];
-
-			foreach ( $this->indexes as $index_name ) {
-				$this->assertStringContainsString( $index_name, $cli_result );
-			}
+		foreach ( $this->indexes as $index_name ) {
+			$I->seeText( $index_name );
 		}
 	}
 
@@ -65,7 +52,7 @@ class BasicTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/?s=test' );
+		$this->moveTo( $I, '/?s=test' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 
@@ -99,11 +86,11 @@ class BasicTest extends TestBase {
 
 		sleep( 2 );
 
-		$I->moveTo( '/?s=Test+ElasticPress+1' );
+		$this->moveTo( $I, '/?s=Test+ElasticPress+1' );
 
 		$I->seeText( 'Test ElasticPress 1', '.hentry' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-weighting' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-weighting' );
 
 		$I->click( '#post-post_title-enabled' );
 
@@ -111,12 +98,12 @@ class BasicTest extends TestBase {
 
 		$I->waitUntilElementContainsText( 'Changes Saved', '.notice-success' );
 
-		$I->moveTo( '/?s=Test+ElasticPress+1' );
+		$this->moveTo( $I, '/?s=Test+ElasticPress+1' );
 
 		$I->dontSeeText( 'Test ElasticPress 1', '.hentry' );
 
 		// Reset Changed Settings.
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-weighting' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-weighting' );
 
 		$I->click( '#post-post_title-enabled' );
 
@@ -151,7 +138,7 @@ class BasicTest extends TestBase {
 
 		$this->publishPost( $data, $I );
 
-		$I->moveTo( '/?s=findme' );
+		$this->moveTo( $I, '/?s=findme' );
 
 		$posts = $I->getElements( '.post' );
 
@@ -159,7 +146,7 @@ class BasicTest extends TestBase {
 
 		$I->seeText( 'test weighting content', $first_post );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-weighting' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-weighting' );
 
 		$I->setElementProperty( 'input[name="weighting[post][post_title][weight]"]', 'value', 20 );
 
@@ -167,7 +154,7 @@ class BasicTest extends TestBase {
 
 		$I->waitUntilElementContainsText( 'Changes Saved', '.notice-success' );
 
-		$I->moveTo( '/?s=findme' );
+		$this->moveTo( $I, '/?s=findme' );
 
 		$posts = $I->getElements( '.post' );
 
@@ -176,7 +163,7 @@ class BasicTest extends TestBase {
 		$I->seeText( 'test weighting title findme', $first_post );
 
 		// Reset Changed Settings.
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-weighting' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-weighting' );
 
 		$I->setElementProperty( 'input[name="weighting[post][post_title][weight]"]', 'value', 1 );
 
@@ -193,7 +180,7 @@ class BasicTest extends TestBase {
 
 		$I = $this->openBrowserPage();
 
-		$I->moveTo( '/' );
+		$this->moveTo( $I, '/' );
 
 		$I->waitUntilElementVisible( '.search-toggle' );
 

--- a/tests/wpa/DashboardSyncTest.php
+++ b/tests/wpa/DashboardSyncTest.php
@@ -24,17 +24,17 @@ class DashboardSyncTest extends TestBase {
 
 		$this->runCommand( 'wp elasticpress delete-index --yes' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-health' );
 
 		$I->seeText( 'We could not find any data for your Elasticsearch indices.' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 
 		$I->waitUntilElementContainsText( 'Sync complete', '.sync-status' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-health' );
 
 		$I->dontSeeText( 'We could not find any data for your Elasticsearch indices.' );
 
@@ -59,21 +59,21 @@ class DashboardSyncTest extends TestBase {
 
 		$this->runCommand( 'wp elasticpress delete-index --network-wide --yes' );
 
-		$I->moveTo( 'wp-admin/network/sites.php' );
+		$this->moveTo( $I, 'wp-admin/network/sites.php' );
 
 		$I->checkOptions( '.index-toggle' );
 
-		$I->moveTo( 'wp-admin/network/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/network/admin.php?page=elasticpress-health' );
 
 		$I->seeText( 'We could not find any data for your Elasticsearch indices.' );
 
-		$I->moveTo( 'wp-admin/network/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/network/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 
 		$I->waitUntilElementContainsText( 'Sync complete', '.sync-status' );
 
-		$I->moveTo( 'wp-admin/network/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/network/admin.php?page=elasticpress-health' );
 
 		$I->dontSeeText( 'We could not find any data for your Elasticsearch indices.' );
 
@@ -95,11 +95,11 @@ class DashboardSyncTest extends TestBase {
 
 		$this->runCommand( 'wp elasticpress delete-index --yes' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-health' );
 
 		$I->seeText( 'We could not find any data for your Elasticsearch indices.' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 
@@ -107,9 +107,9 @@ class DashboardSyncTest extends TestBase {
 
 		sleep( 1 );
 
-		$I->moveTo( 'wp-admin/index.php' );
+		$this->moveTo( $I, 'wp-admin/index.php' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->seeText( 'Sync paused', '.sync-status' );
 
@@ -117,7 +117,7 @@ class DashboardSyncTest extends TestBase {
 
 		$I->waitUntilElementContainsText( 'Sync complete', '.sync-status' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress-health' );
 
 		$I->dontSeeText( 'We could not find any data for your Elasticsearch indices.' );
 
@@ -134,7 +134,7 @@ class DashboardSyncTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$this->runCommand( 'wp elasticpress index --setup --yes' );
 
@@ -166,7 +166,7 @@ class DashboardSyncTest extends TestBase {
 		// Slowing the index process a bit.
 		$old_value = $this->setPerIndexCycle( 10, $I );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 

--- a/tests/wpa/DashboardSyncTest.php
+++ b/tests/wpa/DashboardSyncTest.php
@@ -184,7 +184,7 @@ class DashboardSyncTest extends TestBase {
 
 		$cli_result = $this->runCommand( 'wp elasticpress index' )['stdout'];
 
-		$this->assertStringContainsString( 'An index is already occuring', $cli_result );
+		$this->assertStringContainsString( 'An index is already occurring', $cli_result );
 
 		$I->executeJavaScript( 'document.querySelector( ".resume-sync" ).click();' );
 

--- a/tests/wpa/GeneralTest.php
+++ b/tests/wpa/GeneralTest.php
@@ -36,7 +36,7 @@ class GeneralTest extends TestBase {
 
 		$this->activatePlugin();
 
-		$I->moveTo( '/wp-admin/plugins.php' );
+		$this->moveTo( $I, '/wp-admin/plugins.php' );
 
 		$I->seeText( 'ElasticPress is almost ready to go.' );
 
@@ -57,7 +57,7 @@ class GeneralTest extends TestBase {
 
 		$this->activatePlugin();
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->seeText( 'Index Your Content', '.setup-button' );
 
@@ -78,7 +78,7 @@ class GeneralTest extends TestBase {
 
 		$this->publishPost( $data, $I );
 
-		$I->moveTo( '/?s=Test+ElasticPress+1' );
+		$this->moveTo( $I, '/?s=Test+ElasticPress+1' );
 
 		$I->seeText( 'Test ElasticPress 1', '.hentry' );
 	}
@@ -103,7 +103,7 @@ class GeneralTest extends TestBase {
 
 		$this->activatePlugin();
 
-		$I->moveTo( '/wp-admin/plugins.php' );
+		$this->moveTo( $I, '/wp-admin/plugins.php' );
 
 		$I->seeText( 'ElasticPress may or may not work properly.' );
 

--- a/tests/wpa/HighlightingTest.php
+++ b/tests/wpa/HighlightingTest.php
@@ -27,7 +27,7 @@ class HighlightingTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".ep-feature-search .settings-button" ).click();' );
 
@@ -44,7 +44,7 @@ class HighlightingTest extends TestBase {
 
 		$this->publishPost( $data, $I );
 
-		$I->moveTo( '/?s=findme' );
+		$this->moveTo( $I, '/?s=findme' );
 
 		$I->seeElement( '.ep-highlight' );
 	}

--- a/tests/wpa/WpCliTest.php
+++ b/tests/wpa/WpCliTest.php
@@ -42,11 +42,11 @@ class WpCliTest extends TestBase {
 
 		$this->activatePlugin( null, 'elasticpress', true );
 
-		$I->moveTo( 'wp-admin/network/sites.php' );
+		$this->moveTo( $I, 'wp-admin/network/sites.php' );
 
 		$I->checkOptions( '.index-toggle' );
 
-		$I->moveTo( 'wp-admin/network/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/network/admin.php?page=elasticpress-health' );
 
 		$cli_result = $this->runCommand( 'wp elasticpress index --network-wide' )['stdout'];
 
@@ -54,7 +54,7 @@ class WpCliTest extends TestBase {
 
 		$this->assertStringContainsString( 'Number of posts indexed on site', $cli_result );
 
-		$I->moveTo( 'wp-admin/network/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/network/admin.php?page=elasticpress-health' );
 
 		$I->dontSeeText( 'We could not find any data for your Elasticsearch indices.' );
 
@@ -187,17 +187,17 @@ class WpCliTest extends TestBase {
 
 		$this->activatePlugin( $I, 'elasticpress', true );
 
-		$I->moveTo( 'wp-admin/network/sites.php' );
+		$this->moveTo( $I, 'wp-admin/network/sites.php' );
 
 		$I->checkOptions( '.index-toggle' );
 
-		$I->moveTo( 'wp-admin/network/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/network/admin.php?page=elasticpress-health' );
 
 		$cli_result = $this->runCommand( 'wp elasticpress delete-index --network-wide --yes' )['stdout'];
 
 		$this->assertStringContainsString( 'Index deleted', $cli_result );
 
-		$I->moveTo( 'wp-admin/network/admin.php?page=elasticpress-health' );
+		$this->moveTo( $I, 'wp-admin/network/admin.php?page=elasticpress-health' );
 
 		$I->seeText( 'We could not find any data for your Elasticsearch indices.' );
 
@@ -229,7 +229,7 @@ class WpCliTest extends TestBase {
 
 		$this->activatePlugin( $I, 'elasticpress', true );
 
-		$I->moveTo( 'wp-admin/network/sites.php' );
+		$this->moveTo( $I, 'wp-admin/network/sites.php' );
 
 		$I->checkOptions( '.index-toggle' );
 

--- a/tests/wpa/features/AutosuggestTest.php
+++ b/tests/wpa/features/AutosuggestTest.php
@@ -17,7 +17,7 @@ class FeatureAutosuggestTest extends TestBase {
 
 		$I = $this->openBrowserPage();
 
-		$I->moveTo( '/' );
+		$this->moveTo( $I, '/' );
 
 		$I->waitUntilElementVisible( '.search-toggle' );
 
@@ -42,7 +42,7 @@ class FeatureAutosuggestTest extends TestBase {
 
 		$I = $this->openBrowserPage();
 
-		$I->moveTo( '/' );
+		$this->moveTo( $I, '/' );
 
 		$I->waitUntilElementVisible( '.search-toggle' );
 
@@ -79,7 +79,7 @@ class FeatureAutosuggestTest extends TestBase {
 
 		$I = $this->openBrowserPage();
 
-		$I->moveTo( '/' );
+		$this->moveTo( $I, '/' );
 
 		$I->waitUntilElementVisible( '.search-toggle' );
 
@@ -104,7 +104,7 @@ class FeatureAutosuggestTest extends TestBase {
 
 		$I = $this->openBrowserPage();
 
-		$I->moveTo( '/' );
+		$this->moveTo( $I, '/' );
 
 		$I->waitUntilElementVisible( '.search-toggle' );
 

--- a/tests/wpa/features/DocumentTest.php
+++ b/tests/wpa/features/DocumentTest.php
@@ -19,7 +19,7 @@ class FeatureDocumentTest extends TestBase {
 
 		$this->activateDocumentFeature( $I );
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 
@@ -27,7 +27,7 @@ class FeatureDocumentTest extends TestBase {
 
 		$this->uploadFile( $I, dirname( __DIR__ ) . '/test-docs/pdf-file.pdf' );
 
-		$I->moveTo( '/?s=dummy+pdf' );
+		$this->moveTo( $I, '/?s=dummy+pdf' );
 
 		$I->seeText( 'pdf-file' );
 	}
@@ -46,7 +46,7 @@ class FeatureDocumentTest extends TestBase {
 
 		$this->uploadFile( $I, dirname( __DIR__ ) . '/test-docs/pptx-file.pptx' );
 
-		$I->moveTo( '/?s=dummy+slide' );
+		$this->moveTo( $I, '/?s=dummy+slide' );
 
 		$I->seeText( 'pptx-file' );
 	}
@@ -65,13 +65,13 @@ class FeatureDocumentTest extends TestBase {
 
 		$this->uploadFile( $I, dirname( __DIR__ ) . '/test-docs/pdf-file.pdf' );
 
-		$I->moveTo( '/?s=dummy+pdf' );
+		$this->moveTo( $I, '/?s=dummy+pdf' );
 
 		$I->seeText( 'pdf-file' );
 	}
 
 	private function uploadFile( $actor, $file ) {
-		$actor->moveTo( '/wp-admin/media-new.php?browser-uploader' );
+		$this->moveTo( $actor, '/wp-admin/media-new.php?browser-uploader' );
 
 		$actor->attachFile( '#async-upload', $file );
 
@@ -81,7 +81,7 @@ class FeatureDocumentTest extends TestBase {
 	}
 
 	private function activateDocumentFeature( $actor ) {
-		$actor->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $actor, '/wp-admin/admin.php?page=elasticpress' );
 
 		$class = $actor->getElementAttribute( '.ep-feature-documents', 'class' );
 

--- a/tests/wpa/features/ProtectedContentTest.php
+++ b/tests/wpa/features/ProtectedContentTest.php
@@ -23,7 +23,7 @@ class ProtectedContentTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->click( '.ep-feature-protected_content .settings-button' );
 
@@ -58,7 +58,7 @@ class ProtectedContentTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( 'wp-admin/edit.php' );
+		$this->moveTo( $I, 'wp-admin/edit.php' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 
@@ -93,7 +93,7 @@ class ProtectedContentTest extends TestBase {
 		// Give some time to the async request that indexes the post.
 		sleep( 5 );
 
-		$I->moveTo( 'wp-admin/edit.php?post_status=draft&post_type=post' );
+		$this->moveTo( $I, 'wp-admin/edit.php?post_status=draft&post_type=post' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 

--- a/tests/wpa/features/RelatedPostsTest.php
+++ b/tests/wpa/features/RelatedPostsTest.php
@@ -120,11 +120,27 @@ class FeatureRelatedPostsTest extends TestBase {
 
 		$I->typeInField( 'input[name^="widget-ep-related-posts"]', 'Related Posts' );
 
-		sleep( 2 );
+		$update_button = $I->getElement( ".edit-widgets-header__actions .components-button.is-primary" );
 
-		$I->click( ".edit-widgets-header__actions .components-button.is-primary" );
+		$I->click( $update_button );
 
 		$I->waitUntilPageSourceContains( 'Widgets saved.' );
+
+		sleep ( 1 );
+
+		/**
+		 * It seems sometimes WP keeps a dirty state even after a successful save.
+		 * When that happens, we get stuck with a "Are you sure you want to leave...?" message.
+		 *
+		 * Saving it again seems to fix the issue.
+		 *
+		 * @todo Investigate why WordPress gets stuck in that dirty state.
+		 */
+		if ( $I->elementIsEnabled( $update_button ) ) {
+			$I->click( $update_button );
+
+			sleep( 2 );
+		}
 
 		$posts_data = [
 			[

--- a/tests/wpa/features/RelatedPostsTest.php
+++ b/tests/wpa/features/RelatedPostsTest.php
@@ -25,7 +25,7 @@ class FeatureRelatedPostsTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->click( '.ep-feature-related_posts .settings-button' );
 
@@ -35,31 +35,19 @@ class FeatureRelatedPostsTest extends TestBase {
 
 		sleep( 2 );
 
-		// If we get "Page Crashed!" due to lack of memory, try WP-CLI.
-		try {
-			$this->openWidgetsPage( $I );
+		$this->openWidgetsPage( $I );
 
-			$I->click( '.edit-widgets-header-toolbar__inserter-toggle' );
+		$I->click( '.edit-widgets-header-toolbar__inserter-toggle' );
 
-			$I->waitUntilElementVisible( '.block-editor-inserter__search-input' );
+		$I->waitUntilElementVisible( '.block-editor-inserter__search-input' );
 
-			$I->typeInField( '.block-editor-inserter__search-input', 'ElasticPress Related Posts' );
+		$I->typeInField( '.block-editor-inserter__search-input', 'ElasticPress Related Posts' );
 
-			$I->dontSeeText( 'ElasticPress - Related Posts', '.block-editor-block-types-list' ); // Legacy Widget
+		$I->dontSeeText( 'ElasticPress - Related Posts', '.block-editor-block-types-list' ); // Legacy Widget
 
-			$I->dontSeeText( 'Related Posts (ElasticPress)', '.block-editor-block-types-list' );
-		} catch (\Throwable $th) {
-			// If failed for some other reason, it is a real failure.
-			if ( false === strpos( $th->getMessage(), 'Page crashed' ) ) {
-				throw $th;
-			}
+		$I->dontSeeText( 'Related Posts (ElasticPress)', '.block-editor-block-types-list' );
 
-			$cli_result = $this->runCommand( "wp widget list {$this->sidebar_id}" )['stdout'];
-
-			$this->assertStringNotContainsString( 'ep-related-posts', $cli_result );
-		}
-
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->click( '.ep-feature-related_posts .settings-button' );
 
@@ -69,31 +57,17 @@ class FeatureRelatedPostsTest extends TestBase {
 
 		sleep( 2 );
 
-		// If we get "Page Crashed!" due to lack of memory, try WP-CLI.
-		try {
-			$this->openWidgetsPage( $I );
+		$this->openWidgetsPage( $I );
 
-			$I->click( '.edit-widgets-header-toolbar__inserter-toggle' );
+		$I->click( '.edit-widgets-header-toolbar__inserter-toggle' );
 
-			$I->waitUntilElementVisible( '.block-editor-inserter__search-input' );
+		$I->waitUntilElementVisible( '.block-editor-inserter__search-input' );
 
-			$I->typeInField( '.block-editor-inserter__search-input', 'ElasticPress Related Posts' );
+		$I->typeInField( '.block-editor-inserter__search-input', 'ElasticPress Related Posts' );
 
-			$I->seeText( 'ElasticPress - Related Posts', '.block-editor-block-types-list' ); // Legacy Widget
+		$I->seeText( 'ElasticPress - Related Posts', '.block-editor-block-types-list' ); // Legacy Widget
 
-			$I->seeText( 'Related Posts (ElasticPress)', '.block-editor-block-types-list' );
-		} catch (\Throwable $th) {
-			// If failed for some other reason, it is a real failure.
-			if ( false === strpos( $th->getMessage(), 'Page crashed' ) ) {
-				throw $th;
-			}
-
-			$this->runCommand( "wp widget add ep-related-posts {$this->sidebar_id}" );
-
-			$cli_result = $this->runCommand( "wp widget list {$this->sidebar_id}" )['stdout'];
-
-			$this->assertStringContainsString( 'ep-related-posts', $cli_result );
-		}
+		$I->seeText( 'Related Posts (ElasticPress)', '.block-editor-block-types-list' );
 	}
 
 	/**

--- a/tests/wpa/features/SearchTest.php
+++ b/tests/wpa/features/SearchTest.php
@@ -19,7 +19,7 @@ class FeatureSearchTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/?s=test' );
+		$this->moveTo( $I, '/?s=test' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 
@@ -54,7 +54,7 @@ class FeatureSearchTest extends TestBase {
 			'content' => 'elasticpress',
 		], $I );
 
-		$I->moveTo( '/?s=10up+loves+elasticpress' );
+		$this->moveTo( $I, '/?s=10up+loves+elasticpress' );
 
 		$I->seeText( 'Higher', '#site-content article:nth-of-type(1)' );
 
@@ -85,7 +85,7 @@ class FeatureSearchTest extends TestBase {
 			'content' => '10up loves elasticpress',
 		], $I );
 
-		$I->moveTo( '/?s=10up+loves+elasticpress' );
+		$this->moveTo( $I, '/?s=10up+loves+elasticpress' );
 
 		$I->seeText( '10up loves elasticpress', '#site-content article:nth-of-type(1)' );
 		$I->seeText( '10up loves elasticpress', '#site-content article:nth-of-type(2)' );

--- a/tests/wpa/features/WooCommerceTest.php
+++ b/tests/wpa/features/WooCommerceTest.php
@@ -19,7 +19,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		$this->activatePlugin( $I, 'woocommerce' );
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$this->assertStringContainsString( 'feature-active', $I->getElementAttribute( '.ep-feature-woocommerce', 'class' ) );
 	}
@@ -34,7 +34,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".ep-feature-woocommerce .settings-button" ).click();' );
 
@@ -44,7 +44,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		sleep( 2 );
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->click( '.ep-feature-woocommerce .settings-button' );
 
@@ -67,7 +67,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, '/wp-admin/admin.php?page=elasticpress' );
 
 		$I->click( '.ep-feature-protected_content .settings-button' );
 
@@ -77,7 +77,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		$I->waitUntilElementContainsText( 'Sync complete', '.sync-status' );
 
-		$I->moveTo( '/wp-admin/edit.php?post_type=shop_order' );
+		$this->moveTo( $I, '/wp-admin/edit.php?post_type=shop_order' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 
@@ -96,7 +96,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/wp-admin/edit.php?post_type=product' );
+		$this->moveTo( $I, '/wp-admin/edit.php?post_type=product' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 
@@ -115,7 +115,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/product-category/uncategorized' );
+		$this->moveTo( $I, '/product-category/uncategorized' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 
@@ -134,7 +134,7 @@ class FeatureWooCommerceTest extends TestBase {
 
 		$I->loginAs( 'wpsnapshots' );
 
-		$I->moveTo( '/shop/?filter_size=small' );
+		$this->moveTo( $I, '/shop/?filter_size=small' );
 
 		$I->click( '#wp-admin-bar-debug-bar' );
 

--- a/tests/wpa/inc/TestBase.php
+++ b/tests/wpa/inc/TestBase.php
@@ -383,16 +383,16 @@ class TestBase extends \WPAcceptance\PHPUnit\TestCase {
 	 * @param array ...$args  Arguments to be passed to Actor::moveTo()
 	 */
 	public function moveTo( $actor, ...$args ) {
-		$continue_trying = false;
-		$attempts        = 0;
+		$attempts = 0;
 		do {
 			try {
 				$attempts++;
-				$actor->moveTo( ...$args );
 				$continue_trying = false;
+				$actor->moveTo( ...$args );
 			} catch ( \Throwable $th ) {
 				// If failed due to Page crashed, let's try again. Otherwise, stop.
 				if ( false !== strpos( $th->getMessage(), 'Page crashed' ) ) {
+					\WPAcceptance\Log::instance()->write( 'Page crashed error. Retrying.', 0 );
 					$continue_trying = true;
 					sleep( 2 );
 				}

--- a/tests/wpa/inc/TestBase.php
+++ b/tests/wpa/inc/TestBase.php
@@ -392,9 +392,9 @@ class TestBase extends \WPAcceptance\PHPUnit\TestCase {
 			} catch ( \Throwable $th ) {
 				// If failed due to Page crashed, let's try again. Otherwise, stop.
 				if ( false !== strpos( $th->getMessage(), 'Page crashed' ) ) {
-					\WPAcceptance\Log::instance()->write( 'Page crashed error. Retrying.', 0 );
+					\WPAcceptance\Log::instance()->write( 'Page crashed error. Retrying (' . $attempts . ')', 0 );
 					$continue_trying = true;
-					sleep( 2 );
+					sleep( 5 );
 				}
 			}
 		} while ( $continue_trying && $attempts < 10 );

--- a/tests/wpa/inc/TestBase.php
+++ b/tests/wpa/inc/TestBase.php
@@ -194,7 +194,7 @@ class TestBase extends \WPAcceptance\PHPUnit\TestCase {
 
 		$data = array_merge( $defaults, $data );
 
-		$actor->moveTo( 'wp-admin/post-new.php' );
+		$this->moveTo( $actor, 'wp-admin/post-new.php' );
 
 		try {
 			$actor->click( '.edit-post-welcome-guide .components-modal__header button' );
@@ -256,9 +256,9 @@ class TestBase extends \WPAcceptance\PHPUnit\TestCase {
 		}
 
 		if ( $network ) {
-			$actor->moveTo( '/wp-admin/network/plugins.php' );
+			$this->moveTo( $actor, '/wp-admin/network/plugins.php' );
 		} else {
-			$actor->moveTo( '/wp-admin/plugins.php' );
+			$this->moveTo( $actor, '/wp-admin/plugins.php' );
 		}
 
 		try {
@@ -288,9 +288,9 @@ class TestBase extends \WPAcceptance\PHPUnit\TestCase {
 		}
 
 		if ( $network ) {
-			$actor->moveTo( '/wp-admin/network/plugins.php' );
+			$this->moveTo( $actor, '/wp-admin/network/plugins.php' );
 		} else {
-			$actor->moveTo( '/wp-admin/plugins.php' );
+			$this->moveTo( $actor, '/wp-admin/plugins.php' );
 		}
 
 		try {
@@ -335,7 +335,7 @@ class TestBase extends \WPAcceptance\PHPUnit\TestCase {
 	 * @return string
 	 */
 	public function setPerIndexCycle( int $number, \WPAcceptance\PHPUnit\Actor $actor ) {
-		$actor->moveTo( 'wp-admin/admin.php?page=elasticpress-settings' );
+		$this->moveTo( $actor, 'wp-admin/admin.php?page=elasticpress-settings' );
 
 		$per_page = $actor->getElementAttribute( '#ep_bulk_setting', 'value' );
 
@@ -364,12 +364,39 @@ class TestBase extends \WPAcceptance\PHPUnit\TestCase {
 	 * @param \WPAcceptance\PHPUnit\Actor $actor
 	 */
 	public function openWidgetsPage( $actor ) {
-		$actor->moveTo( '/wp-admin/widgets.php' );
+		$this->moveTo( $actor, '/wp-admin/widgets.php' );
 
 		try {
 			$actor->click( '.edit-widgets-welcome-guide .components-modal__header button' );
 		} catch ( \Exception $e ) {
 			// Do nothing
 		}
+	}
+
+	/**
+	 * Open a page in the browser.
+	 *
+	 * This method will keep trying to move to the new page until a success
+	 * or any error other than "Page crashed"
+	 *
+	 * @param Actor $actor The actor
+	 * @param array ...$args  Arguments to be passed to Actor::moveTo()
+	 */
+	public function moveTo( $actor, ...$args ) {
+		$continue_trying = false;
+		$attempts        = 0;
+		do {
+			try {
+				$attempts++;
+				$actor->moveTo( ...$args );
+				$continue_trying = false;
+			} catch ( \Throwable $th ) {
+				// If failed due to Page crashed, let's try again. Otherwise, stop.
+				if ( false !== strpos( $th->getMessage(), 'Page crashed' ) ) {
+					$continue_trying = true;
+					sleep( 2 );
+				}
+			}
+		} while ( $continue_trying && $attempts < 10 );
 	}
 }

--- a/tests/wpa/indexables/UserTest.php
+++ b/tests/wpa/indexables/UserTest.php
@@ -26,7 +26,7 @@ class UserTest extends TestBase {
 	 * @param \WPAcceptance\PHPUnit\Actor $actor    Current actor.
 	 */
 	public function searchUser( $username = '', \WPAcceptance\PHPUnit\Actor $actor ) {
-		$actor->moveTo( 'wp-admin/users.php' );
+		$this->moveTo( $actor, 'wp-admin/users.php' );
 
 		$actor->waitUntilElementVisible( '#user-search-input' );
 
@@ -54,7 +54,7 @@ class UserTest extends TestBase {
 
 		$this->createUser( $data, $I );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 
@@ -105,7 +105,7 @@ class UserTest extends TestBase {
 
 		$I->click( '#submit' );
 
-		$I->moveTo( 'wp-admin/admin.php?page=elasticpress' );
+		$this->moveTo( $I, 'wp-admin/admin.php?page=elasticpress' );
 
 		$I->executeJavaScript( 'document.querySelector( ".start-sync" ).click();' );
 


### PR DESCRIPTION
### Description of the Change

#### 1. Widget screen and "are you sure..." error

In the Widgets Edit Screen, it seems sometimes WP keeps a dirty state even after a successful save. When that happens, we get stuck with a "Are you sure you want to leave...?" message, and tests fail due to a timeout. Clicking on the "Update" button again seems to fix the issue.

#### 2. Typo in WP-CLI Command

In #2336 a typo was fixed but the WPA test is still checking for the wrong string.

#### 3. New `moveTo()` method

This PR adds a new `moveTo()` method to the `TestBase` class. Using this method, instead of relying on the usual `Actor::moveTo()` will make the test suite retry to access the page until it succeeds or fails with any error other than `Page crashed`.

### Applicable Issues

Closes #2351

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
