### PR TITLE
Syncs: status and error handling

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1036,11 +1036,10 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_last_cli_index( $args, $assoc_args ) {
-
-		$last_sync = get_site_option( 'ep_last_cli_index', array() );
+		$last_sync = Utils\get_option( 'ep_last_cli_index', array() );
 
 		if ( isset( $assoc_args['clear'] ) ) {
-			delete_site_option( 'ep_last_cli_index' );
+			Utils\delete_option( 'ep_last_cli_index' );
 		}
 
 		$this->pretty_json_encode( $last_sync, ! empty( $assoc_args['pretty'] ) );

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1020,6 +1020,26 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Returns a JSON array with the results of the last index (if present) of an empty array.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--pretty]
+	 * : Use this flag to render a pretty-printed version of the JSON response.
+	 *
+	 * @subcommand get-last-sync
+	 * @alias      get-last-index
+	 * @since 4.2.0
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_last_sync( $args, $assoc_args ) {
+		$last_sync = \ElasticPress\IndexHelper::factory()->get_last_index();
+
+		$this->pretty_json_encode( $last_sync, ! empty( $assoc_args['pretty'] ) );
+	}
+
+	/**
 	 * Returns a JSON array with the results of the last CLI index (if present) of an empty array.
 	 *
 	 * ## OPTIONS

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -982,7 +982,7 @@ class Command extends WP_CLI_Command {
 		 */
 		do_action( 'ep_cli_after_clear_index' );
 
-		WP_CLI::success( esc_html__( 'Index cleared.', 'elasticpress' ) );
+		WP_CLI::log( esc_html__( 'Index cleared.', 'elasticpress' ) );
 	}
 
 	/**

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1020,7 +1020,7 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Returns a JSON array with the results of the last index (if present) of an empty array.
+	 * Returns a JSON array with the results of the last index (if present) or an empty array.
 	 *
 	 * ## OPTIONS
 	 *
@@ -1040,7 +1040,7 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Returns a JSON array with the results of the last CLI index (if present) of an empty array.
+	 * Returns a JSON array with the results of the last CLI index (if present) or an empty array.
 	 *
 	 * ## OPTIONS
 	 *

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -65,6 +65,8 @@ class IndexHelper {
 	 * @param array $args Arguments.
 	 */
 	public function full_index( $args ) {
+		register_shutdown_function( [ $this, 'handle_index_error' ] );
+
 		$this->index_meta = Utils\get_indexing_status();
 		$this->args       = $args;
 
@@ -717,16 +719,11 @@ class IndexHelper {
 	}
 
 	/**
-	 * Make the necessary clean up after a sync item of the stack was completely done.
+	 * Update the sync info with the totals from the last sync item.
 	 *
-	 * @since 4.0.0
-	 * @return void
+	 * @since 4.2.0
 	 */
-	protected function index_cleanup() {
-		wp_reset_postdata();
-
-		$indexable = Indexables::factory()->get( $this->index_meta['current_sync_item']['indexable'] );
-
+	protected function update_totals_from_current_sync_item() {
 		$current_sync_item = $this->index_meta['current_sync_item'];
 
 		$this->index_meta['totals']['total']   += $current_sync_item['total'];
@@ -737,6 +734,22 @@ class IndexHelper {
 			$this->index_meta['totals']['errors'],
 			$current_sync_item['errors']
 		);
+	}
+
+	/**
+	 * Make the necessary clean up after a sync item of the stack was completely done.
+	 *
+	 * @since 4.0.0
+	 * @return void
+	 */
+	protected function index_cleanup() {
+		wp_reset_postdata();
+
+		$this->update_totals_from_current_sync_item();
+
+		$indexable = Indexables::factory()->get( $this->index_meta['current_sync_item']['indexable'] );
+
+		$current_sync_item = $this->index_meta['current_sync_item'];
 
 		if ( $current_sync_item['failed'] ) {
 			$this->index_meta['current_sync_item']['failed'] = 0;
@@ -785,11 +798,11 @@ class IndexHelper {
 	}
 
 	/**
-	 * Make the necessary clean up after everything was sync'd.
+	 * Update last sync info.
 	 *
-	 * @since 4.0.0
+	 * @since 4.2.0
 	 */
-	protected function full_index_complete() {
+	protected function update_last_index() {
 		$start_time = $this->index_meta['start_time'];
 		$totals     = $this->index_meta['totals'];
 
@@ -802,6 +815,15 @@ class IndexHelper {
 		$totals['total_time']    = microtime( true ) - $start_time;
 		Utils\update_option( 'ep_last_cli_index', $totals, false );
 		Utils\update_option( 'ep_last_index', $totals, false );
+	}
+
+	/**
+	 * Make the necessary clean up after everything was sync'd.
+	 *
+	 * @since 4.0.0
+	 */
+	protected function full_index_complete() {
+		$this->update_last_index();
 
 		/**
 		 * Fires after executing a reindex
@@ -885,7 +907,7 @@ class IndexHelper {
 			Utils\update_option( 'ep_index_meta', $this->index_meta );
 		} else {
 			Utils\delete_option( 'ep_index_meta' );
-			$totals = Utils\get_option( 'ep_last_index' );
+			$totals = $this->get_last_index();
 		}
 
 		$message = [
@@ -989,6 +1011,16 @@ class IndexHelper {
 	}
 
 	/**
+	 * Get the last index/sync meta information.
+	 *
+	 * @since 4.2.0
+	 * @return array
+	 */
+	public function get_last_index() {
+		return Utils\get_option( 'ep_last_index', [] );
+	}
+
+	/**
 	 * Check if an object should be indexed or skipped.
 	 *
 	 * We used to have two different filters for this (one for the dashboard, another for CLI),
@@ -1087,6 +1119,45 @@ class IndexHelper {
 	 */
 	public function get_index_meta() {
 		return Utils\get_option( 'ep_index_meta', [] );
+	}
+
+	/**
+	 * Handle fatal errors during syncs.
+	 *
+	 * Logs the error and clears the sync status, preventing the sync status from being stuck.
+	 *
+	 * @since 4.2.0
+	 */
+	public function handle_index_error() {
+		$error = error_get_last();
+		if ( empty( $error['type'] ) || E_ERROR !== $error['type'] ) {
+			return;
+		}
+
+		$this->update_totals_from_current_sync_item();
+
+		$totals = $this->index_meta['totals'];
+
+		$this->index_meta['totals']['errors'][] = $error['message'];
+		$this->index_meta['totals']['failed']   = $totals['total'] - ( $totals['synced'] + $totals['skipped'] );
+		$this->update_last_index();
+
+		/**
+		 * Fires after a sync failed due to a PHP fatal error.
+		 *
+		 * @since 4.2.0
+		 * @hook ep_after_sync_error
+		 * @param {array} $error The error
+		 */
+		do_action( 'ep_after_sync_error', $error );
+
+		$this->output_error(
+			sprintf(
+				/* translators: Error message */
+				esc_html__( 'Index failed: %s', 'elasticpress' ),
+				$error['message']
+			)
+		);
 	}
 
 	/**

--- a/includes/classes/Screen/Sync.php
+++ b/includes/classes/Screen/Sync.php
@@ -8,11 +8,9 @@
 
 namespace ElasticPress\Screen;
 
-use ElasticPress\Features as Features;
-use ElasticPress\Screen as Screen;
-use ElasticPress\Utils as Utils;
-use ElasticPress\Elasticsearch as Elasticsearch;
-use ElasticPress\Indexables as Indexables;
+use ElasticPress\IndexHelper;
+use ElasticPress\Screen;
+use ElasticPress\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -89,7 +87,7 @@ class Sync {
 			exit;
 		}
 
-		\ElasticPress\IndexHelper::factory()->full_index(
+		IndexHelper::factory()->full_index(
 			[
 				'method'        => 'dashboard',
 				'put_mapping'   => ! empty( $_REQUEST['put_mapping'] ),
@@ -167,7 +165,7 @@ class Sync {
 			$data['index_meta'] = $index_meta;
 		}
 
-		$ep_last_index = Utils\get_option( 'ep_last_index' );
+		$ep_last_index = IndexHelper::factory()->get_last_index();
 
 		if ( ! empty( $ep_last_index ) ) {
 			$data['ep_last_sync_date'] = ! empty( $ep_last_index['end_date_time'] ) ? $ep_last_index['end_date_time'] : false;

--- a/includes/partials/sync-page.php
+++ b/includes/partials/sync-page.php
@@ -6,9 +6,7 @@
  * @package elasticpress
  */
 
-use ElasticPress\Utils as Utils;
-
-$ep_last_index          = Utils\get_option( 'ep_last_index' );
+$ep_last_index          = \ElasticPress\IndexHelper::factory()->get_last_index();
 $ep_last_sync_has_error = ! empty( $ep_last_index['failed'] );
 
 ?>


### PR DESCRIPTION
### Description of the Change

The code in this PR handles fatal errors during sync processes, so it does not get stuck but rather gets properly cleaned and logged. It also adds a new WP-CLI command: `get-last-sync` with the information of the latest sync performed, no matter the method (dashboard or cli.)

Closes #2737

### Verification Process

In addition to the regular checks, running `php -d max_execution_time=1 "$(which wp)" elasticpress index --per-page=2` makes the sync timeout, generating the main error the PR tries to fix.

### Changelog Entry

Added: New `get-last-sync` WP-CLI command.
Changed: Log errors and remove indexing status on failed syncs.

### Credits

Props @felipeelia 
