### PR TITLE
Automatic update using npm audit --fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4493,9 +4493,10 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "4.2.2",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.4.0.tgz",
+      "integrity": "sha512-qRkomr/URmfLrgVKnq+54l4+J0l6ZXJYKhUnfBbAxGIQKM73vQNFJyEiI2gfEaWcRYtlgPolYtIuwoy/QPz31g==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
@@ -13920,8 +13921,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "license": "MIT"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -22979,7 +22981,9 @@
       }
     },
     "@wordpress/env": {
-      "version": "4.2.2",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.4.0.tgz",
+      "integrity": "sha512-qRkomr/URmfLrgVKnq+54l4+J0l6ZXJYKhUnfBbAxGIQKM73vQNFJyEiI2gfEaWcRYtlgPolYtIuwoy/QPz31g==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -28968,7 +28972,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",


### PR DESCRIPTION
Title says it all

### Changelog Entry

Security: Updated `@wordpress/env` from 4.2.2 to 4.4.0, and `minimist` from 1.2.5 to 1.2.6.

### Credits

Props @felipeelia 
