### PR TITLE
Add a notice for Instant Results in network mode.

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -108,9 +108,9 @@ class InstantResults extends Feature {
 			<?php
 			printf(
 				/* translators: %s: ElasticPress.io link. */
-				esc_html__( 'WordPress search forms will display results instantly. When the search query is submitted, a modal will open that populates results by querying ElasticPress directly, bypassing WordPress. As the user refines their search, results are refreshed. Requires an %s to function.', 'elasticpress' ),
+				esc_html__( 'WordPress search forms will display results instantly. When the search query is submitted, a modal will open that populates results by querying ElasticPress directly, bypassing WordPress. As the user refines their search, results are refreshed. Requires an %s or a custom proxy to function.', 'elasticpress' ),
 				sprintf(
-					'<a href=”%1$s” target="_blank">%2$s</a>',
+					'<a href="%1$s" target="_blank">%2$s</a>',
 					'https://www.elasticpress.io/',
 					esc_html__( 'ElasticPress.io plan', 'elasticpress' )
 				)

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -218,6 +218,18 @@ class InstantResults extends Feature {
 			$status->message[] = wp_kses_post( __( "To use this feature you need to be an <a href='https://elasticpress.io'>ElasticPress.io</a> customer or implement a <a href='https://github.com/10up/elasticpress-proxy'>custom proxy</a>.", 'elasticpress' ) );
 		}
 
+		/**
+		 * Display a warning if ElasticPress is network activated.
+		 */
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$status->message[] = wp_kses_post(
+				__(
+					'ElasticPress is network activated. Additional steps are required to ensure Instant Results works for all sites on the network. See our article on <a href="https://elasticpress.zendesk.com/hc/en-us/articles/10841087797901-Running-ElasticPress-in-a-WordPress-Multisite-Network-Mode-" target="_blank">running ElasticPress in network mode</a> for more details.',
+					'elasticpress'
+				)
+			);
+		}
+
 		return $status;
 	}
 

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -223,9 +223,13 @@ class InstantResults extends Feature {
 		 */
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 			$status->message[] = wp_kses_post(
-				__(
-					'ElasticPress is network activated. Additional steps are required to ensure Instant Results works for all sites on the network. See our article on <a href="https://elasticpress.zendesk.com/hc/en-us/articles/10841087797901-Running-ElasticPress-in-a-WordPress-Multisite-Network-Mode-" target="_blank">running ElasticPress in network mode</a> for more details.',
-					'elasticpress'
+				sprintf(
+					/* translators: Article URL */
+					__(
+						'ElasticPress is network activated. Additional steps are required to ensure Instant Results works for all sites on the network. See our article on <a href="%s" target="_blank">running ElasticPress in network mode</a> for more details.',
+						'elasticpress'
+					),
+					'https://elasticpress.zendesk.com/hc/en-us/articles/10841087797901-Running-ElasticPress-in-a-WordPress-Multisite-Network-Mode-'
 				)
 			);
 		}


### PR DESCRIPTION
### Description of the Change
Adds a notice to the Instant Results feature when ElasticPress is network activated. The notice links to an article which will explain how to save the search template using WP CLI so that Instant Results works for all sites on the network.

![Screenshot 2022-11-23 at 11 01 46 pm](https://user-images.githubusercontent.com/4100733/203547426-82b55603-964e-44e2-bba6-07afe3b24c35.png)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3138

### How to test the Change
1. Network Activate WooCommerce.
2. In _ElasticPress > Features_ there should be a warning message in the Instant Results box.

### Changelog Entry
> Added - A notice to the Instant Results feature settings when ElasticPress is network activated that warns that Instant Results will not work on all sites without additional steps, with a link to an article that describes the required steps.

### Credits
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
