### PR TITLE
Add Support for site__in and site__not_in parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,61 @@ on:
       - '[0-9].[0-9x]*' # Version branches: 4.x.x, 4.1.x, 5.x
 
 jobs:
-  phpunit:
-    name: PHP Unit
+  phpunit_single_site:
+    name: PHP Unit Tests (Single Site)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Start MySQL
+      run: sudo systemctl start mysql.service
+
+    - name: Configure sysctl limits
+      run: |
+        sudo swapoff -a
+        sudo sysctl -w vm.swappiness=1
+        sudo sysctl -w fs.file-max=262144
+        sudo sysctl -w vm.max_map_count=262144
+
+    - name: Setup Elasticsearch
+      uses: getong/elasticsearch-action@v1.2
+      with:
+        elasticsearch version: '7.5.0'
+
+    - name: Set standard 10up cache directories
+      run: |
+        composer config -g cache-dir "${{ env.COMPOSER_CACHE }}"
+
+    - name: Prepare composer cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.COMPOSER_CACHE }}
+        key: composer-${{ env.COMPOSER_VERSION }}-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          composer-${{ env.COMPOSER_VERSION }}-
+
+    - name: Set PHP version
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        coverage: none
+
+    - name: Install dependencies
+      run: composer install
+
+    - name: Setup WP Tests
+      run: |
+        bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1
+        sleep 10
+
+    - name: PHPUnit
+      run: |
+        composer run-script test-single-site
+
+  phpunit_multisite:
+    name: PHP Unit Tests (Multisite)
     runs-on: ubuntu-latest
 
     steps:
@@ -69,4 +122,3 @@ jobs:
     - name: PHPUnit
       run: |
         composer run-script test
-        composer run-script test-single-site

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   phpunit_single_site:
-    name: PHP Unit Tests (Single Site)
+    name: PHP Unit (Single Site)
     runs-on: ubuntu-latest
 
     steps:
@@ -71,7 +71,7 @@ jobs:
         composer run-script test-single-site
 
   phpunit_multisite:
-    name: PHP Unit Tests (Multisite)
+    name: PHP Unit (Multisite)
     runs-on: ubuntu-latest
 
     steps:

--- a/includes/classes/Indexable/Comment/QueryIntegration.php
+++ b/includes/classes/Indexable/Comment/QueryIntegration.php
@@ -133,7 +133,7 @@ class QueryIntegration {
 		}
 
 		if ( ! empty( $query->query_vars['site__not_in'] ) ) {
-			$site__not_in = ! is_array( $query->query_vars['site__not_in'] ) ? array( $query->query_vars['site__not_in'] ) : $query->query_vars['site__not_in'];
+			$site__not_in = (array) $query->query_vars['site__not_in'];
 		}
 
 		/**

--- a/includes/classes/Indexable/Comment/QueryIntegration.php
+++ b/includes/classes/Indexable/Comment/QueryIntegration.php
@@ -123,12 +123,12 @@ class QueryIntegration {
 		if ( ! empty( $query->query_vars['sites'] ) ) {
 
 			_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
-			$site__in = ! is_array( $query->query_vars['sites'] ) ? array( $query->query_vars['sites'] ) : $query->query_vars['sites'];
+			$site__in = (array) $query->query_vars['sites'];
 			$scope    = 'all' === $query->query_vars['sites'] ? 'all' : $site__in;
 		}
 
 		if ( ! empty( $query->query_vars['site__in'] ) ) {
-			$site__in = ! is_array( $query->query_vars['site__in'] ) ? array( $query->query_vars['site__in'] ) : $query->query_vars['site__in'];
+			$site__in = (array) $query->query_vars['site__in'];
 			$scope    = 'all' === $query->query_vars['site__in'] ? 'all' : $site__in;
 		}
 

--- a/includes/classes/Indexable/Comment/QueryIntegration.php
+++ b/includes/classes/Indexable/Comment/QueryIntegration.php
@@ -174,7 +174,7 @@ class QueryIntegration {
 				if ( ! Utils\is_site_indexable( $site_id ) ) {
 					continue;
 				}
-				$index[] = Indexables::factory()->get( 'post' )->get_index_name( $site_id );
+				$index[] = Indexables::factory()->get( 'comment' )->get_index_name( $site_id );
 			}
 
 			$this->index = implode( ',', $index );

--- a/includes/classes/Indexable/Comment/QueryIntegration.php
+++ b/includes/classes/Indexable/Comment/QueryIntegration.php
@@ -116,8 +116,24 @@ class QueryIntegration {
 		$formatted_args = $this->indexable->format_args( $query->query_vars );
 
 		$scope = 'current';
+
+		$site__in     = [];
+		$site__not_in = [];
+
 		if ( ! empty( $query->query_vars['sites'] ) ) {
-			$scope = $query->query_vars['sites'];
+
+			_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
+			$site__in = ! is_array( $query->query_vars['sites'] ) ? array( $query->query_vars['sites'] ) : $query->query_vars['sites'];
+			$scope    = 'all' === $query->query_vars['sites'] ? 'all' : $site__in;
+		}
+
+		if ( ! empty( $query->query_vars['site__in'] ) ) {
+			$site__in = ! is_array( $query->query_vars['site__in'] ) ? array( $query->query_vars['site__in'] ) : $query->query_vars['site__in'];
+			$scope    = 'all' === $query->query_vars['site__in'] ? 'all' : $site__in;
+		}
+
+		if ( ! empty( $query->query_vars['site__not_in'] ) ) {
+			$site__not_in = ! is_array( $query->query_vars['site__not_in'] ) ? array( $query->query_vars['site__not_in'] ) : $query->query_vars['site__not_in'];
 		}
 
 		/**
@@ -138,16 +154,31 @@ class QueryIntegration {
 
 		if ( 'all' === $scope ) {
 			$this->index = $this->indexable->get_network_alias();
-		} elseif ( is_numeric( $scope ) ) {
-			$this->index = $this->indexable->get_index_name( (int) $scope );
-		} elseif ( is_array( $scope ) ) {
+		} elseif ( ! empty( $site__in ) ) {
 			$this->index = [];
 
-			foreach ( $scope as $site_id ) {
+			foreach ( $site__in as $site_id ) {
 				$this->index[] = $this->indexable->get_index_name( $site_id );
 			}
 
 			$this->index = implode( ',', $this->index );
+		} elseif ( ! empty( $site__not_in ) ) {
+
+			$sites = get_sites(
+				array(
+					'fields'       => 'ids',
+					'site__not_in' => $site__not_in,
+				)
+			);
+			foreach ( $sites as $site_id ) {
+				if ( ! Utils\is_site_indexable( $site_id ) ) {
+					continue;
+				}
+				$index[] = Indexables::factory()->get( 'post' )->get_index_name( $site_id );
+			}
+
+			$this->index = implode( ',', $index );
+
 		}
 
 		$ep_query = $this->indexable->query_es( $formatted_args, $query->query_vars, $this->index, $query );

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -275,8 +275,25 @@ class QueryIntegration {
 		if ( count( $new_posts ) < 1 ) {
 
 			$scope = 'current';
+
+			$site__in     = '';
+			$site__not_in = '';
+
 			if ( ! empty( $query_vars['sites'] ) ) {
-				$scope = $query_vars['sites'];
+
+				_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
+				$site__in = ! is_array( $query_vars['sites'] ) ? array( $query_vars['sites'] ) : $query_vars['sites'];
+				$scope    = 'all' === $query_vars['sites'] ? 'all' : $site__in;
+			}
+
+			if ( ! empty( $query_vars['site__in'] ) ) {
+
+				$site__in = ! is_array( $query_vars['site__in'] ) ? array( $query_vars['site__in'] ) : $query_vars['site__in'];
+				$scope    = 'all' === $query_vars['site__in'] ? 'all' : $site__in;
+			}
+
+			if ( ! empty( $query_vars['site__not_in'] ) ) {
+				$site__not_in = ! is_array( $query_vars['site__not_in'] ) ? array( $query_vars['site__not_in'] ) : $query_vars['site__not_in'];
 			}
 
 			$formatted_args = Indexables::factory()->get( 'post' )->format_args( $query_vars, $query );
@@ -301,12 +318,26 @@ class QueryIntegration {
 
 			if ( 'all' === $scope ) {
 				$index = Indexables::factory()->get( 'post' )->get_network_alias();
-			} elseif ( is_numeric( $scope ) ) {
-				$index = Indexables::factory()->get( 'post' )->get_index_name( (int) $scope );
-			} elseif ( is_array( $scope ) ) {
+			} elseif ( ! empty( $site__in ) ) {
 				$index = [];
 
-				foreach ( $scope as $site_id ) {
+				foreach ( $site__in as $site_id ) {
+					$index[] = Indexables::factory()->get( 'post' )->get_index_name( $site_id );
+				}
+
+				$index = implode( ',', $index );
+			} elseif ( ! empty( $site__not_in ) ) {
+
+				$sites = get_sites(
+					array(
+						'fields'       => 'ids',
+						'site__not_in' => $site__not_in,
+					)
+				);
+				foreach ( $sites as $site_id ) {
+					if ( ! Utils\is_site_indexable( $site_id ) ) {
+						continue;
+					}
 					$index[] = Indexables::factory()->get( 'post' )->get_index_name( $site_id );
 				}
 

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -293,7 +293,7 @@ class QueryIntegration {
 			}
 
 			if ( ! empty( $query_vars['site__not_in'] ) ) {
-				$site__not_in = ! is_array( $query_vars['site__not_in'] ) ? array( $query_vars['site__not_in'] ) : $query_vars['site__not_in'];
+				$site__not_in = (array) $query_vars['site__not_in'];
 			}
 
 			$formatted_args = Indexables::factory()->get( 'post' )->format_args( $query_vars, $query );

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -282,13 +282,13 @@ class QueryIntegration {
 			if ( ! empty( $query_vars['sites'] ) ) {
 
 				_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
-				$site__in = ! is_array( $query_vars['sites'] ) ? array( $query_vars['sites'] ) : $query_vars['sites'];
+				$site__in = (array) $query_vars['sites'];
 				$scope    = 'all' === $query_vars['sites'] ? 'all' : $site__in;
 			}
 
 			if ( ! empty( $query_vars['site__in'] ) ) {
 
-				$site__in = ! is_array( $query_vars['site__in'] ) ? array( $query_vars['site__in'] ) : $query_vars['site__in'];
+				$site__in = (array) $query_vars['site__in'];
 				$scope    = 'all' === $query_vars['site__in'] ? 'all' : $site__in;
 			}
 

--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -85,8 +85,24 @@ class QueryIntegration {
 			$formatted_args = $indexable->format_args( $query->query_vars );
 
 			$scope = 'current';
+
+			$site__in     = [];
+			$site__not_in = [];
+
 			if ( ! empty( $query->query_vars['sites'] ) ) {
-				$scope = $query->query_vars['sites'];
+
+				_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
+				$site__in = ! is_array( $query->query_vars['sites'] ) ? array( $query->query_vars['sites'] ) : $query->query_vars['sites'];
+				$scope    = 'all' === $query->query_vars['sites'] ? 'all' : $site__in;
+			}
+
+			if ( ! empty( $query->query_vars['site__in'] ) ) {
+				$site__in = ! is_array( $query->query_vars['site__in'] ) ? array( $query->query_vars['site__in'] ) : $query->query_vars['site__in'];
+				$scope    = 'all' === $query->query_vars['site__in'] ? 'all' : $site__in;
+			}
+
+			if ( ! empty( $query->query_vars['site__not_in'] ) ) {
+				$site__not_in = ! is_array( $query->query_vars['site__not_in'] ) ? array( $query->query_vars['site__not_in'] ) : $query->query_vars['site__not_in'];
 			}
 
 			/**
@@ -107,15 +123,28 @@ class QueryIntegration {
 
 			if ( 'all' === $scope ) {
 				$index = $indexable->get_network_alias();
-			} elseif ( is_numeric( $scope ) ) {
-				$index = $indexable->get_index_name( (int) $scope );
-			} elseif ( is_array( $scope ) ) {
+			} elseif ( ! empty( $site__in ) ) {
 				$index = [];
 
-				foreach ( $scope as $site_id ) {
+				foreach ( $site__in as $site_id ) {
 					$index[] = $indexable->get_index_name( $site_id );
 				}
 
+				$index = implode( ',', $index );
+			} elseif ( ! empty( $site__not_in ) ) {
+
+				$sites = get_sites(
+					array(
+						'fields'       => 'ids',
+						'site__not_in' => $site__not_in,
+					)
+				);
+				foreach ( $sites as $site_id ) {
+					if ( ! Utils\is_site_indexable( $site_id ) ) {
+						continue;
+					}
+					$index[] = Indexables::factory()->get( 'term' )->get_index_name( $site_id );
+				}
 				$index = implode( ',', $index );
 			}
 

--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -92,12 +92,12 @@ class QueryIntegration {
 			if ( ! empty( $query->query_vars['sites'] ) ) {
 
 				_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
-				$site__in = ! is_array( $query->query_vars['sites'] ) ? array( $query->query_vars['sites'] ) : $query->query_vars['sites'];
+				$site__in = (array) $query->query_vars['sites'];
 				$scope    = 'all' === $query->query_vars['sites'] ? 'all' : $site__in;
 			}
 
 			if ( ! empty( $query->query_vars['site__in'] ) ) {
-				$site__in = ! is_array( $query->query_vars['site__in'] ) ? array( $query->query_vars['site__in'] ) : $query->query_vars['site__in'];
+				$site__in = (array) $query->query_vars['site__in'];
 				$scope    = 'all' === $query->query_vars['site__in'] ? 'all' : $site__in;
 			}
 

--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -102,7 +102,7 @@ class QueryIntegration {
 			}
 
 			if ( ! empty( $query->query_vars['site__not_in'] ) ) {
-				$site__not_in = ! is_array( $query->query_vars['site__not_in'] ) ? array( $query->query_vars['site__not_in'] ) : $query->query_vars['site__not_in'];
+				$site__not_in = (array) $query->query_vars['site__not_in'];
 			}
 
 			/**

--- a/single-site.xml.dist
+++ b/single-site.xml.dist
@@ -12,6 +12,9 @@
 	<testsuites>
 		<testsuite name="elasticpress">
 			<directory prefix="Test" suffix=".php">./tests/php/</directory>
+      <exclude>./tests/php/indexables/TestCommentMultisite.php</exclude>
+      <exclude>./tests/php/indexables/TestPostMultisite.php</exclude>
+      <exclude>./tests/php/indexables/TestTermMultisite.php</exclude>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -120,5 +120,7 @@ tests_add_filter( 'translations_api', __NAMESPACE__ . '\skip_translations_api' )
 
 require_once $_tests_dir . '/includes/bootstrap.php';
 
+require_once __DIR__ . '/includes/classes/factory/CategoryFactory.php';
+require_once __DIR__ . '/includes/classes/factory/CommentFactory.php';
 require_once __DIR__ . '/includes/classes/BaseTestCase.php';
 require_once __DIR__ . '/includes/classes/FeatureTest.php';

--- a/tests/php/includes/classes/BaseTestCase.php
+++ b/tests/php/includes/classes/BaseTestCase.php
@@ -31,6 +31,28 @@ class BaseTestCase extends WP_UnitTestCase {
 	protected $applied_filters = array();
 
 	/**
+	 * Holds the factory object
+	 *
+	 * @var obj
+	 * @since 4.4.0
+	 */
+	protected $ep_factory;
+
+	/**
+	 * Set up the test case.
+	 *
+	 * @var obj
+	 * @since 4.4.0
+	 */
+	public function setup() {
+
+		$this->ep_factory           = new \stdClass();
+		$this->ep_factory->category = new CategoryFactory();
+		$this->ep_factory->comment  = new CommentFactory();
+		parent::setup();
+	}
+
+	/**
 	 * Helper function to test whether a post sync has happened
 	 *
 	 * @since 1.0

--- a/tests/php/includes/classes/factory/CategoryFactory.php
+++ b/tests/php/includes/classes/factory/CategoryFactory.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Class for category factory.
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+/**
+ * Unit test factory for the category.
+ *
+ * @since 4.4.0
+ */
+class CategoryFactory extends \WP_UnitTest_Factory_For_Term {
+
+	/**
+	 * Inserts a comment and "sync" it to Elasticsearch
+	 *
+	 * @param array $args The category details.
+	 *
+	 * @return int|false The category's ID on success, false on failure.
+	 */
+	public function create_object( $args ) {
+
+		$args['taxonomy'] = 'category';
+		$id               = parent::create_object( $args );
+
+		ElasticPress\Indexables::factory()->get( 'term' )->index( $id, true );
+
+		return $id;
+	}
+
+}

--- a/tests/php/includes/classes/factory/CommentFactory.php
+++ b/tests/php/includes/classes/factory/CommentFactory.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Class for comment factory.
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+/**
+ * Unit test factory for the comment.
+ *
+ * @since 4.4.0
+ */
+class CommentFactory extends \WP_UnitTest_Factory_For_Comment {
+
+	/**
+	 * Inserts a comment.
+	 *
+	 * @param array $args The comment details.
+	 *
+	 * @return int|false The comment's ID on success, false on failure.
+	 */
+	public function create_object( $args ) {
+		$id = wp_insert_comment( $this->addslashes_deep( $args ) );
+
+		ElasticPress\Indexables::factory()->get( 'comment' )->index( $id );
+
+		return $id;
+	}
+
+}

--- a/tests/php/indexables/TestCommentMultisite.php
+++ b/tests/php/indexables/TestCommentMultisite.php
@@ -99,10 +99,12 @@ class TestCommentMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		$query = new \WP_Comment_Query( array(
-			'ep_integrate' => true,
-			'site__in' => 'all'
-		) );
+		$query = new \WP_Comment_Query(
+			array(
+				'ep_integrate' => true,
+				'site__in'     => 'all',
+			)
+		);
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 9, count( $query->get_comments() ) );
@@ -135,10 +137,12 @@ class TestCommentMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		$query = new \WP_Comment_Query( array(
-			'ep_integrate' => true,
-			'site__in' => [ $sites[0]['blog_id'], $sites[2]['blog_id'] ]
-		) );
+		$query = new \WP_Comment_Query(
+			array(
+				'ep_integrate' => true,
+				'site__in'     => array( $sites[0]['blog_id'], $sites[2]['blog_id'] ),
+			)
+		);
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 6, count( $query->get_comments() ) );
@@ -170,10 +174,12 @@ class TestCommentMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		$query = new \WP_Comment_Query( array(
-			'ep_integrate' => true,
-			'site__not_in' => [ $sites[2]['blog_id'] ]
-		) );
+		$query = new \WP_Comment_Query(
+			array(
+				'ep_integrate' => true,
+				'site__not_in' => array( $sites[2]['blog_id'] ),
+			)
+		);
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 6, count( $query->get_comments() ) );
@@ -199,16 +205,23 @@ class TestCommentMultisite extends BaseTestCase {
 
 			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
 			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
-			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id, 'comment_content' => 'Hello World' ) );
+			$this->ep_factory->comment->create(
+				array(
+					'comment_post_ID' => $post_id,
+					'comment_content' => 'Hello World',
+				)
+			);
 
 			ElasticPress\Elasticsearch::factory()->refresh_indices();
 			restore_current_blog();
 		}
 
-		$query = new \WP_Comment_Query( array(
-			'search' => 'Hello World',
-			'site__in' => 'all'
-		) );
+		$query = new \WP_Comment_Query(
+			array(
+				'search'   => 'Hello World',
+				'site__in' => 'all',
+			)
+		);
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 3, count( $query->get_comments() ) );
@@ -241,10 +254,12 @@ class TestCommentMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		$query = new \WP_Comment_Query( array(
-			'ep_integrate' => true,
-			'sites' => 'all'
-		) );
+		$query = new \WP_Comment_Query(
+			array(
+				'ep_integrate' => true,
+				'sites'        => 'all',
+			)
+		);
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 9, count( $query->get_comments() ) );

--- a/tests/php/indexables/TestCommentMultisite.php
+++ b/tests/php/indexables/TestCommentMultisite.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Test comment indexable functionality
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+class TestCommentMultisite extends BaseTestCase {
+
+	/**
+	 * Setup each test.
+	 *
+	 * @since 4.4.0
+	 */
+	public function setUp() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		global $wpdb;
+		parent::setUp();
+		$wpdb->suppress_errors();
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+
+		ElasticPress\Features::factory()->activate_feature( 'comments' );
+		ElasticPress\Features::factory()->setup_features();
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+
+		ElasticPress\Indexables::factory()->get( 'comment' )->put_mapping();
+
+		// Need to call this since it's hooked to init.
+		ElasticPress\Features::factory()->get_registered_feature( 'comments' )->search_setup();
+
+		$this->factory->blog->create_many( 2, array( 'user_id' => $admin_id ) );
+
+		$sites   = ElasticPress\Utils\get_sites();
+		$indexes = array();
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			ElasticPress\Indexables::factory()->get( 'comment' )->put_mapping();
+			$indexes[] = ElasticPress\Indexables::factory()->get( 'comment' )->get_index_name();
+
+			restore_current_blog();
+		}
+
+		ElasticPress\Indexables::factory()->get( 'comment' )->delete_network_alias();
+		ElasticPress\Indexables::factory()->get( 'comment' )->create_network_alias( $indexes );
+
+		wp_set_current_user( $admin_id );
+
+	}
+
+	/**
+	 * Clean up after each test. Reset our mocks
+	 *
+	 * @since 4.4.0
+	 */
+	public function tearDown() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		parent::tearDown();
+		ElasticPress\Indexables::factory()->get( 'comment' )->delete_network_alias();
+	}
+
+	/**
+	 * Test Comment Query return comments from all sites.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testCommentQueryForAllSites() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$post_id = Functions\create_and_sync_post();
+
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$query = new \WP_Comment_Query( array(
+			'ep_integrate' => true,
+			'site__in' => 'all'
+		) );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 9, count( $query->get_comments() ) );
+	}
+
+
+	/**
+	 * Test Comment Query returns comments from sites subset.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testCommentQueryForSitesSubset() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$post_id = Functions\create_and_sync_post();
+
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$query = new \WP_Comment_Query( array(
+			'ep_integrate' => true,
+			'site__in' => [ $sites[0]['blog_id'], $sites[2]['blog_id'] ]
+		) );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 6, count( $query->get_comments() ) );
+	}
+
+	/**
+	 * Test Comment Query return comments from all sites except one.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testCommentQueryForSitesExceptOne() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$post_id = Functions\create_and_sync_post();
+
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$query = new \WP_Comment_Query( array(
+			'ep_integrate' => true,
+			'site__not_in' => [ $sites[2]['blog_id'] ]
+		) );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 6, count( $query->get_comments() ) );
+	}
+
+	/**
+	 * Test Comment Query search returns result from all sites.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testCommentQuerySearchForAllSites() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$post_id = Functions\create_and_sync_post();
+
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id, 'comment_content' => 'Hello World' ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$query = new \WP_Comment_Query( array(
+			'search' => 'Hello World',
+			'site__in' => 'all'
+		) );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 3, count( $query->get_comments() ) );
+	}
+
+	/**
+	 * Test Comment Query with the deprecated `sites` param
+	 *
+	 * @since 4.4.0
+	 * @expectedDeprecated maybe_filter_query
+	 */
+	public function testCommentQueryWithDeprecatedSitesParam() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$post_id = Functions\create_and_sync_post();
+
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+			$this->ep_factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$query = new \WP_Comment_Query( array(
+			'ep_integrate' => true,
+			'sites' => 'all'
+		) );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 9, count( $query->get_comments() ) );
+	}
+
+}

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -103,7 +103,7 @@ class TestPostMultisite extends BaseTestCase {
 
 			ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-			$sql = "select ID from {$wpdb->posts}";
+			$sql      = "select ID from {$wpdb->posts}";
 			$post_ids = $wpdb->get_col( $sql ); // phpcs:ignore
 
 			foreach ( $post_ids as $post_id ) {
@@ -194,8 +194,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'findme',
-			'sites' => 'all',
+			's'        => 'findme',
+			'site__in' => 'all',
 		);
 
 		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
@@ -267,8 +267,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'findme',
-			'sites' => array( $sites[1]['blog_id'], $sites[2]['blog_id'] ),
+			's'        => 'findme',
+			'site__in' => array( $sites[1]['blog_id'], $sites[2]['blog_id'] ),
 		);
 
 		$query = new \WP_Query( $args );
@@ -281,7 +281,7 @@ class TestPostMultisite extends BaseTestCase {
 	}
 
 	/**
-	 * Test to ensure that if we pass an invalid blog_id to the 'sites' parameter that it doesn't break the search
+	 * Test to ensure that if we pass an invalid blog_id to the 'site__in' parameter that it doesn't break the search
 	 *
 	 * @since 0.9.2
 	 * @group testMultipleTests
@@ -308,8 +308,8 @@ class TestPostMultisite extends BaseTestCase {
 
 		// 200 is an invalid blog_id which we're going to pass to test
 		$args = array(
-			's'     => 'findme',
-			'sites' => array( $sites[1]['blog_id'], $sites[2]['blog_id'], 200 ),
+			's'        => 'findme',
+			'site__in' => array( $sites[1]['blog_id'], $sites[2]['blog_id'], 200 ),
 		);
 
 		$query = new \WP_Query( $args );
@@ -348,8 +348,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'findme',
-			'sites' => $sites[1]['blog_id'],
+			's'        => 'findme',
+			'site__in' => $sites[1]['blog_id'],
 		);
 
 		$query = new \WP_Query( $args );
@@ -390,8 +390,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'findme',
-			'sites' => 'all',
+			's'        => 'findme',
+			'site__in' => 'all',
 		);
 
 		$query = new \WP_Query( $args );
@@ -446,8 +446,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'findme',
-			'sites' => 'all',
+			's'        => 'findme',
+			'site__in' => 'all',
 		);
 
 		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
@@ -495,8 +495,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'findme',
-			'sites' => 'all',
+			's'        => 'findme',
+			'site__in' => 'all',
 		);
 
 		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
@@ -560,7 +560,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'         => 'findme',
-			'sites'     => 'all',
+			'site__in'  => 'all',
 			'tax_query' => array(
 				array(
 					'taxonomy' => 'post_tag',
@@ -618,7 +618,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'         => 'findme',
-			'sites'     => 'all',
+			'site__in'  => 'all',
 			'post_type' => 'page',
 		);
 
@@ -670,7 +670,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'         => 'findme',
-			'sites'     => 'all',
+			'site__in'  => 'all',
 			'post_type' => 'post',
 		);
 
@@ -721,8 +721,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'findme',
-			'sites' => 'all',
+			's'        => 'findme',
+			'site__in' => 'all',
 		);
 
 		$query = new \WP_Query( $args );
@@ -773,7 +773,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			'ep_integrate' => true,
-			'sites'        => 'all',
+			'site__in'     => 'all',
 		);
 
 		$query = new \WP_Query( $args );
@@ -830,9 +830,9 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'      => 'findme',
-			'sites'  => 'all',
-			'author' => $user_id,
+			's'        => 'findme',
+			'site__in' => 'all',
+			'author'   => $user_id,
 		);
 
 		$query = new \WP_Query( $args );
@@ -894,7 +894,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'           => 'findme',
-			'sites'       => 'all',
+			'site__in'    => 'all',
 			'author_name' => 'john',
 		);
 
@@ -943,7 +943,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'             => 'findme',
-			'sites'         => 'all',
+			'site__in'      => 'all',
 			'search_fields' => array(
 				'post_title',
 				'post_excerpt',
@@ -1023,7 +1023,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'          => 'findme',
-			'sites'      => 'all',
+			'site__in'   => 'all',
 			'meta_query' => array(
 				array(
 					'key'   => 'test_key',
@@ -1092,7 +1092,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'             => 'one findme two',
-			'sites'         => 'all',
+			'site__in'      => 'all',
 			'search_fields' => array(
 				'post_title',
 				'post_excerpt',
@@ -1161,7 +1161,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'             => 'john boy',
-			'sites'         => 'all',
+			'site__in'      => 'all',
 			'search_fields' => array(
 				'post_title',
 				'post_excerpt',
@@ -1247,7 +1247,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'             => 'findme',
-			'sites'         => 'all',
+			'site__in'      => 'all',
 			'post_type'     => 'ep_test',
 			'author'        => $user_id,
 			'search_fields' => array(
@@ -1294,7 +1294,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'              => 'findme',
-			'sites'          => 'all',
+			'site__in'       => 'all',
 			'posts_per_page' => 2,
 		);
 
@@ -1311,7 +1311,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'              => 'findme',
-			'sites'          => 'all',
+			'site__in'       => 'all',
 			'posts_per_page' => 2,
 			'paged'          => 2,
 		);
@@ -1368,8 +1368,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'notfirstblog',
-			'sites' => 'all',
+			's'        => 'notfirstblog',
+			'site__in' => 'all',
 		);
 
 		$query = new \WP_Query( $args );
@@ -1433,8 +1433,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'notfirstblog',
-			'sites' => 'all',
+			's'        => 'notfirstblog',
+			'site__in' => 'all',
 		);
 
 		$query = new \WP_Query( $args );
@@ -1502,8 +1502,8 @@ class TestPostMultisite extends BaseTestCase {
 		}
 
 		$args = array(
-			's'     => 'notfirstblog',
-			'sites' => (int) $sites[1]['blog_id'],
+			's'        => 'notfirstblog',
+			'site__in' => (int) $sites[1]['blog_id'],
 		);
 
 		$query = new \WP_Query( $args );
@@ -1643,7 +1643,7 @@ class TestPostMultisite extends BaseTestCase {
 
 		$args = array(
 			's'              => 'findme',
-			'sites'          => 'all',
+			'site__in'       => 'all',
 			'posts_per_page' => 10,
 		);
 
@@ -1770,4 +1770,242 @@ class TestPostMultisite extends BaseTestCase {
 
 		$this->assertNotEquals( $count_indexes, $post_count_indexes );
 	}
+
+	/**
+	 * Tests WP Query returns the result of only those sites which are defined in `site__in` when both `site__in` and `site__not_in` are defined
+	 *
+	 * @since 4.4.0
+	 * @group testMultipleTests
+	 */
+	public function testWPQueryWithSiteInAndNotSiteInParam() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+			Functions\create_and_sync_post();
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			restore_current_blog();
+		}
+
+		$args = array(
+			's'            => 'findme',
+			'site__in'     => $sites[1]['blog_id'],
+			'site__not_in' => $sites[1]['blog_id'],
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( $query->post_count, 2 );
+		$this->assertEquals( $query->found_posts, 2 );
+
+		$this->cleanUpSites( $sites );
+	}
+
+	/**
+	 * Test a simple post content search on a subset of network sites with depreciated `sites` parameter
+	 *
+	 * @since 4.4.0
+	 * @expectedDeprecated get_es_posts
+	 * @group testMultipleTests
+	 */
+	public function testWPQuerySearchContentSiteSubsetWithDeprecatedSitesParam() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+			Functions\create_and_sync_post();
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			restore_current_blog();
+		}
+
+		$args = array(
+			's'     => 'findme',
+			'sites' => array( $sites[1]['blog_id'], $sites[2]['blog_id'] ),
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( $query->post_count, 4 );
+		$this->assertEquals( $query->found_posts, 4 );
+
+		$this->cleanUpSites( $sites );
+	}
+
+	/**
+	 * Test a simple post content search with depreciated `sites` parameter
+	 *
+	 * @since 4.4.0
+	 * @expectedDeprecated get_es_posts
+	 * @group testMultipleTests
+	 */
+	public function testWPQuerySearchContentWithDeprecatedSitesParam() {
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+			Functions\create_and_sync_post();
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			restore_current_blog();
+		}
+
+		$args = array(
+			's'     => 'findme',
+			'sites' => 'all',
+		);
+
+		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+
+		$this->assertEquals( $query->post_count, 6 );
+		$this->assertEquals( $query->found_posts, 6 );
+
+		$other_site_post_count = 0;
+		$original_site_id      = get_current_blog_id();
+
+		while ( $query->have_posts() ) {
+			$query->the_post();
+
+			global $post;
+
+			$wp_post = get_post( get_the_ID() );
+
+			$this->assertEquals( $post->post_title, get_the_title() );
+			$this->assertEquals( $post->post_content, get_the_content() );
+			$this->assertEquals( $post->post_date, $wp_post->post_date );
+			$this->assertEquals( $post->post_modified, $wp_post->post_modified );
+			$this->assertEquals( $post->post_date_gmt, $wp_post->post_date_gmt );
+			$this->assertEquals( $post->post_modified_gmt, $wp_post->post_modified_gmt );
+			$this->assertEquals( $post->post_name, $wp_post->post_name );
+			$this->assertEquals( $post->post_parent, $wp_post->post_parent );
+			$this->assertEquals( $post->post_excerpt, $wp_post->post_excerpt );
+			$this->assertEquals( $post->site_id, get_current_blog_id() );
+
+			if ( get_current_blog_id() !== $original_site_id ) {
+				$other_site_post_count++;
+			}
+		}
+
+		$this->assertEquals( 4, $other_site_post_count );
+
+		wp_reset_postdata();
+
+		$this->cleanUpSites( $sites );
+	}
+
+	/**
+	 * Tests WP Query returns the data from all sites except one.
+	 *
+	 * @since 4.4.0
+	 * @group testMultipleTests
+	 */
+	public function testWPQueryForAllSiteExceptOne() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			Functions\create_and_sync_post();
+			Functions\create_and_sync_post();
+			Functions\create_and_sync_post();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			restore_current_blog();
+		}
+
+		$args = array(
+			'ep_integrate' => true,
+			'site__not_in' => array( $sites[1]['blog_id'] ),
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 6, $query->post_count );
+		$this->assertEquals( 6, $query->found_posts );
+	}
+
+	/**
+	 * Tests a simple post content search returns data from all the sites except one.
+	 *
+	 * @since 4.4.0
+	 * group testMultipleTests
+	 */
+	public function testWPQuerySearchContentForAllSiteExceptOne() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+			Functions\create_and_sync_post();
+			Functions\create_and_sync_post( array( 'post_content' => 'findme' ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			restore_current_blog();
+		}
+
+		$args = array(
+			's'            => 'findme',
+			'site__not_in' => array( $sites[1]['blog_id'] ),
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 4, $query->post_count );
+		$this->assertEquals( 4, $query->found_posts );
+	}
+
+
 }

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -1814,7 +1814,7 @@ class TestPostMultisite extends BaseTestCase {
 	}
 
 	/**
-	 * Test a simple post content search on a subset of network sites with depreciated `sites` parameter
+	 * Test a simple post content search on a subset of network sites with deprecated `sites` parameter
 	 *
 	 * @since 4.4.0
 	 * @expectedDeprecated get_es_posts
@@ -1856,7 +1856,7 @@ class TestPostMultisite extends BaseTestCase {
 	}
 
 	/**
-	 * Test a simple post content search with depreciated `sites` parameter
+	 * Test a simple post content search with deprecated `sites` parameter
 	 *
 	 * @since 4.4.0
 	 * @expectedDeprecated get_es_posts
@@ -1886,8 +1886,6 @@ class TestPostMultisite extends BaseTestCase {
 			's'     => 'findme',
 			'sites' => 'all',
 		);
-
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
 
 		$query = new \WP_Query( $args );
 

--- a/tests/php/indexables/TestTermMultisite.php
+++ b/tests/php/indexables/TestTermMultisite.php
@@ -1,0 +1,375 @@
+<?php
+/**
+ * Test term indexable functionality
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+class TestTermMultisite extends BaseTestCase {
+
+
+	/**
+	 * Setup each test.
+	 *
+	 * @since 4.4.0
+	 */
+	public function setUp() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		global $wpdb;
+		parent::setUp();
+		$wpdb->suppress_errors();
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+
+		ElasticPress\Features::factory()->activate_feature( 'terms' );
+		ElasticPress\Features::factory()->setup_features();
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+
+		ElasticPress\Indexables::factory()->get( 'term' )->put_mapping();
+
+		// Need to call this since it's hooked to init.
+		ElasticPress\Features::factory()->get_registered_feature( 'terms' )->search_setup();
+
+		$this->factory->blog->create_many( 2, array( 'user_id' => $admin_id ) );
+
+		$sites   = ElasticPress\Utils\get_sites();
+		$indexes = array();
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			ElasticPress\Indexables::factory()->get( 'term' )->put_mapping();
+			$indexes[] = ElasticPress\Indexables::factory()->get( 'term' )->get_index_name();
+
+			restore_current_blog();
+		}
+
+		ElasticPress\Indexables::factory()->get( 'term' )->delete_network_alias();
+		ElasticPress\Indexables::factory()->get( 'term' )->create_network_alias( $indexes );
+
+		wp_set_current_user( $admin_id );
+
+	}
+
+	/**
+	 * Clean up after each test. Reset our mocks
+	 *
+	 * @since 4.4.0
+	 */
+	public function tearDown() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		parent::tearDown();
+
+		ElasticPress\Indexables::factory()->get( 'term' )->delete_network_alias();
+	}
+
+	/**
+	 * Test WP Term Query returns the data from all the sites.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testTermQueryForAllSites() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$args  = array(
+			'taxonomy'     => 'category',
+			'ep_integrate' => true,
+			'site__in'     => 'all',
+			'hide_empty'   => false,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 12, count( $query->get_terms() ) );
+	}
+
+	/**
+	 * Test WP Term Query returns the data from the selected sites.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testTermQueryForSitesSubset() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$args  = array(
+			'taxonomy'     => 'category',
+			'ep_integrate' => true,
+			'site__in'     => array( $sites[0]['blog_id'], $sites[1]['blog_id'] ),
+			'hide_empty'   => false,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 8, count( $query->get_terms() ) );
+
+	}
+
+	/**
+	 * Test WP Term Query returns the search data from all the sites.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testTermQuerySearchForAllSites() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create(
+				array(
+					'slug'        => 'apple',
+					'name'        => 'Big Apple ' . $site['blog_id'],
+					'description' => 'The apple fruit term',
+				)
+			);
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$args  = array(
+			'search'     => 'apple',
+			'site__in'   => 'all',
+			'taxonomy'   => 'category',
+			'hide_empty' => false,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 3, count( $query->get_terms() ) );
+	}
+
+	/**
+	 * Test WP Term Query returns the search data from the selected sites.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testTermQuerySearchForSitesSubset() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create(
+				array(
+					'slug'        => 'apple',
+					'name'        => 'Big Apple ' . $site['blog_id'],
+					'description' => 'The apple fruit term',
+				)
+			);
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$args  = array(
+			'search'     => 'apple',
+			'site__in'   => array( $sites[0]['blog_id'], $sites[1]['blog_id'] ),
+			'taxonomy'   => 'category',
+			'hide_empty' => false,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 2, count( $query->get_terms() ) );
+	}
+
+	/**
+	 * Test WP Term Query returns the data from all the sites except one.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testTermQueryForAllSitesExceptOne() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$args  = array(
+			'site__not_in' => array( $sites[0]['blog_id'] ),
+			'taxonomy'     => 'category',
+			'hide_empty'   => false,
+			'ep_integrate' => true,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 8, count( $query->get_terms() ) );
+
+	}
+
+	/**
+	 * Test WP Term Query returns the search data from all the sites except one.
+	 *
+	 * @since 4.4.0
+	 */
+	public function testTermQuerySearchForAllSitesExceptOne() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create(
+				array(
+					'slug'        => 'apple',
+					'name'        => 'Big Apple ' . $site['blog_id'],
+					'description' => 'The apple fruit term',
+				)
+			);
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$args  = array(
+			'search'       => 'apple',
+			'site__not_in' => array( $sites[1]['blog_id'] ),
+			'taxonomy'     => 'category',
+			'hide_empty'   => false,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 2, count( $query->get_terms() ) );
+	}
+
+	/**
+	 * Test WP Term Query with the deprecated `sites` param
+	 *
+	 * @since 4.4.0
+	 * @expectedDeprecated maybe_filter_query
+	 */
+	public function testTermQuerySearchWithDeprecatedSitesParam() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+			$this->ep_factory->category->create();
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		$args  = array(
+			'sites'        => 'all',
+			'taxonomy'     => 'category',
+			'hide_empty'   => false,
+			'ep_integrate' => true,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 12, count( $query->get_terms() ) );
+
+		// test for only one site.
+		$args  = array(
+			'sites'        => $sites[0]['blog_id'],
+			'taxonomy'     => 'category',
+			'hide_empty'   => false,
+			'ep_integrate' => true,
+		);
+		$query = new \WP_Term_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 4, count( $query->get_terms() ) );
+
+	}
+}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the support for the `site__in` and `site__not_in` for the  Post, Term and Comment Query. The old `sites` parameter will throw the deprecated warnings but keep working as it used to. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1781

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - `site__in` and `site__not_in` parameter support for Post, Term and Comment Query.
> Deprecated - `sites` parameter is set to depreciated for. Post, Term and Comment Query.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
