### PR TITLE
Add get_index_settings()

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -921,6 +921,28 @@ class Elasticsearch {
 	}
 
 	/**
+	 * Get index settings.
+	 *
+	 * @param string $index Index name.
+	 * @since  4.3.2
+	 * @return array Raw ES response from the $index/_settings?flat_settings=true endpoint
+	 */
+	public function get_index_settings( $index ) {
+		$endpoint = trailingslashit( $index ) . '_settings?flat_settings=true';
+		$request  = $this->remote_request( $endpoint, [], [], 'get_index_settings' );
+
+		if ( is_wp_error( $request ) ) {
+			return $request;
+		}
+
+		$response_body = wp_remote_retrieve_body( $request );
+
+		$settings = json_decode( $response_body, true );
+
+		return $settings;
+	}
+
+	/**
 	 * Update index settings.
 	 *
 	 * @param  string  $index       Index name.

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -924,10 +924,10 @@ class Elasticsearch {
 	 * Get index settings.
 	 *
 	 * @param string $index Index name.
-	 * @since  4.3.2
-	 * @return array Raw ES response from the $index/_settings?flat_settings=true endpoint
+	 * @since  4.4.0
+	 * @return array|WP_Error Raw ES response from the $index/_settings?flat_settings=true endpoint
 	 */
-	public function get_index_settings( $index ) {
+	public function get_index_settings( string $index ) {
 		$endpoint = trailingslashit( $index ) . '_settings?flat_settings=true';
 		$request  = $this->remote_request( $endpoint, [], [], 'get_index_settings' );
 


### PR DESCRIPTION
### Description of the Change
Since we already have `update_index_settings()`, it makes sense to have `get_index_settings()` too.

### Changelog Entry
> Added - get_index_settings() to retrieve index settings

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @rebeccahum 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
