### PR TITLE
Fix type error in console when searching

### DIFF
--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -479,7 +479,9 @@ function init() {
 				break;
 			case 13: // Enter
 				if (results[currentIndex].classList.contains('selected')) {
-					if(typeof currentIndex === 'undefined')break;
+					if (typeof currentIndex === 'undefined') {
+						break;
+					}
 					// navigate to the item defined in the span's data-url attribute
 					selectItem(input, results[currentIndex].querySelector('.autosuggest-link'));
 				}

--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -479,6 +479,7 @@ function init() {
 				break;
 			case 13: // Enter
 				if (results[currentIndex].classList.contains('selected')) {
+					if(typeof currentIndex === 'undefined')break;
 					// navigate to the item defined in the span's data-url attribute
 					selectItem(input, results[currentIndex].querySelector('.autosuggest-link'));
 				}

--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -478,10 +478,10 @@ function init() {
 				}
 				break;
 			case 13: // Enter
-				if (results[currentIndex].classList.contains('selected')) {
-					if (typeof currentIndex === 'undefined') {
-						break;
-					}
+				if (typeof currentIndex === 'undefined') {
+					break;
+				}
+				if (results[currentIndex]?.classList.contains('selected')) {
 					// navigate to the item defined in the span's data-url attribute
 					selectItem(input, results[currentIndex].querySelector('.autosuggest-link'));
 				}

--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -481,7 +481,7 @@ function init() {
 				if (typeof currentIndex === 'undefined') {
 					break;
 				}
-				if (results[currentIndex]?.classList.contains('selected')) {
+				if (results[currentIndex].classList.contains('selected')) {
 					// navigate to the item defined in the span's data-url attribute
 					selectItem(input, results[currentIndex].querySelector('.autosuggest-link'));
 				}


### PR DESCRIPTION

### Description of the Change

Add a check if currentindex is undefined then break, this prevents a error briefly appearing in the console.

<!-- Enter any applicable Issues here. Example: -->
Closes #2725

### Alternate Designs

None, no designs were made.

### Possible Drawbacks

None, just a quick check.

### Verification Process

Well firstly I got tasked to fix this bug on the website, which quickly led me to the autosuggest.js. But this process was painful since the minified version was throwing the errors, so I had to dig trough a one line file.

The fix I currently have implemented inserts this line of code between the other lines using regex, but it would be better for this fix to be in the plugin itself.

### Checklist:


- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

- Fixed a brief type error in the console

### Credits

Props @MarijnvSprundel
