### PR TITLE
Fix/update ep version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased]
 
+## [3.6.7] - 2021-02-08
+
+## Changed
+- Only update ElasticPress when older version is detected in DB.
+
 ## [3.6.6] - 2021-12-20
 
 ElasticPress 4.0 Beta 1 is [now available](https://github.com/10up/ElasticPress/releases/tag/4.0.0-beta.1) for non-production testing.

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -3,7 +3,7 @@
  * Plugin Name:       ElasticPress
  * Plugin URI:        https://github.com/10up/ElasticPress
  * Description:       A fast and flexible search and query engine for WordPress.
- * Version:           3.6.6
+ * Version:           3.6.7
  * Requires at least: 3.7.1
  * Requires PHP:      5.6
  * Author:            10up
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'EP_URL', plugin_dir_url( __FILE__ ) );
 define( 'EP_PATH', plugin_dir_path( __FILE__ ) );
 define( 'EP_FILE', plugin_basename( __FILE__ ) );
-define( 'EP_VERSION', '3.6.6' );
+define( 'EP_VERSION', '3.6.7' );
 
 /**
  * PSR-4-ish autoloading

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -61,10 +61,12 @@ class Upgrades {
 		 * Note: if a upgrade routine method is hooked to some action,
 		 * this code will be executed *earlier* than the routine method.
 		 */
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			update_site_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
-		} else {
-			update_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
+		if ( EP_VERSION !== $this->old_version ) {
+			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+				update_site_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
+			} else {
+				update_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
+			}
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticpress",
-  "version": "3.6.6",
+  "version": "3.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticpress",
-  "version": "3.6.6",
+  "version": "3.6.7",
   "license": "GPL-2.0-or-later",
   "description": "A fast and flexible search and query engine for WordPress.",
   "devDependencies": {
@@ -44,7 +44,6 @@
       "stats-script.min": "./assets/js/stats.js",
       "synonyms-script.min": "./assets/js/synonyms/index.js",
       "weighting-script.min": "./assets/js/weighting.js",
-
       "autosuggest-styles.min": "./assets/css/autosuggest.css",
       "comments-styles.min": "./assets/css/comments.css",
       "dashboard-styles.min": "./assets/css/dashboard.css",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: 10up, tlovett1, vhauri, tott, oscarssanchez, cmmarslender
 Tags:         performance, slow, search, elasticsearch, fuzzy, facet, aggregation, searching, autosuggest, suggest, elastic, advanced search, woocommerce, related posts, woocommerce
 Tested up to: 5.8
-Stable tag:   3.6.6
+Stable tag:   3.6.7
 License:      GPLv2 or later
 License URI:  http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
### Description of the Change

This update query to update the ElasticPress version kept running all the time on our sites, it also doesn't make any sense to always run it even when you're running the latest version. It caused a lot of `PHP Warning: mysqli_real_connect(): (HY000/1040): Too many connections`


### Alternate Designs

None

### Possible Drawbacks

Don't see any drawbacks of this optimization.

### Verification Process

Implemented this change and then snooped around the website & wp-admin, no more faulty update queries.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Changed - only update ElasticPress when older version is detected in DB.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
