### PR TITLE
Fixed features are still active when disabling them in settings.

### DIFF
--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -186,7 +186,7 @@ abstract class Feature {
 
 		$active = false;
 
-		if ( ! empty( $feature_settings[ $this->slug ] ) && $feature_settings[ $this->slug ]['active'] && empty( $feature_settings[ $this->slug ][ 'force_inactive' ] ) ) {
+		if ( ! empty( $feature_settings[ $this->slug ] ) && $feature_settings[ $this->slug ]['active'] && empty( $feature_settings[ $this->slug ]['force_inactive'] ) ) {
 			$active = true;
 		}
 

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -186,7 +186,7 @@ abstract class Feature {
 
 		$active = false;
 
-		if ( ! empty( $feature_settings[ $this->slug ] ) && $feature_settings[ $this->slug ]['active'] ) {
+		if ( ! empty( $feature_settings[ $this->slug ] ) && $feature_settings[ $this->slug ]['active'] && empty( $feature_settings[ $this->slug ][ 'force_inactive' ] ) ) {
 			$active = true;
 		}
 


### PR DESCRIPTION
### Description of the Change

Problem
- When disabling a feature in the plugin settings, then the feature is still active on the site.

Goal
- We want to disable the Facets feature, because it manipulates taxonomy queries, causing them to yield wrong results (outside of scope of this issue).

Cause
- Disabling a feature sets the 'force_inactive' property on it, but the property is never checked when the settings are read.

Notes
- The 'active' property name is a bit misleading, it only indicates that all requirements of a feature are being met.

### How to test the Change

1. Disable the Facets feature.
2. Go to the Widgets settings page; you should not see the Facets widgets as available widgets anymore.

### Changelog Entry

> Fixed features are still active when disabling them in settings.

### Credits

Props @sun, @bogdanarizancu

w.org tha_sun, bogdanarizancu

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
