### PR TITLE
Preserve existing URL parameters in history.

### DIFF
--- a/assets/js/instant-results/index.js
+++ b/assets/js/instant-results/index.js
@@ -100,11 +100,25 @@ const App = () => {
 		}
 
 		const state = JSON.stringify({ ...args, isOpen });
-		const params = getUrlParamsFromArgs(args, argsSchema, paramPrefix).toString();
-		const url = isOpen ? `?${params}` : window.location.origin + window.location.pathname;
 
 		if (history.state) {
-			history.pushState(state, document.title, url);
+			const params = getUrlParamsFromArgs(args, argsSchema, paramPrefix);
+			const url = new URL(window.location.href);
+			const keys = Array.from(url.searchParams.keys());
+
+			for (const key of keys) {
+				if (key.startsWith(paramPrefix)) {
+					url.searchParams.delete(key);
+				}
+			}
+
+			if (isOpen) {
+				params.forEach((value, key) => {
+					url.searchParams.set(key, value);
+				});
+			}
+
+			history.pushState(state, document.title, url.toString());
 		} else {
 			history.replaceState(state, document.title, window.location.href);
 		}


### PR DESCRIPTION
### Description of the Change

Fixes an issue where any existing non-ElasticPress URL parameters would be cleared when using Instant Results, and an additional side effect where parameters would be removed when page was refreshed while Instant Results was activated, even if it wasn't actively being used at the time.

Previously when Instant Results updated the browser history state it would replace all URL parameters with Instant Results parameters, and when Instant Results was closed all of those parameters would be cleared, leaving none.

This PR changes it so that any URLs present in the URL when a page is loaded are preserved throughout the course of using Instant Results, which also fixes the refresh issue.

<!-- Enter any applicable Issues here. Example: -->
Closes #2775.

### Verification Process

Navigating backwards and forwards through the Instant Results history should work as before, but the issue described in #2775 should not occur.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - A bug where URL search parameters could be cleared when using Instant Results.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 
