### PR TITLE
Add helper get_total_objects_for_query_from_db() which counts directly from the DB

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -189,7 +189,42 @@ class Post extends Indexable {
 			$object_counts[ $cache_key ] = ( new WP_Query( $normalized_query_args ) )->found_posts;
 		}
 
+		if ( 0 === $object_counts[ $cache_key ] ) {
+			// Do a DB count to make sure the query didn't just die and return 0.
+			$db_post_count = $this->get_total_objects_for_query_from_db( $normalized_query_args );
+
+			if ( $db_post_count !== $object_counts[ $cache_key ] ) {
+				$object_counts[ $cache_key ] = $db_post_count;
+			}
+		}
+
 		return $object_counts[ $cache_key ];
+	}
+
+	/**
+	 * Get total posts from DB for a specific query based on it's args.
+	 *
+	 * @param array $query_args The query args.
+	 * @return int The total posts.
+	 */
+	public function get_total_objects_for_query_from_db( $query_args ) {
+		$post_count = 0;
+
+		if ( ! isset( $query_args['post_type'] ) ) {
+			return $post_count;
+		}
+
+		foreach ( $query_args['post_type'] as $post_type ) {
+			$post_counts_by_post_status = wp_count_posts( $post_type );
+			foreach ( $post_counts_by_post_status as $post_status => $post_status_count ) {
+				if ( ! in_array( $post_status, $query_args['post_status'] ) ) {
+					continue;
+				}
+				$post_count += $post_status_count;
+			}
+		}
+
+		return $post_count;
 	}
 
 	/**

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -168,7 +168,7 @@ class Post extends Indexable {
 	 * @param array $query_args The query args.
 	 * @return int The query result's found_posts.
 	 */
-	private function get_total_objects_for_query( $query_args ) {
+	protected function get_total_objects_for_query( $query_args ) {
 		static $object_counts = [];
 
 		// Reset the pagination-related args for optimal caching.
@@ -205,9 +205,10 @@ class Post extends Indexable {
 	 * Get total posts from DB for a specific query based on it's args.
 	 *
 	 * @param array $query_args The query args.
+	 * @since 4.0.0
 	 * @return int The total posts.
 	 */
-	public function get_total_objects_for_query_from_db( $query_args ) {
+	protected function get_total_objects_for_query_from_db( $query_args ) {
 		$post_count = 0;
 
 		if ( ! isset( $query_args['post_type'] ) ) {
@@ -217,7 +218,7 @@ class Post extends Indexable {
 		foreach ( $query_args['post_type'] as $post_type ) {
 			$post_counts_by_post_status = wp_count_posts( $post_type );
 			foreach ( $post_counts_by_post_status as $post_status => $post_status_count ) {
-				if ( ! in_array( $post_status, $query_args['post_status'] ) ) {
+				if ( ! in_array( $post_status, $query_args['post_status'], true ) ) {
 					continue;
 				}
 				$post_count += $post_status_count;


### PR DESCRIPTION
### Description of the Change

We're noticing that on very large sites, the query to count the total objects in `get_total_objects_for_query()` dies. This PR adds an abstracted helper method `get_total_objects_for_query_from_db()` that breaks it down using `wp_count_posts` to count the posts directly from the DB.

### Alternate Designs

N/A.

### Possible Drawbacks

A bit more processing during indexing if the count query has died, but at least the user will have an idea of the number of posts, rather than "0".

### Verification Process

On a verrrry large site where it says `0` as the total objects, i.e. `Processed x/0`, apply the PR and expect it to return a number.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed: Add an alternative way to count total posts on larger DBs during indexing

### Credits

Props @rebeccahum 
