### PR TITLE
npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2981,16 +2981,18 @@
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1"
       }
     },
     "node_modules/@kwsites/promise-deferred": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4495,9 +4497,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.4.0.tgz",
-      "integrity": "sha512-qRkomr/URmfLrgVKnq+54l4+J0l6ZXJYKhUnfBbAxGIQKM73vQNFJyEiI2gfEaWcRYtlgPolYtIuwoy/QPz31g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.5.0.tgz",
+      "integrity": "sha512-1YTYSSrmkfiNIp+dhUnOm9tRg7gs48K3lkaXi053zlS0DMEioP9zJtegrYQfvY31U9Ad+29R7Ck5kYuB3tVY4g==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4509,7 +4511,7 @@
         "js-yaml": "^3.13.1",
         "ora": "^4.0.2",
         "rimraf": "^3.0.2",
-        "simple-git": "^2.35.0",
+        "simple-git": "^3.5.0",
         "terminal-link": "^2.0.0",
         "yargs": "^17.3.0"
       },
@@ -14840,9 +14842,10 @@
       }
     },
     "node_modules/portfinder/node_modules/async": {
-      "version": "2.6.3",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -17632,13 +17635,14 @@
       "license": "ISC"
     },
     "node_modules/simple-git": {
-      "version": "2.48.0",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.6.0.tgz",
+      "integrity": "sha512-2e+4QhOVO59GeLsHgwSMKNrSKCnuACeA/gMNrLCYR8ID9qwm4hViVt4WsODcUGjx//KDv6GMLC6Hs/MeosgXxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       },
       "funding": {
         "type": "github",
@@ -21973,6 +21977,8 @@
     },
     "@kwsites/file-exists": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1"
@@ -21980,6 +21986,8 @@
     },
     "@kwsites/promise-deferred": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
     },
     "@nodelib/fs.scandir": {
@@ -22984,9 +22992,9 @@
       }
     },
     "@wordpress/env": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.4.0.tgz",
-      "integrity": "sha512-qRkomr/URmfLrgVKnq+54l4+J0l6ZXJYKhUnfBbAxGIQKM73vQNFJyEiI2gfEaWcRYtlgPolYtIuwoy/QPz31g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.5.0.tgz",
+      "integrity": "sha512-1YTYSSrmkfiNIp+dhUnOm9tRg7gs48K3lkaXi053zlS0DMEioP9zJtegrYQfvY31U9Ad+29R7Ck5kYuB3tVY4g==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -22998,7 +23006,7 @@
         "js-yaml": "^3.13.1",
         "ora": "^4.0.2",
         "rimraf": "^3.0.2",
-        "simple-git": "^2.35.0",
+        "simple-git": "^3.5.0",
         "terminal-link": "^2.0.0",
         "yargs": "^17.3.0"
       },
@@ -29548,7 +29556,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.3",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"
@@ -31270,12 +31280,14 @@
       "dev": true
     },
     "simple-git": {
-      "version": "2.48.0",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.6.0.tgz",
+      "integrity": "sha512-2e+4QhOVO59GeLsHgwSMKNrSKCnuACeA/gMNrLCYR8ID9qwm4hViVt4WsODcUGjx//KDv6GMLC6Hs/MeosgXxg==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       }
     },
     "sirv": {


### PR DESCRIPTION
The result of an `npm audit fix` call.

### Changelog Entry

Security: Bumped `@wordpress/env` from 4.4.0 to 4.5.0.

### Credits

Props @felipeelia 
