### PR TITLE
Weighting: Add ep_enable_do_weighting to check for request type and re-factor with apply_weighting() into do_weighting()

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -595,7 +595,7 @@ class Weighting {
 		 * Filter whether to enable weighting configuration
 		 *
 		 * @hook ep_enable_do_weighting
-		 * @since 4.2.1
+		 * @since 4.3.0
 		 * @param  {bool}  Whether to enable weight config, defaults to true for search requests that are public or REST
 		 * @param  {array} $weight_config Current weight config
 		 * @param  {array} $args WP Query arguments

--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -585,112 +585,126 @@ class Weighting {
 		 * @hook ep_weighting_configuration_for_search
 		 * @param  {array} $weight_config Current weight config
 		 * @param  {array} $args WP Query arguments
-		 * @return  {array} New configutation
+		 * @return  {array} New configuration
 		 */
 		$weight_config = apply_filters( 'ep_weighting_configuration_for_search', $weight_config, $args );
 
+		$should_do_weighting = Utils\is_integrated_request( 'weighting', [ 'public', 'rest' ] ) && ! empty( $args['s'] );
+
 		/**
-		 * Filter whether to disable weighting configuration
+		 * Filter whether to enable weighting configuration
 		 *
-		 * @hook ep_disable_do_weighting
+		 * @hook ep_enable_do_weighting
 		 * @since 4.2.1
-		 * @param {bool} Whether to use weighting configuration, default is false
-		 * @param {array} $weight_config Current weight config
-		 * @param {array} $args WP Query arguments
-		 * @param {array} $formatted_args Formatted ES arguments
-		 * @return {bool} Whether to use weighting configuration
+		 * @param  {bool}  Whether to enable weight config, defaults to true for search requests that are public or REST
+		 * @param  {array} $weight_config Current weight config
+		 * @param  {array} $args WP Query arguments
+		 * @param  {array} $formatted_args Formatted ES arguments
+		 * @return  {bool} Whether to use weighting configuration
 		 */
-		if ( apply_filters( 'ep_disable_do_weighting', false, $weight_config, $args, $formatted_args ) ) {
-			return $formatted_args;
+		if ( apply_filters( 'ep_enable_do_weighting', $should_do_weighting, $weight_config, $args, $formatted_args ) ) {
+			$formatted_args = $this->apply_weighting( $formatted_args, $args, $weight_config );
 		}
 
-		if ( Utils\is_integrated_request( 'weighting', [ 'public', 'rest' ] ) && ! empty( $args['s'] ) ) {
-			/*
-			 * This section splits up the single query clause for all post types into separate nested clauses (one for each post type)
-			 * which then get combined into one result set. By having separate clauses for each post type, we can then
-			 * weight fields such as post_title per post type so that we can have fine grained control over weights by post
-			 * type, rather than globally on the query
-			 */
-			$new_query = [
-				'bool' => [
-					'should' => [],
-				],
-			];
+		return $formatted_args;
+	}
 
-			// grab the query and keep track of whether or not it is nested in a function score
-			$function_score = isset( $formatted_args['query']['function_score'] );
-			$query          = $function_score ? $formatted_args['query']['function_score']['query'] : $formatted_args['query'];
+	/**
+	 * Applies weighting based on ES args
+	 *
+	 * @since 4.3.0
+	 * @param array $formatted_args Formatted ES args
+	 * @param array $args WP_Query args
+	 * @param array $weight_config Weight configuration to apply
+	 *
+	 * @return array $formatted_args Formatted ES args with weightings applied
+	 */
+	protected function apply_weighting( $formatted_args, $args, $weight_config ) {
+		/*
+		 * This section splits up the single query clause for all post types into separate nested clauses (one for each post type)
+		 * which then get combined into one result set. By having separate clauses for each post type, we can then
+		 * weight fields such as post_title per post type so that we can have fine grained control over weights by post
+		 * type, rather than globally on the query
+		*/
+		$new_query = [
+			'bool' => [
+				'should' => [],
+			],
+		];
 
-			foreach ( (array) $args['post_type'] as $post_type ) {
-				if ( false === $this->post_type_has_fields( $post_type, $args ) ) {
-					continue;
-				}
-				// Copy the query, so we can set specific weight values
-				$current_query = $query;
+		// grab the query and keep track of whether or not it is nested in a function score
+		$function_score = isset( $formatted_args['query']['function_score'] );
+		$query          = $function_score ? $formatted_args['query']['function_score']['query'] : $formatted_args['query'];
 
-				if ( isset( $weight_config[ $post_type ] ) ) {
-					// Find all "fields" values and inject weights for the current post type
-					$this->recursively_inject_weights_to_fields( $current_query, $weight_config[ $post_type ] );
-				} else {
-					// Use the default values for the post type
-					$this->recursively_inject_weights_to_fields( $current_query, $this->get_post_type_default_settings( $post_type ) );
-				}
+		foreach ( (array) $args['post_type'] as $post_type ) {
+			if ( false === $this->post_type_has_fields( $post_type, $args ) ) {
+				continue;
+			}
+			// Copy the query, so we can set specific weight values
+			$current_query = $query;
 
-				// Check for any segments with null fields from recursively_inject function and remove them
-				if ( isset( $current_query['bool'] ) && isset( $current_query['bool']['should'] ) ) {
-					foreach ( $current_query['bool']['should'] as $index => $current_bool_should ) {
-						if ( isset( $current_bool_should['multi_match'] ) && null === $current_bool_should['multi_match'] ) {
-							unset( $current_query['bool']['should'][ $index ] );
-						}
+			if ( isset( $weight_config[ $post_type ] ) ) {
+				// Find all "fields" values and inject weights for the current post type
+				$this->recursively_inject_weights_to_fields( $current_query, $weight_config[ $post_type ] );
+			} else {
+				// Use the default values for the post type
+				$this->recursively_inject_weights_to_fields( $current_query, $this->get_post_type_default_settings( $post_type ) );
+			}
+
+			// Check for any segments with null fields from recursively_inject function and remove them
+			if ( isset( $current_query['bool'] ) && isset( $current_query['bool']['should'] ) ) {
+				foreach ( $current_query['bool']['should'] as $index => $current_bool_should ) {
+					if ( isset( $current_bool_should['multi_match'] ) && null === $current_bool_should['multi_match'] ) {
+						unset( $current_query['bool']['should'][ $index ] );
 					}
 				}
+			}
 
-				/**
-				 * Filter weighting query for a post type
-				 *
-				 * @hook ep_weighted_query_for_post_type
-				 * @param  {array} $query Weighting query
-				 * @param  {string} $post_type Post type
-				 * @param  {array} $args WP Query arguments
-				 * @return  {array} New query
-				 */
-				$new_query['bool']['should'][] = apply_filters(
-					'ep_weighted_query_for_post_type',
-					[
-						'bool' => [
-							'must'   => [
-								$current_query,
-							],
-							'filter' => [
-								[
-									'match' => [
-										'post_type.raw' => $post_type,
-									],
+			/**
+			 * Filter weighting query for a post type
+			 *
+			 * @hook ep_weighted_query_for_post_type
+			 * @param  {array} $query Weighting query
+			 * @param  {string} $post_type Post type
+			 * @param  {array} $args WP Query arguments
+			 * @return  {array} New query
+			 */
+			$new_query['bool']['should'][] = apply_filters(
+				'ep_weighted_query_for_post_type',
+				[
+					'bool' => [
+						'must'   => [
+							$current_query,
+						],
+						'filter' => [
+							[
+								'match' => [
+									'post_type.raw' => $post_type,
 								],
 							],
 						],
 					],
-					$post_type,
-					$args
-				);
-			}
-
-			// put the new query back in the correct location
-			if ( $function_score ) {
-				$formatted_args['query']['function_score']['query'] = $new_query;
-			} else {
-				$formatted_args['query'] = $new_query;
-			}
-
-			/**
-			 * Hook after weighting is added to Elasticsearch query
-			 *
-			 * @hook ep_weighting_added
-			 * @param  {array} $formatted_args Elasticsearch query
-			 * @param  {array} $args WP Query arguments
-			 */
-			do_action( 'ep_weighting_added', $formatted_args, $args );
+				],
+				$post_type,
+				$args
+			);
 		}
+
+		// put the new query back in the correct location
+		if ( $function_score ) {
+			$formatted_args['query']['function_score']['query'] = $new_query;
+		} else {
+			$formatted_args['query'] = $new_query;
+		}
+
+		/**
+		 * Hook after weighting is added to Elasticsearch query
+		 *
+		 * @hook ep_weighting_added
+		 * @param  {array} $formatted_args Elasticsearch query
+		 * @param  {array} $args WP Query arguments
+		 */
+		do_action( 'ep_weighting_added', $formatted_args, $args );
 
 		return $formatted_args;
 	}


### PR DESCRIPTION
### Description of the Change

This PR does two things:
1) Adds the filter `ep_enable_do_weighting`, which combines the logic of checking for an integrated request (that way one can customize it to their liking as well, if they wanted to change the integrated request types allowed)
2) Re-factors the logic to apply weighting into its own function `apply_weighting()`

### Alternate Designs

For point 2, it would be possible to just filter out the request types itself, but not sure if that's worth adding yet another filter on top of things already.

### Possible Drawbacks

N/A

### Verification Process

1) Set up EP with search weighting added by UI (pick whatever values)
2) Verify post weighting is still being added as expected on a front-end search for "bar"
3) Add filter to only disable post weighting for searches of "foo":
```
// Enable weighting only for searches of "foo"
// Enable weighting only for searches of "foo"
add_filter( 'ep_enable_do_weighting', function( $enable_do_weighting, $weight_config, $args, $formatted_arg ) {
   $enable_do_weighting = ElasticPress\Utils\is_integrated_request( 'weighting', [ 'public', 'rest' ] ) && $args['s'] === 'foo';

   return $enable_do_weighting;
}, 10, 4 );

```
4) Verify post weighting is no longer being added on a search query for "foo"

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
Added: Adds `ep_enable_do_weighting` filter and re-factors with new function `apply_weighting`
### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @rebeccahum 
