### PR TITLE
Add aria attributes to improve facet accessibility.

### DIFF
--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -340,9 +340,36 @@ class Widget extends WP_Widget {
 		 */
 		$label = apply_filters( 'ep_facet_widget_term_label', $term->name, $term, $selected );
 
+		/**
+		 * Filter the accessible label for an individual facet term link.
+		 *
+		 * Used as the aria-label attribute for filter links. The accessible
+		 * label should include additional context around what action will be
+		 * performed by visiting the link, such as whether the filter will be
+		 * added or removed.
+		 *
+		 * @since 4.0.0
+		 * @hook ep_facet_widget_term_accessible_label
+		 * @param {string} $label Facet term accessible label.
+		 * @param {WP_Term} $term Term object.
+		 * @param {boolean} $selected Whether the term is selected.
+		 * @return {string} Individual facet term accessible label.
+		 */
+		$accessible_label = apply_filters(
+			'ep_facet_widget_term_accessible_label',
+			$selected
+				/* translators: %s: Filter term name. */
+				? sprintf( __( 'Remove filter: %s', 'elasticpress' ), $term->name )
+				/* translators: %s: Filter term name. */
+				: sprintf( __( 'Apply filter: %s', 'elasticpress' ), $term->name ),
+			$term,
+			$selected
+		);
+
 		$link = sprintf(
-			'<a %1$s rel="nofollow"><div class="ep-checkbox %2$s" role="presentation"></div>%3$s</a>',
-			$term->count ? $href : '',
+			'<a aria-label="%1$s" %2$s rel="nofollow"><div class="ep-checkbox %3$s" role="presentation"></div>%4$s</a>',
+			esc_attr( $accessible_label ),
+			$term->count ? $href : 'aria-role="link" aria-disabled="true"',
 			$selected ? 'checked' : '',
 			wp_kses_post( $label )
 		);


### PR DESCRIPTION
### Description of the Change

Adds aria attributes to facets to improve accessibility. This includes adding `aria-disabled` and `aria-role` attributes to disabled links, as per the solution described in [this article](https://www.scottohara.me/blog/2021/05/28/disabled-links.html). It also includes adding an `aria-label` attribute to the links, so that the accessible label makes it clear whether following the link will add or remove the filter.

The change also includes a filter for the accessible label: `ep_facet_widget_term_accessible_label`.

<!-- Enter any applicable Issues here. Example: -->
Closes #2596

### Verification Process

1. Add a facet widget to a page.
2. Observe the list of links, available facets should have an `aria-label` that reads "Apply filter:", followed by the term name.
3. After applying a filter, observe disabled options, they should have an `aria-disabled="true"` attribute and an `aria-role="link"` attribute. Active filters should have an `aria-label` that reads "Remove filter:", followed by the term name.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added ARIA attributes to Facet widget links to improve accessibility.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 
