### PR TITLE
Use `wp_cache_flush_group()` when available

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -652,8 +652,13 @@ class Autosuggest extends Feature {
 	public function delete_cached_query() {
 		global $wp_object_cache;
 		if ( wp_using_ext_object_cache() ) {
-			// Delete the entire group.
-			unset( $wp_object_cache->cache['ep_autosuggest'] );
+			if ( function_exists( 'wp_cache_supports_group_flush' ) && wp_cache_supports_group_flush() ) {
+				wp_cache_flush_group( 'ep_autosuggest' );
+			} else {
+				// Try to delete the entire group.
+				// This may fail because the `$cache` property is not standardized.
+				unset( $wp_object_cache->cache['ep_autosuggest'] );
+			}
 		} else {
 			delete_transient( 'ep_autosuggest_query_request_cache' );
 		}


### PR DESCRIPTION

### Description of the Change

Unsetting the group key in `$cache` is a shot in the dark, let's use WordPress 6.1 new `wp_cache_flush_group()` when available

Follow-up to #2915.

### Changelog Entry
> Added - Use `wp_cache_flush_group()` when available


### Credits
Props @tillkruss


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
