### PR TITLE
use Utils\*_option()

### DIFF
--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -10,7 +10,7 @@
 
 namespace ElasticPress;
 
-use ElasticPress\Utils;
+use ElasticPress\Utils as Utils;
 use ElasticPress\Elasticsearch;
 use ElasticPress\Screen;
 use ElasticPress\Features;
@@ -772,11 +772,7 @@ class AdminNotices {
 		if ( in_array( $notice, [ 'maybe_wrong_mapping' ], true ) ) {
 			$value = Elasticsearch::factory()->get_elasticsearch_version( false );
 		}
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			update_site_option( 'ep_hide_' . $notice . '_notice', $value );
-		} else {
-			update_option( 'ep_hide_' . $notice . '_notice', $value );
-		}
+		Utils\update_option( 'ep_hide_' . $notice . '_notice', $value );
 	}
 
 	/**

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1198,17 +1198,9 @@ class Command extends WP_CLI_Command {
 		}
 
 		if ( ! empty( $assoc_args['default'] ) ) {
-			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-				delete_site_option( 'ep_search_algorithm_version' );
-			} else {
-				delete_option( 'ep_search_algorithm_version' );
-			}
+			Utils\delete_option( 'ep_search_algorithm_version' );
 		} else {
-			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-				update_site_option( 'ep_search_algorithm_version', $assoc_args['version'] );
-			} else {
-				update_option( 'ep_search_algorithm_version', $assoc_args['version'], false );
-			}
+			Utils\update_option( 'ep_search_algorithm_version', $assoc_args['version'] );
 		}
 
 		/**

--- a/includes/classes/Features.php
+++ b/includes/classes/Features.php
@@ -133,11 +133,7 @@ class Features {
 
 		$sanitize_feature_settings = apply_filters( 'ep_sanitize_feature_settings', $feature_settings, $feature );
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			update_site_option( 'ep_feature_settings', $sanitize_feature_settings );
-		} else {
-			update_option( 'ep_feature_settings', $sanitize_feature_settings );
-		}
+		Utils\update_option( 'ep_feature_settings', $sanitize_feature_settings );
 
 		$data = array(
 			'active'  => $sanitize_feature_settings[ $slug ]['active'],
@@ -194,11 +190,7 @@ class Features {
 		$is_wp_cli = defined( 'WP_CLI' ) && \WP_CLI;
 
 		if ( $is_wp_cli || is_admin() ) {
-			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-				update_site_option( 'ep_feature_requirement_statuses', $new_requirement_statuses );
-			} else {
-				update_option( 'ep_feature_requirement_statuses', $new_requirement_statuses );
-			}
+			Utils\update_option( 'ep_feature_requirement_statuses', $new_requirement_statuses );
 		}
 
 		/**
@@ -242,11 +234,7 @@ class Features {
 						$this->activate_feature( $slug );
 
 						if ( $feature->requires_install_reindex ) {
-							if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-								update_site_option( 'ep_feature_auto_activated_sync', sanitize_text_field( $slug ) );
-							} else {
-								update_option( 'ep_feature_auto_activated_sync', sanitize_text_field( $slug ) );
-							}
+							Utils\update_option( 'ep_feature_auto_activated_sync', sanitize_text_field( $slug ) );
 						}
 					}
 				} else {
@@ -259,11 +247,7 @@ class Features {
 
 							// Need to activate and maybe set a sync notice
 							if ( $feature->requires_install_reindex ) {
-								if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-									update_site_option( 'ep_feature_auto_activated_sync', sanitize_text_field( $slug ) );
-								} else {
-									update_option( 'ep_feature_auto_activated_sync', sanitize_text_field( $slug ) );
-								}
+								Utils\update_option( 'ep_feature_auto_activated_sync', sanitize_text_field( $slug ) );
 							}
 						} elseif ( $feature->is_active() && ! $active ) {
 							// Just deactivate, don't force

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -60,11 +60,7 @@ class Upgrades {
 		 * Note: if a upgrade routine method is hooked to some action,
 		 * this code will be executed *earlier* than the routine method.
 		 */
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			update_site_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
-		} else {
-			update_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
-		}
+		Utils\update_option( 'ep_version', sanitize_text_field( EP_VERSION ) );
 
 		add_filter( 'ep_admin_notices', [ $this, 'resync_notice_4_0_0_instant_results' ] );
 	}
@@ -289,11 +285,7 @@ class Upgrades {
 		}
 
 		if ( $need_upgrade_sync ) {
-			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-				update_site_option( 'ep_need_upgrade_sync', true );
-			} else {
-				update_option( 'ep_need_upgrade_sync', true );
-			}
+			Utils\update_option( 'ep_need_upgrade_sync', true );
 		}
 	}
 

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -203,11 +203,10 @@ function maybe_skip_install() {
 
 	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 		$redirect_url = network_admin_url( 'admin.php?page=elasticpress' );
-		update_site_option( 'ep_skip_install', true );
 	} else {
 		$redirect_url = admin_url( 'admin.php?page=elasticpress' );
-		update_option( 'ep_skip_install', true );
 	}
+	Utils\update_option( 'ep_skip_install', true );
 
 	wp_safe_redirect( $redirect_url );
 	exit;
@@ -439,11 +438,7 @@ function action_wp_ajax_ep_save_feature() {
 
 	// Since we deactivated, delete auto activate notice.
 	if ( empty( $_POST['settings']['active'] ) ) {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			delete_site_option( 'ep_feature_auto_activated_sync' );
-		} else {
-			delete_option( 'ep_feature_auto_activated_sync' );
-		}
+		Utils\delete_option( 'ep_feature_auto_activated_sync' );
 	}
 
 	wp_send_json_success( $data );
@@ -604,16 +599,16 @@ function action_admin_init() {
 		check_admin_referer( 'elasticpress-options' );
 
 		$language = sanitize_text_field( $_POST['ep_language'] );
-		update_site_option( 'ep_language', $language );
+		Utils\update_option( 'ep_language', $language );
 
 		if ( isset( $_POST['ep_host'] ) ) {
 			$host = esc_url_raw( trim( $_POST['ep_host'] ) );
-			update_site_option( 'ep_host', $host );
+			Utils\update_option( 'ep_host', $host );
 		}
 
 		if ( isset( $_POST['ep_prefix'] ) ) {
 			$prefix = ( isset( $_POST['ep_prefix'] ) ) ? sanitize_text_field( wp_unslash( $_POST['ep_prefix'] ) ) : '';
-			update_site_option( 'ep_prefix', $prefix );
+			Utils\update_option( 'ep_prefix', $prefix );
 		}
 
 		if ( isset( $_POST['ep_credentials'] ) ) {
@@ -622,11 +617,11 @@ function action_admin_init() {
 				'token'    => '',
 			];
 
-			update_site_option( 'ep_credentials', $credentials );
+			Utils\update_option( 'ep_credentials', $credentials );
 		}
 
 		if ( isset( $_POST['ep_bulk_setting'] ) ) {
-			update_site_option( 'ep_bulk_setting', intval( $_POST['ep_bulk_setting'] ) );
+			Utils\update_option( 'ep_bulk_setting', intval( $_POST['ep_bulk_setting'] ) );
 		}
 	} else {
 		register_setting( 'elasticpress', 'ep_host', 'esc_url_raw' );


### PR DESCRIPTION
### Description of the Change
A follow-up to #3078, where we also include *_option() rather than just get_option(). Should be no functionality change as well.

### Changelog Entry
Changed - Use `Utils\*_option()` when possible


### Credits
Props @rebasaurus


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
