### PR TITLE
Only remove from the queue the deleted post

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -237,10 +237,12 @@ class SyncManager extends SyncManagerAbstract {
 		Indexables::factory()->get( $this->indexable_slug )->delete( $post_id, false );
 
 		/**
-		 * Make sure to reset sync queue in case an shutdown happens before a redirect
-		 * when a redirect has already been triggered.
+		 * Make sure to remove this post from the sync queue in case an shutdown happens
+		 * before a redirect when a redirect has already been triggered.
 		 */
-		$this->sync_queue = [];
+		if ( isset( $this->sync_queue[ $post_id ] ) ) {
+			unset( $this->sync_queue[ $post_id ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Instead of completely wiping out the queue when a post is deleted, this change only removes from the queue the post that was deleted.

Closes #2568

### Changelog Entry

Fixed: Posts insertion and deletion in the same thread.

### Credits

Props @felipeelia and @tcrsavage
