### PR TITLE
Update ES and WP required versions

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/ElasticPress
  * Description:       A fast and flexible search and query engine for WordPress.
  * Version:           3.6.4
- * Requires at least: 3.7.1
+ * Requires at least: 5.6
  * Requires PHP:      5.6
  * Author:            10up
  * Author URI:        http://10up.com

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -70,12 +70,12 @@ spl_autoload_register(
  *
  * EP_ES_VERSION_MIN <= YOUR ES VERSION <= EP_ES_VERSION_MAX
  *
- * We don't check minor releases so if your ES version if 5.1.1, we consider that 5.1 in our comparison.
+ * We don't check minor releases so if your ES version if 7.10.1, we consider that 7.10 in our comparison.
  *
  * @since  2.2
  */
-define( 'EP_ES_VERSION_MAX', '7.9' );
-define( 'EP_ES_VERSION_MIN', '5.0' );
+define( 'EP_ES_VERSION_MAX', '7.10' );
+define( 'EP_ES_VERSION_MIN', '5.2' );
 
 require_once __DIR__ . '/includes/compat.php';
 require_once __DIR__ . '/includes/utils.php';

--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -451,10 +451,10 @@ class AdminNotices {
 			return false;
 		}
 
-		// First reduce version to major version i.e. 5.1 not 5.1.1.
+		// First reduce version to major version i.e. 7.10 not 7.10.1.
 		$major_es_version = preg_replace( '#^([0-9]+\.[0-9]+).*#', '$1', $es_version );
 
-		// pad a version to have at least two parts (5 -> 5.0)
+		// pad a version to have at least two parts (7 -> 7.0)
 		$parts = explode( '.', $major_es_version );
 
 		if ( 1 === count( $parts ) ) {
@@ -511,7 +511,7 @@ class AdminNotices {
 			return false;
 		}
 
-		// First reduce version to major version i.e. 5.1 not 5.1.1.
+		// First reduce version to major version i.e. 7.10 not 7.10.1.
 		$major_es_version = preg_replace( '#^([0-9]+\.[0-9]+).*#', '$1', $es_version );
 
 		if ( -1 === version_compare( EP_ES_VERSION_MAX, $major_es_version ) ) {


### PR DESCRIPTION
### Description of the Change

This PR updates versions required for Elasticsearch and WordPress

### Applicable Issues

Closes #2431

### Changelog Entry

Changed: Required versions of WordPress and Elasticsearch
