### PR TITLE
Fix negative offset on hierarchical post types

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1659,6 +1659,15 @@ class Post extends Indexable {
 			$formatted_args['from'] = $args['posts_per_page'] * ( $args['paged'] - 1 );
 		}
 
+		/**
+		 * Fix negative offset. This happens, for example, on hierarchical post types.
+		 *
+		 * Ref: https://github.com/10up/ElasticPress/issues/2480
+		 */
+		if ( $formatted_args['from'] < 0 ) {
+			$formatted_args['from'] = 0;
+		}
+
 		if ( $use_filters ) {
 			$formatted_args['post_filter'] = $filter;
 		}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This PR ensures that the `from` argument (offset) for post search requests is not negative. This will happen on hierarchical post types on pages other than the first.

This is because [ElasticPress uses `posts_per_page` to calculate the offset](https://github.com/10up/ElasticPress/blob/a39cb492400854173d65e33acd605883b01cfcaf/includes/classes/Indexable/Post/Post.php#L1659), `POSTS_PER_PAGE * ( PAGE - 1 )`. For hierarchical post types, however, this value is [overwritten to `-1` by WordPress](https://github.com/WordPress/wordpress-develop/blob/db8df6b8e8041e697acb9bd63e28ca35908e2a85/src/wp-admin/includes/post.php#L1230) (most probably to fetch **all** posts so that posts to be shown on the current page that have a parent can be listed with their parent post).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

n/a

### Benefits

<!-- What benefits will be realized by the code change? -->

Working pagination on hierarchical post types such as the default `page`. 🎉

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

n/a

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

1. Go to Pages in the admin: `/wp-admin/edit-php?post_type=page`
2. Search for a word or phrase where you have lots of posts that include this.
3. Use pagination buttons to navigate to, say, page 3.
4. **Without** this change, this will result in a request error for Elasticsearch. **With** this change, everything is working as expected, and you can navigate to any page you like.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#2480

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

- Fix broken search pagination on hierarchical post types