### PR TITLE
switch word_delimeter based filter

### DIFF
--- a/includes/mappings/comment/7-0.php
+++ b/includes/mappings/comment/7-0.php
@@ -93,7 +93,7 @@ return [
 					'max_shingle_size' => 5,
 				],
 				'ewp_word_delimiter' => [
-					'type'              => 'word_delimiter',
+					'type'              => 'word_delimiter_graph',
 					'preserve_original' => true,
 				],
 				'ewp_snowball'       => [

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -102,7 +102,7 @@ return array(
 					'max_shingle_size' => 5,
 				),
 				'ewp_word_delimiter' => array(
-					'type'              => 'word_delimiter',
+					'type'              => 'word_delimiter_graph',
 					'preserve_original' => true,
 				),
 				'ewp_snowball'       => array(

--- a/includes/mappings/term/7-0.php
+++ b/includes/mappings/term/7-0.php
@@ -49,7 +49,7 @@ return [
 					'max_shingle_size' => 5,
 				],
 				'ewp_word_delimiter' => [
-					'type'              => 'word_delimiter',
+					'type'              => 'word_delimiter_graph',
 					'preserve_original' => true,
 				],
 				'ewp_snowball'       => [

--- a/includes/mappings/user/7-0.php
+++ b/includes/mappings/user/7-0.php
@@ -93,7 +93,7 @@ return array(
 					'max_shingle_size' => 5,
 				),
 				'ewp_word_delimiter' => array(
-					'type'              => 'word_delimiter',
+					'type'              => 'word_delimiter_graph',
 					'preserve_original' => true,
 				),
 				'ewp_snowball'       => array(


### PR DESCRIPTION

### Description of the Change

`word_delimiter_graph` [is recommended ](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/analysis-word-delimiter-tokenfilter.html) in ElasticSearch 7.x over `word_delimiter` filter currently used by `ewp_word_delimiter`.

This change switches the underlying filter to match the recommendation.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Run `index --setup`, verify the filter still splits correct on caseChange and non-alpha symbols.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Changed: The base filter for `ewp_word_delimiter` was changed from `word_delimiter` to `word_delimiter_graph` based on ElasticSearch recommendation. 
