### PR TITLE
Add get-mapping WP-CLI Subcommand

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -348,6 +348,32 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Return the mapping as a JSON object. If an index is specified, return its mapping only.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--index-name]
+	 * : The name of the index for which to return the mapping. If not passed, all mappings will be returned
+	 *
+	 * @subcommand get-mapping
+	 * @since      3.7
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_mapping( $args, $assoc_args ) {
+		$path = '_mapping';
+		if ( ! empty( $assoc_args['index-name'] ) ) {
+			$path = $assoc_args['index-name'] . '/' . $path;
+		}
+
+		$response = Elasticsearch::factory()->remote_request( $path );
+
+		$body = wp_remote_retrieve_body( $response );
+
+		WP_CLI::line( $body );
+	}
+
+	/**
 	 * Return all indexes from the cluster as a JSON object.
 	 *
 	 * @subcommand get-cluster-indexes


### PR DESCRIPTION
### Description of the Change

Using the `wp elasticpress` WP-CLI command, I am able to create and retrieve any or all indexes. However, I can **put** mappings only, but not retrieve.

This PR adds a new subcommand, `wp elasticpress get-mapping`, that allows for retrieving the current mappings:

```shell
wp elasticpress get-mapping
```

By passing an optional index name, the command will return the mapping for that index only:

```shell
wp elasticpress get-mapping --index-name=ep-examplecom-post-1
```

### Alternate Designs

If I have access to WP-CLI, but don't have this subcommand, I could do the following:

```shell
wp shell

wp> wp_remote_retrieve_body( ElasticPress\Elasticsearch::factory()->remote_request( '[<index>/]_mapping' ) );
```

That is unneccesarily complicated.

### Benefits

More complete API/feature set. Easier to use than `wp shell` command.

### Possible Drawbacks

I don't see any.

### Verification Process

I tested this locally, both with and without passing an index name.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

```md
### Added
- New WP-CLI subcommand for retrieving mappings: `wp elasticpress get-mapping [--index-name]`. Props [@tfrommen](https://github.com/tfrommen) via [#2378](https://github.com/10up/ElasticPress/pull/2378).
```
