### PR TITLE
Displaying results counts for facet options in Instant Results

### DIFF
--- a/assets/css/instant-results.css
+++ b/assets/css/instant-results.css
@@ -1,4 +1,5 @@
 @import "instant-results/utilities.css";
+@import "instant-results/checkbox.css";
 @import "instant-results/input.css";
 @import "instant-results/modal.css";
 @import "instant-results/options-list.css";

--- a/assets/css/instant-results/checkbox.css
+++ b/assets/css/instant-results/checkbox.css
@@ -1,0 +1,7 @@
+.ep-search-checkbox__count::before {
+	content: "(";
+}
+
+.ep-search-checkbox__count::after {
+	content: ")";
+}

--- a/assets/js/instant-results/components/common/checkbox-list.js
+++ b/assets/js/instant-results/components/common/checkbox-list.js
@@ -122,7 +122,7 @@ export default ({ disabled, label, options, onChange, selected, sortBy }) => {
 	 * @param {Option} option Option.
 	 * @return {WPElement} Render function.
 	 */
-	const displayOption = ({ id, label, value }) => {
+	const displayOption = ({ count, id, label, value }) => {
 		const children = childOptions[value];
 
 		if (!showAll && optionsShown >= optionsLimit) {
@@ -133,6 +133,7 @@ export default ({ disabled, label, options, onChange, selected, sortBy }) => {
 			<li className="ep-search-options-list__item" key={value}>
 				<Checkbox
 					checked={selected.includes(value)}
+					count={count}
 					disabled={disabled}
 					id={id}
 					label={label}

--- a/assets/js/instant-results/components/common/checkbox.js
+++ b/assets/js/instant-results/components/common/checkbox.js
@@ -6,9 +6,9 @@ import { WPElement } from '@wordpress/element';
 /**
  * Checkbox component.
  *
- * @param {Option} props Component props.
+ * @param {Option} props       Component props.
  * @param {string} props.count Checkbox count.
- * @param {string} props.id Checkbox ID.
+ * @param {string} props.id    Checkbox ID.
  * @param {string} props.label Checkbox label.
  *
  * @return {WPElement} Component element.

--- a/assets/js/instant-results/components/common/checkbox.js
+++ b/assets/js/instant-results/components/common/checkbox.js
@@ -7,17 +7,18 @@ import { WPElement } from '@wordpress/element';
  * Checkbox component.
  *
  * @param {Option} props Component props.
+ * @param {string} props.count Checkbox count.
  * @param {string} props.id Checkbox ID.
  * @param {string} props.label Checkbox label.
  *
  * @return {WPElement} Component element.
  */
-export default ({ id, label, ...props }) => {
+export default ({ count, id, label, ...props }) => {
 	return (
 		<div className="ep-search-checkbox">
-			<input className="ep-search-checkbox__input" id={id} type="checkbox" {...props} />
+			<input className="ep-search-checkbox__input" id={id} type="checkbox" {...props} />{' '}
 			<label className="ep-search-checkbox__label" htmlFor={id}>
-				{label}
+				{label} {count && <span className="ep-search-checkbox__count">{count}</span>}
 			</label>
 		</div>
 	);

--- a/assets/js/instant-results/components/facets/post-type-facet.js
+++ b/assets/js/instant-results/components/facets/post-type-facet.js
@@ -41,13 +41,14 @@ export default ({ defaultIsOpen, label }) => {
 	 * @return {Array} Array of options.
 	 */
 	const reduceOptions = useCallback(
-		(options, { key }, index) => {
+		(options, { doc_count, key }, index) => {
 			if (!Object.prototype.hasOwnProperty.call(postTypeLabels, key)) {
 				return options;
 			}
 
 			options.push({
 				checked: selectedPostTypes.includes(key),
+				count: doc_count,
 				id: `ep-search-post-type-${key}`,
 				label: postTypeLabels[key].singular,
 				order: index,

--- a/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
+++ b/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
@@ -66,11 +66,12 @@ export default ({ defaultIsOpen, label, postTypes, taxonomy }) => {
 	 * @return {Array} Array of options.
 	 */
 	const reduceOptions = useCallback(
-		(options, { key }) => {
+		(options, { doc_count, key }) => {
 			const { name, parent, term_id, term_order } = JSON.parse(key);
 
 			options.push({
 				checked: selectedTerms.includes(term_id),
+				count: doc_count,
 				id: `ep-search-${taxonomy}-${term_id}`,
 				label: name,
 				parent: parent.toString(),


### PR DESCRIPTION
### Description of the Change

Adds result counts for facet options in Instant Results.

<!-- Enter any applicable Issues here. Example: -->
Closes #2526.

### Alternate Designs

Design-wise there could be any number of variations, but as the default I stuck with simple numbers in parentheses. To support users and themes styling the counts differently, such as in a bubble or similar, the counts have their own element, and parentheses are added with CSS so that they can be removed with CSS. From testing with VoiceOver there was no difference in accessibility in using CSS for the parentheses.

With this PR the counts are enabled by default, with no setting to choose to enable or disable them, however they occupy their own element so they can be easily hidden with a single line of CSS.

### Possible Drawbacks

N/A

### Verification Process

With this PR checked out the counts should be visible next to filter options in Instant Results. Selecting filter options should narrow down the number of results to the number next to each option, and the counts next to any remaining options should be updated to reflect the number of matching results in the current result set.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Displaying results counts for facet options in Instant Results.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 
