### PR TITLE
Use get_index_default_per_page instead of direct call to Utils\get_option

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -11,6 +11,7 @@ namespace ElasticPress\Feature\WooCommerce;
 use ElasticPress\Feature as Feature;
 use ElasticPress\FeatureRequirementsStatus as FeatureRequirementsStatus;
 use ElasticPress\Indexables as Indexables;
+use ElasticPress\IndexHelper;
 use ElasticPress\Utils as Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -1258,8 +1259,7 @@ class WooCommerce extends Feature {
 			return $notices;
 		}
 
-		/* This filter is documented in /includes/classes/IndexHelper.php */
-		$documents_per_page_sync = (int) apply_filters( 'ep_index_default_per_page', Utils\get_option( 'ep_bulk_setting', 350 ) );
+		$documents_per_page_sync = IndexHelper::factory()->get_index_default_per_page();
 		if ( $documents_per_page_sync >= $wp_query->found_posts ) {
 			return $notices;
 		}
@@ -1285,8 +1285,8 @@ class WooCommerce extends Feature {
 	 * @param array $menu_orders Post IDs and their new menu_order value
 	 */
 	public function action_sync_on_woocommerce_sort_single( $sorting_id, $menu_orders ) {
-		/* This filter is documented in /includes/classes/IndexHelper.php */
-		$documents_per_page_sync = (int) apply_filters( 'ep_index_default_per_page', Utils\get_option( 'ep_bulk_setting', 350 ) );
+
+		$documents_per_page_sync = IndexHelper::factory()->get_index_default_per_page();
 		if ( $documents_per_page_sync < count( $menu_orders ) ) {
 			return;
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR replace the `Utils\get_option( 'ep_bulk_setting', 350 )` with the proper helping method `get_index_default_per_page`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Use get_index_default_per_page instead of direct call to Utils\get_option


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
