### PR TITLE
Fix product visibility evaluation in PHP 8

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -473,7 +473,7 @@ class InstantResults extends Feature {
 	 */
 	public function apply_product_visibility( $query ) {
 		$product_visibility_terms  = wc_get_product_visibility_term_ids();
-		$product_visibility_not_in = $product_visibility_terms['exclude-from-search'];
+		$product_visibility_not_in = (array) $product_visibility_terms['exclude-from-search'];
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 			$product_visibility_not_in[] = $product_visibility_terms['outofstock'];


### PR DESCRIPTION
### Description of the Change

Currently, [InstantResults::apply_product_visibility()](https://github.com/10up/ElasticPress/blob/4.0.0-beta.1/includes/classes/Feature/InstantResults/InstantResults.php#L474) calls `wc_get_product_visibility_term_ids()` and uses `$product_visibility_terms['exclude-from-search']` as an array, when it actually is a term id. In PHP 8, that results in a fatal error:

> PHP Fatal error:  Uncaught Error: Cannot use a scalar value as an array in /var/www/html/wp-content/plugins/elasticpress/includes/classes/Feature/InstantResults/InstantResults.php:479

This PR addresses that, forcing the result to be an array.

### Verification Process

- Spin up a local env using PHP 8
- Install WooCommerce and enable "Hide out of stock items from the catalog" (/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory)
- Install the [EP Proxy](https://github.com/10up/elasticpress-proxy) and activate the Instant Results feature
- See the sync failing

### Changelog Entry

Fixed the sync page when WC's "hide out of stock items" and Instant Results are both enabled.
