### PR TITLE
Prevent order fields from being removed

### DIFF
--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -247,11 +247,13 @@ class ProtectedContent extends Feature {
 		 * Filter to skip the password protected content clean up.
 		 *
 		 * @hook ep_pc_skip_post_content_cleanup
-		 * @since 4.0.0
-		 * @param  {bool} $skip Whether the password protected content should have their content, and meta removed.
+		 * @since 4.0.0, 4.2.0 added $post_args and $post_id
+		 * @param  {bool}  $skip      Whether the password protected content should have their content, and meta removed
+		 * @param  {array} $post_args Post arguments
+		 * @param  {int}   $post_id   Post ID
 		 * @return {bool}
 		 */
-		if ( apply_filters( 'ep_pc_skip_post_content_cleanup', false ) ) {
+		if ( apply_filters( 'ep_pc_skip_post_content_cleanup', false, $post_args, $post_id ) ) {
 			return $post_args;
 		}
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -922,6 +922,7 @@ class WooCommerce extends Feature {
 	 *
 	 * @see https://github.com/10up/ElasticPress/issues/2726
 	 *
+	 * @since 4.2.0
 	 * @param bool  $skip      Whether the password protected content should have their content, and meta removed
 	 * @param array $post_args Post arguments
 	 * @return bool

--- a/tests/php/features/TestWooCommerce.php
+++ b/tests/php/features/TestWooCommerce.php
@@ -212,8 +212,8 @@ class TestWooCommerce extends BaseTestCase {
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
 		$args = array(
-			's'         => (string) $shop_order_id_1,
-			'post_type' => 'shop_order',
+			's'           => (string) $shop_order_id_1,
+			'post_type'   => 'shop_order',
 			'post_status' => 'any',
 		);
 

--- a/tests/php/features/TestWooCommerce.php
+++ b/tests/php/features/TestWooCommerce.php
@@ -197,26 +197,24 @@ class TestWooCommerce extends BaseTestCase {
 		ElasticPress\Features::factory()->activate_feature( 'woocommerce' );
 		ElasticPress\Features::factory()->setup_features();
 
-		$shop_order_id_1 = Functions\create_and_sync_post(
-			array(
-				'post_type' => 'shop_order',
-			)
-		);
+		$this->assertTrue( class_exists( '\WC_Order' ) );
 
-		Functions\create_and_sync_post(
-			array(
-				'post_type' => 'shop_order',
-			),
-			array(
-				'_billing_phone' => 'Phone number that matches an order ID: ' . $shop_order_id_1,
-			)
-		);
+		$shop_order_1 = new \WC_Order();
+		$shop_order_1->save();
+		$shop_order_id_1 = $shop_order_1->get_id();
+		ElasticPress\Indexables::factory()->get( 'post' )->index( $shop_order_id_1, true );
+
+		$shop_order_2 = new \WC_Order();
+		$shop_order_2->set_billing_phone( 'Phone number that matches an order ID: ' . $shop_order_id_1 );
+		$shop_order_2->save();
+		ElasticPress\Indexables::factory()->get( 'post' )->index( $shop_order_2->get_id(), true );
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
 		$args = array(
 			's'         => (string) $shop_order_id_1,
 			'post_type' => 'shop_order',
+			'post_status' => 'any',
 		);
 
 		$query = new \WP_Query( $args );


### PR DESCRIPTION
### Description of the Change

Since ElasticPress 4.0.0, password-protected posts have their content removed during the sync process. As stated in #2726, that is a problem for WooCommerce Orders created in the frontend. This PR adjusts that behavior.

Closes #2726

### Changelog Entry

Added: `$post_args` and `$post_id` to the `ep_pc_skip_post_content_cleanup` filter.
Fixed: Sync of WooCommerce Orders fields when WooCommerce and Protected Content features are enabled.

### Credits

Props @felipeelia @ecaron
