### PR TITLE
Set some default args and instance values

### DIFF
--- a/includes/classes/Feature/Facets/Renderer.php
+++ b/includes/classes/Feature/Facets/Renderer.php
@@ -28,6 +28,22 @@ class Renderer {
 	public function render( $args, $instance ) {
 		global $wp_query;
 
+		$args     = wp_parse_args(
+			$args,
+			[
+				'before_widget' => '',
+				'before_title'  => '',
+				'after_title'   => '',
+				'after_widget'  => '',
+			]
+		);
+		$instance = wp_parse_args(
+			$instance,
+			[
+				'title' => '',
+			]
+		);
+
 		$feature = Features::factory()->get_registered_feature( 'facets' );
 
 		if ( $wp_query->get( 'ep_facet', false ) && ! $feature->is_facetable( $wp_query ) ) {


### PR DESCRIPTION
### Description of the Change

When rendering a block, the new Facet Renderer class relies on some undefined array indexes. This PR sets some defaults so that does not happen anymore.

### Changelog Entry

Fix: Undefined index notice in Facets renderer

### Credits

Props @felipeelia @burhandodhy 
