### PR TITLE
Use Utils\get_option() when possible

### DIFF
--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -91,11 +91,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$last_sync = get_site_option( 'ep_last_sync', false );
-		} else {
-			$last_sync = get_option( 'ep_last_sync', false );
-		}
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
 
 		if ( empty( $last_sync ) ) {
 			return false;
@@ -107,11 +103,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_using_autosuggest_defaults_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_using_autosuggest_defaults_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_using_autosuggest_defaults_notice', false );
 
 		if ( $dismiss ) {
 			return false;
@@ -147,32 +139,20 @@ class AdminNotices {
 	 * @return array|bool
 	 */
 	protected function process_auto_activate_sync_notice() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$need_upgrade_sync = get_site_option( 'ep_need_upgrade_sync', false );
-		} else {
-			$need_upgrade_sync = get_option( 'ep_need_upgrade_sync', false );
-		}
+		$need_upgrade_sync = Utils\get_option( 'ep_need_upgrade_sync', false );
 
 		// need_upgrade_sync takes priority over this notice
 		if ( $need_upgrade_sync ) {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$auto_activate_sync = get_site_option( 'ep_feature_auto_activated_sync', false );
-		} else {
-			$auto_activate_sync = get_option( 'ep_feature_auto_activated_sync', false );
-		}
+		$auto_activate_sync = Utils\get_option( 'ep_feature_auto_activated_sync', false );
 
 		if ( ! $auto_activate_sync ) {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$last_sync = get_site_option( 'ep_last_sync', false );
-		} else {
-			$last_sync = get_option( 'ep_last_sync', false );
-		}
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
 
 		if ( empty( $last_sync ) ) {
 			return false;
@@ -184,11 +164,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_auto_activate_sync_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_auto_activate_sync_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_auto_activate_sync_notice', false );
 
 		$screen = Screen::factory()->get_current_screen();
 
@@ -236,21 +212,13 @@ class AdminNotices {
 	 * @return array|bool
 	 */
 	protected function process_upgrade_sync_notice() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$need_upgrade_sync = get_site_option( 'ep_need_upgrade_sync', false );
-		} else {
-			$need_upgrade_sync = get_option( 'ep_need_upgrade_sync', false );
-		}
+		$need_upgrade_sync = Utils\get_option( 'ep_need_upgrade_sync', false );
 
 		if ( ! $need_upgrade_sync ) {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$last_sync = get_site_option( 'ep_last_sync', false );
-		} else {
-			$last_sync = get_option( 'ep_last_sync', false );
-		}
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
 
 		if ( empty( $last_sync ) ) {
 			return false;
@@ -262,11 +230,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_upgrade_sync_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_upgrade_sync_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_upgrade_sync_notice', false );
 
 		$screen = Screen::factory()->get_current_screen();
 
@@ -314,11 +278,7 @@ class AdminNotices {
 	 * @return array|bool
 	 */
 	protected function process_no_sync_notice() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$last_sync = get_site_option( 'ep_last_sync', false );
-		} else {
-			$last_sync = get_option( 'ep_last_sync', false );
-		}
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
 
 		if ( ! empty( $last_sync ) ) {
 			return false;
@@ -330,11 +290,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_no_sync_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_no_sync_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_no_sync_notice', false );
 
 		$screen = Screen::factory()->get_current_screen();
 
@@ -386,11 +342,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_need_setup_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_need_setup_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_need_setup_notice', false );
 
 		$screen = Screen::factory()->get_current_screen();
 
@@ -442,11 +394,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_es_below_compat_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_es_below_compat_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_es_below_compat_notice', false );
 
 		if ( $dismiss ) {
 			return false;
@@ -502,11 +450,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_es_above_compat_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_es_above_compat_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_es_above_compat_notice', false );
 
 		if ( $dismiss ) {
 			return false;
@@ -602,11 +546,7 @@ class AdminNotices {
 
 		// Only dismissable on non-EP screens
 		if ( ! in_array( $screen, [ 'settings', 'dashboard' ], true ) ) {
-			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-				$dismiss = get_site_option( 'ep_hide_host_error_notice', false );
-			} else {
-				$dismiss = get_option( 'ep_hide_host_error_notice', false );
-			}
+			$dismiss = Utils\get_option( 'ep_hide_host_error_notice', false );
 
 			if ( $dismiss ) {
 				return false;
@@ -660,11 +600,7 @@ class AdminNotices {
 		}
 
 		// we might have this dismissed
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_maybe_wrong_mapping_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_maybe_wrong_mapping_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_maybe_wrong_mapping_notice', false );
 
 		// we need a host
 		$host = Utils\get_host();
@@ -680,11 +616,7 @@ class AdminNotices {
 		}
 
 		// we also likely need a sync to have a mapping
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$last_sync = get_site_option( 'ep_last_sync', false );
-		} else {
-			$last_sync = get_option( 'ep_last_sync', false );
-		}
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
 
 		if ( empty( $last_sync ) ) {
 			return false;
@@ -737,21 +669,13 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$last_sync = get_site_option( 'ep_last_sync', false );
-		} else {
-			$last_sync = get_option( 'ep_last_sync', false );
-		}
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
 
 		if ( empty( $last_sync ) ) {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$dismiss = get_site_option( 'ep_hide_yellow_health_notice', false );
-		} else {
-			$dismiss = get_option( 'ep_hide_yellow_health_notice', false );
-		}
+		$dismiss = Utils\get_option( 'ep_hide_yellow_health_notice', false );
 
 		$screen = Screen::factory()->get_current_screen();
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -140,11 +140,7 @@ class Command extends WP_CLI_Command {
 			WP_CLI::error( esc_html__( 'No feature with that slug is registered', 'elasticpress' ) );
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$active_features = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$active_features = get_option( 'ep_feature_settings', [] );
-		}
+		$active_features = Utils\get_option( 'ep_feature_settings', [] );
 
 		$key = array_search( $feature->slug, array_keys( $active_features ), true );
 
@@ -173,11 +169,8 @@ class Command extends WP_CLI_Command {
 	public function list_features( $args, $assoc_args ) {
 
 		if ( empty( $assoc_args['all'] ) ) {
-			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-				$features = get_site_option( 'ep_feature_settings', [] );
-			} else {
-				$features = get_option( 'ep_feature_settings', [] );
-			}
+			$features = Utils\get_option( 'ep_feature_settings', [] );
+
 			WP_CLI::line( esc_html__( 'Active features:', 'elasticpress' ) );
 
 			foreach ( array_keys( $features ) as $feature_slug ) {
@@ -1237,11 +1230,7 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_search_algorithm_version( $args, $assoc_args ) {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$value = get_site_option( 'ep_search_algorithm_version', '' );
-		} else {
-			$value = get_option( 'ep_search_algorithm_version', '' );
-		}
+		$value = Utils\get_option( 'ep_search_algorithm_version', '' );
 
 		if ( empty( $value ) ) {
 			WP_CLI::line( 'default' );

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -11,6 +11,7 @@
 namespace ElasticPress;
 
 use ElasticPress\FeatureRequirementsStatus as FeatureRequirementsStatus;
+use ElasticPress\Utils as Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -162,11 +163,7 @@ abstract class Feature {
 	 * @return array|bool
 	 */
 	public function get_settings() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', [] );
-		}
+		$feature_settings = Utils\get_option( 'ep_feature_settings', [] );
 
 		return ( ! empty( $feature_settings[ $this->slug ] ) ) ? $feature_settings[ $this->slug ] : false;
 	}
@@ -178,11 +175,7 @@ abstract class Feature {
 	 * @return boolean
 	 */
 	public function is_active() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', [] );
-		}
+		$feature_settings = Utils\get_option( 'ep_feature_settings', [] );
 
 		$active = false;
 

--- a/includes/classes/Features.php
+++ b/includes/classes/Features.php
@@ -8,6 +8,8 @@
 
 namespace ElasticPress;
 
+use ElasticPress\Utils as Utils;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -105,11 +107,7 @@ class Features {
 
 		$original_state = $feature->is_active();
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', [] );
-		}
+		$feature_settings = Utils\get_option( 'ep_feature_settings', [] );
 
 		if ( empty( $feature_settings[ $slug ] ) ) {
 			// If doesn't exist, merge with feature defaults
@@ -184,11 +182,7 @@ class Features {
 		 * Save our current requirement statuses for later
 		 */
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$old_requirement_statuses = get_site_option( 'ep_feature_requirement_statuses', false );
-		} else {
-			$old_requirement_statuses = get_option( 'ep_feature_requirement_statuses', false );
-		}
+		$old_requirement_statuses = Utils\get_option( 'ep_feature_requirement_statuses', false );
 
 		$new_requirement_statuses = [];
 
@@ -211,11 +205,7 @@ class Features {
 		 * If feature settings aren't created, let's create them and finish
 		 */
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', false );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', false );
-		}
+		$feature_settings = Utils\get_option( 'ep_feature_settings', false );
 
 		if ( false === $feature_settings ) {
 			$registered_features = $this->registered_features;

--- a/includes/classes/Installer.php
+++ b/includes/classes/Installer.php
@@ -59,11 +59,7 @@ class Installer {
 	 * @since 3.0
 	 */
 	public function calculate_install_status() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$skip_install = get_site_option( 'ep_skip_install', false );
-		} else {
-			$skip_install = get_option( 'ep_skip_install', false );
-		}
+		$skip_install = Utils\get_option( 'ep_skip_install', false );
 
 		if ( $skip_install ) {
 			$this->install_status = true;
@@ -71,7 +67,7 @@ class Installer {
 			return;
 		}
 
-		$last_sync = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ? get_site_option( 'ep_last_sync', false ) : get_option( 'ep_last_sync', false );
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
 		if ( ! empty( $last_sync ) ) {
 			$this->install_status = true;
 

--- a/includes/classes/Screen/Sync.php
+++ b/includes/classes/Screen/Sync.php
@@ -154,13 +154,12 @@ class Sync {
 
 		$data       = array( 'nonce' => wp_create_nonce( 'ep_dashboard_nonce' ) );
 		$index_meta = Utils\get_indexing_status();
+		$last_sync  = Utils\get_option( 'ep_last_sync', false );
 
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			$install_complete_url = admin_url( 'network/admin.php?page=elasticpress&install_complete' );
-			$last_sync            = get_site_option( 'ep_last_sync', false );
 		} else {
 			$install_complete_url = admin_url( 'admin.php?page=elasticpress&install_complete' );
-			$last_sync            = get_option( 'ep_last_sync', false );
 		}
 
 		if ( isset( $_GET['do_sync'] ) && ( ! defined( 'EP_DASHBOARD_SYNC' ) || EP_DASHBOARD_SYNC ) ) { // phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -8,6 +8,8 @@
 
 namespace ElasticPress;
 
+use ElasticPress\Utils as Utils;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -31,11 +33,7 @@ class Upgrades {
 	 * Initialize class
 	 */
 	public function setup() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$this->old_version = get_site_option( 'ep_version', false );
-		} else {
-			$this->old_version = get_option( 'ep_version', false );
-		}
+		$this->old_version = Utils\get_option( 'ep_version', false );
 
 		/**
 		 * An array with the upgrades routines.
@@ -250,11 +248,7 @@ class Upgrades {
 			return;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$last_sync = get_site_option( 'ep_last_sync', 'never' );
-		} else {
-			$last_sync = get_option( 'ep_last_sync', 'never' );
-		}
+		$last_sync = Utils\get_option( 'ep_last_sync', 'never' );
 
 		// No need to upgrade since we've never synced.
 		if ( empty( $last_sync ) || 'never' === $last_sync ) {

--- a/includes/partials/dashboard-page.php
+++ b/includes/partials/dashboard-page.php
@@ -8,16 +8,13 @@
 
 use ElasticPress\Elasticsearch as Elasticsearch;
 use ElasticPress\Features as Features;
+use ElasticPress\Utils as Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-	$index_meta = get_site_option( 'ep_index_meta', false );
-} else {
-	$index_meta = get_option( 'ep_index_meta', false );
-}
+$index_meta = Utils\get_option( 'ep_index_meta', [] );
 ?>
 
 <?php require_once __DIR__ . '/header.php'; ?>

--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -15,11 +15,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $action = 'options.php';
 
+$index_meta = Utils\get_option( 'ep_index_meta', [] );
+
 if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-	$index_meta = get_site_option( 'ep_index_meta', false );
-	$action     = '';
-} else {
-	$index_meta = get_option( 'ep_index_meta', false );
+	$action = '';
 }
 
 $version = Elasticsearch::factory()->get_elasticsearch_version();
@@ -29,11 +28,7 @@ $is_epio     = Utils\is_epio();
 $credentials = Utils\get_epio_credentials();
 $wpconfig    = defined( 'EP_HOST' ) && EP_HOST;
 
-if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-	$bulk_setting = get_site_option( 'ep_bulk_setting', 350 );
-} else {
-	$bulk_setting = get_option( 'ep_bulk_setting', 350 );
-}
+$bulk_setting = Utils\get_option( 'ep_bulk_setting', 350 );
 ?>
 
 <?php require_once __DIR__ . '/header.php'; ?>

--- a/includes/partials/stats-page.php
+++ b/includes/partials/stats-page.php
@@ -8,6 +8,7 @@
 
 use ElasticPress\Stats as Stats;
 use ElasticPress\Elasticsearch as Elasticsearch;
+use ElasticPress\Utils as Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -15,12 +16,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/header.php';
 
+$index_meta = Utils\get_option( 'ep_index_meta', [] );
+
 if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-	$index_meta = get_site_option( 'ep_index_meta', false );
-	$sync_url   = network_admin_url( 'admin.php?page=elasticpress-sync' );
+	$sync_url = network_admin_url( 'admin.php?page=elasticpress-sync' );
 } else {
-	$index_meta = get_option( 'ep_index_meta', false );
-	$sync_url   = admin_url( 'admin.php?page=elasticpress-sync' );
+	$sync_url = admin_url( 'admin.php?page=elasticpress-sync' );
 }
 
 Stats::factory()->build_stats();

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -202,8 +202,6 @@ function get_host() {
 
 	if ( defined( 'EP_HOST' ) && EP_HOST ) {
 		$host = EP_HOST;
-	} elseif ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		$host = get_site_option( 'ep_host', false );
 	} else {
 		$host = get_option( 'ep_host', false );
 	}


### PR DESCRIPTION
### Description of the Change
Just revising some redundant code. We should be using the `Utils\get_option()` when possible.

### Changelog Entry
Changed - update code to use Utils\get_option() when possible


### Credits
Props @rebeccahum 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
