### PR TITLE
Change Instant Results method name for consistency

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -438,7 +438,7 @@ class InstantResults extends Feature {
 	 *
 	 * @since 4.4.0
 	 */
-	public function get_saved_search_template() {
+	public function epio_get_search_template() {
 		$endpoint = $this->get_template_endpoint();
 		$request  = Elasticsearch::factory()->remote_request( $endpoint );
 

--- a/includes/classes/StatusReport/ElasticPressIo.php
+++ b/includes/classes/StatusReport/ElasticPressIo.php
@@ -146,7 +146,7 @@ class ElasticPressIo extends Report {
 		}
 
 		$feature  = new InstantResults\InstantResults();
-		$template = $feature->get_saved_search_template();
+		$template = $feature->epio_get_search_template();
 
 		if ( is_wp_error( $template ) ) {
 			return [


### PR DESCRIPTION

### Description of the Change
Changes the method for getting the saved search template for consistency with the other methods that interact with the search template on EP.io.

### How to test the Change
Instant Results template should appear as expected in the Status Report.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
