### PR TITLE
Fix encoded characters in term labels in Instant Results

### DIFF
--- a/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
+++ b/assets/js/instant-results/components/facets/taxonomy-terms-facet.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { useCallback, useContext, useMemo, WPElement } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -68,7 +69,7 @@ export default ({ defaultIsOpen, label, postTypes, name }) => {
 				checked: selectedTerms.includes(term_id),
 				count: doc_count,
 				id: `ep-search-${name}-${term_id}`,
-				label,
+				label: decodeEntities(label),
 				parent: parent.toString(),
 				order: term_order,
 				value: term_id.toString(),


### PR DESCRIPTION
### Description of the Change
The data for taxonomy term aggregations is send to Elasticsearch as encoded JSON, like this:

```js
'{\"term_id\":236,\"slug\":\"blue\",\"name\":\"Blue\",\"parent\":0,\"term_taxonomy_id\":236,\"term_order\":0}'
```

This causes some characters, such as ampersands, inside the `name` field to be encoded as HTML entities. This means that when terms are displayed as facet options in Instant Results these characters are displayed in their encoded form.

This fix uses the (tiny) [@wordpress/html-entities](https://www.npmjs.com/package/@wordpress/html-entities) package to decode these entities.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3097

### How to test the Change
Create a term that includes an `&` character and assign it to a post. Add the term's taxonomy as a facet to Instant Results and search for the post. The `&` should appear as expected in the list of facet options, and not as `&amp;`. The character should also appear correct in the active filter 'chip' when the term is applied as a filter.

### Changelog Entry
Fixed - An issue where some characters in taxonomy terms would appear encoded when displayed in Instant Results.


### Credits
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
