### PR TITLE
fallback to empty array if no _source in hit

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -431,7 +431,7 @@ class Elasticsearch {
 			$documents = [];
 
 			foreach ( $hits as $hit ) {
-				$document            = $hit['_source'];
+				$document            = isset( $hit['_source'] ) ? $hit['_source'] : array();
 				$document['site_id'] = $this->parse_site_id( $hit['_index'] );
 
 				if ( ! empty( $hit['highlight'] ) ) {


### PR DESCRIPTION

### Description of the Change
Adding a null check to `$hit[_source]` for instances when source is not returned.

This scenario happens for instance in our count [validation logic](https://github.com/Automattic/vip-go-mu-plugins-built/blob/38365e08c9612e5ec4e3d2c483f1a6d9d191117b/search/includes/classes/class-health.php#L173). We by design suppress `_source` which includes documents' content to limit the amount of data needed to transfer as we are only interested in count in that specific scenario.

### How to test the Change
1) `vip dev-env exec -- wp vip-search health validate-counts`
2) No warnings

### Changelog Entry
> Fixed - Warning if _source is not returned in query hit



### Credits
@pschoffer 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
