### PR TITLE
Fix: Clicking on the Facet Term redirect to Homepage

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -424,7 +424,7 @@ class Facets extends Feature {
 
 		if ( ! empty( $filters ) ) {
 			foreach ( $filters as $filter => $value ) {
-				if ( ! empty( $value ) && in_array( $filter, $allowed_args, true ) ) {
+				if ( in_array( $filter, $allowed_args, true ) ) {
 					$query_param[ $filter ] = $value;
 				}
 			}

--- a/tests/php/features/TestFacet.php
+++ b/tests/php/features/TestFacet.php
@@ -122,6 +122,10 @@ class TestFacets extends BaseTestCase {
 
 		$this->assertEquals( '/?ep_filter_category=augue%2Cconsectetur', $facet_feature->build_query_url( $filters ) );
 
+		// test when search parameter is empty.
+		$filters['s'] = '';
+		$this->assertEquals( '/?ep_filter_category=augue%2Cconsectetur&s=', $facet_feature->build_query_url( $filters ) );
+
 		$_SERVER['REQUEST_URI'] = 'test/page/1';
 
 		$filters['s'] = 'dolor';
@@ -169,7 +173,7 @@ class TestFacets extends BaseTestCase {
 		$query_args = [];
 
 		$query = new \WP_Query();
-		
+
 		// No `ep_facet` in query_args will make it return the same array.
 		$this->assertSame( $args, $facet_feature->set_agg_filters( $args, $query_args, $query ) );
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue when clicking on the Facet terms redirects to homepage when the search parameter value is empty. The issue was that the `s` parameter was removed from the URL because of the `empty` check.  

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3012 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Add the Taxonomy Facet Widget
- Search without adding any search term on frontend
- Click on the term item
- It should open the Search page instead of Homepage

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Clicking on the Facet Term redirect to Homepage


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
