### PR TITLE
New `ep_autosuggest_query_args` filter + tests

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -552,13 +552,36 @@ class Autosuggest extends Feature {
 
 		add_filter( 'posts_pre_query', [ $features->get_registered_feature( $this->slug ), 'return_empty_posts' ], 100, 1 ); // after ES Query to ensure we are not falling back to DB in any case
 
-		$search = new \WP_Query(
-			[
-				'post_type'    => $post_type,
-				'post_status'  => $post_status,
-				's'            => $placeholder,
-				'ep_integrate' => true,
-			]
+		new \WP_Query(
+			/**
+			 * Filter WP Query args of the autosuggest query template.
+			 *
+			 * If you want to display 20 posts in autosuggest:
+			 *
+			 * ```
+			 * add_filter(
+			 *     'ep_autosuggest_query_args',
+			 *     function( $args ) {
+			 *         $args['posts_per_page'] = 20;
+			 *         return $args;
+			 *     }
+			 * );
+			 * ```
+			 *
+			 * @since 4.4.0
+			 * @hook ep_autosuggest_query_args
+			 * @param {array} $args Query args
+			 * @return {array} New query args
+			 */
+			apply_filters(
+				'ep_autosuggest_query_args',
+				[
+					'post_type'    => $post_type,
+					'post_status'  => $post_status,
+					's'            => $placeholder,
+					'ep_integrate' => true,
+				]
+			)
 		);
 
 		remove_filter( 'posts_pre_query', [ $features->get_registered_feature( $this->slug ), 'return_empty_posts' ], 100 );

--- a/tests/php/features/TestAutosuggest.php
+++ b/tests/php/features/TestAutosuggest.php
@@ -195,6 +195,65 @@ class TestAutosuggest extends BaseTestCase {
         $this->assertContains( 'ep_autosuggest_placeholder', $query );
     }
 
+    public function testGenerateSearchQueryFilters() {
+		/**
+		 * Test the `ep_autosuggest_query_placeholder` filter.
+		 */
+        $test_placeholder_filter = function() {
+			return 'lorem-ipsum';
+		};
+
+		add_filter( 'ep_autosuggest_query_placeholder', $test_placeholder_filter );
+
+		$query = $this->get_feature()->generate_search_query();
+		$this->assertContains( 'lorem-ipsum', $query['body'] );
+
+		remove_filter( 'ep_autosuggest_query_placeholder', $test_placeholder_filter );
+
+		/**
+		 * Test the `ep_autosuggest_query_placeholder` filter.
+		 */
+        $test_post_type_filter = function() {
+			return [ 'my-custom-post-type' ];
+		};
+
+		add_filter( 'ep_term_suggest_post_type', $test_post_type_filter );
+
+		$query = $this->get_feature()->generate_search_query();
+		$this->assertContains( 'my-custom-post-type', $query['body'] );
+
+		remove_filter( 'ep_term_suggest_post_type', $test_post_type_filter );
+
+		/**
+		 * Test the `ep_term_suggest_post_status` filter.
+		 */
+        $test_post_status_filter = function() {
+			return [ 'trash' ];
+		};
+
+		add_filter( 'ep_term_suggest_post_status', $test_post_status_filter );
+
+		$query = $this->get_feature()->generate_search_query();
+		$this->assertContains( 'trash', $query['body'] );
+
+		remove_filter( 'ep_term_suggest_post_status', $test_post_status_filter );
+
+		/**
+		 * Test the `ep_term_suggest_post_status` filter.
+		 */
+        $test_args_filter = function( $args ) {
+            $args['posts_per_page'] = 1234;
+			return $args;
+		};
+
+		add_filter( 'ep_autosuggest_query_args', $test_args_filter );
+
+		$query = $this->get_feature()->generate_search_query();
+		$this->assertContains( '1234', $query['body'] );
+
+		remove_filter( 'ep_autosuggest_query_args', $test_args_filter );
+    }
+
     public function testReturnEmptyPosts() {
         $this->assertEmpty( $this->get_feature()->return_empty_posts() );
     }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New `ep_autosuggest_query_args` filter, to change WP Query args of the autosuggest query template.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
