### PR TITLE
Force fetching ep_wpcli_sync_interrupted transient from remote to allow for more reliable remote interruption

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1793,7 +1793,11 @@ class Command extends WP_CLI_Command {
 		global $wpdb;
 
 		if ( wp_using_ext_object_cache() ) {
-			$should_interrupt_sync = wp_cache_get( $transient, 'transient' );
+			/**
+			* When external object cache is used we need to make sure to force a remote fetch,
+			* so that the value from the local memory is discarded.
+			*/
+			$should_interrupt_sync = wp_cache_get( $transient, 'transient', true );
 		} else {
 			$options = $wpdb->options;
 


### PR DESCRIPTION
### Description of the Change

During some testing, it was discovered that `wp elasticpress stop-indexing` doesn't reliably terminate the execution of an already-running process.

I think this is due to the cache value being stuck in local memory, this should help to prevent that by always forcing the remote fetch from the object cache backend.

Props @rinatkhaziev for https://github.com/Automattic/ElasticPress/pull/108

### Alternate Designs

N/A

### Benefits

The command will be more reliable in terminating the execution of an already-running process.

### Possible Drawbacks

None I can think of.

### Verification Process

1. Check out PR.
2. Spin up an indexing process in a memcached-enabled environment
3. Run `wp elasticpress stop-indexing` from another session
4. Repeat the process and verify it gets interrupted properly.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

Fixed: Force fetching ep_wpcli_sync_interrupted transient from remote to allow for more reliable remote interruption