### PR TITLE
Status Report fixes

### DIFF
--- a/assets/js/status-report/components/reports.js
+++ b/assets/js/status-report/components/reports.js
@@ -17,6 +17,6 @@ import Report from './reports/report';
  */
 export default ({ reports }) => {
 	return Object.entries(reports).map(([key, { actions, groups, title }]) => (
-		<Report actions={actions} groups={groups} key={key} title={title} />
+		<Report actions={actions} groups={groups} id={key} key={key} title={title} />
 	));
 };

--- a/assets/js/status-report/components/reports/report.js
+++ b/assets/js/status-report/components/reports/report.js
@@ -16,18 +16,19 @@ import Value from './report/value';
  * @param {object} props Component props.
  * @param {Array} props.actions Report actions.
  * @param {object} props.groups Report groups.
+ * @param {string} props.id Report ID.
  * @param {string} props.title Report title.
  * @returns {WPElement} Report component.
  */
-export default ({ actions, groups, title }) => {
+export default ({ actions, groups, id, title }) => {
 	if (groups.length < 1) {
 		return null;
 	}
 
 	return (
-		<Panel>
+		<Panel id={title}>
 			<PanelHeader>
-				<h2>{title}</h2>
+				<h2 id={id}>{title}</h2>
 				{actions.map(({ href, label }) => (
 					<Button
 						href={decodeEntities(href)}

--- a/assets/js/status-report/components/reports/report/value.js
+++ b/assets/js/status-report/components/reports/report/value.js
@@ -19,10 +19,14 @@ export default ({ value }) => {
 
 	if (typeof value === 'string') {
 		if (value.indexOf('{') === 0) {
-			const data = JSON.parse(value);
-			const json = JSON.stringify(data, null, 2);
+			try {
+				const data = JSON.parse(value);
+				const json = JSON.stringify(data, null, 2);
 
-			return <pre>{json}</pre>;
+				return <pre>{json}</pre>;
+			} catch (e) {
+				return <pre>{value}</pre>;
+			}
 		}
 
 		return <RawHTML>{value}</RawHTML>;

--- a/includes/classes/Screen/StatusReport.php
+++ b/includes/classes/Screen/StatusReport.php
@@ -88,7 +88,7 @@ class StatusReport {
 		/* this filter is documented in elasticpress.php */
 		$query_logger = apply_filters( 'ep_query_logger', new \ElasticPress\QueryLogger() );
 		if ( $query_logger ) {
-			$reports['failed_queries'] = new \ElasticPress\StatusReport\FailedQueries( $query_logger );
+			$reports['failed-queries'] = new \ElasticPress\StatusReport\FailedQueries( $query_logger );
 		}
 
 		$reports['indices'] = new \ElasticPress\StatusReport\Indices();
@@ -97,7 +97,7 @@ class StatusReport {
 			$reports['autosuggest'] = new \ElasticPress\StatusReport\ElasticPressIo();
 		}
 
-		$reports['last_sync'] = new \ElasticPress\StatusReport\LastSync();
+		$reports['last-sync'] = new \ElasticPress\StatusReport\LastSync();
 		$reports['features']  = new \ElasticPress\StatusReport\Features();
 
 		/**

--- a/tests/php/TestStatusReport.php
+++ b/tests/php/TestStatusReport.php
@@ -25,7 +25,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'wordpress', 'indexable', 'elasticpress', 'failed_queries', 'indices', 'last_sync', 'features' ],
+			[ 'wordpress', 'indexable', 'elasticpress', 'failed-queries', 'indices', 'last-sync', 'features' ],
 			array_keys( $reports )
 		);
 	}
@@ -46,7 +46,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'wordpress', 'indexable', 'elasticpress', 'failed_queries', 'indices', 'last_sync', 'features', 'custom' ],
+			[ 'wordpress', 'indexable', 'elasticpress', 'failed-queries', 'indices', 'last-sync', 'features', 'custom' ],
 			array_keys( $reports )
 		);
 	}
@@ -63,7 +63,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'elasticpress', 'failed_queries', 'indices', 'last_sync', 'features' ],
+			[ 'elasticpress', 'failed-queries', 'indices', 'last-sync', 'features' ],
 			array_keys( $reports )
 		);
 	}


### PR DESCRIPTION

### Description of the Change
Fixes 2 issues with the Status Report UI:

- Restores missing anchor IDs to report sections.
- Fixes an issue where the report would crash when the Query Body field of some failed queries would contain invalid JSON. A specific example is the `Limit of total fields [100] has been exceeded` error, which includes 2 separate JSON objects in the query body. In these cases if JSON parsing fails the raw value will be displayed. The only difference in the result is that the value will not be 'pretty-printed'.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3152

### How to test the Change
- Add the following code to the codebase: `add_filter( 'ep_total_field_limit', function() { return 100; } );`
- Run a full sync (Delete all data and sync) 
- Load any admin page (except the Status Report)
- Click on the link in the admin notice
- The window should scroll to the Failed Queries section.
- Try to open the section, the report should not crash to a blank screen.

### Credits
Props @JakePT, @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
