### PR TITLE
Apply post types from search forms to Instant Results as a filter 

### DIFF
--- a/assets/js/instant-results/components/facets/post-type-facet.js
+++ b/assets/js/instant-results/components/facets/post-type-facet.js
@@ -25,7 +25,7 @@ export default ({ defaultIsOpen, label }) => {
 	const {
 		state: {
 			isLoading,
-			postTypes: selectedPostTypes = [],
+			filters: { post_type: selectedPostTypes = [] },
 			postTypesAggregation: { post_types: { buckets = [] } = {} } = {},
 		},
 		dispatch,
@@ -70,7 +70,7 @@ export default ({ defaultIsOpen, label }) => {
 	 * @param {string[]} postTypes Selected post types.
 	 */
 	const onChange = (postTypes) => {
-		dispatch({ type: 'SET_POST_TYPES', payload: postTypes });
+		dispatch({ type: 'APPLY_FILTERS', payload: { post_type: postTypes } });
 	};
 
 	/**
@@ -80,10 +80,11 @@ export default ({ defaultIsOpen, label }) => {
 	 */
 	const onClear = (postType) => {
 		const postTypes = [...selectedPostTypes];
+		const index = postTypes.indexOf(postType);
 
-		postTypes.splice(postTypes.indexOf(postType), 1);
+		postTypes.splice(index, 1);
 
-		dispatch({ type: 'SET_POST_TYPES', payload: postTypes });
+		dispatch({ type: 'APPLY_FILTERS', payload: { post_type: postTypes } });
 	};
 
 	return (

--- a/assets/js/instant-results/components/facets/price-range-facet.js
+++ b/assets/js/instant-results/components/facets/price-range-facet.js
@@ -29,7 +29,7 @@ export default ({ defaultIsOpen, label }) => {
 				max_price: { value: maxAgg = null } = {},
 				min_price: { value: minAgg = null } = {},
 			} = {},
-			priceRange: [minArg = null, maxArg = null],
+			filters: { price_range: [minArg = null, maxArg = null] = [] },
 		},
 		dispatch,
 	} = useContext(Context);
@@ -70,7 +70,7 @@ export default ({ defaultIsOpen, label }) => {
 	 * @param {number[]} values Lowest and highest values.
 	 */
 	const onAfterChange = (values) => {
-		dispatch({ type: 'SET_PRICE_RANGE', payload: values });
+		dispatch({ type: 'APPLY_FILTER', payload: { price_range: values } });
 	};
 
 	/**
@@ -87,7 +87,7 @@ export default ({ defaultIsOpen, label }) => {
 	 * Handle clearing the filter.
 	 */
 	const onClear = () => {
-		dispatch({ type: 'SET_PRICE_RANGE', payload: [] });
+		dispatch({ type: 'APPLY_FILTER', payload: { price_range: [] } });
 	};
 
 	/**

--- a/assets/js/instant-results/components/facets/search-term-facet.js
+++ b/assets/js/instant-results/components/facets/search-term-facet.js
@@ -31,6 +31,7 @@ export default () => {
 	 */
 	const onChange = (event) => {
 		dispatch({ type: 'SET_SEARCH_TERM', payload: event.target.value });
+		dispatch({ type: 'CLEAR_FILTERS' });
 	};
 
 	/**

--- a/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
+++ b/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
@@ -25,7 +25,7 @@ export default ({ defaultIsOpen, label, taxonomy }) => {
 	const {
 		state: {
 			isLoading,
-			taxonomyTerms: { [taxonomy]: selectedTerms = [] },
+			filters: { [taxonomy]: selectedTerms = [] },
 			taxonomyTermsAggregations: {
 				[taxonomy]: { taxonomy_terms: { buckets = [] } = {} } = {},
 			} = {},
@@ -89,7 +89,7 @@ export default ({ defaultIsOpen, label, taxonomy }) => {
 	 * @param {string[]} terms Selected terms.
 	 */
 	const onChange = (terms) => {
-		dispatch({ type: 'SET_TAXONOMY_TERMS', payload: { taxonomy, terms } });
+		dispatch({ type: 'APPLY_FILTERS', payload: { [taxonomy]: terms } });
 	};
 
 	/**
@@ -102,7 +102,7 @@ export default ({ defaultIsOpen, label, taxonomy }) => {
 
 		terms.splice(terms.indexOf(term), 1);
 
-		dispatch({ type: 'SET_TAXONOMY_TERMS', payload: { taxonomy, terms } });
+		dispatch({ type: 'APPLY_FILTERS', payload: { [taxonomy]: terms } });
 	};
 
 	return (

--- a/assets/js/instant-results/components/tools/clear-constraints.js
+++ b/assets/js/instant-results/components/tools/clear-constraints.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
+import { facets } from '../../config';
 import Context from '../../context';
 import SmallButton from '../common/small-button';
 
@@ -17,24 +18,22 @@ import SmallButton from '../common/small-button';
  */
 export default () => {
 	const {
-		state: { postTypes, priceRange, taxonomyTerms },
+		state: { filters },
 		dispatch,
 	} = useContext(Context);
 
 	/**
 	 * Return whether there are active filters.
 	 *
+	 * Only filters that are available as facets are checked, as these are the
+	 * only filters that will be cleared. This is to support applying filters
+	 * that cannot be modified by the user.
+	 *
 	 * @return {boolean} Whether there are active filters.
 	 */
 	const hasFilters = useMemo(() => {
-		const [minPrice, maxPrice] = priceRange;
-
-		const hasPostTypes = postTypes.length > 0;
-		const hasPriceRange = Boolean(minPrice || maxPrice);
-		const hasTaxonomyTerms = Object.values(taxonomyTerms).some((terms) => terms.length > 0);
-
-		return hasPostTypes || hasPriceRange || hasTaxonomyTerms;
-	}, [postTypes, priceRange, taxonomyTerms]);
+		return facets.some(({ name }) => filters[name]?.length > 0);
+	}, [filters]);
 
 	/**
 	 * Handle clicking button.

--- a/assets/js/instant-results/functions.js
+++ b/assets/js/instant-results/functions.js
@@ -4,61 +4,6 @@
 import { currencyCode } from './config';
 
 /**
- * Set API request args for post type.
- *
- * @param {string[]} postTypes Post types.
- * @return {Object} Price range args.
- */
-export const getArgsFromPostTypes = (postTypes) => {
-	const args = {};
-
-	if (postTypes.length > 0) {
-		args.post_type = postTypes;
-	}
-
-	return args;
-};
-
-/**
- * Set API request args for a price range.
- *
- * @param {number} min Minimum price.
- * @param {number} max Maximum price.
- * @return {Object} Request args.
- */
-export const getArgsFromPriceRange = (min, max) => {
-	const args = {};
-
-	if (min) {
-		args.min_price = min;
-	}
-
-	if (max) {
-		args.max_price = max;
-	}
-
-	return args;
-};
-
-/**
- * Set API request args for taxonomy terms.
- *
- * @param {Object[]} taxonomyTerms Taxonomies and their terms.
- * @return {Object} Request args.
- */
-export const getArgsFromTaxonomyTerms = (taxonomyTerms) => {
-	return Object.entries(taxonomyTerms).reduce((args, [taxonomy, terms]) => {
-		const param = `tax-${taxonomy}`;
-
-		if (terms.length > 0) {
-			args[param] = terms.join(',');
-		}
-
-		return args;
-	}, {});
-};
-
-/**
  * Format a number as a price.
  *
  * @param {number} number Number to format.
@@ -83,18 +28,35 @@ export const formatPrice = (number, options) => {
  * @return {URLSearchParams} URLSearchParams instance.
  */
 export const getURLParamsFromState = (state) => {
-	const { args, postTypes, priceRange, taxonomyTerms } = state;
+	const { args, filters } = state;
 
-	const postTypeParam = getArgsFromPostTypes(postTypes);
-	const priceRangeParams = getArgsFromPriceRange(...priceRange);
-	const taxonomyTermsParams = getArgsFromTaxonomyTerms(taxonomyTerms);
+	const filterArgs = Object.entries(filters).reduce((filterArgs, [filter, value]) => {
+		switch (filter) {
+			case 'price_range':
+				if (value.length > 0) {
+					filterArgs.min_price = value[0];
+					filterArgs.max_price = value[1];
+				}
 
-	const init = {
-		...args,
-		...postTypeParam,
-		...priceRangeParams,
-		...taxonomyTermsParams,
-	};
+				break;
+			case 'post_type':
+				if (value.length > 0) {
+					filterArgs[filter] = value.join(',');
+				}
+
+				break;
+			default:
+				if (value.length > 0) {
+					filterArgs[`tax-${filter}`] = value.join(',');
+				}
+
+				break;
+		}
+
+		return filterArgs;
+	}, {});
+
+	const init = { ...args, ...filterArgs };
 
 	return new URLSearchParams(init);
 };

--- a/assets/js/instant-results/functions.js
+++ b/assets/js/instant-results/functions.js
@@ -22,6 +22,26 @@ export const formatPrice = (number, options) => {
 };
 
 /**
+ * Get the post types from a search form.
+ *
+ * @param {HTMLFormElement} form Form element.
+ * @return {Array} Post types.
+ */
+export const getPostTypesFromForm = (form) => {
+	const data = new FormData(form);
+
+	if (data.has('post_type')) {
+		return data.getAll('post_type').slice(-1);
+	}
+
+	if (data.has('post_type[]')) {
+		return data.getAll('post_type[]');
+	}
+
+	return [];
+};
+
+/**
  * Get query parameters for an API request from the state.
  *
  * @param {Object} state State.

--- a/assets/js/instant-results/index.js
+++ b/assets/js/instant-results/index.js
@@ -179,9 +179,7 @@ const App = () => {
 		state.args.offset,
 		state.args.search,
 		state.isOpen,
-		state.postTypes,
-		state.priceRange,
-		state.taxonomyTerms,
+		state.filters,
 	]);
 
 	return (

--- a/assets/js/instant-results/index.js
+++ b/assets/js/instant-results/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import Context from './context';
-import { getURLParamsFromState } from './functions';
+import { getPostTypesFromForm, getURLParamsFromState } from './functions';
 import { useDebounce, useGetResults } from './hooks';
 import { reducer, initialArg } from './reducer';
 import Layout from './components/layout';
@@ -41,6 +41,7 @@ const App = () => {
 	 */
 	const closeModal = useCallback(() => {
 		dispatch({ type: 'CLOSE_MODAL' });
+		dispatch({ type: 'CLEAR_FILTERS' });
 		inputRef.current.focus();
 	}, []);
 
@@ -114,7 +115,11 @@ const App = () => {
 
 			inputRef.current = event.target.s;
 
-			dispatch({ type: 'SET_SEARCH_TERM', payload: event.target.s.value });
+			const searchTerm = inputRef.current.value;
+			const postTypes = getPostTypesFromForm(inputRef.current.form);
+
+			dispatch({ type: 'SET_SEARCH_TERM', payload: searchTerm });
+			dispatch({ type: 'APPLY_FILTERS', payload: { post_type: postTypes } });
 
 			openModal();
 		},

--- a/assets/js/instant-results/reducer.js
+++ b/assets/js/instant-results/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies.
  */
-import { highlightTag, matchType } from './config';
+import { facets, highlightTag, matchType } from './config';
 
 /**
  * Initial state.
@@ -17,17 +17,15 @@ export const initialArg = {
 		search: '',
 		elasticpress: '1',
 	},
+	filters: {},
 	isLoading: false,
 	isOpen: false,
 	isSidebarOpen: false,
 	poppingState: false,
-	postTypes: [],
 	postTypesAggregation: {},
-	priceRange: [],
 	priceRangeAggregations: {},
 	searchResults: [],
 	searchedTerm: '',
-	taxonomyTerms: {},
 	taxonomyTermsAggregations: {},
 	totalResults: 0,
 };
@@ -45,49 +43,27 @@ export const reducer = (state, { type, payload }) => {
 	const newState = { ...state };
 
 	switch (type) {
-		case 'CLEAR_FILTERS': {
-			newState.postTypes = [];
-			newState.priceRange = [];
-			newState.taxonomyTerms = {};
+		case 'APPLY_FILTERS': {
+			newState.args.offset = 0;
+			newState.filters = { ...state.filters, ...payload };
+
 			break;
 		}
-		case 'POP_STATE': {
-			newState.args = payload.args;
-			newState.isOpen = payload.isOpen;
-			newState.poppingState = true;
-			newState.postTypes = payload.postTypes;
-			newState.priceRange = payload.priceRange;
-			newState.taxonomyTerms = payload.taxonomyTerms;
+		case 'CLEAR_FILTERS': {
+			newState.filters = facets.reduce(
+				(filters, { name }) => {
+					delete filters[name];
+
+					return filters;
+				},
+				{ ...state.filters },
+			);
+
 			break;
 		}
 		case 'SET_SEARCH_TERM': {
 			newState.args.offset = 0;
 			newState.args.search = payload;
-
-			if (payload) {
-				newState.postTypes = [];
-				newState.priceRange = [];
-				newState.taxonomyTerms = {};
-			}
-
-			break;
-		}
-		case 'SET_POST_TYPES': {
-			newState.args.offset = 0;
-			newState.postTypes = payload;
-			break;
-		}
-		case 'SET_PRICE_RANGE': {
-			newState.args.offset = 0;
-			newState.priceRange = payload;
-			break;
-		}
-		case 'SET_TAXONOMY_TERMS': {
-			const newTaxonomyTerms = { ...newState.taxonomyTerms };
-
-			newTaxonomyTerms[payload.taxonomy] = payload.terms;
-			newState.args.offset = 0;
-			newState.taxonomyTerms = newTaxonomyTerms;
 			break;
 		}
 		case 'SORT_RESULTS': {
@@ -111,7 +87,6 @@ export const reducer = (state, { type, payload }) => {
 			 */
 			const totalNumber = typeof total === 'number' ? total : total.value;
 
-			newState.poppingState = false;
 			newState.postTypesAggregation = postTypesAggregation;
 			newState.priceRangeAggregations = priceRangeAggregation;
 			newState.searchResults = hits;


### PR DESCRIPTION
### Description of the Change

It's a common practice to create search forms only for particular post types by adding an `input[name="post_type"]` to the search form, often hidden. For example, the WooCommerce product search form has a hidden input named `post_type` with the value `product`, so that only Products are searched. This PR updates Instant Results to automatically apply a post type filter for any post type fields in the search form.

### Benefits

Instant Results will respect any post type filters that have been applied to an existing search form. For example, when submitting the form in the WooCommerce _Product Search_ block/widget or `get_product_search_form()` Instant Results will automatically apply a post type filter so that only Products are searched. If Instant Results is configured with a _Post type_ facet then the filter can be changed or removed using the facet.

### Possible Drawbacks

If a form has a `post_type[]` field, to support searching multiple post types, then this will result in no results if the _Match Type_ setting for Instant Results facets is set to "All", as posts cannot have multiple types. Sites with forms like this will need to use the "any" option. However, these types of forms are very rare.

Better support for this might be possible in future if a UI is configured to support per-facet match types.

### Verification Process

When a regular search form is submitted, Instant Results should function as normal and search all post types. If the _Post type_ facet is in use then those results can be filtered by post type.

When a search form with an `input[name="post_type"]` field is submitted, the results should only come from post type passed as the value of this field. If a _Post type_ facet is in use then this facet's selection should reflect the post type from the search form. If a _Post type_ facet is _not_ in use, then results should still be filtered by the form's post types, but clearing filters should not clear the post type filter.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Resolves #2508.

### Changelog Entry

- Adds support for search form post type fields to Instant Results.