### PR TITLE
Fix Term deletion

### DIFF
--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -122,7 +122,21 @@ class QueryIntegration {
 				return $results;
 			}
 
-			$query->found_terms           = $ep_query['found_documents'];
+			/**
+			 * Elasticsearch 5 will return found_documents as a number,
+			 * ES 7+ will return it as an object with `value`. If any of that is found,
+			 * fallback to a simple count of returned documents.
+			 *
+			 * @since 3.6.3
+			 */
+			if ( is_integer( $ep_query['found_documents'] ) ) {
+				$query->found_terms = $ep_query['found_documents'];
+			} elseif ( is_array( $ep_query['found_documents'] ) && isset( $ep_query['found_documents']['value'] ) ) {
+				$query->found_terms = $ep_query['found_documents']['value'];
+			} else {
+				$query->found_terms = count( $ep_query['documents'] );
+			}
+
 			$query->elasticsearch_success = true;
 
 			// Determine how we should format the results from ES based on the fields parameter.

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -41,7 +41,7 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'deleted_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'updated_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'pre_delete_term', [ $this, 'action_queue_children_sync' ] );
-		add_action( 'delete_term', [ $this, 'action_sync_on_delete' ] );
+		add_action( 'pre_delete_term', [ $this, 'action_sync_on_delete' ] );
 		add_action( 'set_object_terms', [ $this, 'action_sync_on_object_update' ], 10, 2 );
 	}
 


### PR DESCRIPTION
### Description of the Change

As stated in #2365, when a term is deleted, it is not removed from the ES index, as `current_user_can( 'delete_term', $term_id )` will fail after the term deletion. This PR changes the hook used for `action_sync_on_delete`.

### Applicable Issues

Closes #2365

### Changelog Entry

Fixed: Deleted terms are now properly removed from the Elasticsearch index.
