### PR TITLE
Fix EP enabled check when `is_integrated_request` returns false.

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -569,7 +569,7 @@ class Search extends Feature {
 	 */
 	public function integrate_search_queries( $enabled, $query ) {
 		if ( ! Utils\is_integrated_request( $this->slug ) ) {
-			return;
+			return false;
 		}
 
 		if ( ! is_a( $query, 'WP_Query' ) ) {


### PR DESCRIPTION
### Description of the Change

`integrate_search_queries` returns `NULL` when the request is not integrated. But it should return `false`, otherwise `elasticpress_enabled` returns `NULL` and ElasticPress is not override the query.
