### PR TITLE
Adjust compatibility with `all` for WP_User_Query (WP 6.1)

### DIFF
--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -91,11 +91,12 @@ class QueryIntegration {
 			 *
 			 * $query->elasticsearch_success = true;
 			 */
+			$query->query_vars['elasticsearch_success'] = true;
 
 			$fields    = $query->get( 'fields' );
 			$new_users = [];
 
-			if ( 'all_with_meta' === $fields ) {
+			if ( in_array( $fields, [ 'all', 'all_with_meta' ], true ) ) {
 				foreach ( $ep_query['documents'] as $document ) {
 					$new_users[] = $document['ID'];
 				}
@@ -115,7 +116,7 @@ class QueryIntegration {
 
 					$new_users[] = $user;
 				}
-			} elseif ( is_string( $fields ) && ! empty( $fields ) && 'all' !== $fields ) {
+			} elseif ( is_string( $fields ) && ! empty( $fields ) ) {
 				foreach ( $ep_query['documents'] as $document ) {
 					$new_users[] = $document[ $fields ];
 				}

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -146,6 +146,11 @@ describe('Instant Results Feature', () => {
 		});
 
 		it('Is possible to manually open Instant Results with a plugin', () => {
+			Cypress.on(
+				'uncaught:exception',
+				(err) => !err.message.includes('ResizeObserver loop limit exceeded'),
+			);
+
 			/**
 			 * Activate test plugin with JavaScript.
 			 */

--- a/tests/cypress/integration/features/related-posts.cy.js
+++ b/tests/cypress/integration/features/related-posts.cy.js
@@ -195,6 +195,7 @@ describe('Related Posts Feature', () => {
 		 * Check that the block's settings match the widget's.
 		 */
 		cy.get('@block').click();
+		cy.get('.edit-widgets-header__actions button[aria-label="Settings"]').click();
 		cy.get('input[type="number"][aria-label="Number of items"]').should('have.value', '2');
 	});
 });

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -262,10 +262,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( empty( $user->elasticsearch ) );
-		}
-
+		$this->assertArrayNotHasKey( 'elasticsearch_success', $user_query->query_vars );
 		$this->assertEquals( 5, count( $user_query->results ) );
 		$this->assertEquals( 5, $user_query->total_users );
 
@@ -277,10 +274,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 5, count( $user_query->results ) );
 		$this->assertEquals( 5, $user_query->total_users );
 	}
@@ -313,10 +307,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 20, count( $user_query->results ) );
 		$this->assertEquals( 20, $user_query->total_users );
 	}
@@ -347,10 +338,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertNotEquals( $first_user->ID, $user_query->results[0]->ID );
 	}
 
@@ -380,10 +368,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertNotEquals( $first_user->ID, $user_query->results[0]->ID );
 	}
 
@@ -403,10 +388,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertTrue( in_array( 'editor', $user_query->results[0]->roles, true ) );
 	}
@@ -427,10 +409,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 1, $user_query->results[0]->ID );
 	}
@@ -451,10 +430,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 4, $user_query->total_users );
 	}
 
@@ -474,10 +450,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'test_admin', $user_query->results[0]->user_login );
 	}
@@ -498,10 +471,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'test_admin', $user_query->results[0]->user_login );
 	}
@@ -522,10 +492,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 4, $user_query->total_users );
 	}
 
@@ -545,10 +512,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'mike', $user_query->results[0]->user_nicename );
 	}
@@ -569,10 +533,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'mike', $user_query->results[0]->user_nicename );
 	}
@@ -593,10 +554,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 4, $user_query->total_users );
 	}
 
@@ -616,9 +574,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		foreach ( $user_query->results as $user ) {
 			$this->assertFalse( in_array( 'editor', $user_query->results[0]->roles, true ) );
@@ -644,9 +600,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		foreach ( $user_query->results as $user ) {
 			$this->assertTrue( ( in_array( 'editor', $user_query->results[0]->roles, true ) || in_array( 'author', $user_query->results[0]->roles, true ) ) );
@@ -669,9 +623,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		$users_id_fetched = wp_list_pluck( $user_query->results, 'ID' );
 
@@ -740,9 +692,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		$users_id_fetched = wp_list_pluck( $user_query->results, 'ID' );
 
@@ -810,9 +760,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		$users_id_fetched = wp_list_pluck( $user_query->results, 'ID' );
 
@@ -880,9 +828,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		$users_id_fetched = wp_list_pluck( $user_query->results, 'ID' );
 
@@ -949,9 +895,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		foreach ( $user_query->results as $key => $user ) {
 			if ( ! empty( $user_query->results[ $key - 1 ] ) ) {
@@ -976,9 +920,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		foreach ( $user_query->results as $key => $user ) {
 			if ( ! empty( $user_query->results[ $key - 1 ] ) ) {
@@ -1004,9 +946,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		foreach ( $user_query->results as $key => $user ) {
 			if ( ! empty( $user_query->results[ $key - 1 ] ) ) {
@@ -1032,10 +972,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 0, $user_query->total_users );
 
 		// This value exists
@@ -1068,10 +1005,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 4, $user_query->total_users );
 	}
 
@@ -1095,10 +1029,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'value1', get_user_meta( $user_query->results[0]->ID, 'user_1_key', true ) );
 	}
@@ -1124,10 +1055,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'value2', get_user_meta( $user_query->results[0]->ID, 'user_2_key', true ) );
 	}
@@ -1156,10 +1084,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'value1', get_user_meta( $user_query->results[0]->ID, 'user_1_key', true ) );
 	}
@@ -1189,10 +1114,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 2, $user_query->total_users );
 	}
 
@@ -1221,10 +1143,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 	}
 
@@ -1242,10 +1161,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'user3-editor', $user_query->results[0]->user_login );
 	}
@@ -1264,10 +1180,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'user3-editor', $user_query->results[0]->user_login );
 	}
@@ -1289,10 +1202,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'user2-contributor', $user_query->results[0]->user_login );
 	}
@@ -1314,10 +1224,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'user1-author', $user_query->results[0]->user_login );
 	}
@@ -1386,9 +1293,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 
 		$ep_users = $user_query->results;
 
@@ -1479,9 +1384,7 @@ class TestUser extends BaseTestCase {
 
 		$this->assertTrue( $this->get_feature()->integrate_search_queries( false, $query ) );
 		$this->assertEquals( 1, $query->total_users );
-		foreach ( $query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $query->query_vars['elasticsearch_success'] );
 
 		// Search accross all blogs.
 		$query = new \WP_User_Query(
@@ -1493,9 +1396,7 @@ class TestUser extends BaseTestCase {
 
 		$this->assertTrue( $this->get_feature()->integrate_search_queries( false, $query ) );
 		$this->assertEquals( 2, $query->total_users );
-		foreach ( $query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
+		$this->assertTrue( $query->query_vars['elasticsearch_success'] );
 	}
 
 	/**
@@ -1517,7 +1418,7 @@ class TestUser extends BaseTestCase {
 
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'user2-contributor', $user_query->results[0]->user_login );
-		$this->assertTrue( $user_query->results[0]->elasticsearch );
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 	}
 
 	/**
@@ -1539,7 +1440,7 @@ class TestUser extends BaseTestCase {
 
 		$this->assertEquals( 1, $user_query->total_users );
 		$this->assertEquals( 'test_admin', $user_query->results[0]->user_login );
-		$this->assertTrue( $user_query->results[0]->elasticsearch );
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 	}
 
 	/**
@@ -1569,10 +1470,10 @@ class TestUser extends BaseTestCase {
 
 		$user_order = array();
 		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
 			$user_order[] = $user->user_login;
 		}
-
+		
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( $expected_user_order, $user_order );
 	}
 
@@ -1606,10 +1507,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		foreach ( $user_query->results as $user ) {
-			$this->assertTrue( $user->elasticsearch );
-		}
-
+		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3108

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - To be compatible with WordPress 6.1, WP_User_Query passing `all` as `fields` parameter value will receive only user IDs.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
