### PR TITLE
Remove unnecessary order adjustment for WC queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,19 @@ ElasticPress has an in depth documentation site. [Visit the docs ☞](http://10u
 
 ElasticPress FAQs and tutorials can be found on our support site. [Visit the support site ☞](https://elasticpress.zendesk.com/hc/en-us)
 
-## Requirements
+## Requirements and Compatibility
+
+### Requirements
+
+ElasticPress requires these software with the following versions:
 
 * [Elasticsearch](https://www.elastic.co) 5.0+ **ElasticSearch max version supported: 7.9**
 * [WordPress](http://wordpress.org) 3.7.1+
 * [PHP](https://php.net/) 5.6+
+
+### Compatibility
+
+The WooCommerce feature is compatible with the last two major versions of the [WooCommerce plugin](https://wordpress.org/plugins/woocommerce/).
 
 ## React Components
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -373,16 +373,6 @@ class WooCommerce extends Feature {
 			$query->query['ep_integrate']      = true;
 
 			if ( ! empty( $s ) ) {
-				$query->set( 'orderby', false ); // Just order by relevance.
-
-				/**
-				 * Default order when doing search in Woocommerce is 'ASC'
-				 * These lines will change it to 'DESC' as we want to most relevant result
-				 */
-				if ( empty( $_GET['orderby'] ) && $query->is_main_query() ) { // phpcs:ignore WordPress.Security.NonceVerification
-					$query->set( 'order', 'DESC' );
-				}
-
 				// Search query
 				if ( 'shop_order' === $post_type ) {
 					$default_search_fields = array( 'post_title', 'post_content', 'post_excerpt' );


### PR DESCRIPTION
### Description of the Change

This PR removes an adjustment in the `orderby` parameter that EP was doing on WooCommerce queries and is no longer needed. 

In older versions of WC (apparently until [WC 3.0.9](https://github.com/woocommerce/woocommerce/releases/tag/3.0.9), released in June 2017), it was defaulting to `menu_order title => ASC`: https://github.com/woocommerce/woocommerce/blob/3.0.9/includes/class-wc-query.php#L449

Newer versions are already ordering by relevance DESC, as ElasticPress does.

Closes #2473

### Changelog Entry

Changed: to comply with modern WooCommerce behavior, ElasticPress does not change the orderby parameter anymore.

### Credits

Props @felipeelia and @beazuadmin 
