### PR TITLE
Filter passed flag to evaluate as boolean or not

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -391,7 +391,7 @@ class Command extends WP_CLI_Command {
 
 		$response = Elasticsearch::factory()->remote_request( $path );
 
-		$this->print_json_response( $response, ! empty( $assoc_args['pretty'] ) );
+		$this->print_json_response( $response, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}
 
 	/**
@@ -411,7 +411,7 @@ class Command extends WP_CLI_Command {
 
 		$cluster_indices = Elasticsearch::factory()->get_cluster_indices();
 
-		$this->pretty_json_encode( $cluster_indices, ! empty( $assoc_args['pretty'] ) );
+		$this->pretty_json_encode( $cluster_indices, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}
 
 	/**
@@ -430,7 +430,7 @@ class Command extends WP_CLI_Command {
 	public function get_indices( $args, $assoc_args ) {
 		$index_names = $this->get_index_names();
 
-		$this->pretty_json_encode( $index_names, ! empty( $assoc_args['pretty'] ) );
+		$this->pretty_json_encode( $index_names, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}
 
 	/**
@@ -1011,7 +1011,7 @@ class Command extends WP_CLI_Command {
 			];
 		}
 
-		$this->pretty_json_encode( $indexing_status, ! empty( $assoc_args['pretty'] ) );
+		$this->pretty_json_encode( $indexing_status, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}
 
 	/**
@@ -1031,7 +1031,7 @@ class Command extends WP_CLI_Command {
 	public function get_last_sync( $args, $assoc_args ) {
 		$last_sync = \ElasticPress\IndexHelper::factory()->get_last_index();
 
-		$this->pretty_json_encode( $last_sync, ! empty( $assoc_args['pretty'] ) );
+		$this->pretty_json_encode( $last_sync, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}
 
 	/**
@@ -1057,7 +1057,7 @@ class Command extends WP_CLI_Command {
 			Utils\delete_option( 'ep_last_cli_index' );
 		}
 
-		$this->pretty_json_encode( $last_sync, ! empty( $assoc_args['pretty'] ) );
+		$this->pretty_json_encode( $last_sync, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}
 
 
@@ -1455,7 +1455,7 @@ class Command extends WP_CLI_Command {
 			WP_CLI::error( $response->get_error_message() );
 		}
 
-		$this->print_json_response( $response, ! empty( $assoc_args['pretty'] ) );
+		$this->print_json_response( $response, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}
 
 	/**
@@ -1553,5 +1553,15 @@ class Command extends WP_CLI_Command {
 	protected function pretty_json_encode( $json_obj, $pretty_print_flag ) {
 		$flag = $pretty_print_flag ? JSON_PRETTY_PRINT : null;
 		WP_CLI::line( wp_json_encode( $json_obj, $flag ) );
+	}
+
+	/**
+	 * Whether a value can be evaluated as true or not.
+	 *
+	 * @since 4.4.1
+	 * @return bool
+	 */
+		protected function filter_boolean( $value ) {
+		return filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );;
 	}
 }

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -385,9 +385,18 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_mapping( $args, $assoc_args ) {
-		$index_names = (array) ( isset( $assoc_args['index-name'] ) ? $assoc_args['index-name'] : $this->get_index_names() );
+		$defaults = [
+			'index-name' => $this->get_index_names(),
+			'pretty'     => false,
+		];
 
-		$path = join( ',', $index_names ) . '/_mapping';
+		if ( isset( $assoc_args['index-name'] ) ) {
+			$assoc_args['index-name'] = (array) $assoc_args['index-name'];
+		}
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+
+		$path = join( ',', $assoc_args['index-name'] ) . '/_mapping';
 
 		$response = Elasticsearch::factory()->remote_request( $path );
 
@@ -408,6 +417,11 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_cluster_indices( $args, $assoc_args ) {
+		$defaults = [
+			'pretty' => false,
+		];
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
 		$cluster_indices = Elasticsearch::factory()->get_cluster_indices();
 
@@ -428,6 +442,12 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_indices( $args, $assoc_args ) {
+		$defaults = [
+			'pretty' => false,
+		];
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+
 		$index_names = $this->get_index_names();
 
 		$this->pretty_json_encode( $index_names, $this->filter_boolean( $assoc_args['pretty'] ) );
@@ -1000,6 +1020,11 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_ongoing_sync_status( $args, $assoc_args ) {
+		$defaults = [
+			'pretty' => false,
+		];
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 		$indexing_status = Utils\get_indexing_status();
 
 		if ( empty( $indexing_status ) ) {
@@ -1029,6 +1054,11 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_last_sync( $args, $assoc_args ) {
+		$defaults = [
+			'pretty' => false,
+		];
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 		$last_sync = \ElasticPress\IndexHelper::factory()->get_last_index();
 
 		$this->pretty_json_encode( $last_sync, $this->filter_boolean( $assoc_args['pretty'] ) );
@@ -1051,6 +1081,12 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_last_cli_sync( $args, $assoc_args ) {
+		$defaults = [
+			'pretty' => false,
+		];
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+
 		$last_sync = Utils\get_option( 'ep_last_cli_index', array() );
 
 		if ( isset( $assoc_args['clear'] ) ) {
@@ -1393,6 +1429,12 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function request( $args, $assoc_args ) {
+		$defaults = [
+			'pretty' => false,
+		];
+
+		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+
 		$path         = $args[0];
 		$method       = isset( $assoc_args['method'] ) ? $assoc_args['method'] : 'GET';
 		$body         = isset( $assoc_args['body'] ) ? $assoc_args['body'] : '';

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1559,9 +1559,10 @@ class Command extends WP_CLI_Command {
 	 * Whether a value can be evaluated as true or not.
 	 *
 	 * @since 4.4.1
+	 * @param string $value A string value that is going to be evaluated as bool or not.
 	 * @return bool
 	 */
-		protected function filter_boolean( $value ) {
-		return filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );;
+	protected function filter_boolean( $value ) {
+		return filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
 	}
 }

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1024,7 +1024,7 @@ class Command extends WP_CLI_Command {
 			'pretty' => false,
 		];
 
-		$assoc_args = wp_parse_args( $assoc_args, $defaults );
+		$assoc_args      = wp_parse_args( $assoc_args, $defaults );
 		$indexing_status = Utils\get_indexing_status();
 
 		if ( empty( $indexing_status ) ) {
@@ -1059,7 +1059,7 @@ class Command extends WP_CLI_Command {
 		];
 
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
-		$last_sync = \ElasticPress\IndexHelper::factory()->get_last_index();
+		$last_sync  = \ElasticPress\IndexHelper::factory()->get_last_index();
 
 		$this->pretty_json_encode( $last_sync, $this->filter_boolean( $assoc_args['pretty'] ) );
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3166 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Run commands that can use the pretty flag e.g `wp elasticpress get-mapping`

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix - Evaluate as real booleans when using pretty flag
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez , @felipeelia , ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
