### PR TITLE
filter to add autosuggest styles while indexing

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -385,6 +385,13 @@ class Autosuggest extends Feature {
 	 */
 	public function enqueue_scripts() {
 		if ( Utils\is_indexing() ) {
+			/**
+			 * Filter whether to enqueue autosuggest styles while a index process is running or not
+			 *
+			 * @hook ep_autosuggest_styles_if_idexing
+			 * @param {bool} $show true to enqueue styles
+			 * @return {bool} New value
+			 */
 			if ( apply_filters( 'ep_autosuggest_styles_if_idexing', false ) ) {
 				$this->add_autosuggest_styles();
 			}

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -365,12 +365,29 @@ class Autosuggest extends Feature {
 	}
 
 	/**
+	 * Enqueue autosuggest styles
+	 *
+	 * @return void
+	 */
+	private function add_autosuggest_styles() {
+		wp_enqueue_style(
+			'elasticpress-autosuggest',
+			EP_URL . 'dist/css/autosuggest-styles.min.css',
+			Utils\get_asset_info( 'autosuggest-styles', 'dependencies' ),
+			Utils\get_asset_info( 'autosuggest-styles', 'version' )
+		);
+	}
+
+	/**
 	 * Enqueue our autosuggest script
 	 *
 	 * @since  2.4
 	 */
 	public function enqueue_scripts() {
 		if ( Utils\is_indexing() ) {
+			if ( apply_filters( 'ep_autosuggest_styles_if_idexing', false ) ) {
+				$this->add_autosuggest_styles();
+			}
 			return;
 		}
 
@@ -406,12 +423,7 @@ class Autosuggest extends Feature {
 			true
 		);
 
-		wp_enqueue_style(
-			'elasticpress-autosuggest',
-			EP_URL . 'dist/css/autosuggest-styles.min.css',
-			Utils\get_asset_info( 'autosuggest-styles', 'dependencies' ),
-			Utils\get_asset_info( 'autosuggest-styles', 'version' )
-		);
+		$this->add_autosuggest_styles();
 
 		/** Features Class @var Features $features */
 		$features = Features::factory();


### PR DESCRIPTION
### Description of the Change
The filter `ep_autosuggest_styles_if_idexing` should allow enqueueing autosuggest styles even if the website is being reindexed.
We have a project where we rely on those styles on the frontend but we're not relying on the ElasticPress built-in endpoint for autosuggest so not having those styles break the site appearance

Closes #2841 

### Alternate Designs

For now, we add a fix at the theme level where we're enqueuing the styles if are not enqueued but I think it could be helpful to force the styles if it's needed using a filter

### Possible Drawbacks

since this [change](https://github.com/10up/ElasticPress/pull/2163) was introduced as a fix to a JS error, there are no possible side-effects since are just the styles

### Verification Process
Fork the project and test my branch in my local environment. Ran a full site reindex and then test the filter is working properly

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Added - `ep_autosuggest_styles_if_idexing` filter to enqueue autosuggest styles even if index is running

### Credits

Props @hugosolar 
