### PR TITLE
Fixed PHP warning Trying to access array offset on value of type int in get_index_names().

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -411,7 +411,7 @@ class Command extends WP_CLI_Command {
 	 * @return array
 	 */
 	protected function get_index_names() {
-		$sites = ( is_multisite() ) ? Utils\get_sites() : array( 'blog_id' => get_current_blog_id() );
+		$sites = ( is_multisite() ) ? Utils\get_sites() : array( array( 'blog_id' => get_current_blog_id() ) );
 
 		$all_indexables = Indexables::factory()->get_all();
 


### PR DESCRIPTION
### Description of the Change

Problem
- Running `wp elasticpress get-indexes` causes the following PHP warnings:

```console
$ wp elasticpress get-indexes
PHP Warning:  Trying to access array offset on value of type int
  in /wp-content/plugins/elasticpress/includes/classes/Command.php on line 427
PHP Warning:  Trying to access array offset on value of type int
  in /wp-content/plugins/elasticpress/includes/classes/Command.php on line 430
["active-mysite-post-1"]
```

Cause
- On non-multi-site installations, Command::get_index_names() uses a pseudo list of sites only containing the current/single site. The element in this array matches the expected structure of a [WP_Site](https://developer.wordpress.org/reference/classes/wp_site/), but the outer array for the list is missing.

Proposed solution
1. Fix the array structure to return a list of sites.

### Alternate Designs

The fallback/pseudo list of sites on single-site installations could be embedded into `Utils\get_sites()`.

### Possible Drawbacks

–

### Verification Process

The PHP warning is gone:

```console
$ wp elasticpress get-indexes
["active-mysite-post-1"]
```

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Fixed PHP warning Trying to access array offset on value of type int in get_index_names().

### Credits

Props @sun
