### PR TITLE
Add support for multiple aggregations

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1800,9 +1800,13 @@ class Post extends Indexable {
 		/**
 		 * Aggregations
 		 */
-		if ( isset( $args['aggs'] ) ) {
-			// An array of aggregations.
-			if ( isset( $args['aggs'][0] ) ) {
+		if ( ! empty( $args['aggs'] ) && is_array( $args['aggs'] ) ) {
+			// Check if the array indexes are all numeric.
+			$agg_keys          = array_keys( $args['aggs'] );
+			$agg_num_keys      = array_filter( $agg_keys, 'is_int' );
+			$has_only_num_keys = count( $agg_num_keys ) === count( $args['aggs'] );
+
+			if ( $has_only_num_keys ) {
 				foreach ( $args['aggs'] as $agg ) {
 					$formatted_args = $this->apply_aggregations( $formatted_args, $agg, $use_filters, $filter );
 				}

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1800,24 +1800,15 @@ class Post extends Indexable {
 		/**
 		 * Aggregations
 		 */
-		if ( isset( $args['aggs'] ) && ! empty( $args['aggs']['aggs'] ) ) {
-			$agg_obj = $args['aggs'];
-
-			// Add a name to the aggregation if it was passed through
-			if ( ! empty( $agg_obj['name'] ) ) {
-				$agg_name = $agg_obj['name'];
+		if ( isset( $args['aggs'] ) ) {
+			// An array of aggregations.
+			if ( isset( $args['aggs'][0] ) ) {
+				foreach ( $args['aggs'] as $agg ) {
+					$formatted_args = $this->apply_aggregations( $formatted_args, $agg, $use_filters, $filter );
+				}
 			} else {
-				$agg_name = 'aggregation_name';
-			}
-
-			// Add/use the filter if warranted
-			if ( isset( $agg_obj['use-filter'] ) && false !== $agg_obj['use-filter'] && $use_filters ) {
-
-				// If a filter is being used, use it on the aggregation as well to receive relevant information to the query
-				$formatted_args['aggs'][ $agg_name ]['filter'] = $filter;
-				$formatted_args['aggs'][ $agg_name ]['aggs']   = $agg_obj['aggs'];
-			} else {
-				$formatted_args['aggs'][ $agg_name ] = $agg_obj['aggs'];
+				// Single aggregation.
+				$formatted_args = $this->apply_aggregations( $formatted_args, $args['aggs'], $use_filters, $filter );
 			}
 		}
 
@@ -2223,5 +2214,36 @@ class Post extends Indexable {
 		}
 
 		return 'unknown';
+	}
+
+	/**
+	 * Given ES args, add aggregations to it.
+	 *
+	 * @since 4.1.0
+	 * @param array   $formatted_args Formatted Elasticsearch query.
+	 * @param array   $agg            Aggregation data.
+	 * @param boolean $use_filters    Whether filters should be used or not.
+	 * @param array   $filter         Filters defined so far.
+	 * @return array Formatted Elasticsearch query with the aggregation added.
+	 */
+	protected function apply_aggregations( $formatted_args, $agg, $use_filters, $filter ) {
+		if ( empty( $agg['aggs'] ) ) {
+			return $formatted_args;
+		}
+
+		// Add a name to the aggregation if it was passed through
+		$agg_name = ( ! empty( $agg['name'] ) ) ? $agg['name'] : 'aggregation_name';
+
+		// Add/use the filter if warranted
+		if ( isset( $agg['use-filter'] ) && false !== $agg['use-filter'] && $use_filters ) {
+
+			// If a filter is being used, use it on the aggregation as well to receive relevant information to the query
+			$formatted_args['aggs'][ $agg_name ]['filter'] = $filter;
+			$formatted_args['aggs'][ $agg_name ]['aggs']   = $agg['aggs'];
+		} else {
+			$formatted_args['aggs'][ $agg_name ] = $agg['aggs'];
+		}
+
+		return $formatted_args;
 	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5939,6 +5939,38 @@ class TestPost extends BaseTestCase {
 		);
 
 		$this->assertSame( 'terms.post_type', $args['aggs']['aggregation_name']['terms']['field'] );
+
+		// Multiple aggs.
+		$args = $post->format_args(
+			[
+				// Triggers $use_filter to be true.
+				'post_status' => 'publish',
+
+				'aggs' => [
+					[
+						'name' => 'taxonomies',
+						'use-filter' => true,
+						'aggs' => [
+							'terms' => [
+								'field' => 'terms.category.slug',
+							],
+						],
+					],
+					[
+						'aggs' => [
+							'terms' => [
+								'field' => 'terms.post_type',
+							],
+						],
+					]
+				],
+			],
+			new \WP_Query()
+		);
+
+		$this->assertSame( 'publish', $args['aggs']['taxonomies']['filter']['bool']['must'][1]['term']['post_status'] );
+		$this->assertSame( 'terms.category.slug', $args['aggs']['taxonomies']['aggs']['terms']['field'] );
+		$this->assertSame( 'terms.post_type', $args['aggs']['aggregation_name']['terms']['field'] );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Currently, the plugin only supports a single array as the `aggs` parameter of WP_Query. This PR changes that to also support an array of aggregations. This will be needed to implement #1440 in a cleaner way.

Closes #636

### Changelog Entry

Added: Support for an array of aggregations in the `aggs` parameter of WP_Query.

### Credits

Props @felipeelia 
