### PR TITLE
Fix: Deprecated Warning for uasort()

### DIFF
--- a/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
@@ -473,14 +473,14 @@ class Renderer {
 				uasort(
 					$ordered_terms,
 					function( $a, $b ) {
-						return $a->count > $b->count;
+						return $a->count <=> $b->count;
 					}
 				);
 			} else {
 				uasort(
 					$ordered_terms,
 					function( $a, $b ) {
-						return $a->count < $b->count;
+						return $b->count <=> $a->count;
 					}
 				);
 			}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the deprecation warning that uasort throws on the PHP 8.

PHP 8 introduced the [Stable Sorting RFC](https://wiki.php.net/rfc/stable_sorting), which means that all sorting functions in PHP are now "stable".
 
The recommended way is to use the PHP spaceship operate for compare.  [Ref](https://stackoverflow.com/a/65383660/5222707)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3075

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Install ElasticPress on PHP 8 environment.
2. Import WooCommerce Dummy Content.
3. Add the Taxonomy Facet and select the clothing term.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Deprecated Warning: uasort(): Returning bool from comparison function is deprecated


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
