### PR TITLE
Add new filter ep_default_analyzer_char_filters

### DIFF
--- a/includes/mappings/post/5-2.php
+++ b/includes/mappings/post/5-2.php
@@ -61,11 +61,11 @@ return array(
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *
 					 * @since 4.3.0
-					 * @hook ep_default_analyzer_char_filter
-					 * @param  {array<string>} $char_filter Default filter
-					 * @return {array<string>} New filter(s)
+					 * @hook ep_default_analyzer_char_filters
+					 * @param  {array<string>} $char_filters Default filter
+					 * @return {array<string>} New filters
 					 */
-					'char_filter' => apply_filters( 'ep_default_analyzer_char_filter', array( 'html_strip' ) ),
+					'char_filter' => apply_filters( 'ep_default_analyzer_char_filters', array( 'html_strip' ) ),
 					/**
 					 * Filter Elasticsearch default language in mapping
 					 *

--- a/includes/mappings/post/5-2.php
+++ b/includes/mappings/post/5-2.php
@@ -57,7 +57,15 @@ return array(
 					 * @return {array<string>} New filters
 					 */
 					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
-					'char_filter' => array( 'html_strip' ),
+					/**
+					 * Filter Elasticsearch default analyzer's char_filter
+					 *
+					 * @since 4.3.0
+					 * @hook ep_default_analyzer_char_filter
+					 * @param  {array<string>} $char_filter Default filter
+					 * @return {array<string>} New filter(s)
+					 */
+					'char_filter' => apply_filters( 'ep_default_analyzer_char_filter', array( 'html_strip' ) ),
 					/**
 					 * Filter Elasticsearch default language in mapping
 					 *

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -77,11 +77,11 @@ return array(
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *
 					 * @since 4.3.0
-					 * @hook ep_default_analyzer_char_filter
-					 * @param  {array<string>} $char_filter Default filter
-					 * @return {array<string>} New filter(s)
+					 * @hook ep_default_analyzer_char_filters
+					 * @param  {array<string>} $char_filters Default filter
+					 * @return {array<string>} New filters
 					 */
-					'char_filter' => apply_filters( 'ep_default_analyzer_char_filter', array( 'html_strip' ) ),
+					'char_filter' => apply_filters( 'ep_default_analyzer_char_filters', array( 'html_strip' ) ),
 					/**
 					 * Filter Elasticsearch default language in mapping
 					 *

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -73,7 +73,15 @@ return array(
 					 * @return {array<string>} New filters
 					 */
 					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
-					'char_filter' => array( 'html_strip' ),
+					/**
+					 * Filter Elasticsearch default analyzer's char_filter
+					 *
+					 * @since 4.3.0
+					 * @hook ep_default_analyzer_char_filter
+					 * @param  {array<string>} $char_filter Default filter
+					 * @return {array<string>} New filter(s)
+					 */
+					'char_filter' => apply_filters( 'ep_default_analyzer_char_filter', array( 'html_strip' ) ),
 					/**
 					 * Filter Elasticsearch default language in mapping
 					 *


### PR DESCRIPTION
### Description of the Change

`html_strip` doesn't allow searching for text within HTML comments. So, with Gutenberg blocks, if one wanted to search for the Jetpack Slideshow block with `jetpack/slideshow`, it can't be done.

It would be nice if users had that option to filter it out.

### Alternate Designs

N/A.

### Possible Drawbacks

N/A.

### Verification Process

1) Add a Jetpack slideshow block to a post
2) Add the filter to disable the `html_strip`:
```
add_filter( 'ep_default_analyzer_char_filter', '__return_empty_array' );
```
3) Re-index with mappings re-put in place
4) Search for "slideshow" and see result

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added: New filter ep_default_analyzer_char_filters
### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @rebeccahum 
