### PR TITLE
Fix: JS error on Custom Results edit page

### DIFF
--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -383,14 +383,17 @@ class SearchOrdering extends Feature {
 			]
 		);
 
-		$final_posts = [];
+		$final_posts       = [];
+		$filtered_pointers = [];
 
 		foreach ( $query->posts as $post ) {
 			$final_posts[ $post->ID ] = $post;
+			// Add the post to filtered array. By doing this, we removed the posts that don't exist anymore.
+			$filtered_pointers[] = $pointers[ array_search( $post->ID, array_column( $pointers, 'ID' ) ) ];
 		}
 
 		return [
-			'pointers' => $pointers,
+			'pointers' => $filtered_pointers,
 			'posts'    => $final_posts,
 		];
 	}

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -389,7 +389,7 @@ class SearchOrdering extends Feature {
 		foreach ( $query->posts as $post ) {
 			$final_posts[ $post->ID ] = $post;
 			// Add the post to filtered array. By doing this, we removed the posts that don't exist anymore.
-			$filtered_pointers[] = $pointers[ array_search( $post->ID, $post_ids ) ];
+			$filtered_pointers[] = $pointers[ array_search( $post->ID, $post_ids, true ) ];
 		}
 
 		return [

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -389,7 +389,7 @@ class SearchOrdering extends Feature {
 		foreach ( $query->posts as $post ) {
 			$final_posts[ $post->ID ] = $post;
 			// Add the post to filtered array. By doing this, we removed the posts that don't exist anymore.
-			$filtered_pointers[] = $pointers[ array_search( $post->ID, array_column( $pointers, 'ID' ) ) ];
+			$filtered_pointers[] = $pointers[ array_search( $post->ID, $post_ids ) ];
 		}
 
 		return [


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR fixes the issue where the custom result edit page throws a JS error due to unavailability of post. 
It happens because the `get_pointer_data_for_localize` function is used to send the array of all posts even if it doesn't exist. I created a new array that would only return the data of existing WordPress posts based on the results of WP Query.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2881 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Create new Custom Results 
- Add some posts
- Change the position of all posts.
- Delete any post from the WordPress
- Refresh the page and it would not throw any error

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Fixed: JS error on Custom Results edit page

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
