### PR TITLE
Fix --network-wide flag in WP-CLI index command

### DIFF
--- a/bin/setup-cypress-env.sh
+++ b/bin/setup-cypress-env.sh
@@ -61,7 +61,13 @@ fi
 
 npm run env run tests-cli "wp core multisite-convert"
 
-# Not sure why, wp-env makes it http://localhost:8889/:8889
+SITES_COUNT=$(npm --silent run env run tests-cli "wp site list --format=count")
+if [ $SITES_COUNT -eq 1 ]; then
+	npm run env run tests-cli "wp site create --slug=second-site --title='Second Site'"
+	npm --silent run env run tests-cli "wp search-replace localhost/ localhost:8889/ --all-tables"
+fi
+
+# Not sure why, wp-env makes it http://localhost:8889/:8889 (not related to the command above)
 npm run env run tests-cli "option set home 'http://localhost:8889'"
 npm run env run tests-cli "option set siteurl 'http://localhost:8889'"
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -441,7 +441,7 @@ class Command extends WP_CLI_Command {
 	 * @return array
 	 */
 	protected function get_index_names() {
-		$sites = ( is_multisite() ) ? Utils\get_sites() : array( array( 'blog_id' => get_current_blog_id() ) );
+		$sites = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ? Utils\get_sites() : array( array( 'blog_id' => get_current_blog_id() ) );
 
 		$all_indexables = Indexables::factory()->get_all();
 

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -133,8 +133,10 @@ class IndexHelper {
 		$global_indexables     = $this->filter_indexables( Indexables::factory()->get_all( true, true ) );
 		$non_global_indexables = $this->filter_indexables( Indexables::factory()->get_all( false, true ) );
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			if ( empty( $this->args['network_wide'] ) || ! is_numeric( $this->args['network_wide'] ) ) {
+		$is_network_wide = isset( $this->args['network_wide'] ) && ! is_null( $this->args['network_wide'] );
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK && $is_network_wide ) {
+			if ( ! is_numeric( $this->args['network_wide'] ) ) {
 				$this->args['network_wide'] = 0;
 			}
 

--- a/includes/classes/Screen/Sync.php
+++ b/includes/classes/Screen/Sync.php
@@ -94,6 +94,7 @@ class Sync {
 				'put_mapping'   => ! empty( $_REQUEST['put_mapping'] ),
 				'output_method' => [ $this, 'index_output' ],
 				'show_errors'   => true,
+				'network_wide'  => 0,
 			]
 		);
 	}

--- a/tests/cypress/support/global-hooks.js
+++ b/tests/cypress/support/global-hooks.js
@@ -4,9 +4,7 @@ let setFeatures = false;
 
 before(() => {
 	// Clear sync from previous tests.
-	cy.wpCli(
-		'wp eval \'delete_transient( "ep_wpcli_sync" ); delete_option( "ep_index_meta" ); delete_site_transient( "ep_wpcli_sync" ); delete_site_option( "ep_index_meta" );\'',
-	);
+	cy.wpCli('wp elasticpress clear-index');
 
 	if (!window.indexNames) {
 		cy.wpCli('wp elasticpress get-indexes').then((wpCliResponse) => {

--- a/tests/cypress/wordpress-files/test-mu-plugins/unique-index-name.php
+++ b/tests/cypress/wordpress-files/test-mu-plugins/unique-index-name.php
@@ -26,10 +26,10 @@ add_action( 'admin_footer', function() {
  * @return string
  */
 function get_docker_cid() {
-	$docker_cid = get_option( 'ep_tests_docker_cid', '' );
+	$docker_cid = get_site_option( 'ep_tests_docker_cid', '' );
 	if ( ! $docker_cid ) {
 		$docker_cid = exec( 'cat /etc/hostname' );
-		update_option( 'ep_tests_docker_cid', $docker_cid );
+		update_site_option( 'ep_tests_docker_cid', $docker_cid );
 	}
 	return $docker_cid;
 }


### PR DESCRIPTION
### Description of the Change

As stated in #2766, ElasticPress 4.x introduced a change in the `index` WP-CLI command that it would always index all sites, even when the `--network-wide` flag is not passed. This PR changes that back to the 3.x behavior:

In order to index all sites, the user needs to run `wp elasticpres index ... --network-wide`, otherwise only the main site will be indexed.

In addition to that, this PR also fixes all WP-CLI commands that rely on get_index_names() method, using indices names for all sites only when it is network activated. Commands affected are:
- get-mapping
- get-indexes
- status
- stats

Closes #2766

### Changelog Entry

- Fixed: WP-CLI `index` command without the `--network-wide` only syncs the main site.
- Fixed: WP-CLI commands get-mapping, get-indexes, status, and stats only uses all sites' indices name when network activated.

### Credits

Props @felipeelia @colegeissinger
