### PR TITLE
Fix RelatedPosts::get_related_query() call

### DIFF
--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -148,7 +148,7 @@ class RelatedPosts extends Feature {
 	 * @return array|bool
 	 */
 	public function find_related( $post_id, $return = 5 ) {
-		$query = $this->get_related_query( $post_id, $return = 5 );
+		$query = $this->get_related_query( $post_id, $return );
 
 		if ( ! $query->have_posts() ) {
 			return false;

--- a/tests/php/features/TestRelatedPosts.php
+++ b/tests/php/features/TestRelatedPosts.php
@@ -90,6 +90,12 @@ class TestRelatedPosts extends BaseTestCase {
 		$related = ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id );
 		$this->assertEquals( 2, count( $related ) );
 		$this->assertTrue( isset( $related[0] ) && isset( $related[0]->elasticsearch ) );
+
+		// Make sure it will use the number of posts to be returned.
+		$related = ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, 1 );
+		$this->assertEquals( 1, count( $related ) );
+		$this->assertTrue( isset( $related[0] ) && isset( $related[0]->elasticsearch ) );
+
 		remove_filter( 'ep_find_related_args', array( $this, 'find_related_posts_filter' ), 10, 1 );
 	}
 


### PR DESCRIPTION
### Description of the Change

Title says it all.

<!-- Enter any applicable Issues here. Example: -->
Closes #2715

### Changelog Entry

Fixed: Usage of the `$return` parameter in `Feature\RelatedPosts::find_related()`.

### Credits

Props @felipeelia @altendorfme
