### PR TITLE
Fix E2E tests for PHP 8

### DIFF
--- a/tests/cypress/integration/general.cy.js
+++ b/tests/cypress/integration/general.cy.js
@@ -98,7 +98,7 @@ describe('WordPress can perform standard ElasticPress actions', () => {
 	it('Cannot save settings while a sync is in progress', () => {
 		cy.login();
 		cy.visitAdminPage('admin.php?page=elasticpress');
-		cy.wpCliEval(`update_option( 'ep_index_meta', true );`).then(() => {
+		cy.wpCliEval(`update_option( 'ep_index_meta', [ 'indexing' => true ] );`).then(() => {
 			cy.get('.ep-feature-search .settings-button').click();
 			cy.get('.ep-feature-search .button-primary').click();
 			cy.get('.ep-feature-search .requirements-status-notice--syncing').should('be.visible');

--- a/tests/cypress/integration/wp-cli.cy.js
+++ b/tests/cypress/integration/wp-cli.cy.js
@@ -349,7 +349,7 @@ describe('WP-CLI Commands', () => {
 
 		// mock the sync process
 		cy.wpCliEval(
-			`update_option('ep_index_meta', true); set_transient('ep_sync_interrupted', true);`,
+			`update_option('ep_index_meta', [ 'indexing' => true ] ); set_transient('ep_sync_interrupted', true);`,
 		);
 
 		cy.wpCli('wp elasticpress stop-sync').its('stdout').should('contain', 'Done');


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Recently E2E tests are start running on the PHP 8 instead of 7.4 and after this the tests are giving the 500 errors because of the wrong value in the `ep_index_meta` option.  The PR fixes that issue.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2614 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - E2E tests for PHP 8


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
