### PR TITLE
Only try to get ES info if a server is set

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1276,8 +1276,7 @@ class Elasticsearch {
 	 * @return array
 	 */
 	public function get_elasticsearch_info( $force = false ) {
-
-		if ( $force || null === $this->elasticsearch_version || null === $this->elasticsearch_plugins ) {
+		if ( ! empty( Utils\get_host() ) && ( $force || null === $this->elasticsearch_version || null === $this->elasticsearch_plugins ) ) {
 
 			// Get ES info from cache if available. If we are forcing, then skip cache check.
 			if ( $force ) {


### PR DESCRIPTION
### Description of the Change

Currently, during the initial setup, EP tries to get the ES server info even when that is not set yet. This PR addresses that issue.

### Changelog Entry

Fixed: Prevent an unnecessary call when the ES server is not set yet.

### Credits

Props @felipeelia @burhandodhy 
