### PR TITLE
Fix notice for undefined $url

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -518,7 +518,7 @@ function get_indexing_status() {
 				'method'        => 'none',
 				'items_indexed' => 0,
 				'total_items'   => -1,
-				'url'           => $url,
+				'url'           => ( ! empty( $url ) ) ? $url : '',
 			);
 
 			$index_status['indexing'] = true;


### PR DESCRIPTION
### Description of the Change

This PR fixes the notice described in #2538 

### Applicable Issues

Closes #2538 

### Changelog Entry

Fixed: PHP Notice while monitoring a WP-CLI sync in the dashboard. Props @felipeelia and @ParhamG.
