### PR TITLE
Display custom message when a last sync is not detected

### DIFF
--- a/includes/classes/Screen/HealthInfo.php
+++ b/includes/classes/Screen/HealthInfo.php
@@ -38,6 +38,15 @@ class HealthInfo {
 
 		$sync_info = IndexHelper::factory()->get_last_index();
 
+		if ( empty( $sync_info ) ) {
+			$debug_info['ep_last_sync']['fields']['not_available'] = [
+				'label'   => esc_html__( 'Last Sync', 'elasticpress' ),
+				'value'   => esc_html__( 'Last sync info not available.', 'elasticpress' ),
+				'private' => true,
+			];
+			return $debug_info;
+		}
+
 		if ( ! empty( $sync_info['end_time_gmt'] ) ) {
 			unset( $sync_info['end_time_gmt'] );
 		}
@@ -67,15 +76,6 @@ class HealthInfo {
 			];
 
 			$sync_info['method'] = $methods[ $sync_info['method'] ] ?? $sync_info['method'];
-		}
-
-		if ( empty( $sync_info ) ) {
-			$debug_info['ep_last_sync']['fields']['not_available'] = [
-				'label'   => esc_html__( 'Last Sync', 'elasticpress' ),
-				'value'   => esc_html__( 'Last sync info not available.', 'elasticpress' ),
-				'private' => true,
-			];
-			return $debug_info;
 		}
 
 		$labels = [


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
If the last sync is not detected, the current last sync info in Health Tools displays just numeric values. This PR addresses that, displaying a different message.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
