### PR TITLE
Fix: JS error on widget screen

### DIFF
--- a/assets/js/search/editor/plugins/exclude-from-search.js
+++ b/assets/js/search/editor/plugins/exclude-from-search.js
@@ -9,8 +9,8 @@ import { __ } from '@wordpress/i18n';
 export default () => {
 	const { editPost } = useDispatch('core/editor');
 
-	const { ep_exclude_from_search = false, ...meta } = useSelect((select) =>
-		select('core/editor').getEditedPostAttribute('meta'),
+	const { ep_exclude_from_search = false, ...meta } = useSelect(
+		(select) => select('core/editor').getEditedPostAttribute('meta') || {},
 	);
 
 	const onChange = (ep_exclude_from_search) => {

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -689,6 +689,12 @@ class Search extends Feature {
 	 * Enqueue block editor assets.
 	 */
 	public function enqueue_block_editor_assets() {
+		global $post;
+
+		if ( ! $post instanceof \WP_Post ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			'ep-search-editor',
 			EP_URL . '/dist/js/search-editor-script.js',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes a issue where the plugin throws a JS error `TypeError: Cannot read properties of undefined (reading 'ep_exclude_from_search')` on widget screen.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Go to widget screen. 
- Check if there is any console error. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - JS Error on widget screen. 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
