### PR TITLE
update/remove_depricated_type_from_mget

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -663,7 +663,7 @@ class Elasticsearch {
 		if ( version_compare( $this->get_elasticsearch_version(), '7.0', '<' ) ) {
 			$path = apply_filters( 'ep_index_' . $type . '_request_path', $index . '/' . $type . '/_mget', $document_ids, $type );
 		} else {
-			$path = apply_filters( 'ep_index_' . $type . '_request_path', $index . '/_doc/_mget', $document_ids, $type );
+			$path = apply_filters( 'ep_index_' . $type . '_request_path', $index . '/_mget', $document_ids, $type );
 		}
 
 		$request_args = [


### PR DESCRIPTION
### Description of the Change

Avoids the deprecation warnings:
```
Warning: 299 Elasticsearch-7.8.0-757314695644ea9a1dc2fecd26d1a43856725e65 &quot;[types removal] Specifying types in multi get requests is deprecated.&quot; 
```
In 7.X  using mapping types [is deprecated](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/removal-of-types.html). Types are not used anymore (in previous versions of ES types would be used for posts, users and so on) we are using different indexes instead.

In get_documnets we seem to refect it as there is different URL used for > 7.0 ES version. This variant is not using the custom type, but instead, it tries to use `_doc` as kinda default type. This works, but the correct URL in this version for `_mget` is to omit the document type altogether. This change does just that.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1) Add a debug print in `Elasticsearch.php:1136`:
```
			if ( true === apply_filters( 'ep_intercept_remote_request', false ) ) {
				/**
				 * Filter intercepted request
				 *
				 * @hook ep_do_intercept_request
				 * @param {array} $request New remote request response
				 * @param  {array} $query Remote request arguments
				 * @param  {args} $args Request arguments
				 * @param  {int} $failures Number of failures
				 * @return {array} New request
				 */
				$request = apply_filters( 'ep_do_intercept_request', new WP_Error( 400, 'No Request defined' ), $query, $args, $failures );
			} else {
				$request = wp_remote_request( $query['url'], $args ); // try the existing host to avoid unnecessary calls.
			}

			var_dump($request['headers']); // <---- THIS
```
2) Run multi get
```
wp eval "\ElasticPress\Indexables::factory()->get('post')->multi_get([1,2]);"

object(Requests_Utility_CaseInsensitiveDictionary)#3210 (1) {
  ["data":protected]=>
  array(4) {
    ["warning"]=>
    string(136) "299 Elasticsearch-7.8.0-757314695644ea9a1dc2fecd26d1a43856725e65 "[types removal] Specifying types in multi get requests is deprecated.""
    ["content-type"]=>
    string(31) "application/json; charset=UTF-8"
    ["content-encoding"]=>
    string(4) "gzip"
    ["content-length"]=>
    string(4) "1334"
  }
}


```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Fixed: Replaced deprecated URL for multiple documents get from ElasticSearch.
