### PR TITLE
Fix a rare edge-case bug where invalid values in tax_query terms resulted in a broken query

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1822,7 +1822,7 @@ class Post extends Indexable {
 
 				// Set up our terms object
 				$terms_obj = array(
-					'terms.' . $single_tax_query['taxonomy'] . '.' . $field => $terms,
+					'terms.' . $single_tax_query['taxonomy'] . '.' . $field => array_filter( $terms ),
 				);
 
 				$operator = ( ! empty( $single_tax_query['operator'] ) ) ? strtolower( $single_tax_query['operator'] ) : 'in';


### PR DESCRIPTION
### Description of the Change

Having a tax_query with terms being an array of not valid values results in a broken query.

```
{
	"tax_query": [
		{
				"taxonomy": "category",
				"field": "slug",
				"terms": [
						null
				],
				"operator": "IN"
		},
		{
				"taxonomy": "category",
				"field": "term_id",
				"terms": [
						1
				],
				"operator": "NOT IN"
		}
	]
}
```

=> 400

```
{
        "error": {
            "root_cause": [
                {
                    "type": "parsing_exception",
                    "reason": "No value specified for terms query",
                    "line": 1,
                    "col": 507
                }
            ],
            "type": "parsing_exception",
            "reason": "No value specified for terms query",
            "line": 1,
            "col": 507
        }
```


### Alternate Designs

Not sure, this seemed like a most logical place to put it to ensure no invalid terms would ever make it into the final query.

### Possible Drawbacks

This is still not 100% bulletproof because in even edgier case where a non-empty array or an object instance is passed it would not get filtered by array_filter. E.g. this would likely break the query.

```'terms' => [ [ 'arr' ], new YouShouldNotDoThat()  ];```

### Verification Process

```
	// Without the fix
	$q = new WP_Query( [
		'ep_integrate' => true,
		'tax_query' => [
			array(
            'taxonomy' => 'category',
            'field'    => 'slug',
            'terms'    => [ null ],
        ),
		]
	] );

	var_dump( $q->elasticsearch_success ); // => false
	// With the fix
	$q = new WP_Query( [
		'ep_integrate' => true,
		'tax_query' => [
			array(
            'taxonomy' => 'category',
            'field'    => 'slug',
            'terms'    => [ null ],
        ),
		]
	] );

	var_dump( $q->elasticsearch_success ); // => true
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - Invalid values in tax_query terms won't result in a query failure

### Credits

Props @rinatkhaziev
