### PR TITLE
Strip slashes when saving features.

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -421,6 +421,8 @@ function action_wp_ajax_ep_cancel_index() {
  * @since  2.2
  */
 function action_wp_ajax_ep_save_feature() {
+	$_POST = wp_unslash( $_POST );
+
 	if ( empty( $_POST['feature'] ) || empty( $_POST['settings'] ) || ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) ) {
 		wp_send_json_error();
 		exit;


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Strips slashes from post data when saving settings. Not doing this was leading to double slashing when settings were saved to the database, which was particularly notable when [using an attribute selector for Autosuggest](https://github.com/10up/ElasticPress/issues/2731).

<!-- Enter any applicable Issues here. Example: -->
Closes #2731

### Alternate Designs

NA

### Possible Drawbacks

NA

### Verification Process

Go to _ElasticPress > Features_ and save `input[type="text"]` as the _Autosuggest Selector_, then refresh the page. Previously the saved value would appear as `input[type=\"text\"]` and be double slashed as `input[type=\\\"text\\\"]` in the database. With this change it should show as it was entered, and only be single slashed in the database.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

- Fixed - An issue where attribute selectors could not be used for the Autosuggest Selector.

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 
