### PR TITLE
Fix Autosuggest bugs

### DIFF
--- a/assets/js/autosuggest/back-compat.js
+++ b/assets/js/autosuggest/back-compat.js
@@ -3,38 +3,40 @@
  */
 import { addFilter } from '@wordpress/hooks';
 
-if (typeof window.epDataFilter !== 'undefined') {
-	addFilter('ep.Autosuggest.data', 'ep/epDatafilter', window.epDatafilter);
-}
+window.addEventListener('load', () => {
+	if (typeof window.epDataFilter !== 'undefined') {
+		addFilter('ep.Autosuggest.data', 'ep/epDatafilter', window.epDatafilter);
+	}
 
-if (typeof window.epAutosuggestItemHTMLFilter !== 'undefined') {
-	addFilter(
-		'ep.Autosuggest.itemHTML',
-		'ep/epAutosuggestItemHTMLFilter',
-		window.epAutosuggestItemHTMLFilter,
-	);
-}
+	if (typeof window.epAutosuggestItemHTMLFilter !== 'undefined') {
+		addFilter(
+			'ep.Autosuggest.itemHTML',
+			'ep/epAutosuggestItemHTMLFilter',
+			window.epAutosuggestItemHTMLFilter,
+		);
+	}
 
-if (typeof window.epAutosuggestListItemsHTMLFilter !== 'undefined') {
-	addFilter(
-		'ep.Autosuggest.listHTML',
-		'ep/epAutosuggestListItemsHTMLFilter',
-		window.epAutosuggestListItemsHTMLFilter,
-	);
-}
+	if (typeof window.epAutosuggestListItemsHTMLFilter !== 'undefined') {
+		addFilter(
+			'ep.Autosuggest.listHTML',
+			'ep/epAutosuggestListItemsHTMLFilter',
+			window.epAutosuggestListItemsHTMLFilter,
+		);
+	}
 
-if (typeof window.epAutosuggestQueryFilter !== 'undefined') {
-	addFilter(
-		'ep.Autosuggest.query',
-		'ep/epAutosuggestQueryFilter',
-		window.epAutosuggestQueryFilter,
-	);
-}
+	if (typeof window.epAutosuggestQueryFilter !== 'undefined') {
+		addFilter(
+			'ep.Autosuggest.query',
+			'ep/epAutosuggestQueryFilter',
+			window.epAutosuggestQueryFilter,
+		);
+	}
 
-if (typeof window.epAutosuggestElementFilter !== 'undefined') {
-	addFilter(
-		'ep.Autosuggest.element',
-		'ep/epAutosuggestElementFilter',
-		window.epAutosuggestElementFilter,
-	);
-}
+	if (typeof window.epAutosuggestElementFilter !== 'undefined') {
+		addFilter(
+			'ep.Autosuggest.element',
+			'ep/epAutosuggestElementFilter',
+			window.epAutosuggestElementFilter,
+		);
+	}
+});

--- a/assets/js/autosuggest/index.js
+++ b/assets/js/autosuggest/index.js
@@ -311,17 +311,13 @@ function updateAutosuggestBox(options, input) {
 	// append list items to the list
 	suggestList.innerHTML = listHTML;
 
-	const autosuggestItems = Array.from(document.querySelectorAll('.autosuggest-link'));
-
 	suggestList.addEventListener('click', (event) => {
 		event.preventDefault();
-		const target =
-			event.target.tagName === epas.highlightingTag?.toUpperCase()
-				? event.target.parentElement
-				: event.target;
 
-		if (autosuggestItems.includes(target)) {
-			selectItem(input, target);
+		const element = event.target.closest('.autosuggest-link');
+
+		if (suggestList.contains(element)) {
+			selectItem(input, element);
 		}
 	});
 


### PR DESCRIPTION
### Description of the Change
Fixes two Autosuggest issues.

1. An issue where older Autosuggest filter functions were not automatically applies as hooks for backwards compatibility. This can happen if the filter function was defined after the backwards compatibility code is run. This fix defers the backwards compatibility code to run on the `load` event.
2. An issue that prevented clicking Autosuggest suggestions if they had been customized with additional markup. The Autosuggest click listener did not work properly if elements were added inside the `.autosuggest-link` element, so this fix updates the event listener to work no matter how many child elements exist.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3095
Closes #3107

### How to test the Change
- Adding filters to Autosuggest using [the <=4.3.0 method](https://github.com/10up/ElasticPress/blob/4.3.0/docs/theme-integration.md) should work even if the filters are defined in a script that runs _after_ ElasticPress' `autosuggest.js`.
 - Clicking Autosuggest suggestions should work as expected when filtering the item HTML with [this HTML](https://github.com/10up/ElasticPress/issues/3107#issuecomment-1302359122), and it should continue to work with the default HTML.

### Changelog Entry
Fixed - An issue that caused Autosuggest filter functions to no longer work.
Fixed - An issue that prevented clicking Autosuggest suggestions if they had been customized with additional markup.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
