### PR TITLE
Prevent saving feature settings during a sync. 

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -330,6 +330,11 @@ h2.ep-list-features {
 		border-color: var(--statusWarning);
 		display: none; /* Controlled by JavaScript. */
 	}
+
+	&.requirements-status-notice--syncing {
+		border-color: var(--statusError);
+		display: none; /* Controlled by JavaScript. */
+	}
 }
 
 .ep-feature .settings .action-wrap {

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -57,12 +57,30 @@ const onSubmit = async (event) => {
 	}
 
 	const feature = form.closest('.ep-feature');
+	const syncingNotice = feature.querySelector('.requirements-status-notice--syncing');
 
 	feature.classList.add('saving');
 	form.submit.disabled = true;
+	syncingNotice.style.display = null;
 
 	const request = await fetch(ajaxurl, { method: 'POST', body: data });
 	const response = await request.json();
+
+	if (response.success === false) {
+		const { data = [] } = response;
+
+		if (data) {
+			for (const { code = '' } of data) {
+				if (code === 'is_indexing') {
+					syncingNotice.style.display = 'block';
+				}
+			}
+		}
+
+		form.submit.disabled = false;
+		feature.classList.remove('saving');
+		return;
+	}
 
 	feature.classList.toggle('feature-active', response.data.active);
 

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -282,6 +282,9 @@ abstract class Feature {
 	 */
 	public function output_settings_box() {
 		$requirements_status = $this->requirements_status();
+		$sync_url            = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK )
+			? network_admin_url( 'admin.php?page=elasticpress-sync' )
+			: admin_url( 'admin.php?page=elasticpress-sync' );
 		?>
 
 		<form>
@@ -301,6 +304,17 @@ abstract class Feature {
 					<?php esc_html_e( 'Enabling this feature will require re-indexing your content.', 'elasticpress' ); ?>
 				</div>
 			<?php endif; ?>
+
+			<div class="requirements-status-notice requirements-status-notice--syncing" role="alert">
+				<?php
+				printf(
+					'%1$s <a href="%2$s">%3$s</a>',
+					esc_html__( 'Settings not saved. Cannot save settings while a sync is in progress.', 'elasticpress' ),
+					esc_url( $sync_url ),
+					esc_html__( 'View sync status.', 'elasticpress' )
+				);
+				?>
+			</div>
 
 			<h3><?php esc_html_e( 'Settings', 'elasticpress' ); ?></h3>
 

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -428,6 +428,13 @@ function action_wp_ajax_ep_save_feature() {
 		exit;
 	}
 
+	if ( Utils\is_indexing() ) {
+		$error = new \WP_Error( 'is_indexing' );
+
+		wp_send_json_error( $error );
+		exit;
+	}
+
 	$data = Features::factory()->update_feature( $_POST['feature'], $_POST['settings'] );
 
 	// Since we deactivated, delete auto activate notice.


### PR DESCRIPTION
### Description of the Change

Prevents the saving of feature settings while a sync is in progress. Previously settings could be saved during a sync if a tab or window with the Features page was already open before starting a sync.

When the user attempts to save settings during a sync an error message is displayed with a link to view the sync status.

<!-- Enter any applicable Issues here. Example: -->
Closes #2795

### Alternate Designs

Normally when opening the Features page during a sync the page is disabled with an overlay. One approach could have been to display this overlay after the error is returned. 

The problem with displaying an overlay for an error is that there wouldn't a great place to display an error message explaining what had happened. Additionally, if a user had made settings changes that they may not want to have to redo they may prefer to just wait for the sync to finish before pressing Save again. Another way around that could've been to begin periodically checking for the sync progress so that the overlay could be hidden once it had completed, but that would require a lot more engineering for very little gain. However something like that approach might be worth considering if there's ever a UI overhaul of the Features page.

### Verification Process

1. Open two tabs. One should be the Features page and the other should be the Sync page.
2. In the Sync tab start a sync and then immediately pause it.
3. On the Features page, attempt to save a Feature's settings. An error should appear with a link to the Sync page.
4. On the Sync page resume the Sync and let it finish.
5. Back on the Features page, without refreshing, save the feature's settings again. The process should complete with no error.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - An issue where feature settings could be saved during a sync.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 
