### PR TITLE
Remove duplicate orderby for users query

### DIFF
--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -735,6 +735,7 @@ class User extends Indexable {
 		 * WP_User_Query doesn't let us get users across all blogs easily. This is the best
 		 * way to do that.
 		 */
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared  
 		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d", (int) $args['offset'], (int) $args['number'] ) );
 
 		return [

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -728,11 +728,14 @@ class User extends Indexable {
 			$args['order'] = 'desc';
 		}
 
+		$orderby_args = sanitize_sql_orderby( "{$args['orderby']} {$args['order']}" );
+		$orderby      = $orderby_args ? sprintf( 'ORDER BY %s', $orderby_args ) : '';
+
 		/**
 		 * WP_User_Query doesn't let us get users across all blogs easily. This is the best
 		 * way to do that.
 		 */
-		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} ORDER BY %s %s LIMIT %d, %d", $args['orderby'], $args['orderby'], (int) $args['offset'], (int) $args['number'] ) );
+		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d", (int) $args['offset'], (int) $args['number'] ) );
 
 		return [
 			'objects'       => $objects,


### PR DESCRIPTION
### Description of the Change

We noticed that there was a typo for the users query resulting in a duplicate `orderby` clause:

https://github.com/10up/ElasticPress/blob/b14ab9deee5e1c8b5609c9c210be0b91a3b8a97a/includes/classes/Indexable/User/User.php#L735

This resulted in the below query:

```
SELECT SQL_CALC_FOUND_ROWS ID FROM wp_users ORDER BY ‘ID’ ‘ID’ LIMIT 0, 350
```

`sanitize_sql_orderby()` is for sanitizing the ORDER BY clause for variable use in the $wpdb statement. Variable usage is for avoiding quotes since `$wpdb->prepare()` uses quotes in placeholders and that doesn't play nicely with mariadb. 

Props @brettshumaker https://github.com/Automattic/ElasticPress/pull/97, @pschoffer https://github.com/Automattic/ElasticPress/pull/112/files

### Alternate Designs

N/A.

### Benefits

No more duplicate orderby clause!

### Possible Drawbacks

None that I can tell.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

Fixed: Duplicate orderby statement in Users query.