### PR TITLE
Fix Custom results are not highlighted

### DIFF
--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -655,7 +655,7 @@ class SearchOrdering extends Feature {
 				if ( isset( $post->terms ) && isset( $post->terms[ self::TAXONOMY_NAME ] ) ) {
 					foreach ( $post->terms[ self::TAXONOMY_NAME ] as $current_term ) {
 						if ( strtolower( $current_term['name'] ) === $search_query ) {
-							$to_inject[ $current_term['term_order'] ] = $post->ID;
+							$to_inject[ $current_term['term_order'] ] = $post;
 
 							unset( $posts[ $key ] );
 
@@ -673,7 +673,7 @@ class SearchOrdering extends Feature {
 
 			if ( ! empty( $to_inject ) ) {
 				foreach ( $to_inject as $position => $newpost ) {
-					array_splice( $posts, $position - 1, 0, $newpost );
+					array_splice( $posts, $position - 1, 0, array( $newpost ) );
 				}
 			}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the custom results are not highlighted. The root cause of this issue is that in `posts_results` method we replaced the Post Object with just the Post ID and, due to that, we lost the Post that is fetched from the ElasticSearch

https://github.com/10up/ElasticPress/blob/develop/includes/classes/Feature/SearchOrdering/SearchOrdering.php#L658

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2974 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Activate Custom Results feature.
- Create custom results for a search term and manually include results that include the search term in the title.
- Search on the front end.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Custom results are not highlighted



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
