### PR TITLE
Update package-lock.json to work with node 16.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8904,6 +8904,18 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/got/node_modules/type-fest": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+      "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "dev": true,
@@ -17677,11 +17689,14 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.10.0",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.1.tgz",
+      "integrity": "sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -24480,6 +24495,14 @@
         "responselike": "^2.0.0",
         "to-readable-stream": "^2.0.0",
         "type-fest": "^0.10.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+          "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -29959,8 +29982,12 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.10.0",
-      "dev": true
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.1.tgz",
+      "integrity": "sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",


### PR DESCRIPTION
### Description of the Change

This is simply a result of `npm install` on node 16.15.1, so `npm ci` can work again on GitHub Actions.

### Changelog Entry

Fixed: Intermittent error on GitHub Actions using the latest node 16 version.

### Credits

Props @felipeelia 
