### PR TITLE
Node version and replace references to "master" with "trunk"

### DIFF
--- a/.github/hookdoc-tmpl/README.md
+++ b/.github/hookdoc-tmpl/README.md
@@ -9,12 +9,12 @@ ElasticPress, a fast and flexible search and query engine for WordPress, enables
 
 **ElasticPress 3.0:** ElasticPress 3.0 contains major changes from 2.x including a rewrite of the feature registration API and PHP 5.4+ features. If you have problems upgrading, please create an issue. The minimum PHP version for ElasticPress 3.6.2 is 5.6.
 
-**Please note:** currently, `master` is the stable branch on GitHub. The upcoming ElasticPress 3.7.0 release will remove built assets from the `develop` branch, will replace `master` with `trunk`, will build a stable release version including built assets into a `stable` branch, and will include a build script should you want to build assets from a branch.
+**Please note:** currently, `trunk` is the stable branch on GitHub.
 
-**Upgrade Notice:** Versions 1.6.1, 1.6.2, 1.7, 1.8, 2.1, 2.1.2, 2.2, 2.7, 3.0, 3.1, and 3.3 require re-syncing.
+**Upgrade Notice:** For the full list of versions that need re-syncing, check the `check_reindex_needed()` method in the [ElasticPress\Upgrades](https://github.com/10up/ElasticPress/blob/develop/includes/classes/Upgrades.php) class.
 
 For more information about the ElasticPress plugin and ElasticPress.io service, please visit the [website](https://elasticpress.io).
 
 To report an issue with ElasticPress or contribute back to the project, please visit the [GitHub repository](https://github.com/10up/elasticpress/).
 
-<a href="http://10up.com/contact/" class="banner"><img src="https://10updotcom-wpengine.s3.amazonaws.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
+<a href="https://10up.com/contact/" class="banner"><img src="https://10up.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,7 @@ name: Build Docs
 on:
   push:
     branches:
-     - master
+     - trunk
 
 jobs:
   build:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -51,14 +51,14 @@ jobs:
         wp package install felipeelia/cli-command-docs:dev-trunk
         wp cli-command-docs elasticpress --custom-order=index,activate-feature,deactivate-feature,list-features,get-algorithm-version,set-algorithm-version --remove=delete_transient_on_int,custom_get_transient --custom-intro='The following WP-CLI commands are supported by ElasticPress:' > wp-content/plugins/elasticpress/docs/wp-cli.md
 
-    - name: Use Node.js 10
+    - name: Use Node.js 14
       uses: actions/setup-node@v2
       with:
-        node-version: '10.x'
+        node-version: '14.x'
 
-    - name: npm install, and build docs
+    - name: npm ci, and build docs
       run: |
-        npm install
+        npm ci
         npm -g install gulp-cli
         npm run build:docs
       env:

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - trunk
   pull_request:
     branches:
       - develop

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - trunk
   pull_request:
     branches:
       - develop

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,8 +41,8 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
 
-    - name: npm install
-      run: npm install
+    - name: npm ci
+      run: npm ci
 
     - name: es lint
       run: npm run lint-js

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - trunk
   pull_request:
     branches:
       - develop

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -2,10 +2,10 @@ name: Plugin asset/readme update
 on:
   push:
     branches:
-    - master
+    - trunk
 jobs:
-  master:
-    name: Push to master
+  trunk:
+    name: Push to trunk
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -15,14 +15,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: install node v10
+    - name: install node v14
       uses: actions/setup-node@v1
       with:
-        node-version: 10
+        node-version: 14
 
     - name: Build
       run: |
-        npm install
+        npm ci
         npm run build
 
     - name: WordPress Plugin Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - trunk
   pull_request:
     branches:
       - develop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ For more on how 10up writes and manages code, check out our [10up Engineering Be
 
 ## Workflow
 
-The `develop` branch is the development branch which means it contains the next version to be released.  `stable` contains the current latest release and `master` contains the corresponding stable development version.  Always work on the `develop` branch and open up PRs against `develop`.
+The `develop` branch is the development branch which means it contains the next version to be released. `trunk` contains the corresponding stable development version. Always work on the `develop` branch and open up PRs against `develop`.
 
 ## Release instructions
 
@@ -34,11 +34,11 @@ The `develop` branch is the development branch which means it contains the next 
 1. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`, ensuring to link the [X.Y.Z] release reference in the footer of `CHANGELOG.md` (e.g., https://github.com/10up/ElasticPress/compare/X.Y.Z-1...X.Y.Z).
 1. Props: Update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
 1. Readme updates: Make any other readme changes as necessary.  `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
-1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
-1. Merge: Merge the release branch/PR into `develop`, then make a non-fast-forward merge from `develop` into `master` (`git checkout master && git merge --no-ff develop`).  `master` contains the stable development version.
-1. Test: While still on the `master` branch, test for functionality locally.
-1. Push: Push your `master` branch to GitHub (e.g. `git push origin master`).
-1. Release: Create a [new release](https://github.com/10up/elasticpress/releases/new), naming the tag and the release with the new version number, and targeting the `master` branch.  Paste the release changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/elasticpress/milestone/#?closed=1).
+1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
+1. Merge: Merge the release branch/PR into `develop`, then make a non-fast-forward merge from `develop` into `trunk` (`git checkout trunk && git merge --no-ff develop`). `trunk` contains the stable development version.
+1. Test: While still on the `trunk` branch, test for functionality locally.
+1. Push: Push your `trunk` branch to GitHub (e.g. `git push origin trunk`).
+1. Release: Create a [new release](https://github.com/10up/elasticpress/releases/new), naming the tag and the release with the new version number, and targeting the `trunk` branch.  Paste the release changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/elasticpress/milestone/#?closed=1).
 1. [Check the _Publish New Release_ action](https://github.com/10up/ElasticPress/actions/workflows/push-deploy.yml): After the release, GitHub should trigger an action to generate a zip with the plugin and attach it to the GitHub Release page.
 1. SVN: Wait for the [GitHub Action](https://github.com/10up/ElasticPress/actions?query=workflow%3A%22Deploy+to+WordPress.org%22) to finish deploying to the WordPress.org repository.  If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
 1. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/elasticpress/.  This may take a few minutes.
@@ -55,7 +55,7 @@ Pre-releases are different from normal versions because (1) they are not publish
 1. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`, ensuring to link the [X.Y.Z] release reference in the footer of `CHANGELOG.md` (e.g., https://github.com/10up/ElasticPress/compare/X.Y.Z-1...X.Y.Z).
 1. Props: Update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
 1. Readme updates: Make any other readme changes as necessary. `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
-1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
+1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
 1. Merge: Merge the release branch/PR into the next version branch (`4.x.x`, for example).
 1. Test: Checkout the next version branch locally and build assets like the GitHub Action will do (see `.github/workflows/push-deploy.yml`)
 1. Release: Create a [new pre-release](https://github.com/10up/elasticpress/releases/new), naming the tag and the release with the new version number, and targeting the next version branch branch.  Paste the release changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/elasticpress/milestone/#?closed=1). **ATTENTION**: Make sure to check the `This is a pre-release` checkbox, so the release is not published on WordPress.org.
@@ -68,18 +68,18 @@ Pre-releases are different from normal versions because (1) they are not publish
 There may be cases where we have an urgent/important fix that ideally gets into a release quickly without any other changes (e.g., a "hotfix") so as to reduce (1) the amount or testing before being confident in the release and (2) to reduce the chance of unintended side effects from the extraneous non-urgent/important changes.  In cases where code has previously been merged into `develop` but that ideally is not part of a hotfix, the normal release instructions above will not suffice as they would release all code merged to `develop` alongside the intended urgent/important "hotfix" change(s).  In case of needing to release a "hotfix" the following are the recommended steps to take.
 
 1. If the new version requires a reindex, add its number to the `$reindex_versions` array in the `ElasticPress\Upgrades::check_reindex_needed()` method.  If it is the case, remember to add that information to the Changelog listings in `readme.txt` and `CHANGELOG.md`.
-1. Branch: Starting from `master`, cut a hotfix release branch named `hotfix/X.Y.Z` for your hotfix change(s).
+1. Branch: Starting from `trunk`, cut a hotfix release branch named `hotfix/X.Y.Z` for your hotfix change(s).
 1. Version bump: Bump the version number in `elasticpress.php`, `package.json`, `readme.txt`, and any other relevant files if it does not already reflect the version being released.  In `elasticpress.php` update both the plugin "Version:" property and the plugin `EP_VERSION` constant.
 1. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`, ensuring to link the [X.Y.Z] release reference in the footer of `CHANGELOG.md` (e.g., https://github.com/10up/ElasticPress/compare/X.Y.Z-1...X.Y.Z).
 1. Props: Update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.
 1. Readme updates: Make any other readme changes as necessary.  `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
-1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
-1. Merge: Merge the release branch/PR into `master`.  `master` contains the stable development version.
-1. Test: While still on the `master` branch, test for functionality locally.
-1. Push: Push your `master` branch to GitHub (e.g. `git push origin master`).
-1. Release: Create a [new release](https://github.com/10up/elasticpress/releases/new), naming the tag and the release with the new version number, and targeting the `master` branch.  Paste the release changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/elasticpress/milestone/#?closed=1).
+1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
+1. Merge: Merge the release branch/PR into `trunk`.  `trunk` contains the stable development version.
+1. Test: While still on the `trunk` branch, test for functionality locally.
+1. Push: Push your `trunk` branch to GitHub (e.g. `git push origin trunk`).
+1. Release: Create a [new release](https://github.com/10up/elasticpress/releases/new), naming the tag and the release with the new version number, and targeting the `trunk` branch.  Paste the release changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the [milestone](https://github.com/10up/elasticpress/milestone/#?closed=1).
 1. SVN: Wait for the [GitHub Action](https://github.com/10up/ElasticPress/actions?query=workflow%3A%22Deploy+to+WordPress.org%22) to finish deploying to the WordPress.org repository.  If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
 1. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/elasticpress/.  This may take a few minutes.
 1. Close milestone: Edit the [milestone](https://github.com/10up/elasticpress/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
 1. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the hotfix release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
-1. Apply hotfix changes to `develop`: Make a non-fast-forward merge from `master` into `develop` (`git checkout develop && git merge --no-ff master`) to ensure your hotfix change(s) are in sync with active development.
+1. Apply hotfix changes to `develop`: Make a non-fast-forward merge from `trunk` into `develop` (`git checkout develop && git merge --no-ff trunk`) to ensure your hotfix change(s) are in sync with active development.

--- a/README.md
+++ b/README.md
@@ -6,23 +6,7 @@
 
 * Check out the [ElasticPress Docs](http://10up.github.io/ElasticPress/)
 
-**Please note:** master is the stable branch, but that will be changing with the 4.0.0 release (read more on that below).
-
-## ElasticPress 4.0.0
-
-ElasticPress 4.0 Beta 1 is [now available](https://github.com/10up/ElasticPress/releases/tag/4.0.0-beta.1) for non-production testing.
-
-### Planned changes
-
-**Note that the upcoming ElasticPress 4.0.0 release will remove built assets from the `develop` branch, will replace `master` with `trunk`, ~~will build a stable release version including built assets into a `stable` branch,~~ will add a zip with the plugin and its built assets in the GitHub release page, and will include a build script should you want to build assets from a branch.**  As such, please plan to update any references you have from `master` to ~~either `stable` or~~ `trunk` or to GitHub releases depending on whether you require built assets or not.
-
-Supported versions:
-
-||Current (3.6.6)|4.0.0|
-|---|:---:|:---:|
-|Elasticsearch|5.0 - 7.9|5.2 - 7.10|
-|WordPress|3.7.1+|5.6+|
-|PHP|5.6+|7.0+|
+**Please note:** as of ElasticPress 4.0.0 `trunk` is the stable branch, built assets were removed from the `develop` branch, a ZIP with the plugin and its built assets are available on the [GitHub Releases page](https://github.com/10up/ElasticPress/releases), and will include a build script should you want to build assets from a branch.  As such, please ensure you have updated any references you have from `master` to `trunk` or to GitHub releases depending on whether you require built assets or not.
 
 ## Overview
 
@@ -40,9 +24,9 @@ ElasticPress FAQs and tutorials can be found on our support site. [Visit the sup
 
 ElasticPress requires these software with the following versions:
 
-* [Elasticsearch](https://www.elastic.co) 5.0+ **ElasticSearch max version supported: 7.9**
-* [WordPress](http://wordpress.org) 3.7.1+
-* [PHP](https://php.net/) 5.6+
+* [Elasticsearch](https://www.elastic.co) 5.2+ **ElasticSearch max version supported: 7.10**
+* [WordPress](http://wordpress.org) 5.6+
+* [PHP](https://php.net/) 7.0+
 
 ### Compatibility
 
@@ -50,7 +34,7 @@ The WooCommerce feature is compatible with the last two major versions of the [W
 
 ## Building Assets
 
-Simply downloading the repository files is not enough to have the plugin working, as CSS and JavaScript files are built during the release process. If you want to use a development version of the plugin you will to run
+Simply downloading the repository files is not enough to have the plugin working, as CSS and JavaScript files are built during the release process. If you want to use a development version of the plugin you will to run:
 
 `npm install && npm run build`
 
@@ -77,6 +61,10 @@ A complete listing of all notable changes to ElasticPress are documented in [CHA
 ### 3.5
 
 **Search Algorithm Upgrade Notice:** Version 3.5 includes a revamp of the search algorithm. This is a backwards compatibility break. If you'd like to revert to the old search algorithm, you can use the following code: `add_filter( 'ep_search_algorithm_version', function() { return '3.4'; } );`. The new algorithm offers much more relevant search results and removes fuzziness which results in mostly unwanted results for most people. If you are hooking in and modifying the search query directly, it's possible this code might break and you might need to tweak it.
+
+### 4.0.0
+
+**Note that ElasticPress 4.0.0 release removes built assets from the `develop` branch, replaced `master` with `trunk`, added a ZIP with the plugin and its built assets in the [GitHub Releases page](https://github.com/10up/ElasticPress/releases), and included a build script should you want to build assets from a branch.**  As such, please plan to update any references you have from `master` to `trunk` or to GitHub Releases depending on whether you require built assets or not.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ ElasticPress requires these software with the following versions:
 
 The WooCommerce feature is compatible with the last two major versions of the [WooCommerce plugin](https://wordpress.org/plugins/woocommerce/).
 
+## Building Assets
+
+Simply downloading the repository files is not enough to have the plugin working, as CSS and JavaScript files are built during the release process. If you want to use a development version of the plugin you will to run
+
+`npm install && npm run build`
+
+[Node.js](https://nodejs.org/en/) (v14) and [npm](https://www.npmjs.com/) (v8) are required.
+
 ## React Components
 
 Interested in integrating ElasticPress in your headless WordPress website? Check out [ElasticPress React](https://github.com/10up/elasticpress-react).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ Once an issue is reported, 10up uses the following disclosure process:
 - When a report is received, we confirm the issue and determine its severity.
 - If we know of specific third-party services or software that require mitigation before publication, those projects will be notified.
 - An advisory is prepared (but not published) which details the problem and steps for mitigation.
-- Wherever possible, fixes are prepared for the last minor release of the two latest major releases, as well as the master branch.  We will attempt to commit these fixes as soon as possible, and as close together as possible.
+- Wherever possible, fixes are prepared for the last minor release of the two latest major releases, as well as the trunk branch.  We will attempt to commit these fixes as soon as possible, and as close together as possible.
 - Patch releases are published for all fixed released versions and the advisory is published.
 - Release notes and our CHANGELOG.md will include a `Security` section with a link to the advisory.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@
 ## Install Steps
 
 1. First, you will need to sign up for an [ElasticPress.io account](https://elasticpress.io), or if you prefer, you can [install and configure](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html) Elasticsearch.
-2. Install the plugin in WordPress. You can install in the Dashboard, via WP-CLI, or download a [zip via Github](https://github.com/10up/ElasticPress/archive/master.zip) and upload it using the WordPress plugin uploader.
+2. Install the plugin in WordPress. You can install in the Dashboard, via WP-CLI, download a [zip of the latest release in Github](https://github.com/10up/ElasticPress/releases) and upload it using the WordPress plugin uploader, or [build it from the a branch](https://github.com/10up/ElasticPress#building-assets).
 3. Follow the prompts to add your ElasticPress.io or Elasticsearch server. <img src="https://github.com/10up/ElasticPress/raw/develop/images/setup-screenshot.png" width="850">
 4. Sync your content by clicking the sync icon.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">=8.11"
+    "node": ">=14",
+    "npm": ">=8"
   },
   "10up-toolkit": {
     "entry": {

--- a/readme.txt
+++ b/readme.txt
@@ -11,10 +11,6 @@ A fast and flexible search and query engine for WordPress.
 == Description ==
 ElasticPress, a fast and flexible search and query engine for WordPress, enables WordPress to find or “query” relevant content extremely fast through a variety of highly customizable features. WordPress out-of-the-box struggles to analyze content relevancy and can be very slow. ElasticPress supercharges your WordPress website making for happier users and administrators. The plugin even contains features for popular plugins.
 
-## ElasticPress 4.0.0 Beta is now available!
-
-The first Beta for ElasticPress 4.0 brings changes and new features, check the [release page](https://github.com/10up/ElasticPress/releases/tag/4.0.0-beta.1) for more info. ElasticPress 4.0 is still in development, so it is not recommended to run it on a production site.
-
 Here is a list of the amazing ElasticPress features included in the plugin:
 
 __Search__: Instantly find the content you’re looking for. The first time.
@@ -1074,6 +1070,9 @@ ElasticPress 1.6 contains a number of important enhancements and bug fixes. Most
 * Initial plugin
 
 == Upgrade Notice ==
+
+= 4.0.0 =
+**Note that ElasticPress 4.0.0 release removes built assets from the `develop` branch, replaced `master` with `trunk`, added a ZIP with the plugin and its built assets in the [GitHub Releases page](https://github.com/10up/ElasticPress/releases), and included a build script should you want to build assets from a branch.**  As such, please plan to update any references you have from `master` to `trunk` or to GitHub Releases depending on whether you require built assets or not.
 
 = 3.6.0 =
 **Note that the upcoming ElasticPress 3.7.0 release will remove built assets from the `develop` branch, will replace `master` with `trunk`, will build a stable release version including built assets into a `stable` branch, and will include a build script should you want to build assets from a branch.**  As such, please plan to update any references you have from `master` to either `stable` or `trunk` depending on whether you require built assets or not.


### PR DESCRIPTION
### Description of the Change

This PR is the first step of #2492, where all the references to the master branch are replaced with "trunk".

It also adds instructions about how to build assets, updates the node required version, and optimize GitHub actions a bit.

### Changelog Entry

Changed: `trunk` is now the repository main branch.

### Credits

Props @felipeelia 
