### PR TITLE
Fix sync page typo.

### DIFF
--- a/assets/js/sync/components/sync-page.js
+++ b/assets/js/sync/components/sync-page.js
@@ -170,7 +170,7 @@ export default ({
 						<p className="ep-sync-warning">
 							<Icon icon={warning} />
 							{__(
-								'All indexed data on ElasticPress will be deleted without affecting anything on your WordPress website. This may take a few hours depending on the amount of content that needs to be synced and indexed. While this is happenening, searches will use the default WordPress results',
+								'All indexed data on ElasticPress will be deleted without affecting anything on your WordPress website. This may take a few hours depending on the amount of content that needs to be synced and indexed. While this is happening, searches will use the default WordPress results',
 								'elasticpress',
 							)}
 						</p>


### PR DESCRIPTION
### Description of the Change

Fixes a typo on the sync page. The typo existed on the old sync page as was copied to the new one. This fixes it on the new one.

### Verification Process

"happening" should be spelled correctly in the Sync page warning.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
### Changelog Entry

Fixed: Typo in the sync page.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @JakePT @davidegreenwald 
