### PR TITLE
Fix: Intermittent tests failures

### DIFF
--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -380,6 +380,7 @@ class SearchOrdering extends Feature {
 				'post_type' => 'any',
 				'post__in'  => $post_ids,
 				'count'     => count( $post_ids ),
+				'orderby'   => 'post__in',
 			]
 		);
 

--- a/tests/cypress/integration/features/search/search.spec.js
+++ b/tests/cypress/integration/features/search/search.spec.js
@@ -136,7 +136,7 @@ describe('Post Search Feature', () => {
 		}).then(() => {
 			cy.wpCli('elasticpress index --setup --yes').then(() => {
 				// eslint-disable-next-line cypress/no-unnecessary-waiting
-				cy.wait(1000);
+				cy.wait(2000);
 				cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
 				cy.contains(
 					'.site-content article:nth-of-type(1) h2',

--- a/tests/cypress/integration/features/search/search.spec.js
+++ b/tests/cypress/integration/features/search/search.spec.js
@@ -135,6 +135,10 @@ describe('Post Search Feature', () => {
 			},
 		}).then(() => {
 			cy.wpCli('elasticpress index --setup --yes').then(() => {
+				/**
+				 * Give Elasticsearch some time. Apparently, if the visit happens right after the index, it won't find anything.
+				 *
+				 */
 				// eslint-disable-next-line cypress/no-unnecessary-waiting
 				cy.wait(2000);
 				cy.visit('/?s=awesome-aluminum-shoes-variation-sku');

--- a/tests/cypress/integration/features/search/search.spec.js
+++ b/tests/cypress/integration/features/search/search.spec.js
@@ -135,6 +135,8 @@ describe('Post Search Feature', () => {
 			},
 		}).then(() => {
 			cy.wpCli('elasticpress index --setup --yes').then(() => {
+				// eslint-disable-next-line cypress/no-unnecessary-waiting
+				cy.wait(1000);
 				cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
 				cy.contains(
 					'.site-content article:nth-of-type(1) h2',

--- a/tests/cypress/integration/features/terms.spec.js
+++ b/tests/cypress/integration/features/terms.spec.js
@@ -86,6 +86,9 @@ describe('Terms Feature', () => {
 			.find('.row-actions .delete a')
 			.click({ force: true });
 
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(2000);
+
 		// Re-search for the term and make sure it's not there.
 		cy.get('#search-submit').click();
 		cy.get('.wp-list-table tbody').should('contain.text', 'No categories found');

--- a/tests/cypress/integration/features/terms.spec.js
+++ b/tests/cypress/integration/features/terms.spec.js
@@ -90,7 +90,6 @@ describe('Terms Feature', () => {
 		 * Give Elasticsearch some time. Apparently, if we search again it returns the outdated data.
 		 *
 		 * @see https://github.com/10up/ElasticPress/issues/2726
-		 *
 		 */
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(2000);

--- a/tests/cypress/integration/features/terms.spec.js
+++ b/tests/cypress/integration/features/terms.spec.js
@@ -86,6 +86,12 @@ describe('Terms Feature', () => {
 			.find('.row-actions .delete a')
 			.click({ force: true });
 
+		/**
+		 * Give Elasticsearch some time. Apparently, if we search again it returns the outdated data.
+		 *
+		 * @see https://github.com/10up/ElasticPress/issues/2726
+		 *
+		 */
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
 		cy.wait(2000);
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR fixes the following tests.

1) `testGetPointerData` => The WP-Query in `get_pointer_data_for_localize` doesn't preserver the posts id. Passing the `post__in` to orderby fix the issue. [Related Issue](https://wordpress.stackexchange.com/questions/108585/wp-query-orderby-post-in-remains-ineffective-in-the-loop)

2) The [wait](https://github.com/10up/ElasticPress/pull/2984/files#diff-9b32b6c1f3b12ef31dff7f49b2b490b0c2ede0424dbe2b303f8b2c6f6587af7aR90) is necessary. The problem is that test runs too quickly, and occasionally the category is not removed from the ES and because of this ES returns the deleted category. Related Issue https://github.com/10up/ElasticPress/issues/1415

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2971

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed -  Intermittent tests failures


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
