### PR TITLE
Change term objects in `format_hits_as_terms` to `WP_Term` instead of `stdClass`

### DIFF
--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -241,6 +241,7 @@ class QueryIntegration {
 			}
 
 			$term->elasticsearch = true; // Super useful for debugging.
+			$term = new \WP_Term( $term ); // Necessary for WordPress actions that expect WP_Term as the object type.
 
 			if ( $term ) {
 				$new_terms[] = $term;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The description of the `format_hits_as_terms` method reads like this:

```php
/**
 * Format the ES hits/results as term objects.
 *
 * @param  array $terms The terms that should be formatted.
 * @param  array $new_terms Array of terms from cache.
 * @param  array $query_vars Query variables.
 * @since  3.1
 * @return array
*/
```

This pull request makes the term objects into `WP_Term` objects instead of `stdClass` objects. This brings it in line with how WordPress uses this result in actions like `post_tag_row_actions`, which specify that the term parameter should be a `WP_Term` object.

I'm not aware of any drawbacks, but I do realize that this method has been returning `stdClass` objects, even if incorrectly, for some time. I think likely this is causing issues unless the code using it is not using standard WordPress methods, but that is worth noting.

An alternative would be to add a filter instead, allowing developers to use `WP_Term` on their own. Ex: `$term = apply_filters( 'ep_wp_query_terms_object', $term );`. I don't think that is ideal, but if it's necessary for backward compatibility I would understand that.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2912 

### How to test the Change

The way I found this was using The Events Calendar:

1. Index `post_tag`, at least, with some post tags.
2. Install The Events Calendar.
3. Go to `/wp-admin/edit-tags.php?taxonomy=post_tag&post_type=post` and search for a value that will return some tags. Instead of giving a fatal error, it will return the same data but formatted as a `WP_Term` object. Verify by logging in [these lines](https://github.com/the-events-calendar/the-events-calendar/blob/master/src/Tribe/Taxonomy/Taxonomy_Provider.php#L53-L55) like this:

```php
public function event_tag_actions( $actions, WP_Term $tag ) {
    error_log( 'tag is ' . print_r( $tag, true ) );
    return $this->container->make( Event_Tag::class )->event_tag_actions( $actions, $tag );
}
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Change term objects in `format_hits_as_terms` to use `WP_Term` instead of `stdClass` to match WordPress expectations.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jonathanstegall


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.

I don't see any documentation or relevant tests, but am willing to update those if they do apply.