### PR TITLE
IndexHelper: handle the output of an array of messages

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -889,7 +889,7 @@ class IndexHelper {
 		}
 
 		$message = [
-			'message'    => $message_text,
+			'message'    => ( is_array( $message_text ) ) ? implode( "\n", $message_text ) : $message_text,
 			'index_meta' => $this->index_meta,
 			'totals'     => $totals ?? [],
 			'status'     => $type,


### PR DESCRIPTION
### Description of the Change

In some cases, IndexHelper will try to output an array of messages related to the same error. This PR takes that array and transforms it back into a string.

### Verification Process

- Add the following code to a website:
```
add_filter(
	'ep_prepare_meta_data',
	function( $post_meta, $post ) {
		for ( $i = 0; $i < 100; $i++ ) {
			$post_meta[ "test_meta_{$i}_title_{$post->ID}" ] = 'Lorem';
			$post_meta[ "test_meta_{$i}_body_{$post->ID}" ]  = 'Ipsum';
		}
		return $post_meta;
	},
	10,
	2
);
```

Normally, it'd make the index fail due to `[illegal_argument_exception] Limit of total fields [5000] in index [domain-post-1] has been exceeded` error if the user executes `wp elasticpress index --setup --yes --show-errors`. With the code in the PR, the error is properly outputted, instead of silently failing.

### Changelog Entry

Fixed: Handle the output of an array of messages in sync processes.

### Credits

Props @felipeelia 
