### PR TITLE
Fix incorrect sync being triggered by URL parameter.

### DIFF
--- a/assets/js/sync/index.js
+++ b/assets/js/sync/index.js
@@ -483,7 +483,7 @@ const App = () => {
 		 */
 		if (autoIndex) {
 			startSync(true);
-			logMessage(__('Starting sync…', 'elasticpress'), 'info');
+			logMessage(__('Starting delete and sync…', 'elasticpress'), 'info');
 		}
 	};
 

--- a/assets/js/sync/index.js
+++ b/assets/js/sync/index.js
@@ -189,10 +189,15 @@ const App = () => {
 		(indexMeta) => {
 			const isInitialSync = stateRef.current.lastSyncDateTime === null;
 
+			/**
+			 * We should not appear to be deleting if this is the first sync.
+			 */
+			const isDeleting = isInitialSync ? false : indexMeta.put_mapping;
+
 			updateState({
 				isCli: indexMeta.method === 'cli',
 				isComplete: false,
-				isDeleting: isInitialSync ? false : indexMeta.put_mapping,
+				isDeleting,
 				isSyncing: true,
 				itemsProcessed: getItemsProcessedFromIndexMeta(indexMeta),
 				itemsTotal: getItemsTotalFromIndexMeta(indexMeta),
@@ -287,13 +292,13 @@ const App = () => {
 
 	const doIndex = useCallback(
 		/**
-		 * Start or continues a sync.
+		 * Start or continue a sync.
 		 *
-		 * @param {boolean} isDeleting Whether to delete and sync.
+		 * @param {boolean} putMapping Whether to send mapping.
 		 * @returns {void}
 		 */
-		(isDeleting) => {
-			index(isDeleting)
+		(putMapping) => {
+			index(putMapping)
 				.then(updateSyncState)
 				.then(
 					/**
@@ -306,7 +311,7 @@ const App = () => {
 						if (method === 'cli') {
 							doIndexStatus();
 						} else {
-							doIndex(isDeleting);
+							doIndex(putMapping);
 						}
 					},
 				)
@@ -350,8 +355,14 @@ const App = () => {
 			const { isDeleting, lastSyncDateTime } = stateRef.current;
 			const isInitialSync = lastSyncDateTime === null;
 
+			/**
+			 * Send mapping if we are deleting and syncing or if this is the
+			 * first sync.
+			 */
+			const putMapping = isInitialSync || isDeleting;
+
 			updateState({ isComplete: false, isPaused: false, isSyncing: true });
-			doIndex(isInitialSync ? true : isDeleting);
+			doIndex(putMapping);
 		},
 		[doIndex],
 	);
@@ -360,16 +371,27 @@ const App = () => {
 		/**
 		 * Start syncing.
 		 *
-		 * @param {boolean} isDeleting Whether to delete and sync.
+		 * @param {boolean} deleteAndSync Whether to delete and sync.
 		 * @returns {void}
 		 */
-		(isDeleting) => {
+		(deleteAndSync) => {
 			const { lastSyncDateTime } = stateRef.current;
 			const isInitialSync = lastSyncDateTime === null;
 
+			/**
+			 * We should not appear to be deleting if this is the first sync.
+			 */
+			const isDeleting = isInitialSync ? false : deleteAndSync;
+
+			/**
+			 * Send mapping if we are deleting and syncing or if this is the
+			 * first sync.
+			 */
+			const putMapping = isInitialSync || deleteAndSync;
+
 			updateState({ isComplete: false, isDeleting, isPaused: false, isSyncing: true });
 			updateState({ itemsProcessed: 0, syncStartDateTime: Date.now() });
-			doIndex(isInitialSync ? true : isDeleting);
+			doIndex(putMapping);
 		},
 		[doIndex],
 	);
@@ -460,7 +482,7 @@ const App = () => {
 		 * Start an initial index.
 		 */
 		if (autoIndex) {
-			startSync(false);
+			startSync(true);
 			logMessage(__('Starting sync…', 'elasticpress'), 'info');
 		}
 	};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5410,13 +5410,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
+      "version": "1.0.30001375",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
+      "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==",
       "dev": true,
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -22313,7 +22320,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
+      "version": "1.0.30001375",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
+      "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==",
       "dev": true
     },
     "caseless": {

--- a/tests/cypress/integration/dashboard-sync.spec.js
+++ b/tests/cypress/integration/dashboard-sync.spec.js
@@ -62,12 +62,10 @@ describe('Dashboard Sync', () => {
 		 * The sync log should indicate that the sync completed and that
 		 * mapping was sent.
 		 */
-		const timeout = Cypress.config('elasticPressIndexTimeout');
-
 		cy.get('.ep-sync-panel').last().as('syncPanel');
 		cy.get('@syncPanel').find('.components-form-toggle').click();
 		cy.get('@syncPanel')
-			.find('.ep-sync-messages', { timeout })
+			.find('.ep-sync-messages', { timeout: Cypress.config('elasticPressIndexTimeout') })
 			.should('contain.text', 'Mapping sent')
 			.should('contain.text', 'Sync complete');
 

--- a/tests/cypress/integration/dashboard-sync.spec.js
+++ b/tests/cypress/integration/dashboard-sync.spec.js
@@ -57,15 +57,19 @@ describe('Dashboard Sync', () => {
 		 * Perform an initial sync.
 		 */
 		cy.get('@syncPanel').find('.ep-sync-button').click();
-		cy.get('.ep-sync-progress__details', {
-			timeout: Cypress.config('elasticPressIndexTimeout'),
-		}).should('contain.text', 'Sync complete');
 
 		/**
-		 * The sync log should indicate that mapping was sent.
+		 * The sync log should indicate that the sync completed and that
+		 * mapping was sent.
 		 */
+		const timeout = Cypress.config('elasticPressIndexTimeout');
+
+		cy.get('.ep-sync-panel').last().as('syncPanel');
 		cy.get('@syncPanel').find('.components-form-toggle').click();
-		cy.get('@syncPanel').find('.ep-sync-messages').should('contain.text', 'Mapping sent');
+		cy.get('@syncPanel')
+			.find('.ep-sync-messages', { timeout })
+			.should('contain.text', 'Mapping sent')
+			.should('contain.text', 'Sync complete');
 
 		/**
 		 * After the initial sync is complete there should be 2 sync panels

--- a/tests/cypress/integration/dashboard-sync.spec.js
+++ b/tests/cypress/integration/dashboard-sync.spec.js
@@ -62,7 +62,6 @@ describe('Dashboard Sync', () => {
 		 * The sync log should indicate that the sync completed and that
 		 * mapping was sent.
 		 */
-		cy.get('.ep-sync-panel').last().as('syncPanel');
 		cy.get('@syncPanel').find('.components-form-toggle').click();
 		cy.get('@syncPanel')
 			.find('.ep-sync-messages', { timeout: Cypress.config('elasticPressIndexTimeout') })

--- a/tests/cypress/integration/features/protected-content.spec.js
+++ b/tests/cypress/integration/features/protected-content.spec.js
@@ -10,9 +10,14 @@ describe('Protected Content Feature', () => {
 			return true;
 		});
 
-		cy.get('.ep-sync-progress strong', {
-			timeout: Cypress.config('elasticPressIndexTimeout'),
-		}).should('contain.text', 'Sync complete');
+		const timeout = Cypress.config('elasticPressIndexTimeout');
+
+		cy.get('.ep-sync-panel').last().as('syncPanel');
+		cy.get('@syncPanel').find('.components-form-toggle').click();
+		cy.get('@syncPanel')
+			.find('.ep-sync-messages', { timeout })
+			.should('contain.text', 'Mapping sent')
+			.should('contain.text', 'Sync complete');
 
 		cy.wpCli('elasticpress list-features').its('stdout').should('contain', 'protected_content');
 	});

--- a/tests/cypress/integration/features/protected-content.spec.js
+++ b/tests/cypress/integration/features/protected-content.spec.js
@@ -10,12 +10,10 @@ describe('Protected Content Feature', () => {
 			return true;
 		});
 
-		const timeout = Cypress.config('elasticPressIndexTimeout');
-
 		cy.get('.ep-sync-panel').last().as('syncPanel');
 		cy.get('@syncPanel').find('.components-form-toggle').click();
 		cy.get('@syncPanel')
-			.find('.ep-sync-messages', { timeout })
+			.find('.ep-sync-messages', { timeout: Cypress.config('elasticPressIndexTimeout') })
 			.should('contain.text', 'Mapping sent')
 			.should('contain.text', 'Sync complete');
 

--- a/tests/cypress/integration/features/woocommerce.spec.js
+++ b/tests/cypress/integration/features/woocommerce.spec.js
@@ -29,9 +29,14 @@ describe('WooCommerce Feature', () => {
 			return true;
 		});
 
-		cy.get('.ep-sync-progress strong', {
-			timeout: Cypress.config('elasticPressIndexTimeout'),
-		}).should('contain.text', 'Sync complete');
+		const timeout = Cypress.config('elasticPressIndexTimeout');
+
+		cy.get('.ep-sync-panel').last().as('syncPanel');
+		cy.get('@syncPanel').find('.components-form-toggle').click();
+		cy.get('@syncPanel')
+			.find('.ep-sync-messages', { timeout })
+			.should('contain.text', 'Mapping sent')
+			.should('contain.text', 'Sync complete');
 
 		cy.wpCli('elasticpress list-features').its('stdout').should('contain', 'woocommerce');
 	});

--- a/tests/cypress/integration/features/woocommerce.spec.js
+++ b/tests/cypress/integration/features/woocommerce.spec.js
@@ -29,12 +29,10 @@ describe('WooCommerce Feature', () => {
 			return true;
 		});
 
-		const timeout = Cypress.config('elasticPressIndexTimeout');
-
 		cy.get('.ep-sync-panel').last().as('syncPanel');
 		cy.get('@syncPanel').find('.components-form-toggle').click();
 		cy.get('@syncPanel')
-			.find('.ep-sync-messages', { timeout })
+			.find('.ep-sync-messages', { timeout: Cypress.config('elasticPressIndexTimeout') })
 			.should('contain.text', 'Mapping sent')
 			.should('contain.text', 'Sync complete');
 


### PR DESCRIPTION
### Description of the Change
Fixes an issue introduced by #2858 where the do_index parameter was triggering the incorrect sync. 

I've also updated URL parameters and inline documentation to make it clearer what's going on and de-couple the meaning of the  'isDeleting' state from the 'putMapping' action which in some cases were using the same variable and parameter names despite being separate concepts.

Lastly I updated the existing tests that were checking that a sync was performed on feature activation to also check that mapping is being sent for those syncs, as that would've caught this issue.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2938

### How to test the Change
When activating a feature that requires a sync the sync should occur int the _Delete All Data and Sync_ panel and the log should show "Mapping sent".

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
