### PR TITLE
Fix PHP Units after WordPress 5.9

### DIFF
--- a/tests/php/TestFeatureActivation.php
+++ b/tests/php/TestFeatureActivation.php
@@ -82,7 +82,7 @@ class TestFeatureActivation extends BaseTestCase {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
 
 		$this->assertEquals( true, ElasticPress\Features::factory()->registered_features['search']->is_active() );
@@ -111,7 +111,7 @@ class TestFeatureActivation extends BaseTestCase {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
 
 		$requirements_statuses = get_site_option( 'ep_feature_requirement_statuses' );
@@ -137,7 +137,7 @@ class TestFeatureActivation extends BaseTestCase {
 			new FeatureTest()
 		);
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
 
 		$this->assertEquals( true, ElasticPress\Features::factory()->registered_features['test']->is_active() );
@@ -159,7 +159,7 @@ class TestFeatureActivation extends BaseTestCase {
 			new FeatureTest()
 		);
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
 
 		$requirements_statuses = get_site_option( 'ep_feature_requirement_statuses' );
@@ -170,7 +170,7 @@ class TestFeatureActivation extends BaseTestCase {
 
 		update_site_option( 'ep_test_feature_on', 2 );
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 
 		$requirements_statuses = get_site_option( 'ep_feature_requirement_statuses' );
 
@@ -196,7 +196,7 @@ class TestFeatureActivation extends BaseTestCase {
 
 		update_site_option( 'ep_test_feature_on', 2 );
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
 
 		$requirements_statuses = get_site_option( 'ep_feature_requirement_statuses' );
@@ -207,7 +207,7 @@ class TestFeatureActivation extends BaseTestCase {
 
 		update_site_option( 'ep_test_feature_on', 0 );
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 
 		$requirements_statuses = get_site_option( 'ep_feature_requirement_statuses' );
 
@@ -233,7 +233,7 @@ class TestFeatureActivation extends BaseTestCase {
 
 		update_site_option( 'ep_test_feature_on', 0 );
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
 
 		$requirements_statuses = get_site_option( 'ep_feature_requirement_statuses' );
@@ -244,12 +244,24 @@ class TestFeatureActivation extends BaseTestCase {
 
 		update_site_option( 'ep_test_feature_on', 1 );
 
-		ElasticPress\Features::factory()->handle_feature_activation();
+		$this->handle_feature_activation();
 
 		$requirements_statuses = get_site_option( 'ep_feature_requirement_statuses' );
 
 		$this->assertEquals( true, ElasticPress\Features::factory()->registered_features['test']->is_active() );
 		$this->assertEquals( 1, ElasticPress\Features::factory()->registered_features['test']->requirements_status()->code );
 		$this->assertEquals( 1, $requirements_statuses['test'] );
+	}
+
+	/**
+	 * Wrapper for Features::handle_feature_activation() calls in admin context.
+	 *
+	 * To avoid unnecessary updates on the `ep_feature_requirement_statuses` option,
+	 * the `Features::handle_feature_activation()` only changes the option value when called in admin or WP-CLI contexts.
+	 */
+	protected function handle_feature_activation() {
+		set_current_screen( 'edit.php' );
+		ElasticPress\Features::factory()->handle_feature_activation();
+		set_current_screen( 'front' );
 	}
 }


### PR DESCRIPTION
### Description of the Change

I'm still not exactly sure why but after WordPress 5.9 was released our PHP Unit tests stopped passing. This PR addresses the needed change to have them working again.

Related to #2555

### Changelog Entry

Fixed PHPUnit tests

### Credits


