### PR TITLE
Default back to posts for unknown post_type

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -13,6 +13,7 @@
       ],
       "mappings": {
         "wp-content/mu-plugins/unique-index-name.php": "./tests/cypress/wordpress-files/test-mu-plugins/unique-index-name.php",
+        "wp-content/plugins/cpt-and-custom-tax.php": "./tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php",
         "wp-content/plugins/fake-new-activation.php": "./tests/cypress/wordpress-files/test-plugins/fake-new-activation.php",
         "wp-content/plugins/unsupported-server-software.php": "./tests/cypress/wordpress-files/test-plugins/unsupported-server-software.php",
         "wp-content/plugins/unsupported-elasticsearch-version.php": "./tests/cypress/wordpress-files/test-plugins/unsupported-elasticsearch-version.php",

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -244,7 +244,9 @@ class QueryIntegration {
 		 * If not search and not set default to post. If not set and is search, use searchable post types
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
-			if ( empty( $query_vars['s'] ) && empty( $query_vars['ep_facet'] ) ) {
+			if ( $query->is_tax() ) {
+				$query_vars['post_type'] = get_taxonomy( get_queried_object()->taxonomy )->object_type;
+			} elseif ( empty( $query_vars['s'] ) ) {
 				$query_vars['post_type'] = 'post';
 			} else {
 				$query_vars['post_type'] = array_values( get_post_types( array( 'exclude_from_search' => false ) ) );

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -245,7 +245,7 @@ class QueryIntegration {
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
 			if ( $query->is_tax() ) {
-				$query_vars['post_type'] = get_taxonomy( get_queried_object()->taxonomy )->object_type;
+				$query_vars['post_type'] = get_taxonomy( $query->get_queried_object()->taxonomy )->object_type;
 			} elseif ( empty( $query_vars['s'] ) ) {
 				$query_vars['post_type'] = 'post';
 			} else {

--- a/tests/cypress/integration/features/facets.spec.js
+++ b/tests/cypress/integration/features/facets.spec.js
@@ -112,4 +112,33 @@ describe('Facets Feature', () => {
 		cy.url().should('include', 'ep_filter_category=classic%2Cpost-formats');
 		cy.url().should('not.include', 'page');
 	});
+
+	it('Does not change post types being displayed', () => {
+		cy.activatePlugin('cpt-and-custom-tax', 'wpCli');
+
+		cy.wpCli('post create --post_title="A new page" --post_type="page"');
+		cy.wpCli('post create --post_title="A new post" --post_type="post"');
+
+		cy.wpCli(
+			'post create --post_title="A new movie" --post_type="movie" --tax_input="{\'genre\': \'action\'}"',
+		);
+
+		// Blog page
+		cy.visit('/');
+		cy.contains('.site-content article h2', 'A new page').should('not.exist');
+		cy.contains('.site-content article h2', 'A new post').should('exist');
+		cy.contains('.site-content article h2', 'A new movie').should('not.exist');
+
+		// Specific taxonomy archive
+		cy.visit('/blog/genre/action/');
+		cy.contains('.site-content article h2', 'A new page').should('not.exist');
+		cy.contains('.site-content article h2', 'A new post').should('not.exist');
+		cy.contains('.site-content article h2', 'A new movie').should('exist');
+
+		// Search
+		cy.visit('/?s=new');
+		cy.contains('.site-content article h2', 'A new page').should('exist');
+		cy.contains('.site-content article h2', 'A new post').should('exist');
+		cy.contains('.site-content article h2', 'A new movie').should('exist');
+	});
 });

--- a/tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php
+++ b/tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php
@@ -16,7 +16,7 @@ namespace ElasticPress\Tests\E2e;
  */
 function create_post_type() {
 	register_post_type(
-		'movies',
+		'movie',
 		[
 			'labels'      => [
 				'name'          => __( 'Movies' ),
@@ -48,7 +48,7 @@ function create_taxonomy() {
 	];
 
 	$args = [
-		'hierarchical'      => true,
+		'hierarchical'      => false,
 		'labels'            => $labels,
 		'show_ui'           => true,
 		'show_admin_column' => true,
@@ -57,6 +57,6 @@ function create_taxonomy() {
 		'has_archive'       => true,
 	];
 
-	register_taxonomy( 'genre', [ 'movies' ], $args );
+	register_taxonomy( 'genre', [ 'movie' ], $args );
 }
 add_action( 'init', __NAMESPACE__ . '\\create_taxonomy' );

--- a/tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php
+++ b/tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Plugin Name: CPT and Custom Taxonomy
+ * Description: A Custom Post Type and a Custom Taxonomy for general purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+namespace ElasticPress\Tests\E2e;
+
+/**
+ * Create a CPT called "Movies".
+ */
+function create_post_type() {
+	register_post_type(
+		'movies',
+		[
+			'labels'      => [
+				'name'          => __( 'Movies' ),
+				'singular_name' => __( 'Movie' ),
+			],
+			'public'      => true,
+			'has_archive' => true,
+		]
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\\create_post_type' );
+
+/**
+ * Create a custom taxonomy called "Genres" and add it to movies.
+ */
+function create_taxonomy() {
+	$labels = [
+		'name'              => _x( 'Genres', 'taxonomy general name', 'textdomain' ),
+		'singular_name'     => _x( 'Genre', 'taxonomy singular name', 'textdomain' ),
+		'search_items'      => __( 'Search Genres', 'textdomain' ),
+		'all_items'         => __( 'All Genres', 'textdomain' ),
+		'parent_item'       => __( 'Parent Genre', 'textdomain' ),
+		'parent_item_colon' => __( 'Parent Genre:', 'textdomain' ),
+		'edit_item'         => __( 'Edit Genre', 'textdomain' ),
+		'update_item'       => __( 'Update Genre', 'textdomain' ),
+		'add_new_item'      => __( 'Add New Genre', 'textdomain' ),
+		'new_item_name'     => __( 'New Genre Name', 'textdomain' ),
+		'menu_name'         => __( 'Genre', 'textdomain' ),
+	];
+
+	$args = [
+		'hierarchical'      => true,
+		'labels'            => $labels,
+		'show_ui'           => true,
+		'show_admin_column' => true,
+		'query_var'         => true,
+		'rewrite'           => [ 'slug' => 'genre' ],
+		'has_archive'       => true,
+	];
+
+	register_taxonomy( 'genre', [ 'movies' ], $args );
+}
+add_action( 'init', __NAMESPACE__ . '\\create_taxonomy' );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

In #2837 we've made a change in the default post type that ultimately generated the bug seen in #2879. This PR changes the approach, falling back to posts again and addressing a problem outlined in #2834.

<!-- Enter any applicable Issues here. Example: -->
Closes #2879

### Changelog Entry

Fixed - Wrong post types being displayed on the homepage while having the Facets feature enabled.

### Credits

Props @felipeelia @oscarssanchez
