### PR TITLE
Feature/cache last changed time

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -89,6 +89,11 @@ if ( $network_activated ) {
 }
 
 /**
+ * Set global cache groups.
+ */
+wp_cache_add_global_groups( 'elasticpress-network' );
+
+/**
  * Sets up the indexables and features.
  *
  * @return void

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -137,6 +137,8 @@ class Elasticsearch {
 			$response_body = wp_remote_retrieve_body( $request );
 
 			$return = json_decode( $response_body );
+
+			Utils\wp_cache_set_ep_last_changed();
 		} else {
 			$return = false;
 		}
@@ -191,6 +193,8 @@ class Elasticsearch {
 
 		if ( ! is_wp_error( $request ) ) {
 			if ( isset( $request['response']['code'] ) && 200 === $request['response']['code'] ) {
+				Utils\wp_cache_set_ep_last_changed();
+
 				return true;
 			}
 		}
@@ -560,6 +564,8 @@ class Elasticsearch {
 			$response = json_decode( $response_body, true );
 
 			if ( ! empty( $response['found'] ) ) {
+				Utils\wp_cache_set_ep_last_changed();
+
 				return true;
 			}
 		}
@@ -659,6 +665,8 @@ class Elasticsearch {
 
 		if ( ! is_wp_error( $request ) && ( 200 >= wp_remote_retrieve_response_code( $request ) && 300 > wp_remote_retrieve_response_code( $request ) ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
+
+			Utils\wp_cache_set_ep_last_changed();
 
 			return json_decode( $response_body );
 		}
@@ -767,6 +775,8 @@ class Elasticsearch {
 		$request = $this->remote_request( $path, $request_args, [], 'create_network_alias' );
 
 		if ( ! is_wp_error( $request ) && ( 200 >= wp_remote_retrieve_response_code( $request ) && 300 > wp_remote_retrieve_response_code( $request ) ) ) {
+			Utils\wp_cache_set_ep_last_changed();
+
 			return true;
 		}
 
@@ -815,6 +825,8 @@ class Elasticsearch {
 
 		if ( ! is_wp_error( $request ) && 200 === wp_remote_retrieve_response_code( $request ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
+
+			Utils\wp_cache_set_ep_last_changed();
 
 			return true;
 		}
@@ -927,6 +939,8 @@ class Elasticsearch {
 			return ( $updated && $opened );
 		}
 
+		Utils\wp_cache_set_ep_last_changed();
+
 		return $updated;
 	}
 
@@ -950,6 +964,8 @@ class Elasticsearch {
 		// 404 means the index was non-existent, but we should still pass this through as we will occasionally want to delete an already deleted index
 		if ( ! is_wp_error( $request ) && ( 200 === wp_remote_retrieve_response_code( $request ) || 404 === wp_remote_retrieve_response_code( $request ) ) ) {
 			$response_body = wp_remote_retrieve_body( $request );
+
+			Utils\wp_cache_set_ep_last_changed();
 
 			return json_decode( $response_body );
 		}
@@ -1040,6 +1056,8 @@ class Elasticsearch {
 		if ( 200 !== $response ) {
 			return new WP_Error( $response, wp_remote_retrieve_response_message( $request ), $request );
 		}
+
+		Utils\wp_cache_set_ep_last_changed();
 
 		return json_decode( wp_remote_retrieve_body( $request ), true );
 	}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -633,3 +633,22 @@ function is_integrated_request( $context, $types = [] ) {
 	 */
 	return apply_filters( 'ep_is_integrated_request', $is_integrated, $context, $types );
 }
+
+/**
+ * Sets the last changed times for ElasticPress and ElasticPress Network cache groups.
+ *
+ * @return void
+ *
+ * @since 3.7
+ */
+function wp_cache_set_ep_last_changed() {
+	/**
+	 * Set the `last_changed` for this specific blog / site.
+	 */
+	wp_cache_set( 'last_changed', microtime(), 'elasticpress' );
+
+	/**
+	 * Set the `last_changed` for this specific network (for all blogs / sites).
+	 */
+	wp_cache_set( 'last_changed', microtime(), 'elasticpress-network' );
+}


### PR DESCRIPTION
### Description of the Change

This PR implements the ability to make use of `wp_cache_get_last_changed()` for ElasticPress, identifying the last time a modification was made to an index. Both for the current blog / site and the entire network / Multisite. This is borrowed from WordPress Core's use of `wp_cache_get_last_changed( 'posts' )` (and others) which can be a good way of identifying whenever a post, irrespective of post type or type of update, has occurred.

### Alternate Designs

None were considered, as the source / inspiration seem a foundational feature being introduced to ElasticPress from WordPress Core.

### Benefits

This is useful in scenarios of creating cache entries where the contents are sensitive to data changes on indices, especially involving a query spanning multiple sites within a Multisite.

This is currently needed on a project to better enhance Block-level caching of HTML, where the block features a number of posts from a number of websites across a Multisite. The underlying `WP_Query` is powered by ElasticPress. Currently for these blocks I am setting a lower cache time - i.e. 15 minutes - to ensure it updates quickly for new content across the sites.

For Blocks which are purely `WP_Query` / database driven, the cache time can be set much higher as I can utilise `wp_cache_get_last_changed( 'posts' )` to determine when content updates have occurred. This PR provides a way of doing the same with ElasticPress across multiple sites.

The alternative would be to query each site individually to see the latest content updates, however this would negate any meaningful performance benefit of caching the HTML output of the block.

**A quick note on posts and ElasticPress last changed cache:**

The following lines may appear identical in purpose.
```php
wp_cache_get_last_changed( 'posts' );
wp_cache_get_last_changed( 'elasticpress' );
```
However there is a slight difference: `wp_cache_get_last_changed( 'posts' )` will not update when the index is deleted.

Useful Links:

* `wp_cache_get_last_changed()` - [WordPress Code Reference](https://developer.wordpress.org/reference/functions/wp_cache_get_last_changed/)
* [Example of WordPress Core using last changed for posts and terms.](https://github.com/WordPress/WordPress/blob/4132ac0f48654ab90ed24a9e55ae5b48511d48b2/wp-includes/default-filters.php#L101-L109)
* [Example use case of `wp_cache_get_last_changed()` in WordPress Core.](https://github.com/WordPress/WordPress/blob/1309e62457fd45ad1dacd3c77de9ef53da292919/wp-includes/post.php#L6000)

### Possible Drawbacks

None that I can foresee. The change is inconsequential to the general operation of ElasticPress.

### Verification Process

Steps:

1. Create / reuse a Multisite with two or more sites.
2. Add a way to see the values from `wp_cache_get_last_changed()` - I use a dirty / hacky `var_dump()` as noted in the code snippet below.
3. Index both sites.
4. Check the values - `wp_cache_get_last_changed( 'elasticpress-network' )` will be identical on both sites, `wp_cache_get_last_changed( 'elasticpress' ) )` will be different (as the sites were indexed at separate times).
5. Check the values after performing the following operations on one of the two sites:
6. Create / modify / delete new post on Site A = both values on Site A will update. Site B will only update `elasticpress-network`.
7. Reindex Site A = both values on Site A will update. Site B will only update `elasticpress-network`.
8. Run `wp elasticpress index --setup --network-wide` in the terminal - both sites will have identical values.

Apologies for the dirty / hacky way of checking, but it was simpler than creating a custom block and much easier to explain when you can just see a value on the screen.

```php
add_action( 'wp_head', function () {
    var_dump( 'ep - site - ' . wp_cache_get_last_changed( 'elasticpress' ) );
    var_dump( 'ep - network - ' . wp_cache_get_last_changed( 'elasticpress-network' ) );
} );
```

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

My apologies, got this far down the PR before realising that there is suppose to be issue created :grimacing:

### Changelog Entry

```
Added: ability to detect changes to Elasticsearch indices using Object Cache with `wp_cache_get_last_changed( 'elasticpress' )` (for the current site) or `wp_cache_get_last_changed( 'elasticpress-network' )` (for changes across the Multisite).
```