### PR TITLE
Adjust constant name

### DIFF
--- a/includes/classes/Feature/Comments/Comments.php
+++ b/includes/classes/Feature/Comments/Comments.php
@@ -110,7 +110,7 @@ class Comments extends Feature {
 			return $enabled;
 		}
 
-		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOL ) ) {
+		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOLEAN ) ) {
 			$enabled = false;
 		} elseif ( ! empty( $query->query_vars['search'] ) ) {
 			$enabled = true;

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -576,7 +576,7 @@ class Search extends Feature {
 			return $enabled;
 		}
 
-		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOL ) ) {
+		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOLEAN ) ) {
 			return false;
 		}
 

--- a/includes/classes/Feature/Terms/Terms.php
+++ b/includes/classes/Feature/Terms/Terms.php
@@ -87,7 +87,7 @@ class Terms extends Feature {
 			return $enabled;
 		}
 
-		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOL ) ) {
+		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOLEAN ) ) {
 			$enabled = false;
 		} elseif ( ! empty( $query->query_vars['search'] ) ) {
 			$enabled = true;

--- a/includes/classes/Feature/Users/Users.php
+++ b/includes/classes/Feature/Users/Users.php
@@ -87,7 +87,7 @@ class Users extends Feature {
 			return $enabled;
 		}
 
-		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOL ) ) {
+		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOLEAN ) ) {
 			$enabled = false;
 		} elseif ( ! empty( $query->query_vars['search'] ) ) {
 			$enabled = true;

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -947,7 +947,7 @@ class WooCommerce extends Feature {
 		 * @return  {bool} New skip value
 		 */
 		if ( apply_filters( 'ep_skip_query_integration', false, $query ) ||
-			( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOL ) ) ) {
+			( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOLEAN ) ) ) {
 			return false;
 		}
 

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -385,7 +385,7 @@ abstract class Indexable {
 		 */
 		$enabled = apply_filters( 'ep_elasticpress_enabled', $enabled, $query );
 
-		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOL ) ) {
+		if ( isset( $query->query_vars['ep_integrate'] ) && ! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOLEAN ) ) {
 			$enabled = false;
 		}
 


### PR DESCRIPTION
### Description of the Change

In #2547 we've introduced a check for different false values while checking if the request should or not be integrated to EP. I have wrongly suggested the usage of `! filter_var( $query->query_vars['ep_integrate'], FILTER_VALIDATE_BOOL )` when that should use the `FILTER_VALIDATE_BOOLEAN` constant.

This PR fixes the wrong constant usage (sorry!)