### PR TITLE
Fix: Sync interruption message always mentions ElasticPress.io

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -109,7 +109,7 @@ function get_index_prefix() {
  * @return bool
  */
 function is_epio() {
-	return preg_match( '#elasticpress\.io#i', get_host() );
+	return filter_var( preg_match( '#elasticpress\.io#i', get_host() ), FILTER_VALIDATE_BOOLEAN );
 }
 
 /**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes the the issue where the Sync interruption messages always show ElasticPress.io regardless of host settings. The issue was when `Utils\is_epio()` returns `0` ,  `wp_localize_script` convert it into string `'0'` and in JS `if ( '0' )` gives `true` .

With the use of `FILTER_VALIDATE_BOOLEAN`  `is_epio` returns empty in case of `false` and `1` if the value is true. 

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
Closes #2784


### Verification Process

- Start a delete and sync from the sync page.
- Run `wp elasticpress stop-indexing`
- Click Show log and review the message.
- The message would have `Your indexing process has been stopped by WP-CLI and your Elasticsearch index could be missing content` incase of self hosted ElasticSearch

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->


<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Fixed: Sync interruption message always mentions ElasticPress.io
### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 
