### PR TITLE
(fix): correct parameter and return type

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -473,12 +473,12 @@ class Search extends Feature {
 										 * Filter search date weighting decay
 										 *
 										 * @hook epwr_decay
-										 * @param  {string} $decay Current decay
+										 * @param  {float} $decay Current decay
 										 * @param  {array} $formatted_args Formatted Elasticsearch arguments
 										 * @param  {array} $args WP_Query arguments
-										 * @return  {string} New decay
+										 * @return  {float} New decay
 										 */
-										'decay'  => apply_filters( 'epwr_decay', .25, $formatted_args, $args ),
+										'decay'  => apply_filters( 'epwr_decay', 0.25, $formatted_args, $args ),
 										/**
 										 * Filter search date weighting offset
 										 *
@@ -498,10 +498,10 @@ class Search extends Feature {
 								 *
 								 * @since 3.5.6
 								 * @hook epwr_weight
-								 * @param  {string} $weight Current weight
+								 * @param  {float} $weight Current weight
 								 * @param  {array} $formatted_args Formatted Elasticsearch arguments
 								 * @param  {array} $args WP_Query arguments
-								 * @return  {string} New weight
+								 * @return  {float} New weight
 								 */
 								'weight' => apply_filters( 'epwr_weight', 0.001, $formatted_args, $args ),
 							),


### PR DESCRIPTION
### Description of the Change

The properties `decay` and `width` have incorrect type hints in the comments:

* *Decay* should be a float (or double in PHP): https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-weight
* *Width* should be a float (or double in PHP): https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-decay

They are now 'hinted' as strings: https://10up.github.io/ElasticPress/includes_classes_Feature_Search_Search.php.html#line481

This made our application crash (throw an exception), as the return was incorrect.

### Alternate Designs

These properties should be corrected to reflect the correct type. Maybe even forced?

### Benefits

Better understanding what a user should return. Especially with PHP7+/8+ using better type-hinting.

### Possible Drawbacks

None I can think about.

### Verification Process

Only comments are changed with this PR. Maybe, if the returned value would be forced to the correct type, more validation is required.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [-] I have updated the documentation accordingly.
- [-] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

None.

### Changelog Entry

- Correct type hints for `decay` and `width` hook.
