### PR TITLE
Transform the `id` field into `ID`

### DIFF
--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -107,6 +107,9 @@ class QueryIntegration {
 					$user->elasticsearch = true; // Super useful for debugging.
 
 					foreach ( $fields as $field ) {
+						if ( 'id' === $field ) {
+							$field = 'ID';
+						}
 						$user->$field = $document[ $field ];
 					}
 

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -226,8 +226,13 @@ class User extends Indexable {
 		 * Support `fields` query var.
 		 */
 		if ( isset( $query_vars['fields'] ) && 'all' !== $query_vars['fields'] && 'all_with_meta' !== $query_vars['fields'] ) {
+			$fields      = (array) $query_vars['fields'];
+			$id_position = array_search( 'id', $fields, true );
+			if ( false !== $id_position ) {
+				$fields[ $id_position ] = 'ID';
+			}
 			$formatted_args['_source'] = [
-				'includes' => (array) $query_vars['fields'],
+				'includes' => $fields,
 			];
 		}
 


### PR DESCRIPTION
This addresses a change made in WP Core on 6.0

https://github.com/WordPress/WordPress/commit/f6ef37b050db9463d7cc0f8f841b85994062c24c#diff-26773a0cc66b5ba7b3c5108652bb2367424e6a78d4a05d1e35ff6d45701e3c07R300

With the 4.2.0 release planned for tomorrow, this is the minimal change to have it working again.

### Changelog Entry

Fixed: An incompatibility with the way WP 6.0 handles WP_User_Query using fields.

### Credits

Props @felipeelia 
