### PR TITLE
Add $type parameter to ep_do_intercept_request filter

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1151,6 +1151,8 @@ class Elasticsearch {
 				 * Filter intercepted request
 				 *
 				 * @hook ep_do_intercept_request
+				 * @since 3.2.2
+				 * @since 4.0.0 added $type
 				 * @param {array} $request New remote request response
 				 * @param  {array} $query Remote request arguments
 				 * @param  {args} $args Request arguments

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1155,9 +1155,10 @@ class Elasticsearch {
 				 * @param  {array} $query Remote request arguments
 				 * @param  {args} $args Request arguments
 				 * @param  {int} $failures Number of failures
+				 * @param  {string} $type Type of request
 				 * @return {array} New request
 				 */
-				$request = apply_filters( 'ep_do_intercept_request', new WP_Error( 400, 'No Request defined' ), $query, $args, $failures );
+				$request = apply_filters( 'ep_do_intercept_request', new WP_Error( 400, 'No Request defined' ), $query, $args, $failures, $type );
 			} else {
 				$request = wp_remote_request( $query['url'], $args ); // try the existing host to avoid unnecessary calls.
 			}


### PR DESCRIPTION
### Description of the Change

It would be nice if we could pass in the `$type` parameter into the `ep_do_intercept_request` filter:

https://github.com/10up/ElasticPress/blob/5bb9d76ff4bfd85761e4416a892d731e62cdf33d/includes/classes/Elasticsearch.php#L1067-L1071

This way, we have the flexibility of intercepting the request based on the type of request.

### Alternate Designs

N/A.

### Benefits

We would be able to intercept the request based on the type of request.

### Possible Drawbacks

Those hooking onto the filter already may need to update their filter arguments

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Changed: Add $type parameter to ep_do_intercept_request filter
