### PR TITLE
Add capability check to Custom Results API endpoints.

### DIFF
--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -215,7 +215,7 @@ class SearchOrdering extends Feature {
 			'elasticpress',
 			esc_html__( 'Custom Results', 'elasticpress' ),
 			esc_html__( 'Custom Results', 'elasticpress' ),
-			CAPABILITY,
+			self::CAPABILITY,
 			'edit.php?post_type=' . self::POST_TYPE_NAME
 		);
 	}
@@ -695,7 +695,7 @@ class SearchOrdering extends Feature {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'handle_pointer_search' ],
 				'permission_callback' => function() {
-					return current_user_can( CAPABILITY );
+					return current_user_can( self::CAPABILITY );
 				},
 				'args'                => [
 					's' => [
@@ -715,7 +715,7 @@ class SearchOrdering extends Feature {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'handle_pointer_preview' ],
 				'permission_callback' => function() {
-					return current_user_can( CAPABILITY );
+					return current_user_can( self::CAPABILITY );
 				},
 				'args'                => [
 					's' => [

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -36,6 +36,11 @@ class SearchOrdering extends Feature {
 	const TAXONOMY_NAME = 'ep_custom_result';
 
 	/**
+	 * Capability required to manage.
+	 */
+	const CAPABILITY = 'manage_options';
+
+	/**
 	 * Initialize feature setting it's config
 	 *
 	 * @since  3.0
@@ -210,7 +215,7 @@ class SearchOrdering extends Feature {
 			'elasticpress',
 			esc_html__( 'Custom Results', 'elasticpress' ),
 			esc_html__( 'Custom Results', 'elasticpress' ),
-			'manage_options',
+			CAPABILITY,
 			'edit.php?post_type=' . self::POST_TYPE_NAME
 		);
 	}
@@ -689,7 +694,9 @@ class SearchOrdering extends Feature {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'handle_pointer_search' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => function() {
+					return current_user_can( CAPABILITY );
+				},
 				'args'                => [
 					's' => [
 						'validate_callback' => function ( $param ) {
@@ -707,7 +714,9 @@ class SearchOrdering extends Feature {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'handle_pointer_preview' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => function() {
+					return current_user_can( CAPABILITY );
+				},
 				'args'                => [
 					's' => [
 						'validate_callback' => function ( $param ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Adds a capability check to Custom Results API endpoints used for editing results sets. While those endpoints only return content that's normally publicly accessible the endpoints could inadvertently expose protected content that was not adequately protected. Since the endpoints do not need to be publicly available they can be restricted by the same capability required for accessing the admin page.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3001

### How to test the Change
1. Accessing `/wp-json/elasticpress/v1/pointer_search?s=abc` in the browser should return a 401.
2. The search fields when creating a custom results set should function as normal.

### Changelog Entry
Changed - The endpoints used for managing custom results are no longer publicly accessible.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT , @PypWalters 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
