### PR TITLE
Small refactor of parse_orderby to make it easier to read

### DIFF
--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -1043,95 +1043,34 @@ class Comment extends Indexable {
 			return $sort;
 		}
 
-		switch ( $orderby ) {
-			case 'comment_agent':
-				$orderby_field = 'comment_agent.raw';
-				break;
+		$from_to = [
+			'comment_agent'        => 'comment_agent.raw',
+			'comment_approved'     => 'comment_approved.raw',
+			'comment_author'       => 'comment_author.raw',
+			'comment_author_email' => 'comment_author_email.raw',
+			'comment_author_IP'    => 'comment_author_IP.raw',
+			'comment_author_url'   => 'comment_author_url.raw',
+			'comment_content'      => 'comment_content.raw',
+			'comment_type'         => 'comment_type.raw',
+			'comment_post_type'    => 'comment_post_type.raw',
+		];
 
-			case 'comment_approved':
-				$orderby_field = 'comment_approved.raw';
-				break;
-
-			case 'comment_author':
-				$orderby_field = 'comment_author.raw';
-				break;
-
-			case 'comment_author_email':
-				$orderby_field = 'comment_author_email.raw';
-				break;
-
-			case 'comment_author_IP':
-				$orderby_field = 'comment_author_IP.raw';
-				break;
-
-			case 'comment_author_url':
-				$orderby_field = 'comment_author_url.raw';
-				break;
-
-			case 'comment_content':
-				$orderby_field = 'comment_content.raw';
-				break;
-
-			case 'comment_date':
-				$orderby_field = 'comment_date';
-				break;
-
-			case 'comment_date_gmt':
-				$orderby_field = 'comment_date_gmt';
-				break;
-
-			case 'comment_ID':
-				$orderby_field = 'comment_ID';
-				break;
-
-			case 'comment_karma':
-				$orderby_field = 'comment_karma';
-				break;
-
-			case 'comment_parent':
-				$orderby_field = 'comment_parent';
-				break;
-
-			case 'comment_post_ID':
-				$orderby_field = 'comment_post_ID';
-				break;
-
-			case 'comment_type':
-				$orderby_field = 'comment_type.raw';
-				break;
-
-			case 'comment_post_type':
-				$orderby_field = 'comment_post_type.raw';
-				break;
-
-			case 'user_id':
-				$orderby_field = 'user_id';
-				break;
-
-			case 'meta_value':
-				if ( ! empty( $args['meta_key'] ) ) {
-					$orderby_field = 'meta.' . $args['meta_key'] . '.value';
-				}
-				break;
-
-			case 'meta_value_num':
-				if ( ! empty( $args['meta_key'] ) ) {
-					$orderby_field = 'meta.' . $args['meta_key'] . '.long';
-				}
-				break;
-
-			default:
-				$orderby_field = $orderby;
-				break;
+		if ( in_array( $orderby, [ 'meta_value', 'meta_value_num' ], true ) ) {
+			if ( empty( $args['meta_key'] ) ) {
+				return $sort;
+			} else {
+				$from_to['meta_value']     = 'meta.' . $args['meta_key'] . '.raw';
+				$from_to['meta_value_num'] = 'meta.' . $args['meta_key'] . '.long';
+			}
 		}
 
-		if ( ! empty( $orderby_field ) ) {
-			$sort[] = [
-				$orderby_field => [
-					'order' => $order,
-				],
-			];
-		}
+		$orderby = $from_to[ $orderby ] ?? $orderby;
+
+		$sort[] = array(
+			$orderby => array(
+				'order' => $order,
+			),
+		);
 
 		return $sort;
 	}

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -911,59 +911,33 @@ class Term extends Indexable {
 			return $sort;
 		}
 
-		switch ( $orderby ) {
-			case 'name':
-				$es_version    = Elasticsearch::factory()->get_elasticsearch_version();
-				$es_field_name = 'name.sortable';
+		$from_to = [
+			'slug'        => 'slug.raw',
+			'id'          => 'term_id',
+			'description' => 'description.sortable',
+		];
 
-				if ( version_compare( $es_version, '7.0', '<' ) ) {
-					$es_field_name = 'name.raw';
-				}
-
-				break;
-
-			case 'slug':
-				$es_field_name = 'slug.raw';
-				break;
-
-			case 'term_id':
-			case 'id':
-				$es_field_name = 'term_id';
-				break;
-
-			case 'description':
-				$es_field_name = 'description.sortable';
-				break;
-
-			case 'meta_value':
-				if ( ! empty( $args['meta_key'] ) ) {
-					$es_field_name = 'meta.' . $args['meta_key'] . '.value';
-				}
-
-				break;
-
-			case 'meta_value_num':
-				if ( ! empty( $args['meta_key'] ) ) {
-					$es_field_name = 'meta.' . $args['meta_key'] . '.long';
-				}
-
-				break;
-
-			case 'parent':
-			case 'count':
-			default:
-				$es_field_name = $orderby;
-				break;
+		if ( in_array( $orderby, [ 'meta_value', 'meta_value_num' ], true ) ) {
+			if ( empty( $args['meta_key'] ) ) {
+				return $sort;
+			} else {
+				$from_to['meta_value']     = 'meta.' . $args['meta_key'] . '.value';
+				$from_to['meta_value_num'] = 'meta.' . $args['meta_key'] . '.long';
+			}
 		}
 
-		// For `meta_value` and `meta_value_num`, for example, there is a chance this wasn't set.
-		if ( ! empty( $es_field_name ) ) {
-			$sort[] = array(
-				$es_field_name => array(
-					'order' => $order,
-				),
-			);
+		if ( 'name' === $orderby ) {
+			$es_version      = Elasticsearch::factory()->get_elasticsearch_version();
+			$from_to['name'] = version_compare( $es_version, '7.0', '<' ) ? 'name.raw' : 'name.sortable';
 		}
+
+		$orderby = $from_to[ $orderby ] ?? $orderby;
+
+		$sort[] = array(
+			$orderby => array(
+				'order' => $order,
+			),
+		);
 
 		return $sort;
 	}

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -554,6 +554,22 @@ class User extends Indexable {
 			$orderby = explode( ' ', $orderby );
 		}
 
+		$from_to = [
+			'relevance'     => '_score',
+			'user_login'    => 'user_login.raw',
+			'login'         => 'user_login.raw',
+			'id'            => 'ID',
+			'display_name'  => 'display_name.sortable',
+			'name'          => 'display_name.sortable',
+			'nicename'      => 'user_nicename.raw',
+			'user_nicename' => 'user_nicename.raw',
+			'user_email'    => 'user_email.raw',
+			'email'         => 'user_email.raw',
+			'user_url'      => 'user_url.raw',
+			'url'           => 'user_url.raw',
+			'registered'    => 'user_registered',
+		];
+
 		$sort = [];
 
 		if ( empty( $orderby ) ) {
@@ -575,65 +591,19 @@ class User extends Indexable {
 				continue;
 			}
 
-			switch ( $orderby_clause ) {
-				case 'relevance':
-					$orderby_field = '_score';
-					break;
-
-				case 'user_login':
-				case 'login':
-					$orderby_field = 'user_login.raw';
-					break;
-
-				case 'ID':
-				case 'id':
-					$orderby_field = 'ID';
-					break;
-
-				case 'display_name':
-				case 'name':
-					$orderby_field = 'display_name.sortable';
-					break;
-
-				case 'nicename':
-				case 'user_nicename':
-					$orderby_field = 'user_nicename.raw';
-					break;
-
-				case 'user_email':
-				case 'email':
-					$orderby_field = 'user_email.raw';
-					break;
-
-				case 'user_url':
-				case 'url':
-					$orderby_field = 'user_url.raw';
-					break;
-
-				case 'user_registered':
-				case 'registered':
-					$orderby_field = 'user_registered';
-					break;
-
-				case 'meta_value':
-					if ( ! empty( $query_vars['meta_key'] ) ) {
-						$orderby_field = 'meta.' . $query_vars['meta_key'] . '.raw';
-					}
-					break;
-
-				case 'meta_value_num':
-					if ( ! empty( $query_vars['meta_key'] ) ) {
-						$orderby_field = 'meta.' . $query_vars['meta_key'] . '.long';
-					}
-					break;
-
-				default:
-					$orderby_field = $orderby_clause;
-					break;
+			if ( in_array( $orderby_clause, [ 'meta_value', 'meta_value_num' ], true ) ) {
+				if ( empty( $args['meta_key'] ) ) {
+					continue;
+				} else {
+					$from_to['meta_value']     = 'meta.' . $args['meta_key'] . '.raw';
+					$from_to['meta_value_num'] = 'meta.' . $args['meta_key'] . '.long';
+				}
 			}
 
+			$orderby_clause = $from_to[ $orderby_clause ] ?? $orderby_clause;
+
 			$sort[] = array(
-				$orderby_field => array(
+				$orderby_clause => array(
 					'order' => $order,
 				),
 			);


### PR DESCRIPTION
### Description of the Change
This PR is just a small refactor of all Indexables' parse_orderby() method to change it from a stack of if-elses to something a bit more readable.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Small refactor of parse_orderby to make it easier to read

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
