### PR TITLE
Update WP-CLI documentation

### DIFF
--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -1,56 +1,131 @@
 The following WP-CLI commands are supported by ElasticPress:
 
-* `wp elasticpress index [--setup] [--network-wide] [--per-page] [--nobulk] [--offset] [--indexables] [--show-bulk-errors] [--post-type] [--include]`
+* `wp elasticpress index [--network-wide] [--setup] [--per-page] [--nobulk] [--show-errors] [--show-bulk-errors] [--show-nobulk-errors] [--offset] [--indexables] [--post-type] [--include] [--post-ids] [--upper-limit-object-id] [--lower-limit-object-id] [--ep-host] [--ep-prefix] [--yes]` 
 
-    Index all posts in the current blog.
+	Index all posts for a site or network wide.
 
-    * `--network-wide` will force indexing on all the blogs in the network. `--network-wide` takes an optional argument to limit the number of blogs to be indexed across where 0 is no limit. For example, `--network-wide=5` would limit indexing to only 5 blogs on the network.
-    * `--setup` will clear the index first and re-send the put mapping.
-    * `--per-page` let's you determine the amount of posts to be indexed per bulk index (or cycle).
-    * `--nobulk` let's you disable bulk indexing.
-    * `--offset` let's you skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
-    * `--indexables` lets you specify the Indexable(s) which will be indexed.
-    * `--show-bulk-errors` displays the error message returned from Elasticsearch when a post fails to index (as opposed to just the title and ID of the post).
-    * `--post-type` let's you specify which post types will be indexed (by default: all indexable post types are indexed). For example, `--post-type="my_custom_post_type"` would limit indexing to only posts from the post type "my_custom_post_type". Accepts multiple post types separated by comma.
-    * `--include` Choose which object IDs to include in the index.
-    * `--post-ids` Choose which post_ids to include when indexing the Posts Indexable (deprecated).
-    * `--upper-limit-object-id` Upper limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 45.
-    * `--lower-limit-object-id` Lower limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 30.
+	* `[--network-wide]`: Force indexing on all the blogs in the network. `--network-wide` takes an optional argument to limit the number of blogs to be indexed across where 0 is no limit. For example, `--network-wide=5` would limit indexing to only 5 blogs on the network
+	* `[--setup]`: Clear the index first and re-send the put mapping. Use `--yes` to skip the confirmation
+	* `[--per-page]`: Determine the amount of posts to be indexed per bulk index (or cycle)
+	* `[--nobulk]`: Disable bulk indexing
+	* `[--show-errors]`: Show all errors
+	* `[--show-bulk-errors]`: Display the error message returned from Elasticsearch when a post fails to index using the /_bulk endpoint
+	* `[--show-nobulk-errors]`: Display the error message returned from Elasticsearch when a post fails to index while not using the /_bulk endpoint
+	* `[--offset]`: Skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
+	* `[--indexables]`: Specify the Indexable(s) which will be indexed
+	* `[--post-type]`: Specify which post types will be indexed (by default: all indexable post types are indexed). For example, `--post-type="my_custom_post_type"` would limit indexing to only posts from the post type "my_custom_post_type". Accepts multiple post types separated by comma
+	* `[--include]`: Choose which object IDs to include in the index
+	* `[--post-ids]`: Choose which post_ids to include when indexing the Posts Indexable (deprecated)
+	* `[--upper-limit-object-id]`: Upper limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 45
+	* `[--lower-limit-object-id]`: Lower limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 30
+	* `[--ep-host]`: Custom Elasticsearch host
+	* `[--ep-prefix]`: Custom ElasticPress prefix
+	* `[--yes]`: Skip confirmation needed by `--setup`
 
-* `wp elasticpress delete-index [--network-wide]`
+* `wp elasticpress activate-feature <feature-slug>` 
 
-  Deletes the current Indexables indices. `--network-wide` will force every index on the network to be deleted.
+	Activate a feature. If a re-indexing is required, you will need to do it manually.
 
-* `wp elasticpress put-mapping [--network-wide] [--indexables]`
+	* `<feature-slug>`: The feature slug
 
-  Sends plugin put mapping to the current Indexables indices (this will delete the indices). `--network-wide` will force mappings to be sent for every index in the network.
+* `wp elasticpress deactivate-feature <feature-slug>` 
 
-* `wp elasticpress recreate-network-alias`
+	Dectivate a feature.
 
-  Recreates the alias index which points to every index in the network.
+	* `<feature-slug>`: The feature slug
 
-* `wp elasticpress activate-feature <feature-slug>`
+* `wp elasticpress list-features [--all]` 
 
-  Activate a feature. If a re-indexing is required, you will need to do it manually.
+	List features (either active or all).
 
-* `wp elasticpress deactivate-feature <feature-slug>`
+	* `[--all]`: Show all registered features
 
-  Deactivate a feature.
+* `wp elasticpress get-algorithm-version` 
 
-* `wp elasticpress list-features [--all]`
+	Get the algorithm version.
 
-  Lists active features. `--all` will show all registered features.
+	Get the value of the `ep_search_algorithm_version` option, or
+`default` if empty.
 
-* `wp elasticpress stats`
+* `wp elasticpress set-algorithm-version [--version=<version>] [--default]` 
 
-  Returns basic stats on Elasticsearch instance i.e. number of documents in current index as well as disk space used.
+	Set the algorithm version.
 
-* `wp elasticpress status`
+	Set the algorithm version through the `ep_search_algorithm_version` option,
+that will be used by the filter with same name.
+Delete the option if `--default` is passed.
 
-* `wp elasticpress get-indexes`
+	* `[--version=<version>]`: Version name
+	* `[--default]`: Use to set the default version
 
-  Get all index names as json.
+* `wp elasticpress clear-index` 
 
-* `wp elasticpress get-cluster-indexes`
+	Clear a sync/index process.
 
-  Return all indexes from the cluster as json.
+	If an index was stopped prematurely and won't start again, this will clear this cached data such that a new index can start.
+
+* `wp elasticpress delete-index [--index-name] [--network-wide] [--yes]` 
+
+	Delete the index for each indexable. !!Warning!! This removes your elasticsearch index(s) for the entire site.
+
+	* `[--index-name]`: The name of the index to be deleted. If not passed, all indexes will be deleted
+	* `[--network-wide]`: Force every index on the network to be deleted.
+	* `[--yes]`: Skip confirmation
+
+* `wp elasticpress epio-set-autosuggest` 
+
+	A WP-CLI wrapper to run `Autosuggest::epio_send_autosuggest_public_request()`.
+
+* `wp elasticpress get-cluster-indexes` 
+
+	Return all indexes from the cluster as a JSON object.
+
+* `wp elasticpress get-indexes` 
+
+	Return all index names as a JSON object.
+
+* `wp elasticpress get-indexing-status` 
+
+	Returns the status of an ongoing index operation in JSON array.
+
+	Returns the status of an ongoing index operation in JSON array with the following fields:
+indexing | boolean | True if index operation is ongoing or false
+method | string | 'cli', 'web' or 'none'
+items_indexed | integer | Total number of items indexed
+total_items | integer | Total number of items indexed or -1 if not yet determined
+
+* `wp elasticpress get-last-cli-index [--clear]` 
+
+	Returns a JSON array with the results of the last CLI index (if present) of an empty array.
+
+	* `[--clear]`: Clear the `ep_last_cli_index` option.
+
+* `wp elasticpress put-mapping [--network-wide] [--indexables] [--ep-host] [--ep-prefix]` 
+
+	Add document mappings for every indexable.
+
+	Sends plugin put mapping to the current Indexables indices (this will delete the indices)
+
+	* `[--network-wide]`: Force mappings to be sent for every index in the network.
+	* `[--indexables]`: List of indexables
+	* `[--ep-host]`: Custom Elasticsearch host
+	* `[--ep-prefix]`: Custom ElasticPress prefix
+
+* `wp elasticpress recreate-network-alias` 
+
+	Recreates the alias index which points to every index in the network.
+
+	Map network alias to every index in the network for every non-global indexable
+
+* `wp elasticpress stats` 
+
+	Get stats on the current index.
+
+* `wp elasticpress status` 
+
+	Ping the Elasticsearch server and retrieve a status.
+
+* `wp elasticpress stop-indexing` 
+
+	Stop the indexing operation started from the dashboard.
+

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -53,9 +53,13 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Activate a feature.
+	 * Activate a feature. If a re-indexing is required, you will need to do it manually.
 	 *
-	 * @synopsis <feature>
+	 * ## OPTIONS
+	 *
+	 * <feature-slug>
+	 * : The feature slug
+	 *
 	 * @subcommand activate-feature
 	 * @since      2.1
 	 * @param array $args Positional CLI args.
@@ -94,7 +98,11 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Dectivate a feature.
 	 *
-	 * @synopsis <feature>
+	 * ## OPTIONS
+	 *
+	 * <feature-slug>
+	 * : The feature slug
+	 *
 	 * @subcommand deactivate-feature
 	 * @since      2.1
 	 * @param array $args Positional CLI args.
@@ -127,9 +135,13 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * List features (either active or all)
+	 * List features (either active or all).
 	 *
-	 * @synopsis [--all]
+	 * ## OPTIONS
+	 *
+	 * [--all]
+	 * : Show all registered features
+	 *
 	 * @subcommand list-features
 	 * @since      2.1
 	 * @param array $args Positional CLI args.
@@ -163,9 +175,24 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Add document mappings for every indexable
+	 * Add document mappings for every indexable.
 	 *
-	 * @synopsis [--network-wide] [--indexables] [--ep-host] [--ep-prefix]
+	 * Sends plugin put mapping to the current Indexables indices (this will delete the indices.)
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--network-wide]
+	 * : Force mappings to be sent for every index in the network.
+	 *
+	 * [--indexables]
+	 * : List of indexables
+	 *
+	 * [--ep-host]
+	 * : Custom Elasticsearch host
+	 *
+	 * [--ep-prefix]
+	 * : Custom ElasticPress prefix
+	 *
 	 * @subcommand put-mapping
 	 * @since      0.9
 	 * @param array $args Positional CLI args.
@@ -321,7 +348,7 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Return all indexes from the cluster as json
+	 * Return all indexes from the cluster as a JSON object.
 	 *
 	 * @subcommand get-cluster-indexes
 	 * @since      3.2
@@ -339,7 +366,7 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get all index names as json
+	 * Return all index names as a JSON object.
 	 *
 	 * @subcommand get-indexes
 	 * @since      3.2
@@ -363,10 +390,19 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete the index for each indexable. !!Warning!! This removes your elasticsearch index(s)
-	 * for the entire site.
+	 * Delete the index for each indexable. !!Warning!! This removes your elasticsearch index(s) for the entire site.
 	 *
-	 * @synopsis [--index-name] [--network-wide] [--yes]
+	 * ## OPTIONS
+	 *
+	 * [--index-name]
+	 * : The name of the index to be deleted. If not passed, all indexes will be deleted
+	 *
+	 * [--network-wide]
+	 * : Force every index on the network to be deleted.
+	 *
+	 * [--yes]
+	 * : Skip confirmation
+	 *
 	 * @subcommand delete-index
 	 * @since      0.9
 	 * @param array $args Positional CLI args.
@@ -446,6 +482,8 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Recreates the alias index which points to every index in the network.
+	 *
 	 * Map network alias to every index in the network for every non-global indexable
 	 *
 	 * @param array $args Positional CLI args.
@@ -475,7 +513,7 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * A WP-CLI wrapper to run Autosuggest::epio_send_autosuggest_public_request().
+	 * A WP-CLI wrapper to run `Autosuggest::epio_send_autosuggest_public_request()`.
 	 *
 	 * @param array $args       Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
@@ -535,9 +573,60 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Index all posts for a site or network wide
+	 * Index all posts for a site or network wide.
 	 *
-	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--upper-limit-object-id] [--lower-limit-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix] [--yes]
+	 * ## OPTIONS
+	 *
+	 * [--network-wide]
+	 * : Force indexing on all the blogs in the network. `--network-wide` takes an optional argument to limit the number of blogs to be indexed across where 0 is no limit. For example, `--network-wide=5` would limit indexing to only 5 blogs on the network
+	 *
+	 * [--setup]
+	 * : Clear the index first and re-send the put mapping. Use `--yes` to skip the confirmation
+	 *
+	 * [--per-page]
+	 * : Determine the amount of posts to be indexed per bulk index (or cycle)
+	 *
+	 * [--nobulk]
+	 * : Disable bulk indexing
+	 *
+	 * [--show-errors]
+	 * : Show all errors
+	 *
+	 * [--show-bulk-errors]
+	 * : Display the error message returned from Elasticsearch when a post fails to index using the /_bulk endpoint
+	 *
+	 * [--show-nobulk-errors]
+	 * : Display the error message returned from Elasticsearch when a post fails to index while not using the /_bulk endpoint
+	 *
+	 * [--offset]
+	 * : Skip the first n posts (don't forget to remove the `--setup` flag when resuming or the index will be emptied before starting again).
+	 *
+	 * [--indexables]
+	 * : Specify the Indexable(s) which will be indexed
+	 *
+	 * [--post-type]
+	 * : Specify which post types will be indexed (by default: all indexable post types are indexed). For example, `--post-type="my_custom_post_type"` would limit indexing to only posts from the post type "my_custom_post_type". Accepts multiple post types separated by comma
+	 *
+	 * [--include]
+	 * : Choose which object IDs to include in the index
+	 *
+	 * [--post-ids]
+	 * : Choose which post_ids to include when indexing the Posts Indexable (deprecated)
+	 *
+	 * [--upper-limit-object-id]
+	 * : Upper limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 45
+	 *
+	 * [--lower-limit-object-id]
+	 * : Lower limit of a range of IDs to be indexed. If indexing IDs from 30 to 45, this should be 30
+	 *
+	 * [--ep-host]
+	 * : Custom Elasticsearch host
+	 *
+	 * [--ep-prefix]
+	 * : Custom ElasticPress prefix
+	 *
+	 * [--yes]
+	 * : Skip confirmation needed by `--setup`
 	 *
 	 * @param array $args Positional CLI args.
 	 * @since 0.1.2
@@ -1353,8 +1442,9 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * If an index was stopped prematurely and won't start again, this will clear this
-	 * cached data such that a new index can start.
+	 * Clear a sync/index process.
+	 *
+	 * If an index was stopped prematurely and won't start again, this will clear this cached data such that a new index can start.
 	 *
 	 * @subcommand clear-index
 	 * @alias delete-transient
@@ -1446,7 +1536,11 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Returns a JSON array with the results of the last CLI index (if present) of an empty array.
 	 *
-	 * @synopsis [--clear]
+	 * ## OPTIONS
+	 *
+	 * [--clear]
+	 * : Clear the `ep_last_cli_index` option.
+	 *
 	 * @subcommand get-last-cli-index
 	 *
 	 * @param array $args Positional CLI args.
@@ -1550,7 +1644,14 @@ class Command extends WP_CLI_Command {
 	 * that will be used by the filter with same name.
 	 * Delete the option if `--default` is passed.
 	 *
-	 * @synopsis [--version=<version>] [--default]
+	 * ## OPTIONS
+	 *
+	 * [--version=<version>]
+	 * : Version name
+	 *
+	 * [--default]
+	 * : Use to set the default version
+	 *
 	 * @subcommand set-algorithm-version
 	 *
 	 * @since       3.5.4


### PR DESCRIPTION
### Description of the Change

This PR updates our WP-CLI commands documentation. It was generated with this [WP-CLI command](https://github.com/felipeelia/cli-command-docs) using:

```
wp cli-command-docs elasticpress --custom-order=index,activate-feature,deactivate-feature,list-features,get-algorithm-version,set-algorithm-version --remove=delete_transient_on_int,custom_get_transient --custom-intro='The following WP-CLI commands are supported by ElasticPress:' > docs/wp-cli.md
```

Another PR will follow this one to make this process automatic.

### Benefits

WP-CLI already relies on the DocBlock above each subcommand. Generating the documentation from it we will have both things always sync'd.

### Possible Drawbacks

None. If someone wants to contribute with WP-CLI documentation specifically, it should be only a matter of updating the docblock in Command.php.

### Changelog Entry

Changed: WP-CLI documentation was updated
