### PR TITLE
Performance: Use get_term() instead of term_exists() for get_term_tree()

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -353,7 +353,9 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 				$terms_map[ $term->term_id ] = $term;
 			}
 
-			if ( empty( $term->parent ) || is_wp_error( get_term( $term->parent, $term->taxonomy ) ) ) {
+			$parent_term = get_term( $term->parent, $term->taxonomy );
+
+			if ( empty( $term->parent ) || is_wp_error( $parent_term ) || ! $parent_term ) {
 				$term->level = 0;
 
 				if ( empty( $orderby ) ) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -353,7 +353,7 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 				$terms_map[ $term->term_id ] = $term;
 			}
 
-			if ( empty( $term->parent ) || ! term_exists( $term->parent, $term->taxonomy ) ) {
+			if ( empty( $term->parent ) || is_wp_error( get_term( $term->parent, $term->taxonomy ) ) ) {
 				$term->level = 0;
 
 				if ( empty( $orderby ) ) {


### PR DESCRIPTION
### Description of the Change
This is a follow-up to the change in https://github.com/10up/ElasticPress/pull/2687. It'd be better to use `get_term()` to utilize the Object cache, since `term_exists()` does a DB call and thus, if there are several terms with the same parent, that generates a lot of queries.

### Alternate Designs

N/A.

### Possible Drawbacks

N/A.

### Verification Process

Did the same steps described in https://github.com/10up/ElasticPress/pull/2687 but ensure that object caching is utilized.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Changed: Improved performance in get_term_tree()

### Credits

Props @rebeccahum 
