### PR TITLE
When using default max result window value for size, we should account for offsets

### DIFF
--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -85,6 +85,9 @@ class Comment extends Indexable {
 		 */
 		if ( isset( $query_vars['offset'] ) ) {
 			$formatted_args['from'] = (int) $query_vars['offset'];
+			if ( empty( $query_vars['number'] ) ) {
+				$formatted_args['size'] -= (int) $formatted_args['from'];
+			}
 		}
 
 		/**


### PR DESCRIPTION
### Description of the Change

Offset is not accounted for when assigning the default size below for comment queries:

https://github.com/10up/ElasticPress/blob/4a2547e40891895e93361d6063d7f9ddd6e3aa71/includes/classes/Indexable/Comment/Comment.php#L75-L81

In not doing so, we could potentially hit the `ep_max_results_window` if an offset is passed in. Therefore, if we are using the default value for `ep_max_results_window`, we should account for the sum of offset and size being equal (or less than) the maximum results window.

From https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html:
> index.max_result_window The maximum value of from + size for searches to this index. Defaults to 10000. Search requests take heap memory and time proportional to from + size and this limits that memory. 

### Alternate Designs

N/A.

### Benefits

![itsover1000](https://user-images.githubusercontent.com/16962021/140423062-ded14593-b8e3-4ce9-9074-b89024d69f62.jpg)

### Possible Drawbacks

N/A.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Fixed: When using offset and default maximum result window value for size, subtract offset from size
