### PR TITLE
Add epAutosuggestQueryFilter to allow filtering ES query based on input element

### DIFF
--- a/assets/js/autosuggest.js
+++ b/assets/js/autosuggest.js
@@ -562,6 +562,13 @@ function init() {
 				query = JSON.stringify(query);
 			}
 
+			// Allow filtering the search query based on the input.
+			if (typeof window.epAutosuggestQueryFilter !== 'undefined') {
+				query = JSON.stringify(
+					window.epAutosuggestQueryFilter(JSON.parse(query), searchText, input),
+				);
+			}
+
 			// fetch the results
 			const response = await esSearch(query, searchText);
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Currently there is no easy way to filter an autosuggest query based on context. So in the case where you have a global autosuggest input on a page, there's no way to place a secondary autosuggest search on the same screen that covers, e.g., posts with a certain taxonomy term. 

This follows the model of the existing filters, `epDataFilter` and `epAutosuggestItemHTMLFilter` to allow the ElasticSearch query to be modified before it is sent. We check if `epAutosuggestQueryFilter` is defined, and if it is, the query is passed through that function. The function also receives the searchText and the input element, the latter of which is key to customizing the query, as we can identify an input by its attributes or even access its form at `input.form`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2908 

**Note:** I didn't look into using `@wordpress/hooks` because my assumption is that package would bring in unwanted dependencies. If this option is pursued in the future, though, this functionality could be easily adapted. In that scenario I would recommend breaking each of these filters out into helper functions that can keep the current pattern for backward compatibility and fall back to the `@wordpress/hooks` pattern if the global function isn't defined.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Checkout this branch and run `npm run build` or `npm run watch`
2. Go to a page with autosuggest
3. Enter the following in the JS console

```
window.epAutosuggestQueryFilter = (query, searchText, input) => {
    console.log({query, searchText, input});
    return query;
}
```

4. Type in the autosuggest input to see your callback running.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Added - Autosuggest: filter the autosuggest ElasticSearch query by defining a `window.epAutosuggestQueryFilter()` function in JavaScript.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
