### PR TITLE
Add test for WP-CLI Commands

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -121,7 +121,7 @@ class Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Dectivate a feature.
+	 * Deactivate a feature.
 	 *
 	 * ## OPTIONS
 	 *

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -272,7 +272,7 @@ class ProtectedContent extends Feature {
 	}
 
 	/**
-	 * Exclude proctected post from the frontend queries.
+	 * Exclude protected post from the frontend queries.
 	 *
 	 * @since 4.0.0
 	 *

--- a/includes/classes/Features.php
+++ b/includes/classes/Features.php
@@ -49,7 +49,7 @@ class Features {
 	}
 
 	/**
-	 * Dectivate a feature
+	 * Deactivate a feature
 	 *
 	 * @param  string $slug Feature slug
 	 * @param  bool   $force Whether to force deactivation

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,4 +27,9 @@
       <directory prefix="Test" suffix=".php">./tests/php/</directory>
     </testsuite>
   </testsuites>
+  <groups>
+    <exclude>
+      <group>skip-on-multi-site</group>
+    </exclude>
+  </groups>
 </phpunit>

--- a/single-site.xml.dist
+++ b/single-site.xml.dist
@@ -28,4 +28,9 @@
       <exclude>./tests/php/indexables/TestTermMultisite.php</exclude>
     </testsuite>
   </testsuites>
+  <groups>
+    <exclude>
+      <group>skip-on-single-site</group>
+    </exclude>
+  </groups>
 </phpunit>

--- a/tests/php/TestAdminNotices.php
+++ b/tests/php/TestAdminNotices.php
@@ -572,7 +572,7 @@ class TestAdminNotices extends BaseTestCase {
 			}
 		);
 		ElasticPress\Screen::factory()->set_current_screen( 'install' );
-		
+
 		add_filter(
 			'ep_post_pre_meta_keys_db',
 			function() {

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -11,7 +11,7 @@ use ElasticPress;
 use ElasticPress\Command;
 
 /**
- * Commands notices test class
+ * Commands test class
  */
 class TestCommands extends BaseTestCase {
 

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -271,6 +271,7 @@ class TestCommands extends BaseTestCase {
 	/**
 	 * Test recreate-network-alias command can create aliases.
 	 *
+	 * @group skip-on-single-site
 	 * @since 4.4.1
 	 */
 	public function testReCreateNetworkAlias() {
@@ -286,6 +287,7 @@ class TestCommands extends BaseTestCase {
 	/**
 	 * Test sync command can sync content.
 	 *
+	 * @group skip-on-multi-site
 	 * @since 4.4.1
 	 */
 	public function testSync() {
@@ -301,8 +303,34 @@ class TestCommands extends BaseTestCase {
 		$this->command->sync( [], [] );
 
 		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Number of posts indexed: 11', $output );
+		$this->assertStringContainsString( 'Number of comments indexed: 10', $output );
+		$this->assertStringContainsString( 'Sync complete', $output );
+		$this->assertStringContainsString( 'Total time elapsed', $output );
+		$this->assertStringContainsString( 'Done!', $output );
+	}
+
+	/**
+	 * Test sync command can sync content.
+	 *
+	 * @group skip-on-single-site
+	 * @since 4.4.1
+	 */
+	public function testSyncOnNetwork() {
+
+		// activate comments feature
+		ElasticPress\Features::factory()->activate_feature( 'comments' );
+		ElasticPress\Features::factory()->setup_features();
+
+		// create dummy comments
+		$this->ep_factory->post->create_many( 10 );
+		$this->ep_factory->comment->create_many( 10, [ 'comment_post_ID' => $this->ep_factory->post->create() ] );
+
+		$this->command->sync( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
 		$this->assertStringContainsString( 'Number of posts indexed on site 1: 11', $output );
-		$this->assertStringContainsString( 'Indexing comments on site 1', $output );
+		$this->assertStringContainsString( 'Number of comments indexed on site 1: 10', $output );
 		$this->assertStringContainsString( 'Sync complete', $output );
 		$this->assertStringContainsString( 'Total time elapsed', $output );
 		$this->assertStringContainsString( 'Done!', $output );
@@ -399,6 +427,7 @@ class TestCommands extends BaseTestCase {
 	/**
 	 *  Test delete-index command can delete all the indexes if network-wide flag is set.
 	 *
+	 * @group skip-on-single-site
 	 * @since 4.4.1
 	 */
 	public function testDeleteIndexForNetwork() {

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -438,4 +438,175 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringContainsString( 'Deleting post index for site 2', $output );
 	}
 
+	/**
+	 * Test delete-index command can delete all the indexes if network-wide flag is set.
+	 *
+	 * @group skip-on-single-site
+	 * @since 4.4.1
+	 */
+	public function testClearSync() {
+
+		$this->command->clear_sync( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Index cleared.', $output );
+	}
+
+	/**
+	 * Test get-ongoing-sync-status command returns ongoing sync status.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testGetOnGoingSyncStatus() {
+
+		$this->command->get_ongoing_sync_status( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+	}
+
+	/**
+	 * Test get-last-sync command returns last sync information.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testGetLastSync() {
+
+		$this->command->get_last_sync( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+	}
+
+	/**
+	 * Test get-last-cli-sync command returns last cli sync information.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testGetLastCliSync() {
+
+		$this->command->get_last_cli_sync( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+	}
+
+	/**
+	 * Test stop-sync command can stop indexing.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testStopSync() {
+
+		$this->command->stop_sync( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'There is no indexing operation running.', $output );
+
+		// mock sync option
+		ElasticPress\Utils\update_option( 'ep_index_meta', [ 'indexing' => true ] );
+
+		$this->command->stop_sync( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Stopping indexing…', $output );
+		$this->assertStringContainsString( 'Done.', $output );
+	}
+
+	/**
+	 * Test set-search-algorithm-version command can set search algorithm version.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testSetSearchAlgorithmVersion() {
+
+		$this->command->set_search_algorithm_version( [], [ 'version' => 1 ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Done', $output );
+		$this->assertEquals( 1, ElasticPress\Utils\get_option( 'ep_search_algorithm_version' ) );
+
+		// clean output buffer
+		ob_clean();
+
+		// test with default flag
+		$this->command->set_search_algorithm_version( [], [ 'default' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Done', $output );
+		$this->assertEmpty( ElasticPress\Utils\get_option( 'ep_search_algorithm_version' ) );
+	}
+
+	/**
+	 * Test set-search-algorithm-version command throws an error if no version is provided.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testSetSearchAlgorithmVersionWithOutVersion() {
+
+		$this->expectExceptionMessage( 'This command expects a version number or the --default flag.' );
+
+		$this->command->set_search_algorithm_version( [], [] );
+	}
+
+	/**
+	 * Test request command can make a request to Elasticsearch.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testRequest() {
+
+		$this->command->request( [ '_cat/indices' ], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertNotEmpty( $output );
+
+		// clean output buffer
+		ob_clean();
+
+		// test with --pretty flag
+		$this->command->request( [ '_cat/indices' ], [ 'pretty' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertNotEmpty( $output );
+
+		// clean output buffer
+		ob_clean();
+
+		// test with --debug-http-request flag
+		$this->command->request( [ '_cat/indices' ], [ 'debug-http-request' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'URL:', $output );
+		$this->assertStringContainsString( 'Request Args:', $output );
+		$this->assertStringContainsString( 'Transport:', $output );
+		$this->assertStringContainsString( 'Context:', $output );
+		$this->assertStringContainsString( 'Response:', $output );
+	}
+
+	/**
+	 * Test settings-reset command delete all settings.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testSettingsReset() {
+
+		$this->command->settings_reset( [], [ 'yes' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Settings deleted.', $output );
+	}
+
+	/**
+	 * Test settings-reset command ask for confirmation.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testSettingsResetAskForConfirmation() {
+
+		$this->expectExceptionMessage( 'Are you sure you want to delete all ElasticPress settings?' );
+
+		$this->command->settings_reset( [], [] );
+	}
+
 }

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1,0 +1,422 @@
+<?php
+/**
+ * Test WP-CLI commands.
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+use ElasticPress\Command;
+
+/**
+ * Commands notices test class
+ */
+class TestCommands extends BaseTestCase {
+
+	/**
+	 * Holds Command class instance.
+	 */
+	protected $command;
+
+	/**
+	 * Setup each test.
+	 *
+	 * @since 4.4.1
+	 */
+	public function set_up() {
+		$this->command = new Command();
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		delete_option( 'ep_active_features' );
+		parent::set_up();
+	}
+
+	/**
+	 * Clean up after each test.
+	 *
+	 * @since 4.4.1
+	 */
+	public function tear_down() {
+		parent::tear_down();
+	}
+
+	/**
+	 * Test activate-feature command can activate feature.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testActivateFeature() {
+
+		$this->command->activate_feature( [ 'comments' ], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Feature activated', $output );
+	}
+
+	/**
+	 * Test activate-feature throws warning when feature needs re-index.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testActivateFeatureThrowWarnings() {
+
+		$this->command->activate_feature( [ 'comments' ], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Feature is usable but there are warnings', $output );
+		$this->assertStringContainsString( 'This feature requires a re-index. You may want to run the index command next', $output );
+	}
+
+	/**
+	 * Test activate-feature command throws error when feature is already activated.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testActivateFeatureWhenFeatureIsAlreadyActivated() {
+
+		$this->expectExceptionMessage( 'This feature is already active' );
+
+		$this->command->activate_feature( [ 'facets' ], [] );
+	}
+
+	/**
+	 * Test activate-feature command throws error when feature is not registered.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testActivateFeatureForInvalidFeature() {
+
+		$this->expectExceptionMessage( 'No feature with that slug is registered' );
+
+		$this->command->activate_feature( [ 'invalid-feature' ], [] );
+	}
+
+	/**
+	 * Test activate-feature command throws error when requirement is not met.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testActivateFeatureWhenRequirementIsNotMet() {
+
+		$this->expectExceptionMessage( 'Feature requirements are not met' );
+
+		$this->command->activate_feature( [ 'instant-results' ], [] );
+	}
+
+	/**
+	 * Test deactivate-feature command can deactivate feature.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testDeactivateFeature() {
+
+		$this->command->deactivate_feature( [ 'search' ], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Feature deactivated', $output );
+	}
+
+
+	/**
+	 * Test deactivate-feature command throws error when feature is already deactivated.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testDeactivateFeatureWhenFeatureIsAlreadyDeactivated() {
+
+		$this->expectExceptionMessage( 'Feature is not active' );
+
+		$this->command->deactivate_feature( [ 'instant-results' ], [] );
+	}
+
+	/**
+	 * Test deactivate-feature command throws error when feature is not registered.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testDeactivateFeatureForInvalidFeature() {
+
+		$this->expectExceptionMessage( 'No feature with that slug is registered' );
+
+		$this->command->deactivate_feature( [ 'invalid-feature' ], [] );
+	}
+
+	/**
+	 * Test list-features command can list all active features.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testListFeature() {
+
+		$this->command->list_features( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Active features:', $output );
+		$this->assertStringContainsString( 'search', $output );
+	}
+
+	/**
+	 * Test list-features command can list all features.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testListFeatureAll() {
+
+		$this->command->list_features( [], [ 'all' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Registered features:', $output );
+		$this->assertStringContainsString( 'search', $output );
+	}
+
+	/**
+	 * Test put-mapping command can put mapping for active features.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testPutMapping() {
+
+		$this->command->put_mapping( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Adding post mapping', $output );
+		$this->assertStringContainsString( 'Mapping sent', $output );
+	}
+
+	/**
+	 * Test get-mapping command returns mapping.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testGetMapping() {
+
+		$this->command->get_mapping( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+
+		ob_clean();
+
+		// test with index-name option
+		$this->command->get_mapping( [], [ 'index-name' => 'exampleorg-post-1' ] );
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+
+		ob_clean();
+
+		// test with pretty option
+		$this->command->get_mapping( [], [ 'pretty' => true ] );
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+		$this->assertStringContainsString( "[\n", $output );
+
+		ob_clean();
+
+		// test with incorrect index name
+		$this->command->get_mapping( [], [ 'index-name' => 'invalid-index' ] );
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'index_not_found_exception', $output );
+	}
+
+
+	/**
+	 * Test get-cluster-indices command returns cluster indices.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testGetClusterIndices() {
+
+		$this->command->get_cluster_indices( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+
+		// clean output buffer
+		ob_clean();
+
+		$this->command->get_cluster_indices( [], [ 'pretty' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertJson( $output );
+		$this->assertStringContainsString( "[\n", $output );
+	}
+
+	/**
+	 * Test get-indices command returns indices information.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testGetIndices() {
+
+		$this->command->get_indices( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertEquals( "[\"exampleorg-post-1\"]\n", $output );
+
+		// clean output buffer
+		ob_clean();
+
+		$this->command->get_indices( [], [ 'pretty' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( "[\n", $output );
+	}
+
+
+	/**
+	 * Test recreate-network-alias command can create aliases.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testReCreateNetworkAlias() {
+
+		$command = new Command();
+		$command->recreate_network_alias( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Recreating post network alias…', $output );
+		$this->assertStringContainsString( 'Done.', $output );
+	}
+
+	/**
+	 * Test sync command can sync content.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testSync() {
+
+		// activate comments feature
+		ElasticPress\Features::factory()->activate_feature( 'comments' );
+		ElasticPress\Features::factory()->setup_features();
+
+		// create dummy comments
+		$this->ep_factory->post->create_many( 10 );
+		$this->ep_factory->comment->create_many( 10, [ 'comment_post_ID' => $this->ep_factory->post->create() ] );
+
+		$this->command->sync( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Number of posts indexed on site 1: 11', $output );
+		$this->assertStringContainsString( 'Indexing comments on site 1', $output );
+		$this->assertStringContainsString( 'Sync complete', $output );
+		$this->assertStringContainsString( 'Total time elapsed', $output );
+		$this->assertStringContainsString( 'Done!', $output );
+	}
+
+	/**
+	 * Test sync command can ask for confirmation when setup flag is set
+	 *
+	 * @since 4.4.1
+	 */
+	public function testSyncAskForConfirmationWhenSetupIsPassed() {
+
+		$this->expectExceptionMessage( 'Indexing with setup option needs to delete Elasticsearch index first, are you sure you want to delete your Elasticsearch index?' );
+
+		$this->command->sync( [], [ 'setup' => true ] );
+	}
+
+	/**
+	 * Test status command returns status information.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testStatus() {
+
+		$this->command->status( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( '====== Status ======', $output );
+		$this->assertStringContainsString( 'exampleorg-post-1', $output );
+		$this->assertStringContainsString( '====== End Status ======', $output );
+	}
+
+	/**
+	 * Test delete-index command ask for confirmation.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testDeleteIndexAskForConfirmation() {
+
+		$this->expectExceptionMessage( 'Are you sure you want to delete your Elasticsearch index?' );
+
+		$this->command->delete_index( [], [] );
+	}
+
+	/**
+	 * Test delete-index command can delete index.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testDeleteIndex() {
+
+		// activate comments feature
+		ElasticPress\Features::factory()->activate_feature( 'comments' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$this->command->delete_index( [], [ 'yes' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( "Deleting index for posts…\nIndex deleted", $output );
+		$this->assertStringContainsString( "Deleting index for comments…\nIndex deleted", $output );
+
+		// clean output buffer
+		ob_clean();
+
+		// test with index-name option
+		$this->command->delete_index(
+			[],
+			[
+				'yes'        => true,
+				'index-name' => 'exampleorg-post-1',
+			]
+		);
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertEquals( 'Index deleted', $output );
+	}
+
+	/**
+	 * Test delete-index command also delete global index.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testDeleteIndexGlobal() {
+
+		ElasticPress\Features::factory()->activate_feature( 'users' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$this->command->delete_index( [], [ 'yes' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( "Deleting index for users…\nIndex deleted", $output );
+	}
+
+	/**
+	 *  Test delete-index command can delete all the indexes if network-wide flag is set.
+	 *
+	 * @since 4.4.1
+	 */
+	public function testDeleteIndexForNetwork() {
+
+		$this->factory->blog->create();
+
+		$this->command->delete_index(
+			[],
+			[
+				'yes'          => true,
+				'network-wide' => true,
+			]
+		);
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Deleting post index for site 1', $output );
+		$this->assertStringContainsString( 'Deleting post index for site 2', $output );
+
+	}
+
+}

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -37,15 +37,6 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
-	 * Clean up after each test.
-	 *
-	 * @since 4.4.1
-	 */
-	public function tear_down() {
-		parent::tear_down();
-	}
-
-	/**
 	 * Test activate-feature command can activate feature.
 	 *
 	 * @since 4.4.1
@@ -445,7 +436,6 @@ class TestCommands extends BaseTestCase {
 		$output = $this->getActualOutputForAssertion();
 		$this->assertStringContainsString( 'Deleting post index for site 1', $output );
 		$this->assertStringContainsString( 'Deleting post index for site 2', $output );
-
 	}
 
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -126,3 +126,5 @@ require_once __DIR__ . '/includes/classes/factory/TermFactory.php';
 require_once __DIR__ . '/includes/classes/factory/CommentFactory.php';
 require_once __DIR__ . '/includes/classes/BaseTestCase.php';
 require_once __DIR__ . '/includes/classes/FeatureTest.php';
+require_once __DIR__ . '/includes/classes/mock/class-wp-cli-command.php';
+require_once __DIR__ . '/includes/classes/mock/class-wp-cli.php';

--- a/tests/php/includes/classes/mock/class-wp-cli-command.php
+++ b/tests/php/includes/classes/mock/class-wp-cli-command.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Base class for WP-CLI commands
+ *
+ * @package wp-cli
+ */
+abstract class WP_CLI_Command {
+
+	public function __construct() {}
+}

--- a/tests/php/includes/classes/mock/class-wp-cli.php
+++ b/tests/php/includes/classes/mock/class-wp-cli.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Various utilities for WP-CLI commands.
+ */
+class WP_CLI {
+
+	/**
+	 * Display a log message
+	 *
+	 * @param message Message to display to the end user.
+	 */
+	public static function log( $message ) {
+		print $message;
+	}
+
+	/**
+	 * Display a success message.
+	 *
+	 * @param message Message to display to the end user.
+	 */
+	public static function success( $message ) {
+		print $message;
+	}
+
+	/**
+	 * Display debug message.
+	 *
+	 * @param message Message to display to the end user.
+	 * @param boolean                                    $group
+	 */
+	public static function debug( $message, $group = false ) {
+		print $message;
+	}
+
+	/**
+	 * Display warning message
+	 *
+	 * @param message Message to display to the end user.
+	 */
+	public static function warning( $message ) {
+		print $message;
+	}
+
+	/**
+	 * Display error message.
+	 *
+	 * @param string $message
+	 *
+	 * @return Exception
+	 */
+	public static function error( $message, $exit = true ) {
+
+		if ( ! $exit ) {
+			print $message;
+			return;
+		}
+
+		throw new Exception( $message );
+	}
+
+	/**
+	 * Colorize a string for output.
+	 *
+	 * @param string $message Message to display to the end user.
+	 */
+	public static function colorize( $message ) {
+		print $message;
+	}
+
+	/**
+	 * Display informational message without prefix.
+	 *
+	 * @param string $message Message to display to the end user.
+	 */
+	public static function line( $message ) {
+		print $message . "\n";
+	}
+
+	/**
+	 * Ask for confirmation before running a destructive operation.
+	 *
+	 * @param string $message Question to display before the prompt.
+	 * @param array  $args Skips prompt if 'yes' is provided.
+	 */
+	public static function confirm( $message, $args = [] ) {
+
+		if ( isset( $args['yes'] ) && true === $args['yes'] ) {
+			return;
+		}
+
+		throw new Exception( $message );
+	}
+
+}

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -6019,6 +6019,17 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( $post_id_4, $post_ids[0] );
 		$this->assertCount( 1, $results['objects'] );
 		$this->assertEquals( 4, $results['total_objects'] );
+
+		// Test it pulls the post with passwords when password protected feature is enabled.
+		ElasticPress\Features::factory()->activate_feature( 'protected_content' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$results = $indexable_post_object->query_db(
+			[
+				'per_page'     => 1
+			]
+		);
+		$this->assertEquals( 4, $results['total_objects'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the Unit Tests for the WP-CLI commands and one test for the Protected Content feature

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3054 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Unit Tests for WP-CLI Commands and one test for Protected Feature


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
