### PR TITLE
Fix large gap between results in Instant Results when there are few results

### DIFF
--- a/assets/css/instant-results.css
+++ b/assets/css/instant-results.css
@@ -6,6 +6,7 @@
 @import "instant-results/page.css";
 @import "instant-results/panel.css";
 @import "instant-results/pagination.css";
+@import "instant-results/pagination-button.css";
 @import "instant-results/range-slider.css";
 @import "instant-results/result.css";
 @import "instant-results/results.css";

--- a/assets/css/instant-results/pagination-button.css
+++ b/assets/css/instant-results/pagination-button.css
@@ -1,0 +1,6 @@
+.ep-search-pagination-button {
+
+	&[disabled] {
+		visibility: hidden;
+	}
+}

--- a/assets/css/instant-results/results.css
+++ b/assets/css/instant-results/results.css
@@ -1,8 +1,7 @@
 .ep-search-results {
-	display: grid;
-	grid-gap: 2em;
-	grid-template-columns: 100%;
-	grid-template-rows: max-content;
+	display: flex;
+	flex-direction: column;
+	gap: 2em;
 	padding: 0 0 1em 0;
 	width: 100%;
 

--- a/assets/js/instant-results/components/results/pagination.js
+++ b/assets/js/instant-results/components/results/pagination.js
@@ -39,15 +39,14 @@ export default ({ offset, onNext, onPrevious, perPage, total }) => {
 	return (
 		<nav className="ep-search-pagination">
 			<div className="ep-search-pagination__previous">
-				{previousIsAvailable && (
-					<button
-						className="ep-search-pagination-button ep-search-pagination-button--previous"
-						onClick={onPrevious}
-						type="button"
-					>
-						{__('Previous', 'elasticpress')}
-					</button>
-				)}
+				<button
+					className="ep-search-pagination-button ep-search-pagination-button--previous"
+					disabled={!previousIsAvailable}
+					onClick={onPrevious}
+					type="button"
+				>
+					{__('Previous', 'elasticpress')}
+				</button>
 			</div>
 
 			<div className="ep-search-pagination__count" role="status">
@@ -61,15 +60,14 @@ export default ({ offset, onNext, onPrevious, perPage, total }) => {
 			</div>
 
 			<div className="ep-search-pagination__next">
-				{nextIsAvailable && (
-					<button
-						className="ep-search-pagination-button ep-search-pagination-button--next"
-						onClick={onNext}
-						type="button"
-					>
-						{__('Next', 'elasticpress')}
-					</button>
-				)}
+				<button
+					className="ep-search-pagination-button ep-search-pagination-button--next"
+					disabled={!nextIsAvailable}
+					onClick={onNext}
+					type="button"
+				>
+					{__('Next', 'elasticpress')}
+				</button>
 			</div>
 		</nav>
 	);


### PR DESCRIPTION
### Description of the Change
Fixes an issue where a large gap appeared between results when few results were being displayed (the exact amount depended on display size). The fix replaces the use of CSS grid with using the `gap` property with a flex object, which is now supported by the last 2 major versions of all major browsers.

This also includes a tweak to how the Next and Previous buttons are hidden when unavailable. Previously they were simply not rendered, but now they are rendered and hidden with `visibility: hidden`. This allows them to occupy space which will prevent the "Page X of Y" from shifting around as the buttons are rendered and un-rendered.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3173

### How to test the Change
1. Activate Instant Results.
2. Perform a search or filter such that the number of returned results does not require scrolling, and where a large gap would be expected after the last result. 
3. Check that the results are no inappropriately spread out vertically. Instead there should be small gaps between results and a large gap between the last result and the "Page X of Y" text.

### Changelog Entry
> Fixed - An layout issue in Instant Results that would occur with small result sets.

### Credits
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
