### PR TITLE
Restrict to convert meta value into date if year is greater than 2099

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -723,10 +723,14 @@ abstract class Indexable {
 		if ( $new_date ) {
 			$timestamp = $new_date->getTimestamp();
 
+			// date_create converts 5479516sunt meta into 107039-03-10. We keep using default values
+			// if year in date is greater than 2099.
+			$max_year = 2099;
+
 			// PHP allows DateTime to build dates with the non-existing year 0000, and this causes
 			// issues when integrating into stricter systems. This is by design:
 			// https://bugs.php.net/bug.php?id=60288
-			if ( false !== $timestamp && '0000' !== $new_date->format( 'Y' ) ) {
+			if ( false !== $timestamp && '0000' !== $new_date->format( 'Y' ) && $new_date->format( 'Y' ) <= $max_year ) {
 				$meta_types['date']     = $new_date->format( 'Y-m-d' );
 				$meta_types['datetime'] = $new_date->format( 'Y-m-d H:i:s' );
 				$meta_types['time']     = $new_date->format( 'H:i:s' );

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -726,12 +726,15 @@ abstract class Indexable {
 			/**
 			 * Filter the maximum year limit for date conversion.
 			 *
+			 * Use default date if year is greater than max limit. EP has limitation that doesn't allow to have year greater than 2099.
+			 *
+			 * @see https://github.com/10up/ElasticPress/issues/2769
+			 *
 			 * @hook ep_max_year_limit
 			 * @param  {int} $year Maximum year limit.
 			 * @return {int} Maximum year limit.
+			 * @since  4.2.1
 			 */
-			// Use default date if year is greater than max limit. EP has limitation that doesn't allow to have year greater than 2099.
-			// @see https://github.com/10up/ElasticPress/issues/2769
 			$max_year = apply_filters( 'ep_max_year_limit', 2099 );
 
 			// PHP allows DateTime to build dates with the non-existing year 0000, and this causes

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -723,9 +723,16 @@ abstract class Indexable {
 		if ( $new_date ) {
 			$timestamp = $new_date->getTimestamp();
 
-			// date_create converts 5479516sunt meta into 107039-03-10. We keep using default values
-			// if year in date is greater than 2099.
-			$max_year = 2099;
+			/**
+			 * Filter the maximum year limit for date conversion.
+			 *
+			 * @hook ep_max_year_limit
+			 * @param  {int} $year Maximum year limit.
+			 * @return {int} Maximum year limit.
+			 */
+			// Use default date if year is greater than max limit. EP has limitation that doesn't allow to have year greater than 2099.
+			// @see https://github.com/10up/ElasticPress/issues/2769
+			$max_year = apply_filters( 'ep_max_year_limit', 2099 );
 
 			// PHP allows DateTime to build dates with the non-existing year 0000, and this causes
 			// issues when integrating into stricter systems. This is by design:


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
`prepare_date_meta_values ` converts the meta into date even they are not. This PR adds the restriction that will check that if the meta year is greater than 2099 than don't convert into `datetime` format

<!-- Enter any applicable Issues here. Example: -->
Closes #2769 


<!--
What process did you follow to verify that your change has the desired effects?

- Have a post with post meta key test and value 5479516sunt
- Run an indexing operation
- The meta date should be default date `1970-01-01`

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->


<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Fixed: Meta values that are not date are converted into date format

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 
