### PR TITLE
Prevent clicking Related Post links in the editor.

### DIFF
--- a/assets/js/blocks/related-posts/Edit.js
+++ b/assets/js/blocks/related-posts/Edit.js
@@ -4,11 +4,8 @@
 import apiFetch from '@wordpress/api-fetch';
 import { AlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, Placeholder, Spinner, QueryControls } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
 import { Fragment, RawHTML, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticeStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -23,8 +20,6 @@ import { addQueryArgs } from '@wordpress/url';
  */
 const RelatedPostsEdit = ({ attributes, className, context, setAttributes }) => {
 	const { alignment, number } = attributes;
-	const { createWarningNotice } = useDispatch(noticeStore);
-	const instanceId = useInstanceId(RelatedPostsEdit);
 	const [posts, setPosts] = useState(false);
 
 	/**
@@ -51,21 +46,6 @@ const RelatedPostsEdit = ({ attributes, className, context, setAttributes }) => 
 			.catch(() => {
 				setPosts(false);
 			});
-	};
-
-	/**
-	 * Show a notice when redirect is prevented.
-	 *
-	 * @param {Event} event Click event.
-	 * @returns {void}
-	 */
-	const showRedirectionPreventedNotice = (event) => {
-		event.preventDefault();
-
-		createWarningNotice(__('Links are disabled in the editor.'), {
-			id: `elasticpress/related-posts/redirection-prevented/${instanceId}`,
-			type: 'snackbar',
-		});
 	};
 
 	/**
@@ -105,7 +85,7 @@ const RelatedPostsEdit = ({ attributes, className, context, setAttributes }) => 
 							const titleTrimmed = post.title.rendered.trim();
 							return (
 								<li key={post.id}>
-									<a href={post.link} onClick={showRedirectionPreventedNotice}>
+									<a href={post.link} onClick={(e) => e.preventDefault()}>
 										{titleTrimmed ? (
 											<RawHTML>{titleTrimmed}</RawHTML>
 										) : (

--- a/assets/js/blocks/related-posts/Edit.js
+++ b/assets/js/blocks/related-posts/Edit.js
@@ -4,8 +4,11 @@
 import apiFetch from '@wordpress/api-fetch';
 import { AlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, Placeholder, Spinner, QueryControls } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
 import { Fragment, RawHTML, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticeStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -18,8 +21,10 @@ import { addQueryArgs } from '@wordpress/url';
  * @param {Function} props.setAttributes Attribute setter.
  * @returns {Function} Component element.
  */
-export default ({ attributes, className, context, setAttributes }) => {
+const RelatedPostsEdit = ({ attributes, className, context, setAttributes }) => {
 	const { alignment, number } = attributes;
+	const { createWarningNotice } = useDispatch(noticeStore);
+	const instanceId = useInstanceId(RelatedPostsEdit);
 	const [posts, setPosts] = useState(false);
 
 	/**
@@ -46,6 +51,21 @@ export default ({ attributes, className, context, setAttributes }) => {
 			.catch(() => {
 				setPosts(false);
 			});
+	};
+
+	/**
+	 * Show a notice when redirect is prevented.
+	 *
+	 * @param {Event} event Click event.
+	 * @returns {void}
+	 */
+	const showRedirectionPreventedNotice = (event) => {
+		event.preventDefault();
+
+		createWarningNotice(__('Links are disabled in the editor.'), {
+			id: `elasticpress/related-posts/redirection-prevented/${instanceId}`,
+			type: 'snackbar',
+		});
 	};
 
 	/**
@@ -85,7 +105,7 @@ export default ({ attributes, className, context, setAttributes }) => {
 							const titleTrimmed = post.title.rendered.trim();
 							return (
 								<li key={post.id}>
-									<a href={post.link}>
+									<a href={post.link} onClick={showRedirectionPreventedNotice}>
 										{titleTrimmed ? (
 											<RawHTML>{titleTrimmed}</RawHTML>
 										) : (
@@ -101,3 +121,5 @@ export default ({ attributes, className, context, setAttributes }) => {
 		</Fragment>
 	);
 };
+
+export default RelatedPostsEdit;

--- a/assets/js/blocks/related-posts/Edit.js
+++ b/assets/js/blocks/related-posts/Edit.js
@@ -1,109 +1,103 @@
 /**
  * WordPress dependencies.
  */
+import apiFetch from '@wordpress/api-fetch';
 import { AlignmentToolbar, BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, Placeholder, Spinner, QueryControls } from '@wordpress/components';
-import { Fragment, Component, RawHTML } from '@wordpress/element';
+import { Fragment, RawHTML, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
- * Edit component
+ * Related Posts block edit component.
+ *
+ * @param {object} props Component props.
+ * @param {object} props.attributes Block attributes.
+ * @param {string} props.className Additional CSS class(es).
+ * @param {object} props.context Block context,
+ * @param {Function} props.setAttributes Attribute setter.
+ * @returns {Function} Component element.
  */
-class Edit extends Component {
-	/**
-	 * Setup class
-	 *
-	 * @param {object} props Component properties
-	 */
-	constructor(props) {
-		super(props);
-
-		this.state = {
-			posts: false,
-		};
-	}
+export default ({ attributes, className, context, setAttributes }) => {
+	const { alignment, number } = attributes;
+	const [posts, setPosts] = useState(false);
 
 	/**
-	 * Load preview data
+	 * Related posts, limited by the selected number.
 	 */
-	componentDidMount() {
+	const displayPosts = posts.length > number ? posts.slice(0, number) : posts;
+
+	/**
+	 * Initialize block.
+	 */
+	const handleInit = () => {
 		const urlArgs = {
 			number: 100,
 		};
 
-		// Use 0 if in the Widgets Screen
-		const { context: { postId = 0 } = {} } = this.props;
+		const { postId = 0 } = context;
 
-		wp.apiFetch({
+		apiFetch({
 			path: addQueryArgs(`/wp/v2/posts/${postId}/related`, urlArgs),
 		})
 			.then((posts) => {
-				this.setState({ posts });
+				setPosts(posts);
 			})
 			.catch(() => {
-				this.setState({ posts: false });
+				setPosts(false);
 			});
-	}
+	};
 
-	render() {
-		const {
-			attributes: { alignment, number },
-			setAttributes,
-			className,
-		} = this.props;
-		const { posts } = this.state;
+	/**
+	 * Effects.
+	 */
+	useEffect(handleInit, [context]);
 
-		const displayPosts = posts.length > number ? posts.slice(0, number) : posts;
-
-		return (
-			<Fragment>
-				<BlockControls>
-					<AlignmentToolbar
-						value={alignment}
-						onChange={(newValue) => setAttributes({ alignment: newValue })}
+	return (
+		<Fragment>
+			<BlockControls>
+				<AlignmentToolbar
+					value={alignment}
+					onChange={(newValue) => setAttributes({ alignment: newValue })}
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={__('Related Post Settings', 'elasticpress')}>
+					<QueryControls
+						numberOfItems={number}
+						onNumberOfItemsChange={(value) => setAttributes({ number: value })}
 					/>
-				</BlockControls>
-				<InspectorControls>
-					<PanelBody title={__('Related Post Settings', 'elasticpress')}>
-						<QueryControls
-							numberOfItems={number}
-							onNumberOfItemsChange={(value) => setAttributes({ number: value })}
-						/>
-					</PanelBody>
-				</InspectorControls>
+				</PanelBody>
+			</InspectorControls>
 
-				<div className={className}>
-					{displayPosts === false || displayPosts.length === 0 ? (
-						<Placeholder icon="admin-post" label={__('Related Posts', 'elasticpress')}>
-							{posts === false ? (
-								<Spinner />
-							) : (
-								__('No related posts yet.', 'elasticpress')
-							)}
-						</Placeholder>
-					) : (
-						<ul style={{ textAlign: alignment }}>
-							{displayPosts.map((post) => {
-								const titleTrimmed = post.title.rendered.trim();
-								return (
-									<li key={post.id}>
-										<a href={post.link}>
-											{titleTrimmed ? (
-												<RawHTML>{titleTrimmed}</RawHTML>
-											) : (
-												__('(Untitled)', 'elasticpress')
-											)}
-										</a>
-									</li>
-								);
-							})}
-						</ul>
-					)}
-				</div>
-			</Fragment>
-		);
-	}
-}
-
-export default Edit;
+			<div className={className}>
+				{displayPosts === false || displayPosts.length === 0 ? (
+					<Placeholder icon="admin-post" label={__('Related Posts', 'elasticpress')}>
+						{posts === false ? (
+							<Spinner />
+						) : (
+							__('No related posts yet.', 'elasticpress')
+						)}
+					</Placeholder>
+				) : (
+					<ul style={{ textAlign: alignment }}>
+						{displayPosts.map((post) => {
+							const titleTrimmed = post.title.rendered.trim();
+							return (
+								<li key={post.id}>
+									<a href={post.link}>
+										{titleTrimmed ? (
+											<RawHTML>{titleTrimmed}</RawHTML>
+										) : (
+											__('(Untitled)', 'elasticpress')
+										)}
+									</a>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</div>
+		</Fragment>
+	);
+};

--- a/tests/cypress/integration/features/related-posts.spec.js
+++ b/tests/cypress/integration/features/related-posts.spec.js
@@ -71,7 +71,7 @@ describe('Related Posts Feature', () => {
 			.should('have.length', 2);
 
 		/**
-		 * Clicking a related rost link in the editor shouldn't change the URL.
+		 * Clicking a related post link in the editor shouldn't change the URL.
 		 */
 		cy.get('@block').find('a').first().click();
 		cy.url().should('include', 'wp-admin/post.php');

--- a/tests/cypress/integration/features/related-posts.spec.js
+++ b/tests/cypress/integration/features/related-posts.spec.js
@@ -71,6 +71,12 @@ describe('Related Posts Feature', () => {
 			.should('have.length', 2);
 
 		/**
+		 * Clicking a related rost link in the editor shouldn't change the URL.
+		 */
+		cy.get('@block').find('a').first().click();
+		cy.url().should('include', 'wp-admin/post.php');
+
+		/**
 		 * Update the post and visit the front end.
 		 */
 		cy.get('.editor-post-publish-button__button').click();


### PR DESCRIPTION
### Description of the Change
Prevents clicking on links in the Related Posts block in the editor. 

Originally I had planned on mimicking the behaviour of the core Latest Posts block, and the code is based on [that implementation](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/latest-posts/edit.js#L157-L166), which displays a notice when attempting to click a link. However, on investigating more core blocks this behaviour is unique to the Latest Posts block and all other blocks, such as the various query loop blocks like the linked post title or date, simply silently preventDefault on any links. To avoid the overhead of needing to manage a notice I've gone with the more common convention.

This PR also converts the Related Posts block's edit component to a functional component.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2967

### How to test the Change
1. Add a Related Posts block to the editor.
2. Attempt to follow the link for one of the results.
3. The link should not be followed.

### Changelog Entry
Fixed - Clicking a Related Posts link while in the editor will no longer follow the link.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
