### PR TITLE
Shows an error message if the server returned invalid json during a Sync

### DIFF
--- a/assets/js/sync.js
+++ b/assets/js/sync.js
@@ -303,6 +303,25 @@ function updateSyncDash() {
 
 	if (isSyncing) {
 		progressBar.classList.remove('ep-sync-box__progressbar_complete');
+	} else if (syncStatus === 'error') {
+		const progressInfoElement = activeBox.querySelector('.ep-sync-box__progress-info');
+
+		progressInfoElement.innerText = __('Sync failed', 'elasticpress');
+
+		updateStartDateTime(new Date());
+		updateDisabledAttribute(deleteAndSyncButton, false);
+		updateDisabledAttribute(syncButton, false);
+
+		hidePauseStopButtons();
+		hideResumeButton();
+
+		syncButton.style.display = 'flex';
+
+		const learnMoreLink = activeBox.querySelector('.ep-sync-box__learn-more-link');
+
+		if (learnMoreLink?.style) {
+			learnMoreLink.style.display = 'block';
+		}
 	} else if (syncStatus === 'interrupt') {
 		const progressInfoElement = activeBox.querySelector('.ep-sync-box__progress-info');
 
@@ -662,6 +681,13 @@ function sync(putMapping = false) {
 			sync(putMapping);
 		})
 		.catch((response) => {
+			if (response && response.code === 'invalid_json') {
+				syncStatus = 'error';
+				updateSyncDash();
+				cancelSync();
+				addErrorToOutput(response.message);
+			}
+
 			if (
 				response &&
 				response.status &&


### PR DESCRIPTION
### Description of the Change

This PR improves error handling of the Dashboard Sync by displaying an error message when the admin-ajax calls return invalid JSON data. 

This is what the Sync UI looks like without this fix on the develop branch, when the server returns an invalid JSON response.

![sync_json_develop](https://user-images.githubusercontent.com/3541543/159925075-df5bd499-04cc-4752-b065-38697af11a3b.png)

And this is what the Sync UI looks on this feature branch with the same invalid JSON response.

![sync_invalid_json](https://user-images.githubusercontent.com/3541543/159925136-55a259a1-6c06-4e2c-be2f-04a3e944c635.png)

To test this PR I created an mu-plugin with the following code. This can also be seen by introducing other output into admin-ajax calls like PHP Warnings, incorrectly output styles, etc.

```php
<?php

add_action( 'admin_init', function() {
	if ( ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
		return; 
	}

	throw new Exception( 'Exception during Admin AJAX' );
} );

```

Closes #2301

### Possible Drawbacks

NA

### Verification Process

- Create an mu-plugin and copy-paste the above `admin_init` code into it.
- Run the Sync from the Dashboard
- You should see an error message that the Sync failed.
- The logs tab should also show an invalid json error message.


### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

Fixed: Display and error message if syncing failed due to invalid JSON response from the server.

### Credits

Props @dsawardekar 
