### PR TITLE
WP-CLI: stats and status to output all indices info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Supported versions:
 - Duplicate orderby statement in Users query. Props [@brettshumaker](https://github.com/brettshumaker), [@pschoffer](https://github.com/pschoffer), and [@rebeccahum](https://github.com/rebeccahum) via [#2435](https://github.com/10up/ElasticPress/pull/2435).
 - When using offset and default maximum result window value for size, subtract offset from size. Props [@rebeccahum](https://github.com/rebeccahum) via [#2441](https://github.com/10up/ElasticPress/pull/2441).
 - Order for Custom Search Results in autosuggest. Props [@felipeelia](https://github.com/felipeelia) and [@johnwatkins0](https://github.com/johnwatkins0) via [#2447](https://github.com/10up/ElasticPress/pull/2447).
+- WP-CLI stats and status to output all indices related to ElasticPress. Props [@felipeelia](https://github.com/felipeelia) via [#2479](https://github.com/10up/ElasticPress/pull/2479).
 - Tests: Ensure that Posts related queries use ElasticPress. Props [@Rahmon](https://github.com/Rahmon) via [#2401](https://github.com/10up/ElasticPress/pull/2401).
 - Tests: PHPUnit and yoast/phpunit-polyfills. Props [@felipeelia](https://github.com/felipeelia) via [#2457](https://github.com/10up/ElasticPress/pull/2457).
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1228,23 +1228,7 @@ class Command extends WP_CLI_Command {
 
 		$request_args = [ 'headers' => Elasticsearch::factory()->format_request_headers() ];
 
-		$sites = ( is_multisite() ) ? Utils\get_sites() : array( 'blog_id' => get_current_blog_id() );
-
-		$term_indexable = Indexables::factory()->get( 'term' );
-
-		foreach ( $sites as $site ) {
-			$index_names[] = Indexables::factory()->get( 'post' )->get_index_name( $site['blog_id'] );
-
-			if ( ! empty( $term_indexable ) ) {
-				$index_names[] = $term_indexable->get_index_name( $site['blog_id'] );
-			}
-		}
-
-		$user_indexable = Indexables::factory()->get( 'user' );
-
-		if ( ! empty( $user_indexable ) ) {
-			$index_names[] = $user_indexable->get_index_name();
-		}
+		$registered_index_names = $this->get_index_names();
 
 		$response_cat_indices = Elasticsearch::factory()->remote_request( '_cat/indices?format=json' );
 
@@ -1257,7 +1241,7 @@ class Command extends WP_CLI_Command {
 		if ( is_array( $indexes_from_cat_indices_api ) ) {
 			$indexes_from_cat_indices_api = wp_list_pluck( $indexes_from_cat_indices_api, 'index' );
 
-			$index_names = array_intersect( $index_names, $indexes_from_cat_indices_api );
+			$index_names = array_intersect( $registered_index_names, $indexes_from_cat_indices_api );
 		} else {
 			WP_CLI::error( esc_html__( 'Failed to return status.', 'elasticpress' ) );
 		}
@@ -1289,24 +1273,7 @@ class Command extends WP_CLI_Command {
 
 		$request_args = array( 'headers' => Elasticsearch::factory()->format_request_headers() );
 
-		$sites = ( is_multisite() ) ? Utils\get_sites() : array( 'blog_id' => get_current_blog_id() );
-
-		$post_indexable = Indexables::factory()->get( 'post' );
-		$term_indexable = Indexables::factory()->get( 'term' );
-
-		foreach ( $sites as $site ) {
-			$index_names[] = $post_indexable->get_index_name( $site['blog_id'] );
-
-			if ( ! empty( $term_indexable ) ) {
-				$index_names[] = $term_indexable->get_index_name( $site['blog_id'] );
-			}
-		}
-
-		$user_indexable = Indexables::factory()->get( 'user' );
-
-		if ( ! empty( $user_indexable ) ) {
-			$index_names[] = $user_indexable->get_index_name();
-		}
+		$registered_index_names = $this->get_index_names();
 
 		$response_cat_indices = Elasticsearch::factory()->remote_request( '_cat/indices?format=json' );
 
@@ -1319,7 +1286,7 @@ class Command extends WP_CLI_Command {
 		if ( is_array( $indexes_from_cat_indices_api ) ) {
 			$indexes_from_cat_indices_api = wp_list_pluck( $indexes_from_cat_indices_api, 'index' );
 
-			$index_names = array_intersect( $index_names, $indexes_from_cat_indices_api );
+			$index_names = array_intersect( $registered_index_names, $indexes_from_cat_indices_api );
 		} else {
 			WP_CLI::error( esc_html__( 'Failed to return stats.', 'elasticpress' ) );
 		}
@@ -1333,20 +1300,8 @@ class Command extends WP_CLI_Command {
 		}
 		$body = json_decode( wp_remote_retrieve_body( $request ), true );
 
-		foreach ( $sites as $site ) {
-			$current_index = $post_indexable->get_index_name( $site['blog_id'] );
-
-			$this->render_stats( $current_index, $body );
-
-			if ( $term_indexable ) {
-				$this->render_stats( $term_indexable->get_index_name( $site['blog_id'] ), $body );
-			}
-		}
-
-		if ( ! empty( $user_indexable ) ) {
-			$user_index = $user_indexable->get_index_name();
-
-			$this->render_stats( $user_index, $body );
+		foreach ( $registered_index_names as $index_name ) {
+			$this->render_stats( $index_name, $body );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Fixed:
 * Duplicate orderby statement in Users query. Props [@brettshumaker](https://github.com/brettshumaker), [@pschoffer](https://github.com/pschoffer), and [@rebeccahum](https://github.com/rebeccahum).
 * When using offset and default maximum result window value for size, subtract offset from size. Props [@rebeccahum](https://github.com/rebeccahum).
 * Order for Custom Search Results in autosuggest. Props [@felipeelia](https://github.com/felipeelia) and [@johnwatkins0](https://github.com/johnwatkins0).
+* WP-CLI stats and status to output all indices related to ElasticPress. Props [@felipeelia](https://github.com/felipeelia).
 * Tests: Ensure that Posts related queries use ElasticPress. Props [@Rahmon](https://github.com/Rahmon).
 * Tests: PHPUnit and yoast/phpunit-polyfills. Props [@felipeelia](https://github.com/felipeelia).
 


### PR DESCRIPTION
### Description of the Change

Currently, both commands won't output some indices info, as the list is hardcoded in each function. This PR changes the code so it takes advantage of the new `Command::get_index_names()` method introduced in 3.6.4, outputting info of indices of all registered Indexables.

### Changelog Entry

Fixed: WP-CLI `stats` and `status` to output all indices related to ElasticPress. Props @felipeelia 