### PR TITLE
Query Logger

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -164,6 +164,19 @@ function register_indexable_posts() {
 	SearchAlgorithms::factory()->register( new SearchAlgorithm\DefaultAlgorithm() );
 	SearchAlgorithms::factory()->register( new SearchAlgorithm\Version_350() );
 	SearchAlgorithms::factory()->register( new SearchAlgorithm\Version_400() );
+
+	/**
+	 * Filter the query logger object
+	 *
+	 * @since 4.4.0
+	 * @hook ep_query_logger
+	 * @param {QueryLogger} $query_logger Default query logger
+	 * @return {QueryLogger} New query logger
+	 */
+	$query_logger = apply_filters( 'ep_query_logger', new \ElasticPress\QueryLogger() );
+	if ( method_exists( $query_logger, 'setup' ) ) {
+		$query_logger->setup();
+	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\register_indexable_posts' );
 

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -40,6 +40,11 @@ class QueryLogger {
 	 * @param string $type  Request type
 	 */
 	public function log_query( $query, $type ) {
+		$last_sync = Utils\get_option( 'ep_last_sync', false );
+		if ( empty( $last_sync ) ) {
+			return;
+		}
+
 		$logs = $this->get_logs();
 
 		/**

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -138,7 +138,15 @@ class QueryLogger {
 	 * @param array $logs New logs array
 	 */
 	public function update_logs( array $logs ) {
-		$max_cache_size = MB_IN_BYTES;
+		/**
+		 * Filter the max cache size. Defaults to MB_IN_BYTES
+		 *
+		 * @since 4.4.0
+		 * @hook ep_query_logger_max_cache_size
+		 * @param {int} $max_cache_size The max cache size in bytes
+		 * @return {int} New size
+		 */
+		$max_cache_size = apply_filters( 'ep_query_logger_max_cache_size', MB_IN_BYTES );
 
 		$logs_json_str      = wp_json_encode( $logs );
 		$logs_json_str_size = strlen( $logs_json_str );
@@ -302,14 +310,14 @@ class QueryLogger {
 		 * the query will be logged.
 		 *
 		 * @since 4.4.0
-		 * @hook ep_allowed_log_types
+		 * @hook ep_query_logger_allowed_log_types
 		 * @param {array}  $callable_map Array indexed by type and valued by a callable that returns a boolean
 		 * @param {array}  $query        Remote request arguments
 		 * @param {string} $type         Request type
 		 * @return {array} New array
 		 */
 		$allowed_log_types = apply_filters(
-			'ep_allowed_log_types',
+			'ep_query_logger_allowed_log_types',
 			array(
 				'put_mapping'          => array( $this, 'is_query_error' ),
 				'delete_network_alias' => array( $this, 'is_query_error' ),

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -261,12 +261,10 @@ class QueryLogger {
 		if ( strlen( $body ) > 900 * KB_IN_BYTES ) {
 			$body = substr( $body, 0, 1000 ) . ' (trimmed)';
 		} else {
-			$body = json_decode( $body, true );
+			$json_body = json_decode( $body, true );
 			// Bulk indexes are not "valid" JSON, for example.
 			if ( json_last_error() === JSON_ERROR_NONE ) {
-				$body = wp_json_encode( $body );
-			} else {
-				$body = $body;
+				$body = wp_json_encode( $json_body );
 			}
 		}
 

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Query Logger class
+ *
+ * @since 4.4.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Query Logger class
+ *
+ * @package ElasticPress
+ */
+class QueryLogger {
+	/**
+	 * Setup the logging functionality
+	 */
+	public function setup() {
+		add_action( 'ep_remote_request', [ $this, 'log_query' ], 10, 2 );
+	}
+
+	/**
+	 * Conditionally save a query to the log which is stored in options. This is a big performance hit so be careful.
+	 *
+	 * @param array  $query Remote request arguments
+	 * @param string $type  Request type
+	 * @since 1.3
+	 */
+	public function log_query( $query, $type ) {
+		/**
+		 * Filter the array with a map from query types to callables. If the callable returns true,
+		 * the query will be logged.
+		 *
+		 * @since 4.4.0
+		 * @hook ep_allowed_log_types
+		 * @param {array}  $callable_map Array indexed by type and valued by a callable that returns a boolean
+		 * @param {array}  $query        Remote request arguments
+		 * @param {string} $type         Request type
+		 * @return {array} New array
+		 */
+		$allowed_log_types = apply_filters(
+			'ep_allowed_log_types',
+			array(
+				'put_mapping'          => array( $this, 'is_query_error' ),
+				'delete_network_alias' => array( $this, 'is_query_error' ),
+				'create_network_alias' => array( $this, 'is_query_error' ),
+				'bulk_index'           => array( $this, 'is_bulk_index_error' ),
+				'bulk_index_posts'     => array( $this, 'is_query_error' ),
+				'delete_index'         => array( $this, 'maybe_log_delete_index' ),
+				'create_pipeline'      => array( $this, 'is_query_error' ),
+				'get_pipeline'         => array( $this, 'is_query_error' ),
+				'query'                => array( $this, 'is_query_error' ),
+			),
+			$query,
+			$type
+		);
+
+		if ( isset( $allowed_log_types[ $type ] ) ) {
+			$do_log = call_user_func( $allowed_log_types[ $type ], $query );
+
+			if ( ! $do_log ) {
+				return;
+			}
+		} else {
+			return;
+		}
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$log = get_site_transient( 'ep_query_log', [] );
+		} else {
+			$log = get_transient( 'ep_query_log', [] );
+		}
+
+		$log[] = array(
+			'query' => $query,
+			'type'  => $type,
+		);
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			set_site_transient( 'ep_query_log', $log, DAY_IN_SECONDS );
+		} else {
+			set_transient( 'ep_query_log', $log, DAY_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Check the request body, as usually bulk indexing does not return a status error.
+	 *
+	 * @since 2.1.0
+	 * @param array $query Remote request arguments
+	 * @return boolean
+	 */
+	public function is_bulk_index_error( $query ) {
+		if ( $this->is_query_error( $query ) ) {
+			return true;
+		}
+
+		$request_body = json_decode( wp_remote_retrieve_body( $query['request'] ), true );
+		return ! empty( $request_body['errors'] );
+	}
+
+	/**
+	 * Only log delete index error if not 2xx AND not 404
+	 *
+	 * @param  array $query Remote request arguments
+	 * @since  1.3
+	 * @return bool
+	 */
+	public function maybe_log_delete_index( $query ) {
+		$response_code = wp_remote_retrieve_response_code( $query['request'] );
+
+		return ( ( $response_code < 200 || $response_code > 299 ) && 404 !== $response_code );
+	}
+
+	/**
+	 * Log all non-200 requests
+	 *
+	 * @param  array $query Remote request arguments
+	 * @since  1.3
+	 * @return bool
+	 */
+	public function is_query_error( $query ) {
+		if ( is_wp_error( $query['request'] ) ) {
+			return true;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $query['request'] );
+
+		return ( $response_code < 200 || $response_code > 299 );
+	}
+}

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -261,12 +261,12 @@ class QueryLogger {
 		if ( strlen( $body ) > 900 * KB_IN_BYTES ) {
 			$body = substr( $body, 0, 1000 ) . ' (trimmed)';
 		} else {
-			$body = json_decode( $query['args']['body'], true );
+			$body = json_decode( $body, true );
 			// Bulk indexes are not "valid" JSON, for example.
 			if ( json_last_error() === JSON_ERROR_NONE ) {
 				$body = wp_json_encode( $body );
 			} else {
-				$body = $query['args']['body'];
+				$body = $body;
 			}
 		}
 

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -258,7 +258,7 @@ class QueryLogger {
 
 		// If the body is too big, trim it down to avoid storing a too big log entry
 		$body = ! empty( $query['args']['body'] ) ? $query['args']['body'] : '';
-		if ( strlen( $body ) > 900 * KB_IN_BYTES ) {
+		if ( strlen( $body ) > 200 * KB_IN_BYTES ) {
 			$body = substr( $body, 0, 1000 ) . ' (trimmed)';
 		} else {
 			$json_body = json_decode( $body, true );

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -2,6 +2,8 @@
 /**
  * Query Logger class
  *
+ * phpcs:disable WordPress.DateTime.CurrentTimeTimestamp.Requested
+ *
  * @since 4.4.0
  * @package elasticpress
  */
@@ -17,6 +19,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class QueryLogger {
 	/**
+	 * String used to get and update the transient.
+	 */
+	const CACHE_KEY = 'ep_query_log';
+
+	/**
 	 * Setup the logging functionality
 	 */
 	public function setup() {
@@ -31,60 +38,20 @@ class QueryLogger {
 	 * @since 1.3
 	 */
 	public function log_query( $query, $type ) {
-		/**
-		 * Filter the array with a map from query types to callables. If the callable returns true,
-		 * the query will be logged.
-		 *
-		 * @since 4.4.0
-		 * @hook ep_allowed_log_types
-		 * @param {array}  $callable_map Array indexed by type and valued by a callable that returns a boolean
-		 * @param {array}  $query        Remote request arguments
-		 * @param {string} $type         Request type
-		 * @return {array} New array
-		 */
-		$allowed_log_types = apply_filters(
-			'ep_allowed_log_types',
-			array(
-				'put_mapping'          => array( $this, 'is_query_error' ),
-				'delete_network_alias' => array( $this, 'is_query_error' ),
-				'create_network_alias' => array( $this, 'is_query_error' ),
-				'bulk_index'           => array( $this, 'is_bulk_index_error' ),
-				'bulk_index_posts'     => array( $this, 'is_query_error' ),
-				'delete_index'         => array( $this, 'maybe_log_delete_index' ),
-				'create_pipeline'      => array( $this, 'is_query_error' ),
-				'get_pipeline'         => array( $this, 'is_query_error' ),
-				'query'                => array( $this, 'is_query_error' ),
-			),
-			$query,
-			$type
-		);
+		$logs = $this->get_logs();
+		$keep = 5;
 
-		if ( isset( $allowed_log_types[ $type ] ) ) {
-			$do_log = call_user_func( $allowed_log_types[ $type ], $query );
-
-			if ( ! $do_log ) {
-				return;
-			}
-		} else {
+		if ( $keep > 0 && count( $logs ) > $keep ) {
 			return;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$log = get_site_transient( 'ep_query_log', [] );
-		} else {
-			$log = get_transient( 'ep_query_log', [] );
+		if ( ! $this->should_log_query_type( $query, $type ) ) {
+			return;
 		}
 
-		$log[] = array(
-			'query' => $query,
-			'type'  => $type,
-		);
+		array_unshift( $logs, $this->format_log_entry( $query, $type ) );
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			set_site_transient( 'ep_query_log', $log, DAY_IN_SECONDS );
-		} else {
-			set_transient( 'ep_query_log', $log, DAY_IN_SECONDS );
-		}
+		$this->update_logs( $logs );
 	}
 
 	/**
@@ -131,5 +98,127 @@ class QueryLogger {
 		$response_code = wp_remote_retrieve_response_code( $query['request'] );
 
 		return ( $response_code < 200 || $response_code > 299 );
+	}
+
+	/**
+	 * Return logged failed queries.
+	 *
+	 * @return array
+	 */
+	public function get_logs() : array {
+		$current_time   = current_time( 'timestamp' );
+		$period_to_keep = DAY_IN_SECONDS;
+		$time_limit     = $current_time - $period_to_keep;
+
+		$logs = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ?
+			get_site_transient( self::CACHE_KEY, [] ) :
+			get_transient( self::CACHE_KEY, [] );
+
+		$logs = json_decode( $logs, true );
+
+		$logs = array_filter(
+			(array) $logs,
+			function ( $log ) use ( $time_limit ) {
+				return ! empty( $log['timestamp'] ) && $log['timestamp'] > $time_limit;
+			}
+		);
+
+		return $logs;
+	}
+
+	/**
+	 * Given a query, return a formatted log entry
+	 *
+	 * @param array  $query The failed query
+	 * @param string $type  The query type
+	 * @return array
+	 */
+	protected function format_log_entry( array $query, string $type ) : array {
+		global $wp;
+
+		$query_time = ( ! empty( $query['time_start'] ) && ! empty( $query['time_finish'] ) ) ?
+			( $query['time_finish'] - $query['time_start'] ) * 1000 :
+			false;
+
+		// Bulk indexes are not "valid" JSON, for example.
+		$body = '';
+		if ( ! empty( $query['args']['body'] ) ) {
+			$body = json_decode( $query['args']['body'], true );
+			if ( json_last_error() === JSON_ERROR_NONE ) {
+				$body = wp_json_encode( $body );
+			} else {
+				$body = $query['args']['body'];
+			}
+		}
+
+		$result = json_decode( wp_remote_retrieve_body( $query['request'] ), true );
+
+		return [
+			'wp_url'     => home_url( add_query_arg( [ $_GET ], $wp->request ) ), // phpcs:ignore WordPress.Security.NonceVerification
+			'es_url'     => $query['args']['method'] . ' ' . $query['url'],
+			'timestamp'  => current_time( 'timestamp' ),
+			'query_time' => $query_time,
+			'wp_args'    => $query['query_args'] ?? [],
+			'body'       => $body,
+			'result'     => $result,
+		];
+	}
+
+	/**
+	 * Update the logs array in the transient
+	 *
+	 * @param array $logs New logs array
+	 */
+	public function update_logs( array $logs ) {
+		$logs = wp_json_encode( $logs );
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			set_site_transient( self::CACHE_KEY, $logs, DAY_IN_SECONDS );
+		} else {
+			set_transient( self::CACHE_KEY, $logs, DAY_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Given a query and its type, check if it should be logged
+	 *
+	 * @param array  $query The failed query
+	 * @param string $type  The query type
+	 * @return boolean
+	 */
+	protected function should_log_query_type( array $query, string $type ) : bool {
+		/**
+		 * Filter the array with a map from query types to callables. If the callable returns true,
+		 * the query will be logged.
+		 *
+		 * @since 4.4.0
+		 * @hook ep_allowed_log_types
+		 * @param {array}  $callable_map Array indexed by type and valued by a callable that returns a boolean
+		 * @param {array}  $query        Remote request arguments
+		 * @param {string} $type         Request type
+		 * @return {array} New array
+		 */
+		$allowed_log_types = apply_filters(
+			'ep_allowed_log_types',
+			array(
+				'put_mapping'          => array( $this, 'is_query_error' ),
+				'delete_network_alias' => array( $this, 'is_query_error' ),
+				'create_network_alias' => array( $this, 'is_query_error' ),
+				'bulk_index'           => array( $this, 'is_bulk_index_error' ),
+				'bulk_index_posts'     => array( $this, 'is_query_error' ),
+				'delete_index'         => array( $this, 'maybe_log_delete_index' ),
+				'create_pipeline'      => array( $this, 'is_query_error' ),
+				'get_pipeline'         => array( $this, 'is_query_error' ),
+				'query'                => array( $this, 'is_query_error' ),
+			),
+			$query,
+			$type
+		);
+
+		$should_log = isset( $allowed_log_types[ $type ] ) ?
+			call_user_func( $allowed_log_types[ $type ], $query ) :
+			false;
+
+		return $should_log;
 	}
 }

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -29,6 +29,8 @@ class QueryLogger {
 	public function setup() {
 		add_action( 'ep_remote_request', [ $this, 'log_query' ], 10, 2 );
 		add_filter( 'ep_admin_notices', [ $this, 'maybe_add_notice' ] );
+
+		add_action( 'ep_sync_start_index', [ $this, 'clear_logs' ] );
 	}
 
 	/**
@@ -214,6 +216,13 @@ class QueryLogger {
 		];
 
 		return $notices;
+	}
+
+	/**
+	 * Clear the stored logs
+	 */
+	public function clear_logs() {
+		$this->update_logs( [] );
 	}
 
 	/**

--- a/includes/classes/Screen/StatusReport.php
+++ b/includes/classes/Screen/StatusReport.php
@@ -132,7 +132,7 @@ class StatusReport {
 	public function render_html_report( string $title, array $groups ) : string {
 		ob_start();
 		?>
-		<h2><?php echo esc_html( $title ); ?></h2>
+		<h2 id="<?php echo esc_attr( sanitize_title( $title ) ); ?>"><?php echo esc_html( $title ); ?></h2>
 		<table cellpadding="0" cellspacing="0" class="wp-list-table widefat striped">
 			<colgroup>
 				<col>

--- a/includes/classes/Screen/StatusReport.php
+++ b/includes/classes/Screen/StatusReport.php
@@ -64,7 +64,14 @@ class StatusReport {
 		$reports['wordpress']    = new \ElasticPress\StatusReport\WordPress();
 		$reports['indexable']    = new \ElasticPress\StatusReport\IndexableContent();
 		$reports['elasticpress'] = new \ElasticPress\StatusReport\ElasticPress();
-		$reports['indices']      = new \ElasticPress\StatusReport\Indices();
+
+		/* this filter is documented in elasticpress.php */
+		$query_logger = apply_filters( 'ep_query_logger', new \ElasticPress\QueryLogger() );
+		if ( $query_logger ) {
+			$reports['failed_queries'] = new \ElasticPress\StatusReport\FailedQueries( $query_logger );
+		}
+
+		$reports['indices'] = new \ElasticPress\StatusReport\Indices();
 
 		if ( Utils\is_epio() ) {
 			$reports['autosuggest'] = new \ElasticPress\StatusReport\ElasticPressIo();

--- a/includes/classes/Screen/StatusReport.php
+++ b/includes/classes/Screen/StatusReport.php
@@ -114,17 +114,18 @@ class StatusReport {
 		$copy_paste_output = [];
 
 		foreach ( $reports as $report ) {
-			$title  = $report->get_title();
-			$groups = $report->get_groups();
+			$title   = $report->get_title();
+			$groups  = $report->get_groups();
+			$actions = $report->get_actions();
 
-			$html_output[]       = $this->render_html_report( $title, $groups );
+			$html_output[]       = $this->render_html_report( $title, $groups, $actions );
 			$copy_paste_output[] = $this->render_copy_paste_report( $title, $groups );
 		}
 
 		?>
 		<p><?php esc_html_e( 'This screen provides a list of information related to ElasticPress and synced content that can be helpful during troubleshooting. This list can also be copy/pasted and shared as needed.', 'elasticpress' ); ?></p>
 		<p class="ep-copy-button-wrapper">
-			<button class="button" data-clipboard-text="<?php echo esc_attr( implode( "\n\n", $copy_paste_output ) ); ?>" id="ep-copy-report" type="button" >
+			<button class="button" data-clipboard-text="<?php echo esc_attr( implode( "\n\n", $copy_paste_output ) ); ?>" id="ep-copy-report" type="button">
 				<?php esc_html_e( 'Copy status report to clipboard', 'elasticpress' ); ?>
 			</button>
 			<span class="ep-copy-button-wrapper__success">
@@ -138,14 +139,16 @@ class StatusReport {
 	/**
 	 * Render the HTML of a report
 	 *
-	 * @param string $title  Report title
-	 * @param array  $groups Report groups
+	 * @param string $title   Report title
+	 * @param array  $groups  Report groups
+	 * @param string $actions Report actions
 	 * @return string
 	 */
-	public function render_html_report( string $title, array $groups ) : string {
+	public function render_html_report( string $title, array $groups, string $actions ) : string {
 		ob_start();
 		?>
 		<h2 id="<?php echo esc_attr( sanitize_title( $title ) ); ?>"><?php echo esc_html( $title ); ?></h2>
+		<?php echo wp_kses( $actions, 'ep-html' ); ?>
 		<table cellpadding="0" cellspacing="0" class="wp-list-table widefat striped">
 			<colgroup>
 				<col>

--- a/includes/classes/Screen/StatusReport.php
+++ b/includes/classes/Screen/StatusReport.php
@@ -148,7 +148,7 @@ class StatusReport {
 		ob_start();
 		?>
 		<h2 id="<?php echo esc_attr( sanitize_title( $title ) ); ?>"><?php echo esc_html( $title ); ?></h2>
-		<?php echo wp_kses( $actions, 'ep-html' ); ?>
+		<?php echo $actions ? '<p>' . wp_kses( $actions, 'ep-html' ) . '</p>' : ''; ?>
 		<table cellpadding="0" cellspacing="0" class="wp-list-table widefat striped">
 			<colgroup>
 				<col>

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -54,13 +54,14 @@ class FailedQueries extends Report {
 		$logs = $this->query_logger->get_logs();
 
 		$labels = [
-			'wp_url'     => esc_html__( 'Page URL', 'elasticpress' ),
-			'es_req'     => esc_html__( 'Elasticsearch Request', 'elasticpress' ),
-			'timestamp'  => esc_html__( 'Time', 'elasticpress' ),
-			'query_time' => esc_html__( 'Time Spent (ms)', 'elasticpress' ),
-			'wp_args'    => esc_html__( 'WP Query Args', 'elasticpress' ),
-			'body'       => esc_html__( 'Query Body', 'elasticpress' ),
-			'result'     => esc_html__( 'Query Result', 'elasticpress' ),
+			'wp_url'      => esc_html__( 'Page URL', 'elasticpress' ),
+			'es_req'      => esc_html__( 'Elasticsearch Request', 'elasticpress' ),
+			'timestamp'   => esc_html__( 'Time', 'elasticpress' ),
+			'query_time'  => esc_html__( 'Time Spent (ms)', 'elasticpress' ),
+			'wp_args'     => esc_html__( 'WP Query Args', 'elasticpress' ),
+			'status_code' => esc_html__( 'HTTP Status Code', 'elasticpress' ),
+			'body'        => esc_html__( 'Query Body', 'elasticpress' ),
+			'result'      => esc_html__( 'Query Result', 'elasticpress' ),
 		];
 
 		$groups = [];

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -152,6 +152,18 @@ class FailedQueries extends Report {
 			);
 		}
 
-		return '';
+		if ( Utils\is_epio() ) {
+			return sprintf(
+				/* translators: ElasticPress.io My Account URL */
+				__( 'We did not recognize this error. Please open an ElasticPress.io <a href="%s">support ticket</a> so we can troubleshoot further.', 'elasticpress' ),
+				'https://www.elasticpress.io/my-account/'
+			);
+		}
+
+		return sprintf(
+			/* translators: New GitHub issue URL */
+			__( 'We did not recognize this error. Please consider opening a <a href="%s">Github Issue</a> so we can add it to our list of supported errors. ', 'elasticpress' ),
+			'https://github.com/10up/ElasticPress/issues/new/choose'
+		);
 	}
 }

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Failed Queries report class
+ *
+ * @since 4.4.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress\StatusReport;
+
+use \ElasticPress\QueryLogger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * FailedQueries report class
+ *
+ * @package ElasticPress
+ */
+class FailedQueries extends Report {
+
+	/**
+	 * The logger instance
+	 *
+	 * @var QueryLogger
+	 */
+	protected $query_logger;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param QueryLogger $query_logger The logger instance
+	 */
+	public function __construct( QueryLogger $query_logger ) {
+		$this->query_logger = $query_logger;
+	}
+
+	/**
+	 * Return the report title
+	 *
+	 * @return string
+	 */
+	public function get_title() : string {
+		return __( 'Failed Queries', 'elasticpress' );
+	}
+
+	/**
+	 * Return the report fields
+	 *
+	 * @return array
+	 */
+	public function get_groups() : array {
+		$logs = $this->query_logger->get_logs();
+
+		$labels = [
+			'wp_url'     => esc_html__( 'Page URL', 'elasticpress' ),
+			'es_url'     => esc_html__( 'Elasticsearch URL', 'elasticpress' ),
+			'timestamp'  => esc_html__( 'Time', 'elasticpress' ),
+			'query_time' => esc_html__( 'Time Spent (ms)', 'elasticpress' ),
+			'wp_args'    => esc_html__( 'WP Query Args', 'elasticpress' ),
+			'body'       => esc_html__( 'Query Body', 'elasticpress' ),
+			'result'     => esc_html__( 'Query Result', 'elasticpress' ),
+		];
+
+		$groups = [];
+		foreach ( $logs as $log ) {
+			$fields = [];
+
+			foreach ( $log as $field => $value ) {
+				$fields[ $field ] = [
+					'label' => $labels[ $field ] ?? $field,
+					'value' => $value,
+				];
+			}
+
+			$groups[] = [
+				'title'  => sprintf( '%s (%s)', $log['wp_url'], date_i18n( 'Y-m-d H:i:s', $log['timestamp'] ) ),
+				'fields' => $fields,
+			];
+		}
+
+		return $groups;
+	}
+}

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -51,7 +51,7 @@ class FailedQueries extends Report {
 	 * @return array
 	 */
 	public function get_groups() : array {
-		$logs = $this->query_logger->get_logs();
+		$logs = $this->query_logger->get_logs( false );
 
 		$labels = [
 			'wp_url'      => esc_html__( 'Page URL', 'elasticpress' ),

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -110,6 +110,11 @@ class FailedQueries extends Report {
 	public function get_actions() : string {
 		global $wp;
 
+		$logs = $this->query_logger->get_logs( false );
+		if ( empty( $logs ) ) {
+			return '';
+		}
+
 		$button_text = __( 'Clear logged queries', 'elasticpress' );
 		$href        = wp_nonce_url( add_query_arg( [ $_GET ], $wp->request ), 'ep-clear-logged-queries', '_wpnonce' ); // phpcs:ignore WordPress.Security.NonceVerification
 

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -51,6 +51,8 @@ class FailedQueries extends Report {
 	 * @return array
 	 */
 	public function get_groups() : array {
+		$this->maybe_clear_logs();
+
 		$logs = $this->query_logger->get_logs( false );
 
 		$labels = [
@@ -98,6 +100,31 @@ class FailedQueries extends Report {
 		}
 
 		return $groups;
+	}
+
+	/**
+	 * Return the output of a button to clear the logged queries
+	 *
+	 * @return string
+	 */
+	public function get_actions() : string {
+		global $wp;
+
+		$button_text = __( 'Clear logged queries', 'elasticpress' );
+		$href        = wp_nonce_url( add_query_arg( [ $_GET ], $wp->request ), 'ep-clear-logged-queries', '_wpnonce' ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		return '<a href="' . $href . '" class="button">' . $button_text . '</a>';
+	}
+
+	/**
+	 * If a nonce is present, clear the logs
+	 */
+	protected function maybe_clear_logs() {
+		if ( empty( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'ep-clear-logged-queries' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+
+		$this->query_logger->clear_logs();
 	}
 
 	/**

--- a/includes/classes/StatusReport/Report.php
+++ b/includes/classes/StatusReport/Report.php
@@ -30,4 +30,13 @@ abstract class Report {
 	 * @return array
 	 */
 	abstract public function get_groups() : array;
+
+	/**
+	 * Return any actions related to the report, like a button
+	 *
+	 * @return string
+	 */
+	public function get_actions() : string {
+		return '';
+	}
 }

--- a/tests/php/TestQueryLogger.php
+++ b/tests/php/TestQueryLogger.php
@@ -1,0 +1,401 @@
+<?php
+/**
+ * Test the Query Logger
+ *
+ * @since 4.4.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use \ElasticPress\QueryLogger;
+
+/**
+ * Test the Query Logger class
+ */
+class TestQueryLogger extends BaseTestCase {
+	/**
+	 * Setup each test
+	 */
+	public function set_up() {
+		update_site_option( 'ep_last_sync', time() );
+
+		parent::set_up();
+	}
+
+	/**
+	 * Test the log_query method before a sync is performed
+	 *
+	 * @group queryLogger
+	 */
+	public function testLogQueryBeforeFirstSync() {
+		$query_logger = $this->getMockBuilder( QueryLogger::class )
+			->setMethods( [ 'get_logs' ] )
+			->getMock();
+
+		// Call the log_query method twice but it should call get_logs only in the second call, after setting ep_last_sync
+		$query_logger->expects( $this->exactly( 1 ) )->method( 'get_logs' );
+
+		$query_logger->log_query( [], '' );
+
+		delete_site_option( 'ep_last_sync', time() );
+		$query_logger->log_query( [], '' );
+	}
+
+	/**
+	 * Test the ep_query_logger_queries_to_keep filter in the log_query method
+	 *
+	 * @group queryLogger
+	 */
+	public function testLogQueryQueriesToKeepFilter() {
+		$query_logger = $this->getMockBuilder( QueryLogger::class )
+			->setMethods( [ 'get_logs', 'should_log_query_type', 'format_log_entry', 'update_logs' ] )
+			->getMock();
+
+		$query_logger->method( 'get_logs' )->willReturn( [ 1, 2, 3, 4, 5 ] );
+		$query_logger->expects( $this->exactly( 1 ) )->method( 'should_log_query_type' )->willReturn( true );
+		$query_logger->expects( $this->exactly( 1 ) )->method( 'format_log_entry' )->willReturn( [ 'entry' ] );
+		$query_logger->expects( $this->exactly( 1 ) )->method( 'update_logs' )->willReturn( '{somejson}' );
+
+		$query_logger->log_query( [ 'query' ], 'type' );
+		$this->assertEquals( 0, did_action( 'ep_query_logger_logged_query' )  );
+
+		add_filter(
+			'ep_query_logger_queries_to_keep',
+			function( $keep, $query, $type ) {
+				$this->assertSame( 5, $keep );
+				$this->assertSame( [ 'query' ], $query );
+				$this->assertSame( 'type', $type );
+				return 10;
+			},
+			10,
+			3
+		);
+
+		$query_logger->log_query( [ 'query' ], 'type' );
+		$this->assertGreaterThanOrEqual( 1, did_filter( 'ep_query_logger_queries_to_keep' ) );
+		$this->assertGreaterThanOrEqual( 1, did_action( 'ep_query_logger_logged_query' ) );
+	}
+
+	/**
+	 * Test the ep_query_logger_logged_query action in the log_query method
+	 *
+	 * @group queryLogger
+	 */
+	public function testLogQueryLoggedQueryAction() {
+		$query_logger = $this->getMockBuilder( QueryLogger::class )
+			->setMethods( [ 'get_logs', 'should_log_query_type', 'format_log_entry', 'update_logs' ] )
+			->disableOriginalConstructor()
+			->disableOriginalClone()
+			->disableArgumentCloning()
+			->disallowMockingUnknownTypes()
+			->getMock();
+
+		$query_logger->method( 'get_logs' )->willReturn( [] );
+		$query_logger->method( 'should_log_query_type' )->willReturn( true );
+		$query_logger->method( 'format_log_entry' )->willReturn( [ 'entry' ] );
+		$query_logger->method( 'update_logs' )->willReturn( '{somejson}' );
+
+		add_action(
+			'ep_query_logger_logged_query',
+			function( $logs_json_str, $query, $type ) {
+				$this->assertSame( '{somejson}', $logs_json_str );
+				$this->assertSame( [ 'query' ], $query );
+				$this->assertSame( 'type', $type );
+			},
+			10,
+			3
+		);
+
+		$query_logger->log_query( [ 'query' ], 'type' );
+		$this->assertGreaterThanOrEqual( 1, did_action( 'ep_query_logger_logged_query' ) );
+	}
+
+	/**
+	 * Test the get_logs method
+	 *
+	 * @group queryLogger
+	 */
+	public function testGetLogs() {
+		$current_time = current_time( 'timestamp' );
+		$test_logs    = [
+			[ 'timestamp' => $current_time - DAY_IN_SECONDS - 5 ],
+			[ 'timestamp' => $current_time - DAY_IN_SECONDS + 5 ],
+		];
+
+		add_filter(
+			'pre_site_transient_ep_query_log',
+			function() use ( $test_logs ) {
+				return wp_json_encode( $test_logs );
+			}
+		);
+
+		$query_logger = new QueryLogger();
+
+		$this->assertCount( 1, $query_logger->get_logs() );
+		$this->assertCount( 2, $query_logger->get_logs( false ) );
+
+		/**
+		 * Test the ep_query_logger_time_to_keep filter
+		 */
+		$change_time_limit = function( $limit ) {
+			$this->assertSame( $limit, DAY_IN_SECONDS );
+			return 25 * HOUR_IN_SECONDS;
+		};
+		add_filter( 'ep_query_logger_time_to_keep', $change_time_limit );
+
+		$this->assertCount( 2, $query_logger->get_logs() );
+		$this->assertGreaterThanOrEqual( 1, did_filter( 'ep_query_logger_time_to_keep' ) );
+
+		/**
+		 * Test the ep_query_logger_logs filter
+		 */
+		$change_logs = function( $logs ) use ( $test_logs ) {
+			$this->assertSame( $logs, $test_logs );
+			return [ 'custom-logs' ];
+		};
+		add_filter( 'ep_query_logger_logs', $change_logs );
+
+		$this->assertSame( [ 'custom-logs' ], $query_logger->get_logs() );
+		$this->assertGreaterThanOrEqual( 1, did_filter( 'ep_query_logger_logs' ) );
+	}
+
+	/**
+	 * Test the testUpdateLogs method
+	 *
+	 * @group queryLogger
+	 */
+	public function testUpdateLogs() {
+		$query_logger = new QueryLogger();
+
+		/**
+		 * Test the ep_query_logger_max_cache_size filter
+		 */
+		add_filter(
+			'ep_query_logger_max_cache_size',
+			function ( $size ) {
+				$this->assertSame( MB_IN_BYTES, $size );
+				return $size;
+			}
+		);
+
+		$updated_logs = $query_logger->update_logs( [ 'test' ] );
+		$this->assertGreaterThanOrEqual( 1, did_filter( 'ep_query_logger_max_cache_size' ) );
+		$this->assertSame( wp_json_encode( [ 'test' ] ), $updated_logs );
+
+		$this->markTestIncomplete( 'This test should also test the removal of data based on the cache size.' );
+	}
+
+	/**
+	 * Test the clear_logs method
+	 *
+	 * @group queryLogger
+	 */
+	public function testClearLogs() {
+		$query_logger = new QueryLogger();
+		$query_logger->clear_logs();
+		$this->assertEquals( 1, did_action( 'ep_query_logger_cleared_logs' ) );
+	}
+
+	/**
+	 * Test the maybe_add_notice method
+	 *
+	 * @group queryLogger
+	 */
+	public function testMaybeAddNotice() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test the format_log_entry method
+	 *
+	 * @group queryLogger
+	 */
+	public function testFormatLogEntry() {
+		$query_logger = new QueryLogger();
+
+		parse_str( 'query-string=test', $_GET );
+		$query = [
+			'time_start'  => 1,
+			'time_finish' => 2,
+			'args'        => [
+				'method' => 'GET',
+				'body'   => 'request body plain text',
+			],
+			'request'     => null,
+			'url'         => 'ep-url',
+			'query_args'  => [ 'post_type' => 'test' ],
+		];
+
+		$class  = new \ReflectionClass( $query_logger );
+        $method = $class->getMethod( 'format_log_entry' );
+        $method->setAccessible( true );
+        $formatted_log = $method->invokeArgs( $query_logger, [ $query, 'type' ] );
+
+		$this->assertStringContainsString( 'query-string=test', $formatted_log['wp_url'] );
+		$this->assertSame( 'GET ep-url', $formatted_log['es_req'] );
+		$this->assertSame( current_time( 'timestamp' ), $formatted_log['timestamp'] );
+		$this->assertSame( 1000, $formatted_log['query_time'] );
+		$this->assertSame( [ 'post_type' => 'test' ], $formatted_log['wp_args'] );
+		$this->assertSame( 'request body plain text', $formatted_log['body'] );
+		$this->assertGreaterThanOrEqual( 1, did_filter( 'ep_query_logger_formatted_query' ) );
+
+		$this->markTestIncomplete( 'This test still needs to test different bodies and result status code and body' );
+	}
+
+	/**
+	 * Test the should_log_query_type method
+	 *
+	 * @group queryLogger
+	 */
+	public function testShouldLogQueryType() {
+		$query_logger = new QueryLogger();
+
+		$class  = new \ReflectionClass( $query_logger );
+        $method = $class->getMethod( 'should_log_query_type' );
+        $method->setAccessible( true );
+
+		/**
+		 * Test the `ep_query_logger_allowed_log_types` filter
+		 */
+		add_filter(
+			'ep_query_logger_allowed_log_types',
+			function ( $callable_map, $query, $type ) {
+				$this->assertSame(
+					[ 'put_mapping', 'delete_network_alias', 'create_network_alias', 'bulk_index', 'delete_index', 'create_pipeline', 'get_pipeline', 'query' ],
+					array_keys( $callable_map )
+				);
+				$this->assertSame( [], $query );
+				$this->assertContains( $type, [ 'type-should-log', 'type-should-not-log' ] );
+				$callable_map['type-should-log']     = '__return_true';
+				$callable_map['type-should-not-log'] = '__return_false';
+				return $callable_map;
+			},
+			10,
+			3
+		);
+
+		$this->assertTrue( $method->invokeArgs( $query_logger, [ [], 'type-should-log' ] ) );
+		$this->assertFalse( $method->invokeArgs( $query_logger, [ [], 'type-should-not-log' ] ) );
+
+		/**
+		 * Test the `ep_query_logger_should_log_query` filter
+		 * 
+		 * Even though the `type-should-not-log` type should NOT log, this will return true
+		 */
+		add_filter(
+			'ep_query_logger_should_log_query',
+			function( $should_log, $query, $type ) {
+				$this->assertSame( [], $query );
+				$this->assertSame( $type, 'type-should-not-log' );
+
+				return true;
+			},
+			10,
+			3
+		);
+		$this->assertTrue( $method->invokeArgs( $query_logger, [ [], 'type-should-not-log' ] ) );
+	}
+
+	/**
+	 * Test the is_bulk_index_error method
+	 *
+	 * @group queryLogger
+	 */
+	public function testIsBulkIndexError() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test the maybe_log_delete_index method
+	 *
+	 * @dataProvider maybeDeleteIndexDataProvider
+	 * @group queryLogger
+	 */
+	public function testMaybeLogDeleteIndex( $expected, $status_code ) {
+		$query_logger = new QueryLogger();
+
+		$class  = new \ReflectionClass( $query_logger );
+        $method = $class->getMethod( 'maybe_log_delete_index' );
+        $method->setAccessible( true );
+
+		$query = [
+			'request' => [
+				'response' => [
+					'code' => $status_code,
+				],
+			],
+		];
+
+		$this->assertSame( $expected, $method->invokeArgs( $query_logger, [ $query ] ) );
+	}
+
+	/**
+	 * Test the is_query_error method with a WP_Error
+	 *
+	 * @group queryLogger
+	 */
+	public function testIsQueryErrorWithWPError() {
+		$query_logger = new QueryLogger();
+
+		$class  = new \ReflectionClass( $query_logger );
+        $method = $class->getMethod( 'is_query_error' );
+        $method->setAccessible( true );
+
+		$this->assertTrue( $method->invokeArgs( $query_logger, [ [ 'request' => new \WP_Error() ] ] ) );
+	}
+
+	/**
+	 * Test the is_query_error method with a request status code
+	 *
+	 * @dataProvider isQueryErrorWithStatusCodeDataProvider
+	 * @group queryLogger
+	 */
+	public function testIsQueryErrorWithStatusCode( $expected, $status_code ) {
+		$query_logger = new QueryLogger();
+
+		$class  = new \ReflectionClass( $query_logger );
+        $method = $class->getMethod( 'is_query_error' );
+        $method->setAccessible( true );
+
+		$query = [
+			'request' => [
+				'response' => [
+					'code' => $status_code,
+				],
+			],
+		];
+
+		$this->assertSame( $expected, $method->invokeArgs( $query_logger, [ $query ] ) );
+	}
+
+	/**
+	 * Data provider for the testMaybeLogDeleteIndex method
+	 *
+	 * @return array
+	 */
+    public function maybeDeleteIndexDataProvider() : array {
+        return [
+            [ true, 199 ],
+            [ false, 200 ],
+            [ false, 299 ],
+            [ true, 300 ],
+            [ false, 404 ],
+        ];
+    }
+
+	/**
+	 * Data provider for the testIsQueryErrorWithStatusCode method
+	 *
+	 * @return array
+	 */
+    public function isQueryErrorWithStatusCodeDataProvider() : array {
+        return [
+            [ true, 199 ],
+            [ false, 200 ],
+            [ false, 299 ],
+            [ true, 300 ],
+            [ true, 404 ],
+        ];
+    }
+}

--- a/tests/php/TestQueryLogger.php
+++ b/tests/php/TestQueryLogger.php
@@ -124,7 +124,7 @@ class TestQueryLogger extends BaseTestCase {
 		];
 
 		add_filter(
-			'pre_site_transient_ep_query_log',
+			defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'pre_site_transient_ep_query_log' : 'pre_transient_ep_query_log',
 			function() use ( $test_logs ) {
 				return wp_json_encode( $test_logs );
 			}

--- a/tests/php/TestQueryLogger.php
+++ b/tests/php/TestQueryLogger.php
@@ -237,9 +237,9 @@ class TestQueryLogger extends BaseTestCase {
 		];
 
 		$class  = new \ReflectionClass( $query_logger );
-        $method = $class->getMethod( 'format_log_entry' );
-        $method->setAccessible( true );
-        $formatted_log = $method->invokeArgs( $query_logger, [ $query, 'type' ] );
+		$method = $class->getMethod( 'format_log_entry' );
+		$method->setAccessible( true );
+		$formatted_log = $method->invokeArgs( $query_logger, [ $query, 'type' ] );
 
 		$this->assertStringContainsString( 'query-string=test', $formatted_log['wp_url'] );
 		$this->assertSame( 'GET ep-url', $formatted_log['es_req'] );
@@ -261,8 +261,8 @@ class TestQueryLogger extends BaseTestCase {
 		$query_logger = new QueryLogger();
 
 		$class  = new \ReflectionClass( $query_logger );
-        $method = $class->getMethod( 'should_log_query_type' );
-        $method->setAccessible( true );
+		$method = $class->getMethod( 'should_log_query_type' );
+		$method->setAccessible( true );
 
 		/**
 		 * Test the `ep_query_logger_allowed_log_types` filter
@@ -325,8 +325,8 @@ class TestQueryLogger extends BaseTestCase {
 		$query_logger = new QueryLogger();
 
 		$class  = new \ReflectionClass( $query_logger );
-        $method = $class->getMethod( 'maybe_log_delete_index' );
-        $method->setAccessible( true );
+		$method = $class->getMethod( 'maybe_log_delete_index' );
+		$method->setAccessible( true );
 
 		$query = [
 			'request' => [
@@ -348,8 +348,8 @@ class TestQueryLogger extends BaseTestCase {
 		$query_logger = new QueryLogger();
 
 		$class  = new \ReflectionClass( $query_logger );
-        $method = $class->getMethod( 'is_query_error' );
-        $method->setAccessible( true );
+		$method = $class->getMethod( 'is_query_error' );
+		$method->setAccessible( true );
 
 		$this->assertTrue( $method->invokeArgs( $query_logger, [ [ 'request' => new \WP_Error() ] ] ) );
 	}
@@ -364,8 +364,8 @@ class TestQueryLogger extends BaseTestCase {
 		$query_logger = new QueryLogger();
 
 		$class  = new \ReflectionClass( $query_logger );
-        $method = $class->getMethod( 'is_query_error' );
-        $method->setAccessible( true );
+		$method = $class->getMethod( 'is_query_error' );
+		$method->setAccessible( true );
 
 		$query = [
 			'request' => [
@@ -383,28 +383,28 @@ class TestQueryLogger extends BaseTestCase {
 	 *
 	 * @return array
 	 */
-    public function maybeDeleteIndexDataProvider() : array {
-        return [
-            [ true, 199 ],
-            [ false, 200 ],
-            [ false, 299 ],
-            [ true, 300 ],
-            [ false, 404 ],
-        ];
-    }
+	public function maybeDeleteIndexDataProvider() : array {
+		return [
+			[ true, 199 ],
+			[ false, 200 ],
+			[ false, 299 ],
+			[ true, 300 ],
+			[ false, 404 ],
+		];
+	}
 
 	/**
 	 * Data provider for the testIsQueryErrorWithStatusCode method
 	 *
 	 * @return array
 	 */
-    public function isQueryErrorWithStatusCodeDataProvider() : array {
-        return [
-            [ true, 199 ],
-            [ false, 200 ],
-            [ false, 299 ],
-            [ true, 300 ],
-            [ true, 404 ],
-        ];
-    }
+	public function isQueryErrorWithStatusCodeDataProvider() : array {
+		return [
+			[ true, 199 ],
+			[ false, 200 ],
+			[ false, 299 ],
+			[ true, 300 ],
+			[ true, 404 ],
+		];
+	}
 }

--- a/tests/php/TestQueryLogger.php
+++ b/tests/php/TestQueryLogger.php
@@ -24,6 +24,15 @@ class TestQueryLogger extends BaseTestCase {
 	}
 
 	/**
+	 * Clean up after each test
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		delete_site_option( 'ep_last_sync' );
+	}
+
+	/**
 	 * Test the log_query method before a sync is performed
 	 *
 	 * @group queryLogger

--- a/tests/php/TestStatusReport.php
+++ b/tests/php/TestStatusReport.php
@@ -25,7 +25,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'wordpress', 'indexable', 'elasticpress', 'indices', 'last_sync', 'features' ],
+			[ 'wordpress', 'indexable', 'elasticpress', 'failed_queries', 'indices', 'last_sync', 'features' ],
 			array_keys( $reports )
 		);
 	}
@@ -46,7 +46,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'wordpress', 'indexable', 'elasticpress', 'indices', 'last_sync', 'features', 'custom' ],
+			[ 'wordpress', 'indexable', 'elasticpress', 'failed_queries', 'indices', 'last_sync', 'features', 'custom' ],
 			array_keys( $reports )
 		);
 	}
@@ -63,7 +63,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'elasticpress', 'indices', 'last_sync', 'features' ],
+			[ 'elasticpress', 'failed_queries', 'indices', 'last_sync', 'features' ],
 			array_keys( $reports )
 		);
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->
### Description of the Change

This PR adds a query logger functionality. It stores failed queries (up to 5 in the last 24 hours) and displays (1) an admin notice if failed queries are detected and (2) the failed queries in the new Status Report page.
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - new Query Logger to display admin notices about failed queries and the list in the new Status Report page

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @JakePT @brandwaffle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
