### PR TITLE
Weighting: Add ability to bail early from do_weighting

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -589,6 +589,10 @@ class Weighting {
 		 */
 		$weight_config = apply_filters( 'ep_weighting_configuration_for_search', $weight_config, $args );
 
+		if ( apply_filters( 'ep_disable_do_weighting', false, $weight_config, $args ) ) {
+			return $formatted_args;
+		}
+
 		if ( Utils\is_integrated_request( 'weighting', [ 'public', 'rest' ] ) && ! empty( $args['s'] ) ) {
 			/*
 			 * This section splits up the single query clause for all post types into separate nested clauses (one for each post type)

--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -589,7 +589,18 @@ class Weighting {
 		 */
 		$weight_config = apply_filters( 'ep_weighting_configuration_for_search', $weight_config, $args );
 
-		if ( apply_filters( 'ep_disable_do_weighting', false, $weight_config, $args ) ) {
+		/**
+		 * Filter whether to disable weighting configuration
+		 *
+		 * @hook ep_disable_do_weighting
+		 * @since 4.2.1
+		 * @param {bool} Whether to use weighting configuration, default is false
+		 * @param {array} $weight_config Current weight config
+		 * @param {array} $args WP Query arguments
+		 * @param {array} $formatted_args Formatted ES arguments
+		 * @return {bool} Whether to use weighting configuration
+		 */
+		if ( apply_filters( 'ep_disable_do_weighting', false, $weight_config, $args, $formatted_args ) ) {
 			return $formatted_args;
 		}
 


### PR DESCRIPTION
### Description of the Change

This adds a filter which adds a way to _maybe_ bail early from `do_weighting()` if one wanted to keep the Search Weighting engine on. It is to solve the issue described in https://github.com/10up/ElasticPress/pull/2512, but account for any search weighting configurations.

### Alternate Designs

Instead of adding a filter, just bail under set conditions:
- `$weight_config` is empty
- there are no Custom Search Results 

### Possible Drawbacks

N/A, since this offers the most flexibility, while not affecting current EP installs

### Verification Process

1) Spin up EP with no Custom Search Results or Search Weighting set up
2) Add the below snippet:

```
add_filter( 'ep_disable_do_weighting', function ( $disable, $weight_config, $args ) {
	if ( empty( $weight_config ) ) {
		$disable = true;
	}
	return $disable;
}, 10, 3 );
```
3) Check that the query doesn't have any weighting added to it

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added - new filter ep_disable_search_weighting_config to bail early on do_weighting()

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @rebeccahum 
