### PR TITLE
Fix: Undefined array key ep-synonym and ep-pointer

### DIFF
--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -98,9 +98,7 @@ class ProtectedContent extends Feature {
 		];
 
 		foreach ( $ignored_post_types as $ignored_post_type ) {
-			if ( isset( $pc_post_types[ $ignored_post_type ] ) ) {
-				unset( $pc_post_types[ $ignored_post_type ] );
-			}
+			unset( $pc_post_types[ $ignored_post_type ] );
 		}
 
 		// By default, attachments are not indexed, we have to make sure they are included (Could already be included by documents feature).

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -98,7 +98,7 @@ class ProtectedContent extends Feature {
 		];
 
 		foreach ( $ignored_post_types as $ignored_post_type ) {
-			if ( $pc_post_types[ $ignored_post_type ] ) {
+			if ( isset( $pc_post_types[ $ignored_post_type ] ) ) {
 				unset( $pc_post_types[ $ignored_post_type ] );
 			}
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes a issue where the plugin throws warnings `Undefined array key "ep-synonym"` and `Undefined array key "ep-pointer"` when the Protected Content feature is enabled. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Enable the Protected Content feature
- Check there is now issue.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
