### PR TITLE
Give sticky posts an earlier date

### DIFF
--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4459,10 +4459,23 @@ class TestPost extends BaseTestCase {
 	 * @group post-sticky
 	 */
 	public function testStickyPostsIncludedOnHome() {
-		Functions\create_and_sync_post( array( 'post_title' => 'Normal post 1' ) );
-		$sticky_id = Functions\create_and_sync_post( array( 'post_title' => 'Sticky post' ) );
+		Functions\create_and_sync_post(
+			[
+				'post_title' => 'Normal post 1',
+			]
+		);
+		$sticky_id = Functions\create_and_sync_post(
+			[
+				'post_title' => 'Sticky post',
+				'post_date'  => gmdate( 'Y-m-d H:i:s', strtotime( '2 days ago' ) ),
+			]
+		);
 		stick_post( $sticky_id );
-		Functions\create_and_sync_post( array( 'post_title' => 'Normal post 2' ) );
+		Functions\create_and_sync_post(
+			[
+				'post_title' => 'Normal post 2',
+			]
+		);
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
@@ -4480,10 +4493,23 @@ class TestPost extends BaseTestCase {
 	 * @group post-sticky
 	 */
 	public function testStickyPostsExcludedOnNotHome() {
-		Functions\create_and_sync_post( array( 'post_title' => 'Normal post 1' ) );
-		$sticky_id = Functions\create_and_sync_post( array( 'post_title' => 'Sticky post' ) );
+		Functions\create_and_sync_post(
+			[
+				'post_title' => 'Normal post 1',
+			]
+		);
+		$sticky_id = Functions\create_and_sync_post(
+			[
+				'post_title' => 'Sticky post',
+				'post_date'  => gmdate( 'Y-m-d H:i:s', strtotime( '2 days ago' ) ),
+			]
+		);
 		stick_post( $sticky_id );
-		Functions\create_and_sync_post( array( 'post_title' => 'Normal post 2' ) );
+		Functions\create_and_sync_post(
+			[
+				'post_title' => 'Normal post 2',
+			]
+		);
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Occasionally we get an error in our PHP Unit tests suite related to sticky posts being displayed at the top when they shouldn't. It turns out it is displayed at the top as it is considered the latest post (not because it is sticky.) This PR addresses that problem, giving sticky posts an earlier date.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Intermittent error with sticky posts in the tests suite.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 