### PR TITLE
Allow truthy values for enabling weighting

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -546,15 +546,17 @@ class Weighting {
 			$weights = $weight_config[ $post_type ];
 		}
 
-		$weights = array_diff_key( $weights, $ignore_keys );
+		$fields = array_diff_key( $weights, $ignore_keys );
 
-		$found_enabled = array_search( true, array_column( $weights, 'enabled' ), true );
-
-		if ( false !== $found_enabled ) {
-			return true;
+		$found_enabled = false;
+		foreach ( $fields as $field ) {
+			if ( filter_var( $field['enabled'], FILTER_VALIDATE_BOOLEAN ) ) {
+				$found_enabled = true;
+				break;
+			}
 		}
 
-		return false;
+		return $found_enabled;
 	}
 
 	/**

--- a/tests/php/features/TestWeighting.php
+++ b/tests/php/features/TestWeighting.php
@@ -303,6 +303,45 @@ class TestWeighting extends BaseTestCase {
 		$this->assertFalse( $this->get_weighting_feature()->post_type_has_fields( 'page' ) );
 	}
 
+	/**
+	 * Check if `post_type_has_fields()` behaves correctly when using the `ep_weighting_configuration_for_search` filter.
+	 *
+	 * @since 4.1.0
+	 */
+	public function testPostTypeHasFieldsWithCustomConfigViaFilter() {
+		$function = function() {
+			return [
+				'page' => [],
+				'post' => [
+					'post_title' => [
+						'enabled' => 'on',
+						'weight'  => 1
+					]
+				],
+				'test' => [
+					'post_title' => [
+						'enabled' => true,
+						'weight'  => 1
+					]
+				],
+				'test-2' => [
+					'post_title' => [
+						'enabled' => 10, // This is not considered a "truthy" value
+						'weight'  => 1
+					]
+				],
+			];
+		};
+		add_filter( 'ep_weighting_configuration_for_search', $function );
+
+		$this->assertTrue( $this->get_weighting_feature()->post_type_has_fields( 'post' ) );
+		$this->assertFalse( $this->get_weighting_feature()->post_type_has_fields( 'page' ) );
+		$this->assertTrue( $this->get_weighting_feature()->post_type_has_fields( 'test' ) );
+		$this->assertFalse( $this->get_weighting_feature()->post_type_has_fields( 'test-2' ) );
+
+		remove_filter( 'ep_weighting_configuration_for_search', $function );
+	}
+
 	public function testDoWeightingWithQueryContainsSearchFields() {
 		// Test search fields are set on the query.
 		$this->assertSame( ['do', 'nothing'], $this->get_weighting_feature()->do_weighting( ['do', 'nothing'], ['search_fields' => [ 'post_title' ] ] ) );


### PR DESCRIPTION
### Description of the Change

This PR is an alternative version of #2597, changing the approach a little bit and also adding unit tests.

Note that this bug only happens when only fields using `'enabled' => 1` are added, i.e., if default fields are enabled, it will still work properly.

### Changelog Entry

Fixed: Truthy values for the `'enabled'` field's attribute while using the `ep_weighting_configuration_for_search` filter.

### Credits

Props @felipeelia and @moritzlang
