### PR TITLE
Add a new `ep_weighting_default_enabled_taxonomies` filter

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -126,12 +126,21 @@ class Weighting {
 			],
 		];
 
-		/*
+		$post_type_taxonomies = get_object_taxonomies( $post_type );
+
+		/**
+		 * Filter install status
+		 *
 		 * Previous behavior had post_tag and category enabled by default, so if this is supported on the post type
 		 * we add them as enabled by default
+		 *
+		 * @hook ep_weighting_default_enabled_taxonomies
+		 * @param  {array}  $enabled_taxonomies Taxonomies that should be enabled by default
+		 * @param  {string} $post_type          Post type slug
+		 * @return {array}  New taxonomies
+		 * @since  3.6.5
 		 */
-		$post_type_taxonomies = get_object_taxonomies( $post_type );
-		$enabled_by_default   = [ 'post_tag', 'category' ];
+		$enabled_by_default = apply_filters( 'ep_weighting_default_enabled_taxonomies', [ 'post_tag', 'category' ], $post_type );
 
 		foreach ( $enabled_by_default as $default_tax ) {
 			if ( in_array( $default_tax, $post_type_taxonomies, true ) ) {

--- a/tests/php/features/TestWeighting.php
+++ b/tests/php/features/TestWeighting.php
@@ -124,6 +124,44 @@ class TestWeighting extends BaseTestCase {
 
 	}
 
+	/**
+	 * Test the `ep_weighting_default_enabled_taxonomies` filter.
+	 *
+	 * This filter should affect the weighting dashboard only if it was not saved yet.
+	 *
+	 * @since 3.6.5
+	 * @group weighting
+	 */
+	public function testWeightingDefaultEnabledTaxonomies() {
+		// By default, `post_format` should not be enabled, only `category` and `post_tag`.
+		$post_default_config = $this->get_weighting_feature()->get_post_type_default_settings( 'post' );
+		$this->assertArrayNotHasKey( 'terms.post_format.name', $post_default_config );
+		$this->assertTrue( $post_default_config['terms.category.name']['enabled'] );
+		$this->assertTrue( $post_default_config['terms.post_tag.name']['enabled'] );
+
+
+		add_filter(
+			'ep_weighting_default_enabled_taxonomies',
+			function ( $taxs, $post_type ) {
+				if ( 'post' === $post_type ) {
+					$taxs[] = 'post_format';
+				}
+				return $taxs;
+			},
+			10,
+			2
+		);
+
+		$post_default_config = $this->get_weighting_feature()->get_post_type_default_settings( 'post' );
+		$this->assertTrue( $post_default_config['terms.post_format.name']['enabled'] );
+
+		// `$this->weighting_settings` does not have post_format. So, once saved, the configuration should not have it enabled too.
+		$this->get_weighting_feature()->save_weighting_configuration( $this->weighting_settings );
+		$weighting_configuration = $this->get_weighting_feature()->get_weighting_configuration();
+		$this->assertArrayNotHasKey( 'post_format', $weighting_configuration['post'] );
+		$this->assertArrayNotHasKey( 'terms.post_format.name', $weighting_configuration['post'] );
+	}
+
 	public function testGetWeightableFieldsForPostType() {
 		$fields = $this->get_weighting_feature()->get_weightable_fields_for_post_type( 'ep_test' );
 


### PR DESCRIPTION
### Description of the Change

This PR adds a new filter, so developers can enable some taxonomies by default in the weighting dashboard.

### Applicable Issues

Closes #1503

### Changelog Entry

Added: New `ep_weighting_default_enabled_taxonomies` filter. Props @felipeelia and @tott 
