### PR TITLE
get_total_objects_for_query_from_db(): bail if we have any limits set

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -211,7 +211,8 @@ class Post extends Indexable {
 	protected function get_total_objects_for_query_from_db( $query_args ) {
 		$post_count = 0;
 
-		if ( ! isset( $query_args['post_type'] ) ) {
+		if ( ! isset( $query_args['post_type'] ) || isset( $query_args['ep_indexing_upper_limit_object_id'] ) 
+		|| isset( $query_args['ep_indexing_lower_limit_object_id'] ) ) {
 			return $post_count;
 		}
 


### PR DESCRIPTION
### Description of the Change

Slight continuation from #2571. We should bail if `ep_indexing_lower_limit_object_id` or `ep_indexing_upper_limit_object_id` is set since we're only looking for the total count from the DB and there's no way to determine that based on the object ID limits.

### Alternate Designs

N/A.

### Possible Drawbacks

It will return a 0, so doesn't exactly fix the initial problem if we run into that with the limit ids.

### Verification Process

On a yuge site where it kills the `found_posts` in `get_total_objects_for_query()`, pass in `--upper-limit-object-id` and expect it to return `0` instead of an inaccurate number.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed: Do not count posts in get_total_objects_for_query_from_db() if any object limit IDs are passed in

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @rebeccahum 
