### PR TITLE
Fix: Admin searches in WooCommerce taxonomies return no results

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -796,6 +796,8 @@ abstract class Indexable {
 				$compare = '=';
 				if ( ! empty( $single_meta_query['compare'] ) ) {
 					$compare = strtolower( $single_meta_query['compare'] );
+				} elseif ( ! isset( $single_meta_query['value'] ) ) {
+					$compare = 'exists';
 				}
 
 				$type = null;

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1280,23 +1280,24 @@ class Post extends Indexable {
 		$meta_queries = [];
 
 		/**
-		 * Support meta_key
-		 *
-		 * @since  2.1
+		 * Support `meta_key`, `meta_value`, `meta_value_num`, and `meta_compare` query args
 		 */
 		if ( ! empty( $args['meta_key'] ) ) {
-			if ( ! empty( $args['meta_value'] ) ) {
-				$meta_value = $args['meta_value'];
-			} elseif ( ! empty( $args['meta_value_num'] ) ) {
-				$meta_value = $args['meta_value_num'];
+			$meta_query_array = [
+				'key' => $args['meta_key'],
+			];
+
+			if ( isset( $args['meta_value'] ) && '' !== $args['meta_value'] ) {
+				$meta_query_array['value'] = $args['meta_value'];
+			} elseif ( isset( $args['meta_value_num'] ) && '' !== $args['meta_value_num'] ) {
+				$meta_query_array['value'] = $args['meta_value_num'];
 			}
 
-			if ( ! empty( $meta_value ) ) {
-				$meta_queries[] = array(
-					'key'   => $args['meta_key'],
-					'value' => $meta_value,
-				);
+			if ( isset( $args['meta_compare'] ) ) {
+				$meta_query_array['compare'] = $args['meta_compare'];
 			}
+
+			$meta_queries[] = $meta_query_array;
 		}
 
 		/**

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -478,7 +478,7 @@ class Term extends Indexable {
 				'key' => $query_vars['meta_key'],
 			];
 
-			if ( isset( $query_vars['meta_value'] ) ) {
+			if ( isset( $query_vars['meta_value'] ) && '' !== $query_vars['meta_value'] ) {
 				$meta_query_array['value'] = $query_vars['meta_value'];
 			}
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5636,7 +5636,7 @@ class TestPost extends BaseTestCase {
 		);
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
-		
+
 		$query = new \WP_Query(
 			[
 				'ep_integrate' => true,
@@ -5649,7 +5649,7 @@ class TestPost extends BaseTestCase {
 		$this->assertEqualsCanonicalizing( [ $post1 ], $query->posts );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
-		
+
 		$query = new \WP_Query(
 			[
 				'ep_integrate' => true,
@@ -5662,7 +5662,7 @@ class TestPost extends BaseTestCase {
 		$this->assertEqualsCanonicalizing( [ $post1, $post2 ], $query->posts );
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
-		
+
 		$query = new \WP_Query(
 			[
 				'ep_integrate' => true,
@@ -5675,7 +5675,7 @@ class TestPost extends BaseTestCase {
 		$this->assertEqualsCanonicalizing( [ $post2 ], $query->posts );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
-		
+
 		$query = new \WP_Query(
 			[
 				'ep_integrate' => true,
@@ -5687,7 +5687,7 @@ class TestPost extends BaseTestCase {
 		$this->assertEqualsCanonicalizing( [ $post1, $post2, $post4 ], $query->posts );
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
-		
+
 		$query = new \WP_Query(
 			[
 				'ep_integrate' => true,
@@ -6812,5 +6812,59 @@ class TestPost extends BaseTestCase {
 		$document = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
 		$this->assertEquals( 'different-tag-slug', $document['terms']['post_tag'][0]['slug'] );
 		$this->assertEquals( 'Different Tag Name', $document['terms']['post_tag'][0]['name'] );
+	}
+
+	/**
+	 * Tests post without meta value.
+	 *
+	 * @return void
+	 */
+	public function testMetaWithoutValue() {
+
+		Functions\create_and_sync_post( array(), array( 'test_key' => '' ) );
+		Functions\create_and_sync_post( array(), array( 'test_key' => '' ) );
+		Functions\create_and_sync_post();
+
+		$expected_result = '2';
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		// Make sure WordPress returns only 2 posts.
+		$args  = array(
+			'meta_query' => array(
+				array(
+					'key' => 'test_key',
+				),
+			),
+		);
+		$query = new \WP_Query( $args );
+
+		$this->assertEquals( $expected_result, $query->post_count );
+		$this->assertNull( $query->elasticsearch_success );
+
+		// Make sure ElasticPress returns only 2 posts when meta query is set
+		$args  = array(
+			'ep_integrate' => true,
+			'meta_query'   => array(
+				array(
+					'key' => 'test_key',
+				),
+			),
+		);
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( $expected_result, $query->post_count );
+
+		// Make sure ElasticPress returns only 2 posts when meta key is set
+		$args  = array(
+			'ep_integrate' => true,
+			'meta_key'     => 'test_key',
+		);
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( $expected_result, $query->post_count );
+
 	}
 }

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1589,11 +1589,11 @@ class TestTerm extends BaseTestCase {
 	public function testMetaWithoutValue() {
 
 		$term_id = Functions\create_and_sync_term( 'term-name', 'term name', '', 'category' );
-		update_term_meta( $term_id, 'key', 'value' );
+		update_term_meta( $term_id, 'test_key', 'value' );
 		ElasticPress\Indexables::factory()->get( 'term' )->index( $term_id, true );
 
 		$term_id = Functions\create_and_sync_term( 'term-name-2', 'term name 2', '', 'category' );
-		update_term_meta( $term_id, 'key', 'value' );
+		update_term_meta( $term_id, 'test_key', 'value' );
 		ElasticPress\Indexables::factory()->get( 'term' )->index( $term_id, true );
 
 		Functions\create_and_sync_term( 'term-name-3', 'term name 3', '', 'category' );
@@ -1602,10 +1602,10 @@ class TestTerm extends BaseTestCase {
 
 		// Make sure WP_Term_Query returns only taxonomies for whom meta exists.
 		$args = array(
-			'taxonomy' => 'category',
-			'meta_key' => 'key',
+			'taxonomy'     => 'category',
+			'meta_key'     => 'test_key',
 			'ep_integrate' => true,
-			'hide_empty' => false,
+			'hide_empty'   => false,
 
 		);
 		$query = new \WP_Term_Query( $args );
@@ -1613,20 +1613,19 @@ class TestTerm extends BaseTestCase {
 		$this->assertEquals( 2, count( $query->terms ) );
 
 		// Make sure get_terms returns only taxonomies for whom meta exists.
-		$args = array(
-			'taxonomy' => 'category',
-			'hide_empty' => false,
+		$args  = array(
+			'taxonomy'     => 'category',
+			'hide_empty'   => false,
 			'ep_integrate' => true,
-			'meta_query' => array(
+			'meta_query'   => array(
 				array(
-					'key' => 'key',
-				)
-			)
+					'key' => 'test_key',
+				),
+			),
 		);
 		$terms = get_terms( $args );
 		$this->assertTrue( $terms[0]->elasticsearch );
 		$this->assertEquals( 2, count( $terms ) );
-
 	}
 
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes the issue where the EP returns incorrect result when the `meta_value` key is not set in `WP_Query` and `WP_Term_Query`.

 When the  `meta_value` is not set, WordPress runs the exact SQL query that it runs in case of the `meta_compare => 'Exists'` and when the `meta_value` is empty, WordPress only returns the posts where the meta value is empty. This statement is only true for the `WP Query` and not for the `Term Query`


For the `Term Query`, WordPress runs the same query either the `meta_value` is set to empty or its not set. The query in both cases is exact what we have in the case of `Exists`. To tackle this case, I added another check that check if the `meta_value` is not empty indexable Term class


<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
Closes #2791 


### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
I didn't find any negative impact. I tried to test all the cases and its working fine. 


### Verification Process

1) Import WooCommerce Dummy data.
2) Run the below code first and then uncomment `ep_integrate` line and run it again. In both cases result should be same

```
	$args = array(
		'taxonomy'   => 'product_cat',
		// 'ep_integrate' => 1,
		'hide_empty' => false,
		'meta_key' => 'order',
		'meta_value' => 0
	);
	var_dump( get_terms( $args ) );
```
3) To run the test against `WP_Query`. Run the below code twice. First without EP and second time with EP integration. In both case the result should be same. 

```
	$args = array(
		'post_type'  => 'post',
		// 'ep_integrate' => 1,
		'posts_per_page' => -1,
		'meta_query' => array(
			array(
	 			'key' => 'invalid',
			),
		),
	);
	$query = new WP_Query( $args );

	var_dump( $query->post_count );

```
4) If you test the both snippet with develop branch, you will the result EP result will not be same what WordPress returns. 
5) To test against admin search in WooCommerce taxonomies. 
   - Go to WordPress admin dashboard -> Products -> Categories
   - Search `Clothing`
   - It should return only returns Clothing category.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - Meta queries with 'exists' as compare operator and empty meta values handling
<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 
