### PR TITLE
Auto sync parent terms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "lint-fix": "phpcbf elasticpress.php includes",
     "test": "phpunit",
     "test-single-site": "phpunit -c single-site.xml.dist",
-    "setup-local-tests": "bash bin/install-wp-tests.sh ep_wp_test root password 172.29.96.1 latest true"
+    "setup-local-tests": "bash bin/install-wp-tests.sh ep_wp_test root password 127.0.0.1 latest true"
   },
   "extra": {
     "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "lint-fix": "phpcbf elasticpress.php includes",
     "test": "phpunit",
     "test-single-site": "phpunit -c single-site.xml.dist",
-    "setup-local-tests": "bash bin/install-wp-tests.sh ep_wp_test root password 127.0.0.1 latest true"
+    "setup-local-tests": "bash bin/install-wp-tests.sh ep_wp_test root password 172.29.96.1 latest true"
   },
   "extra": {
     "installer-paths": {

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -396,9 +396,27 @@ class SyncManager extends SyncManagerAbstract {
 		}
 
 		if ( IndexHelper::factory()->get_index_default_per_page() >= $tag->count ) {
+
+			$child_tags = get_term_children( $tag->term_id, $tag->taxonomy );
+			if ( ! empty( $child_tags ) ) {
+				foreach ( $child_tags as $child_tag_id ) {
+					$child_tag = get_term( $child_tag_id );
+					if ( ! is_wp_error( $child_tag ) && IndexHelper::factory()->get_index_default_per_page() < $child_tag->count && ! isset( $notices['edited_single_parent_term'] ) ) {
+						$notices['edited_single_parent_term'] = [
+							'html'    => sprintf(
+								/* translators: Sync Page URL */
+								__( 'Due to the number of posts associated with its child terms, you will need to <a href="%s">resync</a> after editing or deleting it.', 'elasticpress' ),
+								Utils\get_sync_url()
+							),
+							'type'    => 'warning',
+							'dismiss' => true,
+						];
+					}
+				}
+			}
+
 			return $notices;
 		}
-
 		$notices['edited_single_term'] = [
 			'html'    => sprintf(
 				/* translators: Sync Page URL */

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -554,14 +554,14 @@ class SyncManager extends SyncManagerAbstract {
 		}
 
 		// Find ID of all attached posts (query lifted from wp_delete_term())
-		$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $tt_id ) );
+		$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM {$wpdb->term_relationships} WHERE term_taxonomy_id = %d", $tt_id ) );
 
 		// If the current term is not attached, check if the child terms are attached to the post
 		if ( empty( $object_ids ) ) {
 			$child_terms = get_term_children( $term_id, $taxonomy );
 			if ( ! empty( $child_terms ) ) {
 				$in_id      = join( ',', array_fill( 0, count( $child_terms ), '%d' ) );
-				$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id IN ( $in_id )", $child_terms ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN ( {$in_id} )", $child_terms ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 			}
 		}
 		if ( ! count( $object_ids ) ) {

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -398,20 +398,22 @@ class SyncManager extends SyncManagerAbstract {
 		if ( IndexHelper::factory()->get_index_default_per_page() >= $tag->count ) {
 
 			$child_tags = get_term_children( $tag->term_id, $tag->taxonomy );
-			if ( ! empty( $child_tags ) ) {
-				foreach ( $child_tags as $child_tag_id ) {
-					$child_tag = get_term( $child_tag_id );
-					if ( ! is_wp_error( $child_tag ) && IndexHelper::factory()->get_index_default_per_page() < $child_tag->count && ! isset( $notices['edited_single_parent_term'] ) ) {
-						$notices['edited_single_parent_term'] = [
-							'html'    => sprintf(
-								/* translators: Sync Page URL */
-								__( 'Due to the number of posts associated with its child terms, you will need to <a href="%s">resync</a> after editing or deleting it.', 'elasticpress' ),
-								Utils\get_sync_url()
-							),
-							'type'    => 'warning',
-							'dismiss' => true,
-						];
-					}
+			if ( empty( $child_tags ) ) {
+				return $notices;
+			}
+			foreach ( $child_tags as $child_tag_id ) {
+				$child_tag = get_term( $child_tag_id );
+				if ( ! is_wp_error( $child_tag ) && IndexHelper::factory()->get_index_default_per_page() < $child_tag->count && ! isset( $notices['edited_single_parent_term'] ) ) {
+					$notices['edited_single_parent_term'] = [
+						'html'    => sprintf(
+							/* translators: Sync Page URL */
+							__( 'Due to the number of posts associated with its child terms, you will need to <a href="%s">resync</a> after editing or deleting it.', 'elasticpress' ),
+							Utils\get_sync_url()
+						),
+						'type'    => 'warning',
+						'dismiss' => true,
+					];
+					break;
 				}
 			}
 

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -556,6 +556,14 @@ class SyncManager extends SyncManagerAbstract {
 		// Find ID of all attached posts (query lifted from wp_delete_term())
 		$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $tt_id ) );
 
+		// If the current term is not attached, check if the child terms are attached to the post
+		if ( empty( $object_ids ) ) {
+			$child_terms = get_term_children( $term_id, $taxonomy );
+			if ( ! empty( $child_terms ) ) {
+				$in_id      = join( ',', array_fill( 0, count( $child_terms ), '%d' ) );
+				$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id IN ( $in_id )", $child_terms ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			}
+		}
 		if ( ! count( $object_ids ) ) {
 			return;
 		}

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -7396,16 +7396,16 @@ class TestPost extends BaseTestCase {
 		register_taxonomy_for_object_type( $tax_name, $post->post_type );
 
 		$term_1_name = rand_str( 32 );
-		$term1       = wp_insert_term( $term_1_name, $tax_name );
+		$term_1      = wp_insert_term( $term_1_name, $tax_name );
 
 		$term_2_name = rand_str( 32 );
-		$term2       = wp_insert_term( $term_2_name, $tax_name, array( 'parent' => $term1['term_id'] ) );
+		$term_2       = wp_insert_term( $term_2_name, $tax_name, array( 'parent' => $term_1['term_id'] ) );
 
-		wp_set_object_terms( $post->ID, array( $term2['term_id'] ), $tax_name, true );
+		wp_set_object_terms( $post->ID, array( $term_2['term_id'] ), $tax_name, true );
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		$test_tag = get_term_by( 'id', $term1['term_id'], $tax_name );
+		$test_tag = get_term_by( 'id', $term_1['term_id'], $tax_name );
 
 		wp_update_term(
 			$test_tag->term_id,
@@ -7420,8 +7420,8 @@ class TestPost extends BaseTestCase {
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
 		$document = ElasticPress\Indexables::factory()->get( 'post' )->get( $post->ID );
-		$this->assertEquals( 'parent-term', $document['terms'][$tax_name][1]['slug'] );
-		$this->assertEquals( 'Parent Term', $document['terms'][$tax_name][1]['name'] );
+		$this->assertEquals( 'parent-term', $document['terms'][ $tax_name ][1]['slug'] );
+		$this->assertEquals( 'Parent Term', $document['terms'][ $tax_name ][1]['name'] );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -7383,6 +7383,48 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Tests parent term edition when child term is attached to post
+	 *
+	 * @return void
+	 * @group  post
+	 */
+	public function testParentEditedTerm() {
+		$post = $this->ep_factory->post->create_and_get();
+
+		$tax_name = rand_str( 32 );
+		register_taxonomy( $tax_name, $post->post_type, array( 'label' => $tax_name ) );
+		register_taxonomy_for_object_type( $tax_name, $post->post_type );
+
+		$term_1_name = rand_str( 32 );
+		$term1       = wp_insert_term( $term_1_name, $tax_name );
+
+		$term_2_name = rand_str( 32 );
+		$term2       = wp_insert_term( $term_2_name, $tax_name, array( 'parent' => $term1['term_id'] ) );
+
+		wp_set_object_terms( $post->ID, array( $term2['term_id'] ), $tax_name, true );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$test_tag = get_term_by( 'id', $term1['term_id'], $tax_name );
+
+		wp_update_term(
+			$test_tag->term_id,
+			$tax_name,
+			[
+				'slug' => 'parent-term',
+				'name' => 'Parent Term',
+			]
+		);
+
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->index_sync_queue();
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$document = ElasticPress\Indexables::factory()->get( 'post' )->get( $post->ID );
+		$this->assertEquals( 'parent-term', $document['terms'][$tax_name][1]['slug'] );
+		$this->assertEquals( 'Parent Term', $document['terms'][$tax_name][1]['name'] );
+	}
+
+	/**
 	 * Tests post without meta value.
 	 *
 	 * @return void


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Auto-sync the parent terms when child terms are selected in the posts
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3105 

### How to test the Change

- Go to WordPress default categories
- Add 2 terms, make one of them child to the other
- Go to WordPress default posts
- Add a new post and link the child term with it
- Edit the parent term slug
- Go to Elasticsearch and check the post document and note that parent slug is also updated

<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Auto sync issue with parent term
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
