### PR TITLE
Replace deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -187,7 +187,7 @@ class Synonyms {
 			return;
 		}
 
-		$update = filter_input( INPUT_GET, 'ep_synonym_update', FILTER_SANITIZE_STRING );
+		$update = filter_input( INPUT_GET, 'ep_synonym_update', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		if ( ! in_array( $update, [ 'success', 'error-update-post', 'error-update-index' ], true ) ) {
 			return;
@@ -327,7 +327,7 @@ class Synonyms {
 			return false;
 		}
 
-		return filter_var( trim( $synonym ), FILTER_SANITIZE_STRING );
+		return sanitize_text_field( $synonym, true );
 	}
 
 	/**
@@ -386,13 +386,13 @@ class Synonyms {
 	 * @return void
 	 */
 	public function handle_update_synonyms() {
-		$nonce   = filter_input( INPUT_POST, $this->get_nonce_field(), FILTER_SANITIZE_STRING );
-		$referer = filter_input( INPUT_POST, '_wp_http_referer', FILTER_SANITIZE_STRING );
+		$nonce   = filter_input( INPUT_POST, $this->get_nonce_field(), FILTER_SANITIZE_SPECIAL_CHARS );
+		$referer = filter_input( INPUT_POST, '_wp_http_referer', FILTER_SANITIZE_URL );
 		$post_id = false;
 
 		if ( wp_verify_nonce( $nonce, $this->get_nonce_action() ) ) {
-			$synonyms = filter_input( INPUT_POST, $this->get_synonym_field(), FILTER_SANITIZE_STRING );
-			$mode     = filter_input( INPUT_POST, 'synonyms_editor_mode', FILTER_SANITIZE_STRING );
+			$synonyms = filter_input( INPUT_POST, $this->get_synonym_field(), FILTER_SANITIZE_SPECIAL_CHARS );
+			$mode     = filter_input( INPUT_POST, 'synonyms_editor_mode', FILTER_SANITIZE_SPECIAL_CHARS );
 			$content  = trim( sanitize_textarea_field( $synonyms ) );
 
 			// Content can't be empty.


### PR DESCRIPTION
### Description of the Change

This PR replaces the [deprecated](https://wiki.php.net/rfc/deprecations_php_8_1#filter_sanitize_string) `FILTER_SANITIZE_STRING` with other filters, mostly with `FILTER_SANITIZE_SPECIAL_CHARS`.

It is a copy of Automattic/ElasticPress#135, and it has already been tested.

### Alternate Designs

N/A

### Benefits

* Better compatibility with PHP 8.1

### Possible Drawbacks

N/A

### Verification Process

The changes were verified by vip-go-mu-plugin's test suite as described in Automattic/vip-go-mu-plugins#2667; this patch was tested against WP 5.5, 5.6, 5.7, 5.8, trunk; PHP 7.4, PHP 8.0, PHP 8.1

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

* Automattic/vip-go-mu-plugins#2667

### Changelog Entry

Fixed: better compatibility with PHP 8.1 by replacing the deprecated `FILTER_SANITIZE_STRING`.
