### PR TITLE
Comments: Make a proper count call instead of counting the results

### DIFF
--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -882,18 +882,17 @@ class Comment extends Indexable {
 
 		unset( $all_query_args['number'] );
 		unset( $all_query_args['offset'] );
+		$all_query_args['count'] = true;
 
 		/**
-		 * Filter database arguments for term count query
+		 * Filter database arguments for comment count query
 		 *
 		 * @hook ep_comment_all_query_db_args
 		 * @param  {array} $args Query arguments based to WP_Comment_Query
 		 * @since  3.6.0
 		 * @return {array} New arguments
 		 */
-		$all_query = new WP_Comment_Query( apply_filters( 'ep_comment_all_query_db_args', $all_query_args, $args ) );
-
-		$total_objects = count( $all_query->comments );
+		$total_objects = get_comments( apply_filters( 'ep_comment_all_query_db_args', $all_query_args, $args ) );
 
 		if ( ! empty( $args['offset'] ) ) {
 			if ( (int) $args['offset'] >= $total_objects ) {


### PR DESCRIPTION
### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

As stated in #2897, the current count call is fetching all the comments, exhausting all memory available in some scenarios. This PR changes that query to be a proper count call.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2897

### Changelog Entry

Changed - Total comment count made during sync process to be a proper count call.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @bsabalaskey
