### PR TITLE
Show Facet widgets on taxonomy archives

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -237,11 +237,7 @@ class Facets extends Feature {
 			return false;
 		}
 
-		if ( ! ( ( function_exists( 'is_product_category' ) && is_product_category() )
-			|| $query->is_post_type_archive()
-			|| $query->is_search()
-			|| ( is_home() && empty( $query->get( 'page_id' ) ) ) )
-		) {
+		if ( ! $this->is_facetable_page( $query ) ) {
 			return false;
 		}
 
@@ -554,5 +550,16 @@ class Facets extends Feature {
 		 * @return  {array} New taxonomies
 		 */
 		return apply_filters( 'ep_facet_include_taxonomies', $taxonomies );
+	}
+
+	/**
+	 * Figure out if Facet widget can display on page.
+	 *
+	 * @param  WP_Query $query WP Query
+	 * @since  4.2.1
+	 * @return bool
+	 */
+	protected function is_facetable_page( $query ) {
+		return $query->is_home() || $query->is_search() || $query->is_tax() || $query->is_tag() || $query->is_category() || $query->is_post_type_archive();
 	}
 }

--- a/includes/classes/Feature/Facets/Renderer.php
+++ b/includes/classes/Feature/Facets/Renderer.php
@@ -63,10 +63,11 @@ class Renderer {
 		$taxonomy = $instance['facet'];
 
 		if ( ! is_search() ) {
-			$post_type = $wp_query->get( 'post_type' );
 
-			if ( empty( $post_type ) ) {
-				$post_type = 'post';
+			if ( is_tax() ) {
+				$post_type = get_taxonomy( get_queried_object()->taxonomy )->object_type;
+			} else {
+				$post_type = $wp_query->get( 'post_type' ) ? $wp_query->get( 'post_type' ) : 'post';
 			}
 
 			if ( ! is_object_in_taxonomy( $post_type, $taxonomy ) ) {

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -244,7 +244,7 @@ class QueryIntegration {
 		 * If not search and not set default to post. If not set and is search, use searchable post types
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
-			if ( empty( $query_vars['s'] ) ) {
+			if ( empty( $query_vars['s'] ) && empty( $query_vars['ep_facet'] ) ) {
 				$query_vars['post_type'] = 'post';
 			} else {
 				$query_vars['post_type'] = array_values( get_post_types( array( 'exclude_from_search' => false ) ) );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->
This PR adds the ability to show the Facet widgets on the taxonomy archives. 

<!-- Enter any applicable Issues here. Example: -->
Closes #2808

### Verification Process


- Add the Facet Widget.
- Go to a product category archive
- See the facets

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Fixed: Show Facet widgets on taxonomy archives

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 
