### PR TITLE
Fix: Network alias creation failed

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1306,7 +1306,7 @@ class Command extends WP_CLI_Command {
 				break;
 
 			case 'error':
-				$this->clear_index();
+				$this->clear_sync();
 				WP_CLI::error( $message['message'] );
 				break;
 

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -877,6 +877,11 @@ class IndexHelper {
 		$sites = Utils\get_sites();
 
 		foreach ( $sites as $site ) {
+
+			if ( ! Utils\is_site_indexable( $site['blog_id'] ) ) {
+				continue;
+			}
+
 			switch_to_blog( $site['blog_id'] );
 			$indexes[] = $indexable->get_index_name();
 			restore_current_blog();


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where `sync` command throws a warning message while creating the network alias when one of the sites is deactivated in the network.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3134 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Enabled the ElasticPress on network
Mark any site as a Deactivate
Try to index the the content either from dashboard or cli


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Network alias creation failed warning when one of the sites is deactivated.
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
