### PR TITLE
Synonyms: ignore ep-synonym post status

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -253,10 +253,11 @@ class Synonyms {
 					'post_type'      => self::POST_TYPE_NAME,
 					'posts_per_page' => 1,
 					'orderby'        => 'modified',
+					'post_status'    => 'any',
 				)
 			);
 
-			$this->synonym_post_id = 1 === $query_synonym_post->post_count ? $query_synonym_post->posts[0] : false;
+			$this->synonym_post_id = ( $query_synonym_post->post_count >= 1 ) ? $query_synonym_post->posts[0] : false;
 
 			if ( ! $this->synonym_post_id ) {
 				$this->synonym_post_id = $this->insert_default_synonym_post();

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -46,6 +46,7 @@ class Upgrades {
 		$routines = [
 			'3.5.2' => [ 'upgrade_3_5_2', 'init' ],
 			'3.5.3' => [ 'upgrade_3_5_3', 'init' ],
+			'3.6.6' => [ 'upgrade_3_6_6', 'init' ],
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ] );
@@ -129,6 +130,36 @@ class Upgrades {
 	public function upgrade_3_5_3() {
 		delete_option( 'elasticpress_synonyms_post_id' );
 		delete_site_option( 'elasticpress_synonyms_post_id' );
+	}
+
+	/**
+	 * Upgrade routine of v3.6.6.
+	 *
+	 * Delete all synonyms that have the post content identical to the example we set.
+	 * In previous versions we had a bug that created several posts with it.
+	 *
+	 * @see https://github.com/10up/ElasticPress/issues/2516
+	 */
+	public function upgrade_3_6_6() {
+		global $wpdb;
+
+		$synonyms = \ElasticPress\Features::factory()->get_registered_feature( 'search' )->synonyms;
+
+		$synonyms_example_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_content = %s LIMIT 500",
+				$synonyms::POST_TYPE_NAME,
+				$synonyms->example_synonym_list()
+			)
+		);
+
+		if ( ! $synonyms_example_ids ) {
+			return;
+		}
+
+		foreach ( $synonyms_example_ids as $synonym_post_id ) {
+			wp_delete_post( $synonym_post_id, true );
+		}
 	}
 
 	/**

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -147,7 +147,7 @@ class Upgrades {
 
 		$synonyms_example_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_content = %s LIMIT 500",
+				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_content = %s LIMIT 100",
 				$synonyms::POST_TYPE_NAME,
 				$synonyms->example_synonym_list()
 			)


### PR DESCRIPTION
### Description of the Change

This PR changes the WP_Query to fetch ep-synonyms, getting all synonyms with any post status. It also makes the check a little looser, simply checking it the post count is greater than or equal to 1, in case someone is changing posts_per_page in all queries.

### Applicable Issues

Closes #2516 

### Changelog Entry

Fixed: Synonyms erased when syncing via WP-CLI. Props @felipeelia and @oscarssanchez 