### PR TITLE
Refactor Status Report UI

### DIFF
--- a/assets/css/status-report.css
+++ b/assets/css/status-report.css
@@ -1,30 +1,29 @@
-.wrap .ep-status-report {
-	max-width: 1200px;
+.ep-status-report {
+	max-width: 800px;
 
-	& h2 {
-		margin-top: 20px;
+	& .components-panel {
+		margin-bottom: 1rem;
 	}
 
 	& table {
 		table-layout: fixed;
 
 		& col:first-of-type {
-			width: 30%;
+			width: 40%;
 		}
 
-		& thead {
-
-			& th {
-				font-weight: 600;
-			}
-
-			&:not(:first-child) th {
-				border-top: 1px solid #c3c4c7;
-			}
+		& td,
+		& th {
+			line-height: 1.5;
 		}
 
 		& small {
 			display: block;
+		}
+
+		& pre {
+			margin: 0;
+			overflow-x: scroll;
 		}
 	}
 }

--- a/assets/js/status-report/components/reports.js
+++ b/assets/js/status-report/components/reports.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies.
+ */
+import { WPElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import Report from './reports/report';
+
+/**
+ * Reports component.
+ *
+ * @param {object} props Component props.
+ * @param {object} props.reports Status reports.
+ * @returns {WPElement} Reports component.
+ */
+export default ({ reports }) => {
+	return Object.entries(reports).map(([key, { actions, groups, title }]) => (
+		<Report actions={actions} groups={groups} key={key} title={title} />
+	));
+};

--- a/assets/js/status-report/components/reports/report.js
+++ b/assets/js/status-report/components/reports/report.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies.
+ */
+import { Button, Panel, PanelBody, PanelHeader } from '@wordpress/components';
+import { WPElement } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies.
+ */
+import Value from './report/value';
+
+/**
+ * Report components.
+ *
+ * @param {object} props Component props.
+ * @param {Array} props.actions Report actions.
+ * @param {object} props.groups Report groups.
+ * @param {string} props.title Report title.
+ * @returns {WPElement} Report component.
+ */
+export default ({ actions, groups, title }) => {
+	if (groups.length < 1) {
+		return null;
+	}
+
+	return (
+		<Panel>
+			<PanelHeader>
+				<h2>{title}</h2>
+				{actions.map(({ href, label }) => (
+					<Button
+						href={decodeEntities(href)}
+						isDestructive
+						isSecondary
+						isSmall
+						key={href}
+					>
+						{label}
+					</Button>
+				))}
+			</PanelHeader>
+			{groups.map(({ fields, title }) => (
+				<PanelBody key={title} title={decodeEntities(title)} initialOpen={false}>
+					<table
+						cellPadding="0"
+						cellSpacing="0"
+						className="wp-list-table widefat striped"
+					>
+						<colgroup>
+							<col />
+							<col />
+						</colgroup>
+						<tbody>
+							{Object.entries(fields).map(
+								([key, { description = '', label, value }]) => (
+									<tr key={key}>
+										<td>
+											{label}
+											{description ? <small>{description}</small> : null}
+										</td>
+										<td>
+											<Value value={value} />
+										</td>
+									</tr>
+								),
+							)}
+						</tbody>
+					</table>
+				</PanelBody>
+			))}
+		</Panel>
+	);
+};

--- a/assets/js/status-report/components/reports/report/value.js
+++ b/assets/js/status-report/components/reports/report/value.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies.
+ */
+import { RawHTML, WPElement } from '@wordpress/element';
+
+/**
+ * Field value component.
+ *
+ * @param {object} props Component props.
+ * @param {any} props.value Value to render.
+ * @returns {WPElement} Value component.
+ */
+export default ({ value }) => {
+	if (typeof value === 'object') {
+		const json = JSON.stringify(value, null, 2);
+
+		return <pre>{json}</pre>;
+	}
+
+	if (typeof value === 'string') {
+		if (value.indexOf('{') === 0) {
+			const data = JSON.parse(value);
+			const json = JSON.stringify(data, null, 2);
+
+			return <pre>{json}</pre>;
+		}
+
+		return <RawHTML>{value}</RawHTML>;
+	}
+
+	return value.toString();
+};

--- a/assets/js/status-report/config.js
+++ b/assets/js/status-report/config.js
@@ -1,0 +1,6 @@
+/**
+ * Window dependencies.
+ */
+const reports = window.epStatusReport;
+
+export { reports };

--- a/assets/js/status-report/index.js
+++ b/assets/js/status-report/index.js
@@ -4,6 +4,13 @@
  * WordPress dependencies.
  */
 import domReady from '@wordpress/dom-ready';
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { reports } from './config';
+import Reports from './components/reports';
 
 /**
  * Status report copy button.
@@ -11,6 +18,7 @@ import domReady from '@wordpress/dom-ready';
  * @returns {void}
  */
 const init = () => {
+	const report = document.getElementById('ep-status-reports');
 	const clipboard = new ClipboardJS('#ep-copy-report');
 
 	/**
@@ -30,9 +38,14 @@ const init = () => {
 	};
 
 	/**
-	 * Bind events.
+	 * Bind copy button events.
 	 */
 	clipboard.on('success', onSuccess);
+
+	/**
+	 * Render reports.
+	 */
+	render(<Reports reports={reports} />, report);
 };
 
 domReady(init);

--- a/includes/classes/StatusReport/ElasticPressIo.php
+++ b/includes/classes/StatusReport/ElasticPressIo.php
@@ -151,7 +151,7 @@ class ElasticPressIo extends Report {
 		if ( is_wp_error( $template ) ) {
 			return [
 				$index => [
-					'title' => $index,
+					'label' => $index,
 					'value' => $template->get_error_message(),
 				],
 			];
@@ -159,7 +159,7 @@ class ElasticPressIo extends Report {
 
 		return [
 			$index => [
-				'title' => $index,
+				'label' => $index,
 				'value' => $template,
 			],
 		];

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -71,11 +71,11 @@ class FailedQueries extends Report {
 			list( $error, $solution ) = $this->analyze_log( $log );
 
 			$fields = [
-				[
+				'error'                => [
 					'label' => __( 'Error', 'elasticpress' ),
 					'value' => $error,
 				],
-				[
+				'recommended_solution' => [
 					'label' => __( 'Recommended Solution', 'elasticpress' ),
 					'value' => $solution,
 				],

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -107,18 +107,24 @@ class FailedQueries extends Report {
 	 *
 	 * @return string
 	 */
-	public function get_actions() : string {
+	public function get_actions() : array {
 		global $wp;
 
 		$logs = $this->query_logger->get_logs( false );
+
 		if ( empty( $logs ) ) {
-			return '';
+			return [];
 		}
 
-		$button_text = __( 'Clear logged queries', 'elasticpress' );
-		$href        = wp_nonce_url( add_query_arg( [ $_GET ], $wp->request ), 'ep-clear-logged-queries', '_wpnonce' ); // phpcs:ignore WordPress.Security.NonceVerification
+		$label = __( 'Clear query log', 'elasticpress' );
+		$href  = wp_nonce_url( add_query_arg( [ $_GET ], $wp->request ), 'ep-clear-logged-queries', '_wpnonce' ); // phpcs:ignore WordPress.Security.NonceVerification
 
-		return '<a href="' . $href . '" class="button">' . $button_text . '</a>';
+		return [
+			[
+				'href'  => $href,
+				'label' => $label,
+			],
+		];
 	}
 
 	/**

--- a/includes/classes/StatusReport/Features.php
+++ b/includes/classes/StatusReport/Features.php
@@ -25,7 +25,7 @@ class Features extends Report {
 	 * @return string
 	 */
 	public function get_title() : string {
-		return __( 'Features Settings', 'elasticpress' );
+		return __( 'Feature Settings', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/StatusReport/Report.php
+++ b/includes/classes/StatusReport/Report.php
@@ -36,7 +36,7 @@ abstract class Report {
 	 *
 	 * @return string
 	 */
-	public function get_actions() : string {
-		return '';
+	public function get_actions() : array {
+		return [];
 	}
 }

--- a/includes/partials/status-report-page.php
+++ b/includes/partials/status-report-page.php
@@ -19,5 +19,6 @@ require_once __DIR__ . '/header.php';
 	<h1><?php esc_html_e( 'Status Report', 'elasticpress' ); ?></h1>
 	<div class="ep-status-report">
 		<?php $status_report->render_reports(); ?>
+		<div id="ep-status-reports"></div>
 	</div>
 </div>

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
       "sync-script": "./assets/js/sync/index.js",
       "sites-admin-script": "./assets/js/sites-admin.js",
       "stats-script": "./assets/js/stats.js",
-      "status-report-script": "./assets/js/status-report.js",
+      "status-report-script": "./assets/js/status-report/index.js",
       "synonyms-script": "./assets/js/synonyms/index.js",
       "admin-script": "./assets/js/admin.js",
       "weighting-script": "./assets/js/weighting.js",


### PR DESCRIPTION
### Description of the Change
Updates the UI of the Status Report page (#3130) to use Gutenberg components for collapsible sections.

![elasticpress test_wp-admin_network_admin php_page=elasticpress-status-report (2)](https://user-images.githubusercontent.com/4100733/203502180-1ddb41d4-0d45-44ec-973b-1779c5b40378.png)
![elasticpress test_wp-admin_network_admin php_page=elasticpress-status-report (3)](https://user-images.githubusercontent.com/4100733/203502191-81200f73-8abf-402d-aee8-769e496e43ae.png)
![elasticpress test_wp-admin_network_admin php_page=elasticpress-status-report (4)](https://user-images.githubusercontent.com/4100733/203502200-21c59a4b-1df9-4254-bbc8-67f1d6861ffe.png)

Styling and layout is consistent with the updated Weighting page from #3068.

NOTE: This PR has `feature/query-log` merged into it, so #3136 should be merged first.

### How to test the Change
Navigate to _ElasticPress > Status Report_ and confirm reports are visible as expected and that sections are expandable.

### Credits
Props @JakePT

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
