### PR TITLE
Fix/ir and pw protected posts

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -377,6 +377,7 @@ class InstantResults extends Feature {
 		add_filter( 'ep_intercept_remote_request', '__return_true' );
 		add_filter( 'ep_do_intercept_request', [ $this, 'intercept_search_request' ], 10, 4 );
 		add_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request' ], 10, 2 );
+		add_filter( 'ep_exclude_password_protected_from_search', '__return_true' );
 
 		$query = new \WP_Query(
 			array(
@@ -391,6 +392,7 @@ class InstantResults extends Feature {
 		remove_filter( 'ep_intercept_remote_request', '__return_true' );
 		remove_filter( 'ep_do_intercept_request', [ $this, 'intercept_search_request' ], 10 );
 		remove_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request' ], 10 );
+		remove_filter( 'ep_exclude_password_protected_from_search', '__return_true' );
 
 		return $this->search_template;
 	}

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -241,10 +241,11 @@ class ProtectedContent extends Feature {
 			 * Filter to exclude protected posts from search.
 			 *
 			 * @hook ep_exclude_password_protected_from_search
+			 * @since 4.0.0
 			 * @param  {bool} $exclude Exclude post from search.
 			 * @return {bool}
 			 */
-			if ( ! is_user_logged_in() && apply_filters( 'ep_exclude_password_protected_from_search', true ) ) {
+			if ( ! is_user_logged_in() || apply_filters( 'ep_exclude_password_protected_from_search', false ) ) {
 				$formatted_args['post_filter']['bool']['must_not'][] = array(
 					'exists' => array(
 						'field' => 'post_password',

--- a/tests/php/features/TestProtectedContent.php
+++ b/tests/php/features/TestProtectedContent.php
@@ -323,9 +323,11 @@ class TestProtectedContent extends BaseTestCase {
 		ElasticPress\Features::factory()->activate_feature( 'protected_content' );
 		ElasticPress\Features::factory()->setup_features();
 
+		// Post title is indexed but content is not.
 		Functions\create_and_sync_post(
 			array(
-				'post_content' => 'findme 123',
+				'post_title'    => 'findmetitle 123',
+				'post_content'  => 'findmecontent 123',
 				'post_password' => 'test'
 			)
 		);
@@ -339,7 +341,7 @@ class TestProtectedContent extends BaseTestCase {
 		$wp_the_query = $query;
 
 		$args = array(
-			's' => 'findme',
+			's' => 'findmetitle',
 		);
 
 		$query->query( $args );
@@ -347,6 +349,16 @@ class TestProtectedContent extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
+
+		$new_query = new \WP_Query(
+			[
+				's' => 'findmecontent',
+			]
+		);
+
+		$this->assertTrue( $new_query->elasticsearch_success );
+		$this->assertEquals( 0, $new_query->post_count );
+		$this->assertEquals( 0, $new_query->found_posts );
 	}
 
 	/**
@@ -367,7 +379,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		Functions\create_and_sync_post(
 			array(
-				'post_content'  => 'findme 123',
+				'post_title'    => 'findmetitle 123',
 				'post_password' => 'test',
 			)
 		);
@@ -375,7 +387,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		$query = new \WP_Query(
 			array(
-				's' => 'findme',
+				's' => 'findmetitle',
 			)
 		);
 


### PR DESCRIPTION
### Changelog Entry

Changed: Password Protected Posts are now completely ignored by Instant Results. When `ep_exclude_password_protected_from_search` is true, no password-protected content is searched.

### Credits

Props @felipeelia @oscarssanchez 
