### PR TITLE
Fix: recreate-network-alias throw error on single site

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -571,7 +571,7 @@ class Command extends WP_CLI_Command {
 		$this->index_occurring();
 
 		if ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) {
-			WP_CLI::error( esc_html__( 'ElasticPress is not activated on network.', 'elasticpress' ) );
+			WP_CLI::error( esc_html__( 'ElasticPress is not network activated.', 'elasticpress' ) );
 		}
 
 		$indexables = Indexables::factory()->get_all( false );

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -570,6 +570,10 @@ class Command extends WP_CLI_Command {
 		$this->connect_check();
 		$this->index_occurring();
 
+		if ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) {
+			WP_CLI::error( esc_html__( 'ElasticPress is not activated on network.', 'elasticpress' ) );
+		}
+
 		$indexables = Indexables::factory()->get_all( false );
 
 		foreach ( $indexables as $indexable ) {

--- a/tests/cypress/integration/wp-cli.spec.js
+++ b/tests/cypress/integration/wp-cli.spec.js
@@ -144,10 +144,10 @@ describe('WP-CLI Commands', () => {
 
 	it('Can recreate the alias index which points to every index in the network if user runs wp elasticpress recreate-network-alias command', () => {});
 
-	it('wp elasticpress recreate-network-alias throws an error message if the plugin is not activated on the network', () => {
+	it('Can throw an error while running wp elasticpress recreate-network-alias if the plugin is not network activated', () => {
 		cy.wpCli('wp elasticpress recreate-network-alias', true)
 			.its('stderr')
-			.should('contain', 'ElasticPress is not activated on network');
+			.should('contain', 'ElasticPress is not network activated');
 	});
 
 	it('Can activate and deactivate a feature', () => {

--- a/tests/cypress/integration/wp-cli.spec.js
+++ b/tests/cypress/integration/wp-cli.spec.js
@@ -144,6 +144,12 @@ describe('WP-CLI Commands', () => {
 
 	it('Can recreate the alias index which points to every index in the network if user runs wp elasticpress recreate-network-alias command', () => {});
 
+	it('wp elasticpress recreate-network-alias throws an error message if the plugin is not activated on the network', () => {
+		cy.wpCli('wp elasticpress recreate-network-alias', true)
+			.its('stderr')
+			.should('contain', 'ElasticPress is not activated on network');
+	});
+
 	it('Can activate and deactivate a feature', () => {
 		cy.wpCli('wp elasticpress activate-feature search', true)
 			.its('stderr')


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds the check that will check throw the error message if EP is not activated on the network

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2868 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Run `wp elasticpress recreate-network-alias` command on single site.
- Command should throw the error message `ElasticPress is not activated on network.`. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - recreate-network-alias CLI command returns an error without explanation on single site 



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
