### PR TITLE
Remove duplicate "case 'description'"

### DIFF
--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -1010,10 +1010,6 @@ class Term extends Indexable {
 
 				break;
 
-			case 'description':
-				$es_field_name = 'description.sortable';
-				break;
-
 			case 'parent':
 			case 'count':
 			default:


### PR DESCRIPTION
### Description of the Change

This PR removes a duplicate `case 'description':` from `ElasticPress\Indexable\Term\Term::parse_orderby()`.

### Alternate Designs

N/A

### Benefits

Dead code elimination.

### Possible Drawbacks

N/A

### Verification Process

Run the test suite locally.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

N/A

### Changelog Entry

Removed a duplicate `case 'description':` from `ElasticPress\Indexable\Term\Term::parse_orderby()`
