### PR TITLE
Cypress tests for the Synonyms feature

### DIFF
--- a/tests/cypress/integration/features/search/synonyms.spec.js
+++ b/tests/cypress/integration/features/search/synonyms.spec.js
@@ -41,7 +41,7 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
 		cy.get('.synonym-sets-editor').within(() => {
 			cy.get('.synonym__remove').click();
-			cy.contains('.button', 'Add Set').as('addset').click();
+			cy.contains('.button', 'Add Set').click();
 			cy.get('.ep-synonyms__linked-multi-input').type(`${word1}{enter}${word2}{enter}`);
 		});
 		cy.get('#synonym-root .button-primary').click();
@@ -64,7 +64,7 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
 		cy.get('.synonym-alternatives-editor').within(() => {
 			cy.get('.synonym__remove').click();
-			cy.contains('.button', 'Add Alternative').as('addset').click();
+			cy.contains('.button', 'Add Alternative').click();
 			cy.get('.ep-synonyms__input').type(word1);
 			cy.get('.ep-synonyms__linked-multi-input').type(`${word2}{enter}`);
 		});
@@ -84,5 +84,45 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		// Check if it works
 		cy.visit(`/?s=${word1}`);
 		cy.contains('.site-content article h2', word2).should('not.exist');
+	});
+	it('Can use the Advanced Text Editor', () => {
+		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
+		cy.contains('.page-title-action', 'Switch to Advanced Text Editor').click();
+		cy.get('#ep-synonym-input').clearThenType(`{enter}
+		{enter}
+		{enter}
+		{enter}
+		{enter}
+		{enter}
+		{enter}
+		{enter}
+		{enter}
+		{enter}
+		{enter}
+		foo => bar
+		test =>
+		list,of,words
+		`);
+		cy.get('#synonym-root .button-primary').click();
+
+		cy.contains(
+			'.synonym-solr-editor__validation',
+			'Alternatives must have both a primary term and at least one alternative term.',
+		).should('exist');
+
+		cy.get('#ep-synonym-input').clearThenType('foo => bar{enter}list,of,words');
+		cy.get('#synonym-root .button-primary').click();
+		cy.contains('.notice-success', 'Successfully updated synonym filter.').should('exist');
+
+		cy.contains('.page-title-action', 'Switch to Visual Editor').click();
+		cy.contains('.synonym-set-editor div', 'list').should('exist');
+		cy.contains('.synonym-set-editor div', 'of').should('exist');
+		cy.contains('.synonym-set-editor div', 'words').should('exist');
+
+		cy.get('.synonym-alternative-editor input[value="foo"]').should('exist');
+		cy.contains(
+			'.synonym-alternative-editor .ep-synonyms__linked-multi-input div',
+			'bar',
+		).should('exist');
 	});
 });

--- a/tests/cypress/integration/features/search/synonyms.spec.js
+++ b/tests/cypress/integration/features/search/synonyms.spec.js
@@ -1,0 +1,58 @@
+describe('Post Search Feature - Synonyms Functionality', () => {
+	before(() => {
+		cy.wpCli("wp post list --post_type='ep-synonym' --format=ids", true).then(
+			(wpCliResponse) => {
+				if (wpCliResponse.code === 0) {
+					cy.wpCli(`wp post delete ${wpCliResponse.stdout} --force`, true);
+				}
+			},
+		);
+		cy.wpCli(
+			"wp post list --s='Testing Synonyms' --ep_integrate='false' --format=ids",
+			true,
+		).then((wpCliResponse) => {
+			if (wpCliResponse.code === 0) {
+				cy.wpCli(`wp post delete ${wpCliResponse.stdout} --force`, true);
+			}
+		});
+
+		cy.login();
+
+		const postsData = [
+			{
+				title: 'Testing Synonyms - Shoes',
+			},
+			{
+				title: 'Testing Synonyms - Sneakers',
+			},
+		];
+		postsData.forEach((postData) => {
+			cy.publishPost(postData);
+		});
+	});
+	it('Can create, search, and delete synonyms sets', () => {
+		cy.login();
+
+		// Add the set
+		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
+		cy.get('.synonym-sets-editor .synonym__remove').click();
+		cy.contains('.synonym-sets-editor .button', 'Add Set').as('addset').click();
+		cy.get('.synonym-sets-editor .ep-synonyms__linked-multi-input').type(
+			'sneakers{enter}shoes{enter}',
+		);
+		cy.get('#synonym-root .button-primary').click();
+
+		// Check if it works
+		cy.visit('/?s=sneakers');
+		cy.contains('.site-content article h2', 'Shoes').should('exist');
+
+		// Remove the set
+		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
+		cy.get('.synonym-sets-editor .synonym__remove').click();
+		cy.get('#synonym-root .button-primary').click();
+
+		// Check if it works
+		cy.visit('/?s=sneakers');
+		cy.contains('.site-content article h2', 'Shoes').should('not.exist');
+	});
+});

--- a/tests/cypress/integration/features/search/synonyms.spec.js
+++ b/tests/cypress/integration/features/search/synonyms.spec.js
@@ -1,4 +1,7 @@
 describe('Post Search Feature - Synonyms Functionality', () => {
+	const word1 = 'authenticity';
+	const word2 = 'credibility';
+
 	before(() => {
 		cy.wpCli("wp post list --post_type='ep-synonym' --format=ids", true).then(
 			(wpCliResponse) => {
@@ -20,31 +23,32 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 
 		const postsData = [
 			{
-				title: 'Testing Synonyms - Shoes',
+				title: `Testing Synonyms - ${word1}`,
 			},
 			{
-				title: 'Testing Synonyms - Sneakers',
+				title: `Testing Synonyms - ${word2}`,
 			},
 		];
 		postsData.forEach((postData) => {
 			cy.publishPost(postData);
 		});
 	});
-	it('Can create, search, and delete synonyms sets', () => {
+	beforeEach(() => {
 		cy.login();
-
+	});
+	it('Can create, search, and delete synonyms sets', () => {
 		// Add the set
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
-		cy.get('.synonym-sets-editor .synonym__remove').click();
-		cy.contains('.synonym-sets-editor .button', 'Add Set').as('addset').click();
-		cy.get('.synonym-sets-editor .ep-synonyms__linked-multi-input').type(
-			'sneakers{enter}shoes{enter}',
-		);
+		cy.get('.synonym-sets-editor').within(() => {
+			cy.get('.synonym__remove').click();
+			cy.contains('.button', 'Add Set').as('addset').click();
+			cy.get('.ep-synonyms__linked-multi-input').type(`${word1}{enter}${word2}{enter}`);
+		});
 		cy.get('#synonym-root .button-primary').click();
 
 		// Check if it works
-		cy.visit('/?s=sneakers');
-		cy.contains('.site-content article h2', 'Shoes').should('exist');
+		cy.visit(`/?s=${word2}`);
+		cy.contains('.site-content article h2', word1).should('exist');
 
 		// Remove the set
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
@@ -52,7 +56,33 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		cy.get('#synonym-root .button-primary').click();
 
 		// Check if it works
-		cy.visit('/?s=sneakers');
-		cy.contains('.site-content article h2', 'Shoes').should('not.exist');
+		cy.visit(`/?s=${word2}`);
+		cy.contains('.site-content article h2', word1).should('not.exist');
+	});
+	it('Can create, search, and delete synonyms alternatives', () => {
+		// Add the set
+		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
+		cy.get('.synonym-alternatives-editor').within(() => {
+			cy.get('.synonym__remove').click();
+			cy.contains('.button', 'Add Alternative').as('addset').click();
+			cy.get('.ep-synonyms__input').type(word1);
+			cy.get('.ep-synonyms__linked-multi-input').type(`${word2}{enter}`);
+		});
+		cy.get('#synonym-root .button-primary').click();
+
+		// Check if it works
+		cy.visit(`/?s=${word1}`);
+		cy.contains('.site-content article h2', word2).should('exist');
+		cy.visit(`/?s=${word2}`);
+		cy.contains('.site-content article h2', word1).should('not.exist');
+
+		// Remove the set
+		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
+		cy.get('.synonym-alternatives-editor .synonym__remove').click();
+		cy.get('#synonym-root .button-primary').click();
+
+		// Check if it works
+		cy.visit(`/?s=${word1}`);
+		cy.contains('.site-content article h2', word2).should('not.exist');
 	});
 });

--- a/tests/cypress/integration/features/search/synonyms.spec.js
+++ b/tests/cypress/integration/features/search/synonyms.spec.js
@@ -125,4 +125,22 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 			'bar',
 		).should('exist');
 	});
+	it('Can preserve synonyms if a sync is performed', () => {
+		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
+		cy.get('.page-title-action').then(($button) => {
+			if ($button.text() === 'Switch to Advanced Text Editor') {
+				$button.click();
+			}
+		});
+
+		cy.get('#ep-synonym-input').clearThenType('foo => bar{enter}list,of,words');
+		cy.get('#synonym-root .button-primary').click();
+
+		cy.wpCli('elasticpress index --setup --yes');
+
+		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
+		cy.get('#ep-synonym-input')
+			.should('contain', 'foo => bar')
+			.should('contain', 'list, of, words');
+	});
 });


### PR DESCRIPTION
### Description of the Change

This PR adds cypress tests related to the Synonyms feature.

- [ ] Create a synonym set with “hoodie” and “sweatshirt” -> ensure searching for “sweatshirt” returns the hoodie from the WC sample data
- [ ] Delete all synonym sets and synonym alternatives, test “sweatshirt” again to ensure “hoodie” no longer matches
- [ ] Add an alternative with a primary term of “sweater” and a term of “hoodie”, then search for “sweater” and expect the result of “hoodie” to appear. Repeat search with “hoodie” and expect only hoodie (but not sweater) to appear.
- [ ] Delete all synonym sets one more time to confirm the dashboard is still working.
- [ ] Switching to the “Advanced Text Editor” allows the user to:
  - [ ] Create new lines
  - [ ] Freely edit existent sets of synonyms
  - [ ] Give proper warning for wrong entries (a line with only “word =>” for example)
- [ ] Index via WP-CLI and verify if the synonyms previously set weren’t removed

Related to #2614

### Changelog Entry

Added: e2e tests for the Synonyms feature.

### Credits

Props @felipeelia 
