### PR TITLE
Add new `_variations_skus` meta field for products

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -128,6 +128,7 @@ class WooCommerce extends Feature {
 					'_billing_first_name',
 					'_shipping_first_name',
 					'_shipping_last_name',
+					'_variations_skus',
 				)
 			)
 		);
@@ -805,6 +806,7 @@ class WooCommerce extends Feature {
 		add_filter( 'ep_facet_include_taxonomies', [ $this, 'add_product_attributes' ] );
 		add_filter( 'ep_weighting_fields_for_post_type', [ $this, 'add_product_attributes_to_weighting' ], 10, 2 );
 		add_filter( 'ep_weighting_default_post_type_weights', [ $this, 'add_product_default_post_type_weights' ], 10, 2 );
+		add_filter( 'ep_prepare_meta_data', [ $this, 'add_variations_skus_meta' ], 10, 2 );
 	}
 
 	/**
@@ -933,6 +935,42 @@ class WooCommerce extends Feature {
 		}
 
 		return $skip;
+	}
+
+	/**
+	 * Add a new `_variations_skus` meta field to the product to be indexed in Elasticsearch.
+	 *
+	 * @since 4.2.0
+	 * @param array   $post_meta Post meta
+	 * @param WP_Post $post      Post object
+	 * @return array
+	 */
+	public function add_variations_skus_meta( $post_meta, $post ) {
+		if ( 'product' !== $post->post_type ) {
+			return $post_meta;
+		}
+
+		$product        = wc_get_product( $post );
+		$variations_ids = $product->get_children();
+
+		$post_meta['_variations_skus'] = array_reduce(
+			$variations_ids,
+			function ( $variations_skus, $current_id ) {
+				$variation = wc_get_product( $current_id );
+				if ( ! $variation || ! $variation->exists() ) {
+					return $variations_skus;
+				}
+				$variation_sku = $variation->get_sku();
+				if ( ! $variation_sku ) {
+					return $variations_skus;
+				}
+				$variations_skus[] = $variation_sku;
+				return $variations_skus;
+			},
+			[]
+		);
+
+		return $post_meta;
 	}
 
 	/**

--- a/tests/php/features/TestWooCommerce.php
+++ b/tests/php/features/TestWooCommerce.php
@@ -247,4 +247,41 @@ class TestWooCommerce extends BaseTestCase {
 
 		$this->assertTrue( $query->elasticsearch_success );
 	}
+
+	/**
+	 * Test the addition of variations skus to product meta
+	 * 
+	 * @since 4.2.0
+	 * @group woocommerce
+	 */
+	public function testAddVariationsSkusMeta() {
+		ElasticPress\Features::factory()->activate_feature( 'woocommerce' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$this->assertTrue( class_exists( '\WC_Product_Variable' ) );
+		$this->assertTrue( class_exists( '\WC_Product_Variation' ) );
+
+		$main_product = new \WC_Product_Variable();
+		$main_product->set_sku('main-product_sku');
+		$main_product_id = $main_product->save();
+
+		$variation_1 = new \WC_Product_Variation();
+		$variation_1->set_parent_id( $main_product_id );
+		$variation_1->set_sku('child-sku-1');
+		$variation_1->save();
+
+		$variation_2 = new \WC_Product_Variation();
+		$variation_2->set_parent_id( $main_product_id );
+		$variation_2->set_sku('child-sku-2');
+		$variation_2->save();
+
+		$main_product_as_post  = get_post( $main_product_id );
+		$product_meta_to_index = ElasticPress\Features::factory()
+			->get_registered_feature( 'woocommerce' )
+			->add_variations_skus_meta( [], $main_product_as_post );
+
+		$this->assertArrayHasKey( '_variations_skus', $product_meta_to_index );
+		$this->assertContains( 'child-sku-1', $product_meta_to_index['_variations_skus'] );
+		$this->assertContains( 'child-sku-2', $product_meta_to_index['_variations_skus'] );
+	}
 }


### PR DESCRIPTION
### Description of the Change

This PR adds a new meta field called `_variations_skus` to WooCommerce products with their variations SKUs. This is a revamp of #1828, with some changes:
1. Although perhaps not as performant, this PR relies more on code and WC solutions than a direct DB query
2. Instead of concatenating all SKUs in a single string, it actually creates an array of values
3. It does not add code to handle variations creations/edit/deletions because recent versions of WooCommerce will already trigger that update
4. It does not add code to change the admin search. That will come in #2757

### Changelog Entry

Added: New `_variations_skus` field to WooCommerce products.

### Credits

Props @felipeelia @kallehauge @lukaspawlik
