### PR TITLE
Display post types on facets with duplicate labels.

### DIFF
--- a/assets/js/instant-results/components/facets/facet.js
+++ b/assets/js/instant-results/components/facets/facet.js
@@ -17,10 +17,11 @@ import TaxonomyTermsFacet from './taxonomy-terms-facet';
  * @param {number} props.index Facet index.
  * @param {string} props.name Facet name.
  * @param {string} props.label Facet label.
+ * @param {string} props.postTypes Facet post types.
  * @param {'post_type'|'price_range'|'taxonomy'} props.type Facet type.
  * @return {WPElement} Component element.
  */
-export default ({ index, label, name, type }) => {
+export default ({ index, label, name, postTypes, type }) => {
 	const defaultIsOpen = index < 2;
 
 	switch (type) {
@@ -30,7 +31,12 @@ export default ({ index, label, name, type }) => {
 			return <PriceRangeFacet defaultIsOpen={defaultIsOpen} label={label} />;
 		case 'taxonomy':
 			return (
-				<TaxonomyTermsFacet defaultIsOpen={defaultIsOpen} label={label} taxonomy={name} />
+				<TaxonomyTermsFacet
+					defaultIsOpen={defaultIsOpen}
+					label={label}
+					postTypes={postTypes}
+					taxonomy={name}
+				/>
 			);
 		default:
 			return <></>;

--- a/assets/js/instant-results/components/facets/post-type-facet.js
+++ b/assets/js/instant-results/components/facets/post-type-facet.js
@@ -49,7 +49,7 @@ export default ({ defaultIsOpen, label }) => {
 			options.push({
 				checked: selectedPostTypes.includes(key),
 				id: `ep-search-post-type-${key}`,
-				label: postTypeLabels[key],
+				label: postTypeLabels[key].singular,
 				order: index,
 				value: key,
 			});
@@ -102,7 +102,7 @@ export default ({ defaultIsOpen, label }) => {
 						{selectedPostTypes.map((value) => (
 							<ActiveContraint
 								key={value}
-								label={postTypeLabels[value]}
+								label={postTypeLabels[value].singular}
 								onClick={() => onClear(value)}
 							/>
 						))}

--- a/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
+++ b/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
+import { facets, postTypeLabels } from '../../config';
 import Context from '../../context';
 import Panel from '../common/panel';
 import CheckboxList from '../common/checkbox-list';
@@ -18,10 +19,11 @@ import { ActiveContraint } from '../tools/active-constraints';
  * @param {Object} props Components props.
  * @param {boolean} props.defaultIsOpen Whether the panel is open by default.
  * @param {string} props.label Facet label.
+ * @param {Array} props.postTypes Facet post types.
  * @param {string} props.taxonomy Facet taxonomy.
  * @return {WPElement} Component element.
  */
-export default ({ defaultIsOpen, label, taxonomy }) => {
+export default ({ defaultIsOpen, label, postTypes, taxonomy }) => {
 	const {
 		state: {
 			isLoading,
@@ -32,6 +34,28 @@ export default ({ defaultIsOpen, label, taxonomy }) => {
 		},
 		dispatch,
 	} = useContext(Context);
+
+	/**
+	 * A unique label for the facet. Adds additional context to the label if
+	 * another taxonomy with the same label is being used as a facet.
+	 */
+	const uniqueLabel = useMemo(() => {
+		const isNotUnique = facets.some(
+			(facet) => facet.label === label && facet.name !== taxonomy,
+		);
+
+		const typeLabels = postTypes.map((postType) => postTypeLabels[postType].plural);
+		const typeSeparator = __(', ', 'elasticpress');
+
+		return isNotUnique
+			? sprintf(
+					/* translators: %1$s: Facet label. $2$s: Facet post types. */
+					__('%1$s (%2$s)', 'elasticpress'),
+					label,
+					typeLabels.join(typeSeparator),
+			  )
+			: label;
+	}, [label, postTypes, taxonomy]);
 
 	/**
 	 * Create list of filter options from aggregation buckets.
@@ -107,7 +131,7 @@ export default ({ defaultIsOpen, label, taxonomy }) => {
 
 	return (
 		options.length > 0 && (
-			<Panel defaultIsOpen={defaultIsOpen} label={label}>
+			<Panel defaultIsOpen={defaultIsOpen} label={uniqueLabel}>
 				{(isOpen) => (
 					<>
 						{isOpen && (

--- a/assets/js/instant-results/components/layout.js
+++ b/assets/js/instant-results/components/layout.js
@@ -43,8 +43,8 @@ export default () => {
 			<div className="ep-search-page__body">
 				<Sidebar isOpen={isSidebarOpen}>
 					<Sort />
-					{facets.map(({ name, label, type }, index) => (
-						<Facet index={index} key={name} label={label} name={name} type={type} />
+					{facets.map((facet, index) => (
+						<Facet {...facet} index={index} />
 					))}
 				</Sidebar>
 

--- a/assets/js/instant-results/components/results/result.js
+++ b/assets/js/instant-results/components/results/result.js
@@ -32,7 +32,7 @@ export default ({ hit }) => {
 		},
 	} = hit;
 
-	const postTypeLabel = postTypeLabels?.[resultPostType];
+	const postTypeLabel = postTypeLabels[resultPostType]?.singular;
 
 	return (
 		<article

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -646,12 +646,13 @@ class InstantResults extends Feature {
 		 * Post type facet.
 		 */
 		$facets['post_type'] = array(
-			'type'   => 'post_type',
-			'labels' => array(
+			'type'       => 'post_type',
+			'post_types' => [],
+			'labels'     => array(
 				'admin'    => __( 'Post type', 'elasticpress' ),
 				'frontend' => __( 'Type', 'elasticpress' ),
 			),
-			'aggs'   => array(
+			'aggs'       => array(
 				'post_types' => array(
 					'terms' => array(
 						'field' => 'post_type.raw',
@@ -677,12 +678,13 @@ class InstantResults extends Feature {
 			);
 
 			$facets[ $slug ] = array(
-				'type'   => 'taxonomy',
-				'labels' => array(
+				'type'       => 'taxonomy',
+				'post_types' => $taxonomy->object_type,
+				'labels'     => array(
 					'admin'    => $admin_label,
 					'frontend' => $labels->singular_name,
 				),
-				'aggs'   => array(
+				'aggs'       => array(
 					'taxonomy_terms' => array(
 						'terms' => array(
 							'field' => 'terms.' . $slug . '.facet',
@@ -698,12 +700,13 @@ class InstantResults extends Feature {
 		 */
 		if ( $this->is_woocommerce ) {
 			$facets['price_range'] = array(
-				'type'   => 'price_range',
-				'labels' => array(
+				'type'       => 'price_range',
+				'post_types' => [ 'product' ],
+				'labels'     => array(
 					'admin'    => __( 'Price range', 'elasticpress' ),
 					'frontend' => __( 'Price', 'elasticpress' ),
 				),
-				'aggs'   => array(
+				'aggs'       => array(
 					'max_price' => array(
 						'max' => array(
 							'field' => 'meta._price.double',
@@ -737,9 +740,10 @@ class InstantResults extends Feature {
 				$facet = $available_facets[ $key ];
 
 				$facets[] = array(
-					'name'  => $key,
-					'label' => $facet['labels']['frontend'],
-					'type'  => $facet['type'],
+					'name'      => $key,
+					'label'     => $facet['labels']['frontend'],
+					'type'      => $facet['type'],
+					'postTypes' => $facet['post_types'],
 				);
 			}
 		}

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -623,9 +623,12 @@ class InstantResults extends Feature {
 
 		foreach ( $post_types as $post_type ) {
 			$post_type_object = get_post_type_object( $post_type );
-			$post_type_label  = get_post_type_labels( $post_type_object )->singular_name;
+			$post_type_labels = get_post_type_labels( $post_type_object );
 
-			$labels[ $post_type ] = $post_type_label;
+			$labels[ $post_type ] = array(
+				'plural'   => $post_type_labels->name,
+				'singular' => $post_type_labels->singular_name,
+			);
 		}
 
 		return $labels;


### PR DESCRIPTION

### Description of the Change

When two or more taxonomy facets are added with the same label, such as the core `category` ("Category") taxonomy and the WooCommerce `product_cat` (also "Category") taxonomy, they are not differentiated on the front end. This PR adds the labels for associated post types in parentheses to the headings of taxonomy facets whenever there are other facets with the same label. For example, if both the category taxonomies mentioned above are added they will be displayed as "Category (Posts)" and "Category (Products)", but if only one is present then the post type will be omitted.

### Alternate Designs

I experimented with displaying the post types as little badges next to the headings, like on search results, but it required a bit too much CSS and I was not confident that the appearance would be consistent across different themes.

### Benefits

If a user adds taxonomy facets with ambiguous headings, they will automatically be differentiated.

### Possible Drawbacks

In some cases the post type name may be ambiguous to end users and the site owner may not want to expose it to them. Arguably "Posts" falls into this category for sites that normally present these as "News" or "Articles". Long term a more robust user interface where users can enter any arbitrary heading they like for facets may be preferable.

### Verification Process

1. Set up a site with Instant Results. The site should have multiple taxonomies with the same label. Using WooCommerce is the simplest way to do this.
2. Configure Instant Results with a single `Category (category)` facet. On the front end this facet should be labelled "Category".
3. Add a `Category (product_cat)` facet. On the front end this should be labelled "Category (Products)" and the existing `Category (category)` facet should be labelled "Category (Posts)".
4. Remove the `Category (product_cat)` facet. On the front end the remaining `Category (product_cat)` facet should be labelled just "Category".

For sites where one of these taxonomies is associated with multiple post types, the post types should all be listed, separated by comments. For example, if the `category` taxonomy is added to Pages then the label should be "Category (Posts, Pages)" when another category facet is present.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Addresses #2497.

### Changelog Entry

Adds post types to facet labels when needed to to differentiate facets with duplicate labels.
