### PR TITLE
Fix: JS error on Status Report page

### DIFF
--- a/includes/classes/StatusReport/ElasticPressIo.php
+++ b/includes/classes/StatusReport/ElasticPressIo.php
@@ -36,10 +36,12 @@ class ElasticPressIo extends Report {
 	 * @return array
 	 */
 	public function get_groups() : array {
-		return [
+		$groups = [
 			$this->get_autosuggest_group(),
 			$this->get_instant_results_group(),
 		];
+
+		return array_values( array_filter( $groups ) );
 	}
 
 	/**
@@ -48,10 +50,14 @@ class ElasticPressIo extends Report {
 	 * @return array
 	 */
 	protected function get_autosuggest_group() : array {
-		$title = __( 'Allowed Autosuggest Parameters', 'elasticpress' );
-
 		$autosuggest_feature = \ElasticPress\Features::factory()->get_registered_feature( 'autosuggest' );
-		$allowed_params      = $autosuggest_feature->epio_autosuggest_set_and_get();
+
+		if ( ! $autosuggest_feature->is_active() ) {
+			return [];
+		}
+
+		$title          = __( 'Allowed Autosuggest Parameters', 'elasticpress' );
+		$allowed_params = $autosuggest_feature->epio_autosuggest_set_and_get();
 
 		if ( empty( $allowed_params ) ) {
 			$fields['not_available'] = [
@@ -60,10 +66,8 @@ class ElasticPressIo extends Report {
 			];
 
 			return [
-				[
-					'title'  => $title,
-					'fields' => $fields,
-				],
+				'title'  => $title,
+				'fields' => $fields,
 			];
 		}
 
@@ -105,6 +109,13 @@ class ElasticPressIo extends Report {
 	 * @return array
 	 */
 	protected function get_instant_results_group() : array {
+
+		$instant_results_feature = \ElasticPress\Features::factory()->get_registered_feature( 'instant-results' );
+
+		if ( ! $instant_results_feature->is_active() ) {
+			return [];
+		}
+
 		$title  = __( 'Instant Results Template', 'elasticpress' );
 		$fields = [];
 

--- a/includes/classes/StatusReport/ElasticPressIo.php
+++ b/includes/classes/StatusReport/ElasticPressIo.php
@@ -109,7 +109,6 @@ class ElasticPressIo extends Report {
 	 * @return array
 	 */
 	protected function get_instant_results_group() : array {
-
 		$instant_results_feature = \ElasticPress\Features::factory()->get_registered_feature( 'instant-results' );
 
 		if ( ! $instant_results_feature->is_active() ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the Status Report page returns the JS error when allow parameter information is empty and it return the array within array https://github.com/10up/ElasticPress/blob/4.4.0/includes/classes/StatusReport/ElasticPressIo.php#L62

Also it adds additional check that will check if the feature is not activate than don't add the information in report. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3179 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - JS error on Status Report page.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
