### PR TITLE
Support an accurate preview of the Related Posts block inside query loop block

### DIFF
--- a/assets/js/blocks/related-posts/Edit.js
+++ b/assets/js/blocks/related-posts/Edit.js
@@ -33,7 +33,7 @@ class Edit extends Component {
 		};
 
 		// Use 0 if in the Widgets Screen
-		const postId = wp.data.select('core/editor').getCurrentPostId() ?? 0;
+		const { context: { postId = 0 } = {} } = this.props;
 
 		wp.apiFetch({
 			path: addQueryArgs(`/wp/v2/posts/${postId}/related`, urlArgs),

--- a/assets/js/blocks/related-posts/block.js
+++ b/assets/js/blocks/related-posts/block.js
@@ -25,6 +25,7 @@ registerBlockType('elasticpress/related-posts', {
 			default: 5,
 		},
 	},
+	usesContext: ['postId'],
 
 	/**
 	 * Handle edit


### PR DESCRIPTION
### Description of the Change

The Related Posts block currently uses the post ID returned by `select('core/editor').getCurrentPostId()` to get the list of related posts for the preview. When adding the block to a post this works as expected and it displays the related posts for the post being edited, while adding the block to a widget area, where there is no ID available, it displays a generic list of posts as a preview.

Similarly, when adding the block to a FSE template there is no ID available, so the generic list is used. However, this is also the case when using the block inside the Query Loop block, where there is an actual post that could theoretically be used. This is because `select('core/editor').getCurrentPostId()` only returns the ID for the post being edited, and there is no post when editing an FSE template. This also means that if the query loop block is used on a single post then the list of related posts for the edited post will be used, rather than those for each individual post in the loop or the generic list.

This PR updates the Related Posts block to use the `postID` [block context](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/), which allows it to use the post ID of each post in the query loop block. The correct post ID is also returned by this context when editing single posts, or the template for a single post, so it can replace the method for getting the relevant post ID entirely.

### Possible Drawbacks

I'm not actually sure which version of WordPress core block contexts were introduced in, so this may require a higher minimum version.

### Verification Process

1. With a block theme activated edit a template that uses the Query Loop block.
2. Inside the Query Loop block, add the Related Posts block to the post template. The preview should show the correct related posts for each post in the loop.
3. Edit an individual post and add the Related Posts block. The preview should show the correct related posts for that post.
4. While editing that post, add a Query Loop block and add the Related Posts block to the post template. The preview should show the correct related posts for each post in the loop. The Related Posts block outside the loop should continue to show the related Posts for the post being edited.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - An issue where the Related Posts block would display the wrong posts in the preview when added inside a Query Loop block.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 
