### PR TITLE
Add filter ep_integrate_search_queries

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -594,7 +594,7 @@ class Search extends Feature {
 		/**
 		 * Filter whether to enable integration on search queries or not.
 		 *
-		 * @since 4.1.1
+		 * @since 4.2.0
 		 * @param {bool} $enabled Original enabled value
 		 * @param {WP_Query} WP_Query
 		 * @return {bool} New $enabled value

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -594,9 +594,10 @@ class Search extends Feature {
 		/**
 		 * Filter whether to enable integration on search queries or not.
 		 *
+		 * @hook ep_integrate_search_queries
 		 * @since 4.2.0
-		 * @param {bool} $enabled Original enabled value
-		 * @param {WP_Query} WP_Query
+		 * @param {bool}     $enabled Original enabled value
+		 * @param {WP_Query} $query   WP_Query
 		 * @return {bool} New $enabled value
 		 */
 		return apply_filters( 'ep_integrate_search_queries', $enabled, $query );

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -591,7 +591,15 @@ class Search extends Feature {
 			}
 		}
 
-		return $enabled;
+		/**
+		 * Filter whether to enable integration on search queries or not.
+		 *
+		 * @since 4.1.1
+		 * @param {bool} $enabled Original enabled value
+		 * @param {WP_Query} WP_Query
+		 * @return {bool} New $enabled value
+		 */
+		return apply_filters( 'ep_integrate_search_queries', $enabled, $query );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

This adds a filter to `integrate_search_queries()` in case someone wanted to filter how they wanted to integrate their search queries. For example, if they wanted search queries with an empty 's' parameter, they should be able to use the filter to do so.

### Alternate Designs

N/A.

### Possible Drawbacks

N/A.

### Verification Process

1) Apply PR
2) Add the filter:
```
add_filter( 'ep_integrate_search_queries', 'empty_search_integrated_request', 10, 2 );

function empty_search_integrated_request( $enabled, $query ) {
	if ( empty( $query->query_vars['s'] ) ) {
		$enabled = true;
	}

	return $enabled;
}
```
3) Go to an empty search page aka example.com/?s=
4) Expect to see search query offloaded still

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - New filter ep_integrate_search_queries

### Credits

Props @rebeccahum 
