### PR TITLE
Adjust the documentation for ep_woocommerce_admin_products_list_search_fields

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -1058,13 +1058,22 @@ class WooCommerce extends Feature {
 			$query->set( 's', sanitize_text_field( $search_term ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 			/**
-			 * Filter to skip integration with WooCommerce Admin Product List.
+			 * Filter the fields used in WooCommerce Admin Product Search.
+			 *
+			 * ```
+			 * add_filter(
+			 *     'ep_woocommerce_admin_products_list_search_fields',
+			 *     function ( $wc_admin_search_fields ) {
+			 *         $wc_admin_search_fields['meta'][] = 'custom_field';
+			 *         return $wc_admin_search_fields;
+			 *     }
+			 * );
+			 * ```
 			 *
 			 * @hook ep_woocommerce_admin_products_list_search_fields
 			 * @since 4.2.0
-			 * @param {bool}  $integrate  True to integrate, false to preserve original behavior. Defaults to true.
-			 * @param {array} $query_vars Query vars.
-			 * @return {bool} New integrate value
+			 * @param {array} $wc_admin_search_fields Fields to be used in the WooCommerce Admin Product Search
+			 * @return {array} New fields
 			 */
 			$search_fields = apply_filters(
 				'ep_woocommerce_admin_products_list_search_fields',


### PR DESCRIPTION
### Description of the Change
This PR simply fixes the documentation of the `ep_woocommerce_admin_products_list_search_fields` filter.

### Changelog Entry
> Fixed - Documentation of the ep_woocommerce_admin_products_list_search_fields filter.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
