### PR TITLE
Uncaught TypeError on Settings Page

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -24,7 +24,7 @@ const init = () => {
 	 * @returns {boolean} Whether the current tab is for ElasticPress.io.
 	 */
 	const isEpio = () => {
-		return 'epio' in activeTab.dataset;
+		return activeTab && 'epio' in activeTab.dataset;
 	};
 
 	let epioHost = isEpio() ? host.value : '';


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
The PR fixes the issue where plugin throws the `Uncaught TypeError` on Settings Page when the `EP_HOST` is defined in `wp-config.php`

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
Closes #2815 


### Verification Process

- Define EP_HOST in `wp-config.php`
- Go to ElasticPress Settings page.
- You will not see any error in console.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Fixed: Uncaught TypeError on Settings Page

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 
