### PR TITLE
Cache the post mapping version

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -277,18 +277,36 @@ class Post extends Indexable {
 	 * @return string|WP_Error|false $version
 	 */
 	public function determine_mapping_version() {
-		$index   = $this->get_index_name();
-		$mapping = Elasticsearch::factory()->get_mapping( $index );
+		$version = get_transient( 'ep_post_mapping_version' );
 
-		if ( empty( $mapping ) ) {
-			return new \WP_Error( 'ep_failed_mapping_version', esc_html__( 'Error while fetching the mapping version.', 'elasticpress' ) );
+		if ( empty( $version ) ) {
+			$index   = $this->get_index_name();
+			$mapping = Elasticsearch::factory()->get_mapping( $index );
+
+			if ( empty( $mapping ) ) {
+				return new \WP_Error( 'ep_failed_mapping_version', esc_html__( 'Error while fetching the mapping version.', 'elasticpress' ) );
+			}
+
+			if ( ! isset( $mapping[ $index ] ) ) {
+				return false;
+			}
+
+			$version = $this->determine_mapping_version_based_on_existing( $mapping, $index );
+
+			set_transient(
+				'ep_post_mapping_version',
+				$version,
+				/**
+				 * Filter the post mapping version cache expiration.
+				 *
+				 * @hook ep_post_mapping_version_cache_expiration
+				 * @since 4.0.0
+				 * @param  {int} $version Time in seconds for the transient expiration
+				 * @return {int} New time
+				 */
+				apply_filters( 'ep_post_mapping_version_cache_expiration', DAY_IN_SECONDS )
+			);
 		}
-
-		if ( ! isset( $mapping[ $index ] ) ) {
-			return false;
-		}
-
-		$version = $this->determine_mapping_version_based_on_existing( $mapping, $index );
 
 		/**
 		 * Filter the mapping version for posts.
@@ -327,6 +345,8 @@ class Post extends Indexable {
 		 * @return  {array} New mapping
 		 */
 		$mapping = apply_filters( 'ep_post_mapping', $mapping );
+
+		delete_transient( 'ep_post_mapping_version' );
 
 		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
 	}


### PR DESCRIPTION
### Description of the Change

This PR caches the detected Posts mapping version for a day. This way, we don't send get_mapping calls on every request but we are still able to detect if the ES server was upgraded in a timely manner. People wanting to change that period can do that via the new `ep_post_mapping_version_cache_expiration` filter.

### Applicable Issues

Closes #2432

### Changelog Entry

Changed: Cache the detect posts mapping version, avoiding get_mapping calls in all admin requests.
