### PR TITLE
Add E2E for Prevent saving feature settings during a sync #2823

### DIFF
--- a/tests/cypress/integration/general.spec.js
+++ b/tests/cypress/integration/general.spec.js
@@ -94,4 +94,15 @@ describe('WordPress can perform standard ElasticPress actions', () => {
 		cy.get('.dashicons.start-sync').should('have.attr', 'title', 'Sync Page');
 		cy.get('.dashicons.dashicons-admin-generic').should('have.attr', 'title', 'Settings Page');
 	});
+
+	it('Cannot save settings while a sync is in progress', () => {
+		cy.login();
+		cy.visitAdminPage('admin.php?page=elasticpress');
+		cy.wpCliEval(`update_option( 'ep_index_meta', true );`).then(() => {
+			cy.get('.ep-feature-search .settings-button').click();
+			cy.get('.ep-feature-search .button-primary').click();
+			cy.get('.ep-feature-search .requirements-status-notice--syncing').should('be.visible');
+			cy.wpCliEval(`delete_option( 'ep_index_meta' );`);
+		});
+	});
 });


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->
This PR add the E2E test that will verify that the user can't save settings while the sync is in progresss. 

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 
