### PR TITLE
Ensure array query parameters do not contain empty items

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -887,6 +887,32 @@ class Post extends Indexable {
 			),
 		);
 		$use_filters = false;
+		
+		// Sanitize array query args. Elasticsearch will error if a terms query contains empty items like an
+		// empty string.
+		$keys_to_sanitize = [
+			'author__in',
+			'author__not_in',
+			'category__and',
+			'category__in',
+			'category__not_in',
+			'tag__and',
+			'tag__in',
+			'tag__not_in',
+			'tag_slug__and',
+			'tag_slug__in',
+			'post_parent__in',
+			'post_parent__not_in',
+			'post__in',
+			'post__not_in',
+			'post_name__in',
+		];
+		foreach ( $keys_to_sanitize as $key ) {
+			if ( ! isset( $args[ $key ] ) ) {
+				continue;
+			}
+			$args[ $key ] = array_filter( (array) $args[ $key ] );
+		}
 
 		/**
 		 * Tax Query support
@@ -1072,7 +1098,7 @@ class Post extends Indexable {
 		 *
 		 * @since 3.6.0
 		 */
-		if ( ! empty( $args['post_name__in'] ) ) {
+		if ( ! empty( array_filter( (array) $args['post_name__in'] ) ) ) {
 			$filter['bool']['must'][]['bool']['must'] = array(
 				'terms' => array(
 					'post_name.raw' => array_values( (array) $args['post_name__in'] ),

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -887,7 +887,7 @@ class Post extends Indexable {
 			),
 		);
 		$use_filters = false;
-		
+
 		// Sanitize array query args. Elasticsearch will error if a terms query contains empty items like an
 		// empty string.
 		$keys_to_sanitize = [
@@ -1098,7 +1098,7 @@ class Post extends Indexable {
 		 *
 		 * @since 3.6.0
 		 */
-		if ( ! empty( array_filter( (array) $args['post_name__in'] ) ) ) {
+		if ( ! empty( $args['post_name__in'] ) ) {
 			$filter['bool']['must'][]['bool']['must'] = array(
 				'terms' => array(
 					'post_name.raw' => array_values( (array) $args['post_name__in'] ),


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

In some cases query args like `post__in` that are expected to be array might contain invalid data such as an empty string. An array like `[ '' ]` will not appear as empty when checked with `empty( [ '' ] )` so this update ensures the arrays only contain real values. Database IDs all start from 1 so removing `0` is ok here.

This issue was observed with Yoast SEO adding subqueries for indexables to populate `post__in` parameters, however the index was incomplete. Can also happens in non-production environments where indexables aren't saved to the database.


<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

Prevents ES query errors such as this one:

```
Warning[16-Nov-2021 09:00:26 UTC] PHP Warning:  Error in ElasticSearch request: {"error":{"root_cause":[{"type":"query_shard_exception","reason":"failed to create query: empty String","index_uuid":"nRExUs6-TSCUfwX3cBDodg","index":"examplecom-post-2"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":4,"index":"examplecom-post-2","node":"-ftiX3JgRtC_yi8bXpnR9A","reason":{"type":"query_shard_exception","reason":"failed to create query: empty String","index_uuid":"nRExUs6-TSCUfwX3cBDodg","index":"examplecom-post-2","caused_by":{"type":"number_format_exception","reason":"empty String"}}}]},"status":400} (400) in /usr/src/app/vendor/altis/cloud/inc/namespace.php on line 365
```

Note this part:

```
"caused_by":{"type":"number_format_exception","reason":"empty String"}
```

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

I added this code to as a `mu-plugin` reproduce the WP Query args as a minimal test case:

```
add_action( 'pre_get_posts', function( \WP_Query $query ) : void {
	$query->set( 'post__not_in', [ '' ] );
}  );
```

Observe running a search query yields no results (or falls back to a db query).

The change is intentionally light in terms of sanitisation and I haven observed no regressions with valid values for the listed query arguments, even if provided as strings e.g. `(array) "some string" -> [ "some string" ]`.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
