### PR TITLE
Apply deprecated filters without overwritting values

### DIFF
--- a/includes/classes/SearchAlgorithm/DefaultAlgorithm.php
+++ b/includes/classes/SearchAlgorithm/DefaultAlgorithm.php
@@ -148,7 +148,7 @@ class DefaultAlgorithm extends \ElasticPress\SearchAlgorithm {
 		 */
 		$query['bool']['should'][0]['multi_match']['boost'] = apply_filters_deprecated(
 			'ep_match_phrase_boost',
-			[ 4, $search_fields, $query_vars ],
+			[ $query['bool']['should'][0]['multi_match']['boost'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_match_phrase_boost'
 		);
@@ -166,7 +166,7 @@ class DefaultAlgorithm extends \ElasticPress\SearchAlgorithm {
 		 */
 		$query['bool']['should'][1]['multi_match']['boost'] = apply_filters_deprecated(
 			'ep_match_boost',
-			[ 2, $search_fields, $query_vars ],
+			[ $query['bool']['should'][1]['multi_match']['boost'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_match_boost'
 		);
@@ -184,7 +184,7 @@ class DefaultAlgorithm extends \ElasticPress\SearchAlgorithm {
 		 */
 		$query['bool']['should'][2]['multi_match']['fuzziness'] = apply_filters_deprecated(
 			'ep_fuzziness_arg',
-			[ 1, $search_fields, $query_vars ],
+			[ $query['bool']['should'][2]['multi_match']['fuzziness'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_fuzziness_arg'
 		);

--- a/includes/classes/SearchAlgorithm/Version_350.php
+++ b/includes/classes/SearchAlgorithm/Version_350.php
@@ -101,7 +101,7 @@ class Version_350 extends \ElasticPress\SearchAlgorithm {
 		/** This filter is documented in /includes/classes/SearchAlgorithm/Basic.php */
 		$query['bool']['should'][0]['multi_match']['boost'] = apply_filters_deprecated(
 			'ep_match_phrase_boost',
-			[ 3, $search_fields, $query_vars ],
+			[ $query['bool']['should'][0]['multi_match']['boost'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_match_phrase_boost'
 		);

--- a/includes/classes/SearchAlgorithm/Version_400.php
+++ b/includes/classes/SearchAlgorithm/Version_400.php
@@ -134,7 +134,7 @@ class Version_400 extends \ElasticPress\SearchAlgorithm {
 		/** This filter is documented in /includes/classes/SearchAlgorithm/Basic.php */
 		$query['bool']['should'][0]['multi_match']['boost'] = apply_filters_deprecated(
 			'ep_match_phrase_boost',
-			[ 3, $search_fields, $query_vars ],
+			[ $query['bool']['should'][0]['multi_match']['boost'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_match_phrase_boost'
 		);
@@ -142,7 +142,7 @@ class Version_400 extends \ElasticPress\SearchAlgorithm {
 		/** This filter is documented in /includes/classes/SearchAlgorithm/Basic.php */
 		$query['bool']['should'][1]['multi_match']['boost'] = apply_filters_deprecated(
 			'ep_match_boost',
-			[ 1, $search_fields, $query_vars ],
+			[ $query['bool']['should'][1]['multi_match']['boost'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_match_boost'
 		);
@@ -161,7 +161,7 @@ class Version_400 extends \ElasticPress\SearchAlgorithm {
 		 */
 		$query['bool']['should'][1]['multi_match']['fuzziness'] = apply_filters_deprecated(
 			'ep_match_fuzziness',
-			[ 'auto', $search_fields, $query_vars ],
+			[ $query['bool']['should'][1]['multi_match']['fuzziness'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_match_fuzziness'
 		);
@@ -180,7 +180,7 @@ class Version_400 extends \ElasticPress\SearchAlgorithm {
 		 */
 		$query['bool']['should'][2]['multi_match']['boost'] = apply_filters_deprecated(
 			'ep_match_cross_fields_boost',
-			[ 1, $search_fields, $query_vars ],
+			[ $query['bool']['should'][2]['multi_match']['boost'], $search_fields, $query_vars ],
 			'4.3.0',
 			'ep_post_match_cross_fields_boost'
 		);

--- a/tests/php/searchAlgorithms/TestVersion_350SearchAlgorithm.php
+++ b/tests/php/searchAlgorithms/TestVersion_350SearchAlgorithm.php
@@ -70,6 +70,35 @@ class TestVersion_350SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 	}
 
 	/**
+	 * Test filters with posts
+	 * 
+	 * As posts also apply the legacy filters, these tests assure code honors the value of the newer filters
+	 *
+	 * @see https://github.com/10up/ElasticPress/issues/3033 
+	 * @group searchAlgorithms
+	 */
+	public function testPostFilters() {
+		$basic = new Version_350();
+
+		$search_term   = 'search_term';
+		$search_fields = [ 'post_title', 'post_content' ];
+
+		$test_filter = function() {
+			return 1234;
+		};
+
+		/**
+		 * Test the `ep_post_match_phrase_boost` filter.
+		 */
+		add_filter( 'ep_post_match_phrase_boost', $test_filter );
+
+		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
+		$this->assertEquals( 1234, $query['bool']['should'][0]['multi_match']['boost'] );
+
+		remove_filter( 'ep_post_match_phrase_boost', $test_filter );
+	}
+
+	/**
 	 * Test deprecated/legacy filters
 	 *
 	 * @expectedDeprecated ep_match_phrase_boost

--- a/tests/php/searchAlgorithms/TestVersion_400SearchAlgorithm.php
+++ b/tests/php/searchAlgorithms/TestVersion_400SearchAlgorithm.php
@@ -100,6 +100,65 @@ class TestVersion_400SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 	}
 
 	/**
+	 * Test filters with posts
+	 * 
+	 * As posts also apply the legacy filters, these tests assure code honors the value of the newer filters
+	 *
+	 * @see https://github.com/10up/ElasticPress/issues/3033 
+	 * @group searchAlgorithms
+	 */
+	public function testPostFilters() {
+		$basic = new Version_400();
+
+		$search_term   = 'search_term';
+		$search_fields = [ 'post_title', 'post_content' ];
+
+		$test_filter = function() {
+			return 1234;
+		};
+
+		/**
+		 * Test the `ep_post_match_phrase_boost` filter.
+		 */
+		add_filter( 'ep_post_match_phrase_boost', $test_filter );
+
+		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
+		$this->assertEquals( 1234, $query['bool']['should'][0]['multi_match']['boost'] );
+
+		remove_filter( 'ep_post_match_phrase_boost', $test_filter );
+
+		/**
+		 * Test the `ep_post_match_boost` filter.
+		 */
+		add_filter( 'ep_post_match_boost', $test_filter );
+
+		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
+		$this->assertEquals( 1234, $query['bool']['should'][1]['multi_match']['boost'] );
+
+		remove_filter( 'ep_post_match_boost', $test_filter );
+
+		/**
+		 * Test the `ep_post_match_fuzziness` filter.
+		 */
+		add_filter( 'ep_post_match_fuzziness', $test_filter );
+
+		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
+		$this->assertEquals( 1234, $query['bool']['should'][1]['multi_match']['fuzziness'] );
+
+		remove_filter( 'ep_post_match_fuzziness', $test_filter );
+
+		/**
+		 * Test the `ep_post_match_cross_fields_boost` filter.
+		 */
+		add_filter( 'ep_post_match_cross_fields_boost', $test_filter );
+
+		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
+		$this->assertEquals( 1234, $query['bool']['should'][2]['multi_match']['boost'] );
+
+		remove_filter( 'ep_post_match_cross_fields_boost', $test_filter );
+	}
+
+	/**
 	 * Test deprecated/legacy filters
 	 *
 	 * @expectedDeprecated ep_match_phrase_boost


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3033

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Deprecated filters for search algorithms do not overwrite values set with the newer filters


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @marc-tt 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
