### PR TITLE
Generate search template as anonymous user.

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -385,8 +385,8 @@ class InstantResults extends Feature {
 		 * current user while the template is generated.
 		 *
 		 * @hook ep_search_template_user_id
-		 * @param int|WP $user_id User ID to use.
-		 *
+		 * @param  {int} $user_id User ID to use.
+		 * @return {int} New user ID to use.
 		 * @since 4.1.0
 		 */
 		$template_user_id = apply_filters( 'ep_search_template_user_id', 0 );

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -374,10 +374,29 @@ class InstantResults extends Feature {
 			]
 		);
 
+		/**
+		 * The ID of the current user when generating the Instant Results
+		 * search template.
+		 *
+		 * By default Instant Results sets the current user as anomnymous when
+		 * generating the search template, so that any filters applied to
+		 * queries for logged-in or specific users are not applied to the
+		 * template. This filter supports setting a specific user as the
+		 * current user while the template is generated.
+		 *
+		 * @hook ep_search_template_user_id
+		 * @param int|WP $user_id User ID to use.
+		 *
+		 * @since 4.1.0
+		 */
+		$template_user_id = apply_filters( 'ep_search_template_user_id', 0 );
+		$original_user_id = get_current_user_id();
+
+		wp_set_current_user( $template_user_id );
+
 		add_filter( 'ep_intercept_remote_request', '__return_true' );
 		add_filter( 'ep_do_intercept_request', [ $this, 'intercept_search_request' ], 10, 4 );
 		add_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request' ], 10, 2 );
-		add_filter( 'ep_exclude_password_protected_from_search', '__return_true' );
 
 		$query = new \WP_Query(
 			array(
@@ -392,7 +411,8 @@ class InstantResults extends Feature {
 		remove_filter( 'ep_intercept_remote_request', '__return_true' );
 		remove_filter( 'ep_do_intercept_request', [ $this, 'intercept_search_request' ], 10 );
 		remove_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request' ], 10 );
-		remove_filter( 'ep_exclude_password_protected_from_search', '__return_true' );
+
+		wp_set_current_user( $original_user_id );
 
 		return $this->search_template;
 	}


### PR DESCRIPTION
### Description of the Change

As discussed on #2650, the query that generates the Elasticsearch search template for Instant Results runs in the context of the user being logged in as an admin. This means that the template generated will be for the query for an administrator, so things like excluding password protected posts will not be applied.

This change sets the current user as anonymous while generating the template to resolve this issue. It also includes a filter to allow developers to set a specific user for whom the template should be generated as.

<!-- Enter any applicable Issues here. Example: -->
Closes #2650

### Alternate Designs

The original issue suggested using the `determine_current_user` filter to achieve this, by adding a filter that returns false for the current user during template generation. The problem with this is that it turns out that this filter does not actually run if the current user has already been set.

### Possible Drawbacks

None that I can think of.

### Verification Process

1. Without this change applied, save the weighting settings to ensure the search template is saved to EP.io (or a custom proxy).
2. Apply this change, save the weighting settings, and use Postman or similar to check the search template. On a bare bones install there should be no obvious change (4.0.0 included an alternative fix for password protected posts).
3. Add a filter to `pre_get_posts` that applies a change to the query, but only for logged in users. Save the weighting settings and  check the search template. This change should _not_ be apparent in the template.
4. Add `add_filter( 'ep_search_template_user_id', 'get_current_user_id' );`, save the weighting settings, and check the search template. The change should be apparent in the template.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - An issue where Instant Results may return results intended for logged-in users only.

### Credits

Props @JakePT 
