### PR TITLE
Make last_processed_object_id be the last ID of fetched objects

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -683,8 +683,6 @@ class IndexHelper {
 				}
 			}
 
-			$this->index_meta['current_sync_item']['last_processed_object_id'] = end( $queued_items_ids );
-
 			if ( is_wp_error( $return ) ) {
 				$this->index_meta['current_sync_item']['failed'] += count( $queued_items );
 				$this->index_meta['current_sync_item']['errors']  = array_merge( $this->index_meta['current_sync_item']['errors'], $return->get_error_messages() );
@@ -702,6 +700,8 @@ class IndexHelper {
 				$this->index_meta['current_sync_item']['synced'] += count( $queued_items );
 			}
 		}
+
+		$this->index_meta['current_sync_item']['last_processed_object_id'] = end( $this->current_query['objects'] )->ID;
 
 		$this->output(
 			sprintf(


### PR DESCRIPTION
### Description of the Change

This PR is an attempt to fix the problem outlined in #2755. When the last object of a batch is skipped, the last_processed_object_id isn't properly updated. That is easier to test when indexing only one document at a time (--no-bulk), as the only ID in the queue is the one that was skipped.

Closes #2755

### Verification Process

Add a code like this to the codebase:
```
add_filter(
	'ep_item_sync_kill',
	function( $skip, $object ) {
		return ( 2958 === $object->ID ) ? true : $skip;
	},
	10,
	2
);
```
And run `wp elasticpress index --setup --no-bulk --show-errors --yes`

### Changelog Entry

Fixed: Sync process with skipped objects.

### Credits

Props @juliecampbell @felipeelia 
