### PR TITLE
Change GH Action used to publish to GH Pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -64,7 +64,7 @@ jobs:
         CI: true
 
     - name: Deploy to GH Pages
-      uses: maxheld83/ghpages@v0.3.0
-      env:
-        BUILD_DIR: 'wp-content/plugins/elasticpress/docs-built/'
-        GH_PAT: ${{ secrets.GH_PAT }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: './wp-content/plugins/elasticpress/docs-built'


### PR DESCRIPTION
### Description of the Change

During ElasticPress 4.2.0 release, we got an error with the GitHub Pages update. It is outlined in this [issue](https://github.com/maxheld83/ghpages/issues/35).

This PR applies the same fix used by Automattic/sensei in this PR: https://github.com/Automattic/sensei/pull/5052

As a bonus, the action we are switching to seems to have much more traction and frequent updates.

### Verification Process

We will need to merge this one to trunk to see if it works.

### Changelog Entry

Changed: GH Action used to update the documentation.

### Credits

Props @felipeelia 