### PR TITLE
New add_synonyms_to_settings method + default_search analyzer

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -781,6 +781,12 @@ class Synonyms {
 			$settings['analysis']['analyzer']['default_search'] = $settings['analysis']['analyzer']['default'];
 		}
 
+		// Remove ewp_word_delimiter from default_search filters, as that is incompatible with synonyms
+		$settings['analysis']['analyzer']['default_search']['filter'] = array_diff(
+			$settings['analysis']['analyzer']['default_search']['filter'],
+			[ 'ewp_word_delimiter' ]
+		);
+
 		// Tell the analyzer to use our newly created filter.
 		$settings['analysis']['analyzer']['default_search']['filter'] = array_values(
 			array_unique(

--- a/tests/cypress/integration/features/search/search.spec.js
+++ b/tests/cypress/integration/features/search/search.spec.js
@@ -120,25 +120,4 @@ describe('Post Search Feature', () => {
 
 		cy.get('.ep-highlight').should('be.visible');
 	});
-
-	it('Can Search Product by Variation SKU', () => {
-		cy.login();
-		cy.activatePlugin('woocommerce', 'wpCli');
-		cy.maybeEnableFeature('woocommerce');
-
-		cy.updateWeighting({
-			product: {
-				'meta._variations_skus.value': {
-					weight: 1,
-					enabled: true,
-				},
-			},
-		}).then(() => {
-			cy.wpCli('elasticpress index --setup --yes');
-			cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
-			cy.contains('.site-content article:nth-of-type(1) h2', 'Awesome Aluminum Shoes').should(
-				'exist',
-			);
-		});
-	});
 });

--- a/tests/cypress/integration/features/search/synonyms.spec.js
+++ b/tests/cypress/integration/features/search/synonyms.spec.js
@@ -33,9 +33,11 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 			cy.publishPost(postData);
 		});
 	});
+
 	beforeEach(() => {
 		cy.login();
 	});
+
 	it('Can create, search, and delete synonyms sets', () => {
 		// Add the set
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
@@ -59,6 +61,7 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		cy.visit(`/?s=${word2}`);
 		cy.contains('.site-content article h2', word1).should('not.exist');
 	});
+
 	it('Can create, search, and delete synonyms alternatives', () => {
 		// Add the set
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
@@ -85,7 +88,8 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		cy.visit(`/?s=${word1}`);
 		cy.contains('.site-content article h2', word2).should('not.exist');
 	});
-	it('Can use the Advanced Text Editor', () => {
+
+	it('Can use the Advanced Text Editor and terms with spaces', () => {
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
 		cy.contains('.page-title-action', 'Switch to Advanced Text Editor').click();
 		cy.get('#ep-synonym-input').clearThenType(`{enter}
@@ -110,7 +114,11 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 			'Alternatives must have both a primary term and at least one alternative term.',
 		).should('exist');
 
-		cy.get('#ep-synonym-input').clearThenType('foo => bar{enter}list,of,words');
+		cy.get('#ep-synonym-input').clearThenType(
+			`foo => bar
+			list,of,words
+			IoT, Internet of Things`,
+		);
 		cy.get('#synonym-root .button-primary').click();
 		cy.contains('.notice-success', 'Successfully updated synonym filter.').should('exist');
 
@@ -126,7 +134,13 @@ describe('Post Search Feature - Synonyms Functionality', () => {
 		cy.contains('.synonym-alternative-editor .components-form-token-field span', 'bar').should(
 			'exist',
 		);
+
+		/**
+		 * Check if it is able to sync having a term with spaces
+		 */
+		cy.wpCli('elasticpress index --setup --yes');
 	});
+
 	it('Can preserve synonyms if a sync is performed', () => {
 		cy.visitAdminPage('admin.php?page=elasticpress-synonyms');
 		cy.get('.page-title-action').then(($button) => {

--- a/tests/cypress/integration/features/woocommerce.spec.js
+++ b/tests/cypress/integration/features/woocommerce.spec.js
@@ -85,4 +85,25 @@ describe('WooCommerce Feature', () => {
 			'Query Response Code: HTTP 200',
 		);
 	});
+
+	it('Can Search Product by Variation SKU', () => {
+		cy.login();
+
+		cy.maybeEnableFeature('woocommerce');
+
+		cy.updateWeighting({
+			product: {
+				'meta._variations_skus.value': {
+					weight: 1,
+					enabled: true,
+				},
+			},
+		}).then(() => {
+			cy.wpCli('elasticpress index --setup --yes');
+			cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
+			cy.contains('.site-content article:nth-of-type(1) h2', 'Awesome Aluminum Shoes').should(
+				'exist',
+			);
+		});
+	});
 });

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -187,7 +187,8 @@ class TestSynonyms extends BaseTestCase {
 
 		/**
 		 * Test an array that does not have a `default_search` yet.
-		 * Filters should be copied from `default` to `default_search`
+		 * Filters should be copied from `default` to `default_search`,
+		 * except `ewp_word_delimiter` which is incompatible with synonyms.
 		 */
 		$settings = [
 			'analysis' => [
@@ -197,6 +198,7 @@ class TestSynonyms extends BaseTestCase {
 						'filter' => [
 							'filter_a',
 							'filter_b',
+							'ewp_word_delimiter',
 						],
 					],
 				],
@@ -205,9 +207,11 @@ class TestSynonyms extends BaseTestCase {
 		$changed_settings = $instance->add_synonyms_to_settings( $settings );
 		$this->assertContains( 'filter_a', $changed_settings['analysis']['analyzer']['default']['filter'] );
 		$this->assertContains( 'filter_b', $changed_settings['analysis']['analyzer']['default']['filter'] );
+		$this->assertContains( 'ewp_word_delimiter', $changed_settings['analysis']['analyzer']['default']['filter'] );
 		$this->assertNotContains( 'ep_synonyms_filter', $changed_settings['analysis']['analyzer']['default']['filter'] );
 		$this->assertContains( 'filter_a', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
 		$this->assertContains( 'filter_b', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+		$this->assertNotContains( 'ewp_word_delimiter', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
 		$this->assertContains( 'ep_synonyms_filter', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
 
 		/**

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -142,22 +142,10 @@ class TestSynonyms extends BaseTestCase {
 			],
 		];
 
-		$synonyms = $instance->get_synonyms();
-
-		// For some reason, the greater-than gets encoded during the multi-site
-		// tests but not the single-site tests. This updates the encoding so
-		// they both match. See https://travis-ci.com/github/petenelson/ElasticPress/jobs/470254351.
-		$synonyms = array_map(
-			function ( $synonym ) {
-				return str_replace( '>', '&gt;', $synonym );
-			},
-			$synonyms
-		);
-
 		$synonym_es_filter = [
 			'type'     => 'synonym_graph',
 			'lenient'  => true,
-			'synonyms' => $synonyms,
+			'synonyms' => $instance->get_synonyms(),
 		];
 
 		$changed_settings = $instance->add_synonyms_to_settings( $settings );

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -108,4 +108,212 @@ class TestSynonyms extends BaseTestCase {
 		$this->assertEquals( 'foo, bar', $instance->validate_synonym( ' foo, bar ' ) );
 		$this->assertEquals( 'foo => bar', $instance->validate_synonym( ' foo => bar ' ) );
 	}
+
+	/**
+	 * Test add_synonyms_to_settings against arrays with the wrong format.
+	 *
+	 * @since 4.3.0
+	 * @dataProvider settingsWithWrongFormatProvider
+	 * @return void
+	 */
+	public function testAddSynonymsToSettingsWithWrongFormat() {
+		$settings = func_get_args(); // It will not work with empty arrays
+		$instance = $this->getFeature();
+
+		$this->assertSame( $settings, $instance->add_synonyms_to_settings( $settings ) );
+	}
+
+	/**
+	 * Test setting filters in add_synonyms_to_settings
+	 *
+	 * @since 4.3.0
+	 */
+	public function testAddSynonymsToSettingsFilter() {
+		$instance = $this->getFeature();
+
+		$settings = [
+			'analysis' => [
+				'filter'   => [],
+				'analyzer' => [
+					'default' => [
+						'filter' => [],
+					],
+				],
+			],
+		];
+
+		$synonyms = $instance->get_synonyms();
+
+		// For some reason, the greater-than gets encoded during the multi-site
+		// tests but not the single-site tests. This updates the encoding so
+		// they both match. See https://travis-ci.com/github/petenelson/ElasticPress/jobs/470254351.
+		$synonyms = array_map(
+			function ( $synonym ) {
+				return str_replace( '>', '&gt;', $synonym );
+			},
+			$synonyms
+		);
+
+		$synonym_es_filter = [
+			'type'     => 'synonym_graph',
+			'lenient'  => true,
+			'synonyms' => $synonyms,
+		];
+
+		$changed_settings = $instance->add_synonyms_to_settings( $settings );
+		$this->assertArrayHasKey( 'ep_synonyms_filter', $changed_settings['analysis']['filter'] );
+		$this->assertSame( $synonym_es_filter, $changed_settings['analysis']['filter']['ep_synonyms_filter'] );
+
+		/**
+		 * Test the `ep_synonyms_filter_name` filter.
+		 */
+		$change_filter_name = function () {
+			return 'ep_custom_synonyms_filter';
+		};
+		add_filter( 'ep_synonyms_filter_name', $change_filter_name );
+		$changed_settings = $instance->add_synonyms_to_settings( $settings );
+		$this->assertArrayNotHasKey( 'ep_synonyms_filter', $changed_settings['analysis']['filter'] );
+		$this->assertArrayHasKey( 'ep_custom_synonyms_filter', $changed_settings['analysis']['filter'] );
+		$this->assertSame( $synonym_es_filter, $changed_settings['analysis']['filter']['ep_custom_synonyms_filter'] );
+		remove_filter( 'ep_synonyms_filter_name', $change_filter_name );
+
+		/**
+		 * Test the `ep_synonyms_filter` filter.
+		 */
+		$change_es_filter_content = function() {
+			return [ 'lenient'  => false ];
+		};
+		add_filter( 'ep_synonyms_filter', $change_es_filter_content );
+		$changed_settings = $instance->add_synonyms_to_settings( $settings );
+		$this->assertSame( [ 'lenient'  => false ], $changed_settings['analysis']['filter']['ep_synonyms_filter'] );
+		remove_filter( 'ep_synonyms_filter', $change_es_filter_content );
+	}
+	
+	/**
+	 * Test setting analyzers in add_synonyms_to_settings
+	 *
+	 * @since 4.3.0
+	 */
+	public function testAddSynonymsToSettingsAnalyzer() {
+		$instance = $this->getFeature();
+
+		/**
+		 * Test an array that does not have a `default_search` yet.
+		 * Filters should be copied from `default` to `default_search`
+		 */
+		$settings = [
+			'analysis' => [
+				'filter'   => [],
+				'analyzer' => [
+					'default' => [
+						'filter' => [
+							'filter_a',
+							'filter_b',
+						],
+					],
+				],
+			],
+		];
+		$changed_settings = $instance->add_synonyms_to_settings( $settings );
+		$this->assertContains( 'filter_a', $changed_settings['analysis']['analyzer']['default']['filter'] );
+		$this->assertContains( 'filter_b', $changed_settings['analysis']['analyzer']['default']['filter'] );
+		$this->assertNotContains( 'ep_synonyms_filter', $changed_settings['analysis']['analyzer']['default']['filter'] );
+		$this->assertContains( 'filter_a', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+		$this->assertContains( 'filter_b', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+		$this->assertContains( 'ep_synonyms_filter', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+
+		/**
+		 * Test an array that has a `default_search`.
+		 * Filters should be kept as they are now.
+		 */
+		$settings = [
+			'analysis' => [
+				'filter'   => [],
+				'analyzer' => [
+					'default' => [
+						'filter' => [
+							'filter_a',
+							'filter_b',
+						],
+					],
+					'default_search' => [
+						'filter' => [
+							'filter_c',
+						],
+					],
+				],
+			],
+		];
+		$changed_settings = $instance->add_synonyms_to_settings( $settings );
+		$this->assertContains( 'filter_a', $changed_settings['analysis']['analyzer']['default']['filter'] );
+		$this->assertContains( 'filter_b', $changed_settings['analysis']['analyzer']['default']['filter'] );
+		$this->assertNotContains( 'ep_synonyms_filter', $changed_settings['analysis']['analyzer']['default']['filter'] );
+		$this->assertNotContains( 'filter_c', $changed_settings['analysis']['analyzer']['default']['filter'] );
+
+		$this->assertContains( 'ep_synonyms_filter', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+		$this->assertNotContains( 'filter_a', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+		$this->assertNotContains( 'filter_b', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+		$this->assertContains( 'filter_c', $changed_settings['analysis']['analyzer']['default_search']['filter'] );
+	}
+
+	/**
+	 * Data Provider with some arrays that do not follow expected
+	 * format for index settings.
+	 *
+	 * @return array
+	 */
+	public function settingsWithWrongFormatProvider() {
+		return [
+			// Simple empty array
+			[],
+			// Analysis array without a filter
+			[
+				'analysis' => [],
+			],
+			// It has filter but no analyzer
+			[
+				'analysis' => [
+					'filter' => [],
+				],
+			],
+			// It has filter and analyzer but no default nor default_search analyzer
+			[
+				'analysis' => [
+					'filter'   => [],
+					'analyzer' => [],
+				],
+			],
+			// Default analyzer without filters
+			[
+				'analysis' => [
+					'filter'   => [],
+					'analyzer' => [
+						'default' => [],
+					],
+				],
+			],
+			// default_search analyzer without filters
+			[
+				'analysis' => [
+					'filter'   => [],
+					'analyzer' => [
+						'default_search' => [],
+					],
+				],
+			],
+			// default and default_search analyzers without filters. Filters in another analyzer
+			[
+				'analysis' => [
+					'filter'   => [],
+					'analyzer' => [
+						'custom_analyzer' => [
+							'filter' => [],
+						],
+						'default'        => [],
+						'default_search' => [],
+					],
+				],
+			],
+		];
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds synonyms in a new default_analyzer, so its filter doesn't conflict with word_delimiter_graph during index time.

**It still needs some tests**

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2877

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry

> Fixed - Synonyms are now applied only during search time, fixing an incompatibility with the `word_delimiter_graph` filter.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 