### PR TITLE
Update the list of post types ignored by Protected Content

### DIFF
--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -81,33 +81,26 @@ class ProtectedContent extends Feature {
 		// Let's get non public post types first
 		$pc_post_types = get_post_types( array( 'public' => false ) );
 
-		// We don't want to deal with nav menus
-		if ( $pc_post_types['nav_menu_item'] ) {
-			unset( $pc_post_types['nav_menu_item'] );
-		}
+		$ignored_post_types = [
+			'custom_css',
+			'customize_changeset',
+			'ep-synonym',
+			'ep-pointer',
+			'nav_menu_item',
+			'oembed_cache',
+			'revision',
+			'user_request',
+			'wp_block',
+			'wp_global_styles',
+			'wp_navigation',
+			'wp_template',
+			'wp_template_part',
+		];
 
-		if ( ! empty( $pc_post_types['revision'] ) ) {
-			unset( $pc_post_types['revision'] );
-		}
-
-		if ( ! empty( $pc_post_types['custom_css'] ) ) {
-			unset( $pc_post_types['custom_css'] );
-		}
-
-		if ( ! empty( $pc_post_types['customize_changeset'] ) ) {
-			unset( $pc_post_types['customize_changeset'] );
-		}
-
-		if ( ! empty( $pc_post_types['oembed_cache'] ) ) {
-			unset( $pc_post_types['oembed_cache'] );
-		}
-
-		if ( ! empty( $pc_post_types['wp_block'] ) ) {
-			unset( $pc_post_types['wp_block'] );
-		}
-
-		if ( ! empty( $pc_post_types['user_request'] ) ) {
-			unset( $pc_post_types['user_request'] );
+		foreach ( $ignored_post_types as $ignored_post_type ) {
+			if ( $pc_post_types[ $ignored_post_type ] ) {
+				unset( $pc_post_types[ $ignored_post_type ] );
+			}
 		}
 
 		// By default, attachments are not indexed, we have to make sure they are included (Could already be included by documents feature).


### PR DESCRIPTION
### Description of the Change

WordPress introduced some new post types recently that should not be indexed by ElasticPress.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Removed - [Protected Content] removed post types to be indexed by default: ep-synonym, ep-pointer, wp_global_styles, wp_navigation, wp_template, and wp_template_part


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
