### PR TITLE
Fix: put-mapping --network-wide when plugin is not network activated

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -248,7 +248,7 @@ class Command extends WP_CLI_Command {
 		$non_global_indexable_objects = Indexables::factory()->get_all( false );
 		$global_indexable_objects     = Indexables::factory()->get_all( true );
 
-		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
+		if ( isset( $assoc_args['network-wide'] ) && defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			if ( ! is_numeric( $assoc_args['network-wide'] ) ) {
 				$assoc_args['network-wide'] = 0;
 			}

--- a/tests/cypress/integration/wp-cli.spec.js
+++ b/tests/cypress/integration/wp-cli.spec.js
@@ -152,11 +152,9 @@ describe('WP-CLI Commands', () => {
 			.should('contain', 'Adding post mapping')
 			.should('contain', 'Mapping sent');
 
-		cy.activatePlugin('elasticpress', 'wpCli', 'network');
-
 		cy.wpCli('wp elasticpress put-mapping --network-wide')
 			.its('stdout')
-			.should('contain', 'Adding post mapping for site')
+			.should('contain', 'Adding post mapping')
 			.should('contain', 'Mapping sent');
 	});
 

--- a/tests/cypress/integration/wp-cli.spec.js
+++ b/tests/cypress/integration/wp-cli.spec.js
@@ -151,6 +151,13 @@ describe('WP-CLI Commands', () => {
 			.its('stdout')
 			.should('contain', 'Adding post mapping')
 			.should('contain', 'Mapping sent');
+
+		cy.activatePlugin('elasticpress', 'wpCli', 'network');
+
+		cy.wpCli('wp elasticpress put-mapping --network-wide')
+			.its('stdout')
+			.should('contain', 'Adding post mapping for site')
+			.should('contain', 'Mapping sent');
 	});
 
 	it('Can recreate the alias index which points to every index in the network if user runs wp elasticpress recreate-network-alias command', () => {});


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where `wp elasticpress put-mapping --network-wide` throw error when the plugin is not network activated

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3040 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed -  put-mapping --network-wide throws error when plugin is not activated on network

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
