### PR TITLE
WP-CLI index timers: Cast values to float

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1530,7 +1530,7 @@ class Command extends WP_CLI_Command {
 	 */
 	protected function timer_stop( $precision = 3 ) {
 		$diff = microtime( true ) - $this->time_start;
-		return number_format( $diff, $precision );
+		return (float) number_format( (float) $diff, $precision );
 	}
 
 	/**
@@ -1542,7 +1542,7 @@ class Command extends WP_CLI_Command {
 	 * @return string
 	 */
 	protected function timer_format( $microtime, $format = 'H:i:s.u' ) {
-		$microtime_date = \DateTime::createFromFormat( 'U.u', number_format( $microtime, 3, '.', '' ) );
+		$microtime_date = \DateTime::createFromFormat( 'U.u', number_format( (float) $microtime, 3, '.', '' ) );
 		return $microtime_date->format( $format );
 	}
 


### PR DESCRIPTION
### Description of the Change

Currently, if the sync takes long enough, an occasional `Error: Index failed: Uncaught TypeError: number_format(): Argument #1 ($num) must be of type float, string given in /var/www/html/wp-content/plugins/elasticpress/includes/classes/Command.php:1545` will happen. That occurs because PHP's floats have a limit of digits and anything exceeding that limit will be cast to a string. This PR forces it to cast back to float, eventually dropping precision characters that wouldn't be needed anyway if the sync process is already taking this long.

<!-- Enter any applicable Issues here. Example: -->
Closes #2807

### Changelog Entry

Fixed: Fatal error related to WP-CLI timers on long-running syncs.

### Credits

Props @felipeelia @przestrzal
