### PR TITLE
Add option to toggle term counter

### DIFF
--- a/assets/js/instant-results/components/common/checkbox-list.js
+++ b/assets/js/instant-results/components/common/checkbox-list.js
@@ -9,6 +9,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import Checkbox from './checkbox';
 import SmallButton from './small-button';
+import { termCount } from '../../config';
 
 /**
  * Checkbox list component.
@@ -124,6 +125,10 @@ export default ({ disabled, label, options, onChange, selected, sortBy }) => {
 	 */
 	const displayOption = ({ count, id, label, value }) => {
 		const children = childOptions[value];
+		/**
+		 * Check for term count option.
+		 */
+		const counter = termCount === '1' ? count : '';
 
 		if (!showAll && optionsShown >= optionsLimit) {
 			return <Fragment key={value} />;
@@ -133,7 +138,7 @@ export default ({ disabled, label, options, onChange, selected, sortBy }) => {
 			<li className="ep-search-options-list__item" key={value}>
 				<Checkbox
 					checked={selected.includes(value)}
-					count={count}
+					count={counter}
 					disabled={disabled}
 					id={id}
 					label={label}

--- a/assets/js/instant-results/config.js
+++ b/assets/js/instant-results/config.js
@@ -18,6 +18,7 @@ const {
 	paramPrefix,
 	postTypeLabels,
 	taxonomyLabels,
+	termCount,
 } = window.epInstantResults;
 
 /**
@@ -72,4 +73,5 @@ export {
 	postTypeLabels,
 	sortOptions,
 	taxonomyLabels,
+	termCount,
 };

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -83,6 +83,7 @@ class InstantResults extends Feature {
 			'highlight_tag' => 'mark',
 			'facets'        => 'post_type,category,post_tag',
 			'match_type'    => 'all',
+			'term_count'    => '1',
 		];
 
 		$settings = $this->get_settings() ? $this->get_settings() : array();
@@ -171,6 +172,18 @@ class InstantResults extends Feature {
 				<p class="field-description"><?php esc_html_e( '"All" will only show content that matches all facets. "Any" will show content that matches any facet.', 'elasticpress' ); ?></p>
 			</div>
 		</div>
+		<div class="field">
+			<div class="field-name status"><?php esc_html_e( 'Term Count', 'elasticpress' ); ?></div>
+			<div class="input-wrap">
+				<label>
+					<input name="settings[term_count]" <?php checked( (bool) $this->settings['term_count'] ); ?> type="radio" value="1"><?php esc_html_e( 'Enabled', 'elasticpress' ); ?>
+				</label><br>
+				<label>
+					<input name="settings[term_count]" <?php checked( ! (bool) $this->settings['term_count'] ); ?> type="radio" value="0"><?php esc_html_e( 'Disabled', 'elasticpress' ); ?>
+				</label>
+				<p class="field-description"><?php esc_html_e( 'When enabled, it will show the term count in the instant results widget.', 'elasticpress' ); ?></p>
+			</div>
+		</div>
 
 		<?php
 	}
@@ -224,6 +237,7 @@ class InstantResults extends Feature {
 		add_action( 'pre_get_posts', [ $this, 'maybe_apply_product_visibility' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend_assets' ] );
 		add_action( 'wp_footer', [ $this, 'render' ] );
+		add_filter( 'ep_sanitize_feature_settings', [ $this, 'sanitize_count_settings' ] );
 	}
 
 	/**
@@ -281,6 +295,7 @@ class InstantResults extends Feature {
 				'matchType'      => $this->settings['match_type'],
 				'paramPrefix'    => 'ep-',
 				'postTypeLabels' => $this->get_post_type_labels(),
+				'termCount'      => $this->settings['term_count'],
 			)
 		);
 	}
@@ -922,5 +937,19 @@ class InstantResults extends Feature {
 			}
 		}
 		return $args;
+	}
+
+	/**
+	 * Sanitizes our term count settings.
+	 *
+	 * @param array $settings Array of current settings
+	 * @return mixed
+	 */
+	public function sanitize_count_settings( $settings ) {
+		if ( ! empty( $settings['instant-results']['term_count'] ) ) {
+			$settings['instant-results']['term_count'] = (bool) $settings['instant-results']['term_count'];
+		}
+
+		return $settings;
 	}
 }

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -237,7 +237,6 @@ class InstantResults extends Feature {
 		add_action( 'pre_get_posts', [ $this, 'maybe_apply_product_visibility' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend_assets' ] );
 		add_action( 'wp_footer', [ $this, 'render' ] );
-		add_filter( 'ep_sanitize_feature_settings', [ $this, 'sanitize_count_settings' ] );
 	}
 
 	/**
@@ -939,17 +938,4 @@ class InstantResults extends Feature {
 		return $args;
 	}
 
-	/**
-	 * Sanitizes our term count settings.
-	 *
-	 * @param array $settings Array of current settings
-	 * @return mixed
-	 */
-	public function sanitize_count_settings( $settings ) {
-		if ( ! empty( $settings['instant-results']['term_count'] ) ) {
-			$settings['instant-results']['term_count'] = (bool) $settings['instant-results']['term_count'];
-		}
-
-		return $settings;
-	}
 }


### PR DESCRIPTION
### Description of the Change
This PR adds an option to enable/disable the term count option in the Instant results widget. 
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2610

### How to test the Change
- By default the counter is enabled
- Go to ElasticPress features -> Instant results -> Disable the term count option
- Notice that the number of posts is disabled
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - An option to toggle the term count in Instant results


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
