### PR TITLE
Apply the 'all' operator correctly within widgets

### DIFF
--- a/includes/classes/Feature/Facets/Types/Meta/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/Meta/FacetType.php
@@ -214,12 +214,24 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 		}
 
 		$meta_fields = $selected_filters[ $this->get_filter_type() ];
+		$match_type  = $feature->get_match_type();
+
 		foreach ( $meta_fields as $meta_field => $values ) {
-			$filters[] = [
-				'terms' => [
-					'meta.' . $meta_field . '.raw' => array_keys( $values['terms'] ),
-				],
-			];
+			if ( 'any' === $match_type ) {
+				$filters[] = [
+					'terms' => [
+						'meta.' . $meta_field . '.raw' => array_keys( $values['terms'] ),
+					],
+				];
+			} else {
+				foreach ( $values['terms'] as $meta_key => $bool ) {
+					$filters[] = [
+						'term' => [
+							'meta.' . $meta_field . '.raw' => $meta_key,
+						],
+					];
+				}
+			}
 		}
 
 		return $filters;

--- a/includes/classes/Feature/Facets/Types/Taxonomy/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/FacetType.php
@@ -210,14 +210,26 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 			}
 		}
 
+		$match_type = $feature->get_match_type();
+
 		foreach ( $selected_filters['taxonomies'] as $taxonomy => $filter ) {
 			$taxonomy_slug = $attribute_taxonomies[ $taxonomy ] ?? $taxonomy;
 
-			$filters[] = [
-				'terms' => [
-					'terms.' . $taxonomy_slug . '.slug' => array_keys( $filter['terms'] ),
-				],
-			];
+			if ( 'any' === $match_type ) {
+				$filters[] = [
+					'terms' => [
+						'terms.' . $taxonomy_slug . '.slug' => array_keys( $filter['terms'] ),
+					],
+				];
+			} else {
+				foreach ( $filter['terms'] as $term_slug => $term ) {
+					$filters[] = [
+						'term' => [
+							'terms.' . $taxonomy_slug . '.slug' => $term_slug,
+						],
+					];
+				}
+			}
 		}
 
 		return $filters;

--- a/tests/php/features/TestFacetTypeMeta.php
+++ b/tests/php/features/TestFacetTypeMeta.php
@@ -220,13 +220,36 @@ class TestFacetTypeMeta extends BaseTestCase {
 		$facet_feature = Features::factory()->get_registered_feature( 'facets' );
 		$facet_type    = $facet_feature->types['meta'];
 
-		parse_str( 'ep_meta_filter_my_custom_field=dolor', $_GET );
+		parse_str( 'ep_meta_filter_my_custom_field=dolor,amet', $_GET );
+
+		$new_filters = $facet_type->add_query_filters( [] );
+		$expected    = [
+			[
+				'term' => [
+					'meta.my_custom_field.raw' => 'dolor',
+				],
+			],
+			[
+				'term' => [
+					'meta.my_custom_field.raw' => 'amet',
+				],
+			],
+		];
+		$this->assertSame( $expected, $new_filters );
+
+		/**
+		 * Changing the match type should change from `term` to `terms`
+		 */
+		$change_match_type = function () {
+			return 'any';
+		};
+		add_filter( 'ep_facet_match_type', $change_match_type );
 
 		$new_filters = $facet_type->add_query_filters( [] );
 		$expected    = [
 			[
 				'terms' => [
-					'meta.my_custom_field.raw' => [ 'dolor' ],
+					'meta.my_custom_field.raw' => [ 'dolor', 'amet' ],
 				],
 			],
 		];

--- a/tests/php/features/TestFacetTypeTaxonomy.php
+++ b/tests/php/features/TestFacetTypeTaxonomy.php
@@ -163,13 +163,36 @@ class TestFacetTypeTaxonomy extends BaseTestCase {
 		$facet_feature = Features::factory()->get_registered_feature( 'facets' );
 		$facet_type    = $facet_feature->types['taxonomy'];
 
-		parse_str( 'ep_filter_taxonomy=dolor', $_GET );
+		parse_str( 'ep_filter_taxonomy=dolor,amet', $_GET );
+
+		$new_filters = $facet_type->add_query_filters( [] );
+		$expected    = [
+			[
+				'term' => [
+					'terms.taxonomy.slug' => 'dolor',
+				],
+			],
+			[
+				'term' => [
+					'terms.taxonomy.slug' => 'amet',
+				],
+			],
+		];
+		$this->assertSame( $expected, $new_filters );
+
+		/**
+		 * Changing the match type should change from `term` to `terms`
+		 */
+		$change_match_type = function () {
+			return 'any';
+		};
+		add_filter( 'ep_facet_match_type', $change_match_type );
 
 		$new_filters = $facet_type->add_query_filters( [] );
 		$expected    = [
 			[
 				'terms' => [
-					'terms.taxonomy.slug' => [ 'dolor' ],
+					'terms.taxonomy.slug' => [ 'dolor', 'amet' ],
 				],
 			],
 		];


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
After #3045, the logic of all/any within widgets is wrongly applied. This PR fixes that behavior.


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
Can be added to the #3045 entry


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia and @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
