### PR TITLE
Use correct sync link on index health page

### DIFF
--- a/includes/partials/stats-page.php
+++ b/includes/partials/stats-page.php
@@ -17,8 +17,10 @@ require_once __DIR__ . '/header.php';
 
 if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 	$index_meta = get_site_option( 'ep_index_meta', false );
+	$sync_url   = network_admin_url( 'admin.php?page=elasticpress-sync' );
 } else {
 	$index_meta = get_option( 'ep_index_meta', false );
+	$sync_url   = admin_url( 'admin.php?page=elasticpress-sync' );
 }
 
 Stats::factory()->build_stats();
@@ -86,6 +88,18 @@ $totals       = Stats::factory()->get_totals();
 			</div>
 		</div>
 	<?php else : ?>
-		<p><?php echo wp_kses( __( 'We could not find any data for your Elasticsearch indices. Maybe you need to <a href="admin.php?page=elasticpress">sync your content</a>?', 'elasticpress' ), 'ep-html' ); ?></p>
+		<p>
+			<?php
+			printf(
+				/* translators: %s: Sync page link. */
+				esc_html__( 'We could not find any data for your Elasticsearch indices. Maybe you need to %s?', 'elasticpress' ),
+				sprintf(
+					'<a href="%1$s">%2$s</a>',
+					esc_url( $sync_url ),
+					esc_html__( 'sync your content', 'elasticpress' )
+				)
+			);
+			?>
+		</p>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
### Description of the Change

Correct the link on the Index Health page when no indexes are found.

<!-- Enter any applicable Issues here. Example: -->
Closes #2641.

### Verification Process

1. Delete any indexes via WP CLI, `wp elasticpress delete-index`.
2. Visit _ElasticPress > Index Health_.
3. You'll see a message, "We could not find any data for your Elasticsearch indices. Maybe you need to sync your content?". Follow the "sync your content" link.
4. You should be taken to the _ElasticPress > Sync_ page.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
