### PR TITLE
Remove legacy hook from unit tests

### DIFF
--- a/tests/php/features/TestProtectedContent.php
+++ b/tests/php/features/TestProtectedContent.php
@@ -70,8 +70,6 @@ class TestProtectedContent extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query();
 
 		global $wp_the_query;
@@ -80,7 +78,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		$query->query( array() );
 
-		$this->assertTrue( empty( $this->fired_actions['ep_wp_query_search'] ) );
+		$this->assertNull( $query->elasticsearch_success );
 	}
 
 	/**
@@ -99,8 +97,6 @@ class TestProtectedContent extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query();
 
 		global $wp_the_query;
@@ -109,7 +105,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		$wp_the_query->query( array() );
 
-		$this->assertTrue( ! empty( $this->fired_actions['ep_wp_query_search'] ) );
+		$this->assertTrue( $query->elasticsearch_success );
 	}
 
 	/**
@@ -129,8 +125,6 @@ class TestProtectedContent extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query();
 
 		global $wp_the_query;
@@ -143,7 +137,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		$query->query( $args );
 
-		$this->assertTrue( ! empty( $this->fired_actions['ep_wp_query_search'] ) );
+		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
 	}
@@ -174,8 +168,6 @@ class TestProtectedContent extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query();
 
 		global $wp_the_query;
@@ -188,7 +180,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		$query->query( $args );
 
-		$this->assertTrue( ! empty( $this->fired_actions['ep_wp_query_search'] ) );
+		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
 	}
@@ -211,8 +203,6 @@ class TestProtectedContent extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query();
 
 		global $wp_the_query;
@@ -230,7 +220,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		$query->query( $args );
 
-		$this->assertTrue( ! empty( $this->fired_actions['ep_wp_query_search'] ) );
+		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
 	}

--- a/tests/php/features/TestSearch.php
+++ b/tests/php/features/TestSearch.php
@@ -70,15 +70,13 @@ class TestSearch extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$args = array(
 			's' => 'findme',
 		);
 
 		$query = new \WP_Query( $args );
 
-		$this->assertTrue( ! empty( $this->fired_actions['ep_wp_query_search'] ) );
+		$this->assertTrue( $query->elasticsearch_success );
 	}
 
 	/**
@@ -367,4 +365,3 @@ class TestSearch extends BaseTestCase {
 		$this->assertTrue( $settings['highlight_excerpt'] );
 	}
 }
-

--- a/tests/php/features/TestWooCommerce.php
+++ b/tests/php/features/TestWooCommerce.php
@@ -54,7 +54,7 @@ class TestWooCommerce extends BaseTestCase {
 	}
 
 	/**
-	 * Test products post type query does get integrated when the feature is not active
+	 * Test products post type query does get integrated when the feature is active
 	 *
 	 * @since 2.1
 	 * @group woocommerce
@@ -73,8 +73,6 @@ class TestWooCommerce extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$args = array(
 			'post_type' => 'product',
 		);
@@ -84,8 +82,6 @@ class TestWooCommerce extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
-
-		$this->assertTrue( ! empty( $this->fired_actions['ep_wp_query_search'] ) );
 	}
 
 	/**
@@ -102,8 +98,6 @@ class TestWooCommerce extends BaseTestCase {
 		Functions\create_and_sync_post();
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
-
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
 
 		$args = array(
 			'tax_query' => array(
@@ -236,8 +230,6 @@ class TestWooCommerce extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$args = array(
 			's'         => 'findme',
 			'post_type' => 'product',
@@ -250,7 +242,7 @@ class TestWooCommerce extends BaseTestCase {
 
 	/**
 	 * Test the addition of variations skus to product meta
-	 * 
+	 *
 	 * @since 4.2.0
 	 * @group woocommerce
 	 */
@@ -287,7 +279,7 @@ class TestWooCommerce extends BaseTestCase {
 
 	/**
 	 * Test the translate_args_admin_products_list method
-	 * 
+	 *
 	 * @since 4.2.0
 	 * @group woocommerce
 	 */
@@ -329,7 +321,7 @@ class TestWooCommerce extends BaseTestCase {
 
 	/**
 	 * Test the ep_woocommerce_admin_products_list_search_fields filter
-	 * 
+	 *
 	 * @since 4.2.0
 	 * @group woocommerce
 	 */

--- a/tests/php/includes/classes/BaseTestCase.php
+++ b/tests/php/includes/classes/BaseTestCase.php
@@ -49,15 +49,6 @@ class BaseTestCase extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Helper function to test whether a EP search has happened
-	 *
-	 * @since 1.0
-	 */
-	public function action_wp_query_search() {
-		$this->fired_actions['ep_wp_query_search'] = true;
-	}
-
-	/**
 	 * Helper function to check post sync args
 	 *
 	 * @param  array $post_args Post arguments

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -199,8 +199,6 @@ class TestPost extends BaseTestCase {
 			's' => 'findme',
 		);
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query( $args );
 
 		$this->assertTrue( $query->elasticsearch_success );
@@ -250,8 +248,6 @@ class TestPost extends BaseTestCase {
 		$args = array(
 			's' => 'findme',
 		);
-
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
 
 		$query = new \WP_Query( $args );
 
@@ -412,7 +408,6 @@ class TestPost extends BaseTestCase {
 		ElasticPress\Indexables::factory()->get( 'post' )->index( $post_id, true );
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
 		$query = new \WP_Query( array( 's' => '#findme' ) );
 
 		$this->assertTrue( $query->elasticsearch_success );
@@ -549,8 +544,6 @@ class TestPost extends BaseTestCase {
 		$args = array(
 			's' => 'findme',
 		);
-
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
 
 		$query = new \WP_Query( $args );
 
@@ -3107,8 +3100,6 @@ class TestPost extends BaseTestCase {
 		$args = array(
 			's' => 'findme',
 		);
-
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
 
 		$query = new \WP_Query( $args );
 

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -198,8 +198,6 @@ class TestPostMultisite extends BaseTestCase {
 			'sites' => 'all',
 		);
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query( $args );
 
 		$this->assertTrue( $query->elasticsearch_success );
@@ -450,8 +448,6 @@ class TestPostMultisite extends BaseTestCase {
 			'sites' => 'all',
 		);
 
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
-
 		$query = new \WP_Query( $args );
 
 		$this->assertTrue( $query->elasticsearch_success );
@@ -498,8 +494,6 @@ class TestPostMultisite extends BaseTestCase {
 			's'     => 'findme',
 			'sites' => 'all',
 		);
-
-		add_action( 'ep_wp_query_search', array( $this, 'action_wp_query_search' ), 10, 0 );
 
 		$query = new \WP_Query( $args );
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR removes the legacy hook from tests that is used to test either the query gets the data from ElasticSearch or not

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Removed -  Legacy hook from unit tests


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
