### PR TITLE
Do not do any weighting query modifications if there is nothing in config

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -574,7 +574,8 @@ class Weighting {
 		 */
 		$weight_config = apply_filters( 'ep_weighting_configuration_for_search', $weight_config, $args );
 
-		if ( ! empty( $weight_config ) && Utils\is_integrated_request( 'weighting', [ 'public', 'rest' ] ) && ! empty( $args['s'] ) ) {
+		if ( ! empty( $weight_config ) && ! has_filter( 'ep_weighted_query_for_post_type' ) && ! has_filter( 'ep_weighting_default_post_type_weights' ) && ! has_filter( 'ep_weighting_default_enabled_taxonomies' )
+		&& Utils\is_integrated_request( 'weighting', [ 'public', 'rest' ] ) && ! empty( $args['s'] ) ) {
 			/*
 			 * This section splits up the single query clause for all post types into separate nested clauses (one for each post type)
 			 * which then get combined into one result set. By having separate clauses for each post type, we can then


### PR DESCRIPTION
### Description of the Change

I'm seeing unnecessary bits of the ES query being generated on search if we are not actively using the weighting feature. For example, searching with "hello":

```
{
  "from": 0,
  "size": 10,
  "sort": [
    {
      "_score": {
        "order": "desc"
      }
    }
  ],
  "query": {
    "function_score": {
      "query": {
        "bool": {
          "should": [
            {
              "bool": {
                "must": [
                  {
                    "bool": {
                      "must": [
                        {
                          "multi_match": {
                            "query": "hello",
                            "type": "phrase",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.post_tag.name^1",
                              "terms.category.name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "boost": 3,
                            "operator": "AND"
                          }
                        },
                        {
                          "multi_match": {
                            "query": "hello",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.post_tag.name^1",
                              "terms.category.name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "type": "phrase",
                            "slop": 5
                          }
                        }
                      ]
                    }
                  }
                ],
                "filter": [
                  {
                    "match": {
                      "post_type.raw": "post"
                    }
                  }
                ]
              }
            },
            {
              "bool": {
                "must": [
                  {
                    "bool": {
                      "must": [
                        {
                          "multi_match": {
                            "query": "hello",
                            "type": "phrase",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "boost": 3,
                            "operator": "AND"
                          }
                        },
                        {
                          "multi_match": {
                            "query": "hello",
                            "fields": [
                              "post_title^1",
                              "post_excerpt^1",
                              "post_content^1",
                              "post_author.display_name^1",
                              "terms.ep_custom_result.name^9999"
                            ],
                            "type": "phrase",
                            "slop": 5
                          }
                        }
                      ]
                    }
                  }
                ],
                "filter": [
                  {
                    "match": {
                      "post_type.raw": "page"
                    }
                  }
                ]
              }
            }
          ]
        }
      },
      "functions": [
        {
          "gauss": {
            "post_date_gmt": {
              "scale": "360d",
              "decay": 0.9,
              "offset": "0d"
            }
          }
        },
        {
          "weight": 0.001
        }
      ],
      "score_mode": "multiply",
      "boost_mode": "multiply"
    }
  },
  "post_filter": {
    "bool": {
      "must": [
        {
          "terms": {
            "post_type.raw": [
              "post",
              "page"
            ]
          }
        },
        {
          "terms": {
            "post_status": [
              "publish"
            ]
          }
        }
      ]
    }
  },
  "track_total_hits": true
}
```

Since it appears that the `post_filter` already takes care of it, we can simplify it to:

```
{
  "from": 0,
  "size": 10,
  "sort": [
    {
      "_score": {
        "order": "desc"
      }
    }
  ],
  "query": {
    "function_score": {
      "query": {
        "bool": {
          "must": [
            {
              "multi_match": {
                "query": "hello",
                "type": "phrase",
                "fields": [
                  "post_title",
                  "post_excerpt",
                  "post_content"
                ],
                "boost": 3,
                "operator": "AND"
              }
            },
            {
              "multi_match": {
                "query": "hello",
                "fields": [
                  "post_title",
                  "post_excerpt",
                  "post_content"
                ],
                "type": "phrase",
                "slop": 5
              }
            }
          ]
        }
      },
      "functions": [
        {
          "gauss": {
            "post_date_gmt": {
              "scale": "360d",
              "decay": 0.9,
              "offset": "0d"
            }
          }
        },
        {
          "weight": 0.001
        }
      ],
      "score_mode": "multiply",
      "boost_mode": "multiply"
    }
  },
  "post_filter": {
    "bool": {
      "must": [
        {
          "terms": {
            "post_type.raw": [
              "post",
              "page"
            ]
          }
        },
        {
          "terms": {
            "post_status": [
              "publish"
            ]
          }
        }
      ]
    }
  },
  "track_total_hits": true
}
```

### Alternate Designs

N/A.

### Benefits

A simplified query.

### Possible Drawbacks

Uncertain if there are any.

### Verification Process
Do a search for "hello" on a clean install with ES and compare the search query before and after change.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Changed: Do not do search weighting if feature is not used.