### PR TITLE
Update the build:zip command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ test-coverage-html/
 screenshots
 .DS_Store
 
-payload
+elasticpress.zip

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -3,8 +3,7 @@
 npm ci
 npm run build
 
-rm -r ./payload
+rm ./elasticpress.zip
 
-TMP_DIR="./payload/elasticpress"
-mkdir -p $TMP_DIR
-rsync -rc --exclude-from=".distignore" --exclude="payload" . "$TMP_DIR/" && cd $TMP_DIR/.. && zip -r "./elasticpress.zip" .
+git archive --output=elasticpress.zip HEAD
+zip -ur elasticpress.zip dist


### PR DESCRIPTION
### Description of the Change

With the change we made on #2799, the .distignore file is no longer available to be used in the rsync call we used to have in build-zip.sh. This PR changes that script to use `git archive`, so it also uses the same `.gitattributes` file we use during the release process.

### Changelog Entry

Changed: `npm run build:zip` to use `git archive`.

### Credits

Props @felipeelia 
