### PR TITLE
Delete all indices after e2e tests execution

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -120,4 +120,4 @@ jobs:
       run: |
         PLUGIN_NAME=$(basename "$PWD")
         npm run env run tests-cli "wp plugin activate ${PLUGIN_NAME} --network"
-        npm run env run tests-cli "wp elasticpress delete-index --network-wide --yes"
+        npm run env run tests-cli "wp elasticpress-tests delete-all-indices"

--- a/tests/cypress/wordpress-files/test-mu-plugins/unique-index-name.php
+++ b/tests/cypress/wordpress-files/test-mu-plugins/unique-index-name.php
@@ -35,3 +35,38 @@ function get_docker_cid() {
 }
 
 add_filter( 'ep_es_info_cache_expiration', '__return_zero' );
+
+/**
+ * From this point, only WP-CLI context should be executed.
+ */
+if ( ! defined( 'WP_CLI' ) ) {
+	return;
+}
+
+/**
+ * WP-CLI command to delete all indices used in the search.
+ */
+function ep_tests_delete_all_indices() {
+	$docker_cid = get_docker_cid();
+	if ( ! $docker_cid ) {
+		WP_CLI::error( 'Docker CID not set.' );
+	}
+
+	// Get full list of indices.
+	$response_cat_indices = \ElasticPress\Elasticsearch::factory()->remote_request( '_cat/indices?format=json' );
+
+	if ( is_wp_error( $response_cat_indices ) ) {
+		WP_CLI::error( 'Could not fetch indices names.' );
+	}
+
+	// Delete all indices matching the docker unique id.
+	$indices_from_cat_indices_api = json_decode( wp_remote_retrieve_body( $response_cat_indices ), true );
+	foreach ( $indices_from_cat_indices_api as $index ) {
+		if ( false === strpos( $index['index'], $docker_cid ) ) {
+			continue;
+		}
+
+		\ElasticPress\Elasticsearch::factory()->delete_index( $index['index'] );
+	}
+}
+WP_CLI::add_command( 'elasticpress-tests delete-all-indices', 'ep_tests_delete_all_indices' );


### PR DESCRIPTION
### Description of the Change

This PR adds a new WP-CLI command to the mu-plugin used in e2e tests, so all indices are deleted after the execution of the tests.

Closes #2708

### Changelog Entry

Added: Full indices removal after e2e tests.

### Credits

Props @felipeelia @dustinrue 
