### PR TITLE
get_term_tree(): fix infinite loop for non-existent parent

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -353,7 +353,7 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 				$terms_map[ $term->term_id ] = $term;
 			}
 
-			if ( empty( $term->parent ) || ( ! empty( $term->parent ) && ! term_exists( $term->parent, $term->taxonomy ) ) ) {
+			if ( empty( $term->parent ) || ! term_exists( $term->parent, $term->taxonomy ) ) {
 				$term->level = 0;
 
 				if ( empty( $orderby ) ) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -353,7 +353,7 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 				$terms_map[ $term->term_id ] = $term;
 			}
 
-			if ( empty( $term->parent ) ) {
+			if ( empty( $term->parent ) || ( ! empty( $term->parent ) && ! term_exists( $term->parent, $term->taxonomy ) ) ) {
 				$term->level = 0;
 
 				if ( empty( $orderby ) ) {


### PR DESCRIPTION

### Description of the Change

When calling `get_term_tree()` and a term has a parent ID that doesn't exist (possibly due to reasons such as a bad import), we should check for that to prevent an infinite loop from occurring. 

Reproduction steps:

```
$terms = array(
	0 => (object)  array
	(
		'term_id' => 2,
		'name' => 'ingredients',
		'slug' => 'ingredients',
		'term_group' => 0,
		'term_taxonomy_id' => 2,
		'taxonomy' => 'category',
		'description' => '',
		'parent' => 0,
		'count' => 1,
		'filter' => 'raw'
	),

);

$terms[0]->parent = 100; // non-existing parent in the terms

print_r( \ElasticPress\Utils\get_term_tree( $terms ) );
```

### Alternate Designs

N/A

### Possible Drawbacks

None that comes to mind.

### Verification Process

Reproduce the reproduction steps with the PR applied and ensure no critical errors occur.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - get_term_tree() will no longer infinite loop when parent ID is non-existent

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @rebeccahum 
