### PR TITLE
Fix URL for Related Posts API Functions

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -30,9 +30,13 @@ ElasticPress understands data in real time, so it can instantly deliver engaging
 
 Available API functions:
 
-* `ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, $return = 5 )`
+* `\ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, $return = 5 )`
 
   Get related posts for a given `$post_id`. Use this in a theme or plugin to get related content.
+
+* `\ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->get_related_query( $post_id, $return = 5 )`
+
+  Get a `WP_Query` object with the related posts for a given `$post_id`.
 
 ## Protected Content
 

--- a/hookdoc-conf.json
+++ b/hookdoc-conf.json
@@ -13,6 +13,9 @@
     "node_modules/wp-hookdoc/plugin",
     "plugins/markdown"
   ],
+  "markdown": {
+    "idInHeadings": true
+  },
   "templates":  {
     "default": {
       "layoutFile": ".github/hookdoc-tmpl/layout.tmpl",

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -356,7 +356,7 @@ class RelatedPosts extends Feature {
 	 */
 	public function output_feature_box_long() {
 		?>
-		<p><?php echo wp_kses_post( __( 'Output related content using our Widget or directly in your theme using our <a href="https://github.com/10up/ElasticPress/#related-posts">API functions.</a>', 'elasticpress' ) ); ?></p>
+		<p><?php echo wp_kses_post( __( 'Output related content using our Widget or directly in your theme using our <a href="https://10up.github.io/ElasticPress/tutorial-features.html#related-posts">API functions.</a>', 'elasticpress' ) ); ?></p>
 		<?php
 	}
 }


### PR DESCRIPTION
### Description of the Change

This PR fixes some issues with our documentation:
1. Add ids to headings so they can be easier linked
2. Add a reference to get_related_query under the Related Posts feature section
3. Fix the link to API Functions under the Related Posts feature -> Learn more

Closes #2724

### Changelog Entry

Fixed: link to API Functions under the Related Posts feature -> Learn more.

### Credits

Props @felipeelia @burhandodhy