### PR TITLE
Delete the ep_es_info transient to force fetch es info again

### DIFF
--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -47,6 +47,7 @@ class Upgrades {
 			'3.5.2' => [ 'upgrade_3_5_2', 'init' ],
 			'3.5.3' => [ 'upgrade_3_5_3', 'init' ],
 			'3.6.6' => [ 'upgrade_3_6_6', 'init' ],
+			'4.2.2' => [ 'upgrade_4_2_2', 'init' ],
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ] );
@@ -165,6 +166,22 @@ class Upgrades {
 
 		foreach ( $synonyms_example_ids as $synonym_post_id ) {
 			wp_delete_post( $synonym_post_id, true );
+		}
+	}
+
+	/**
+	 * Upgrade routine of v4.2.2.
+	 *
+	 * Delete the transient with ES info, so EP is forced to fetch it again,
+	 * determining the correct software type (elasticsearch or opensearch, for example)
+	 *
+	 * @see https://github.com/10up/ElasticPress/issues/2882
+	 */
+	public function upgrade_4_2_2() {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			delete_site_transient( 'ep_es_info' );
+		} else {
+			delete_transient( 'ep_es_info' );
 		}
 	}
 


### PR DESCRIPTION
### Description of the Change

After we've introduced server software detection in #2835, some users are receiving errors because the ep_es_info transient was not updated. This PR adds the deletion of that transient as a v4.2.2 upgrade routine, so we force EP to fetch the information.

For v4.2.1 users facing this problem, simply visiting the Features page or saving the Settings page should fix it.

<!-- Enter any applicable Issues here. Example: -->
Closes #2882

### Changelog Entry

Fixed - Wrong notice about unsupported server software

### Credits

Props @felipeelia 
