### PR TITLE
Improve CLI commands tests coverage

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -221,10 +221,7 @@ class Command extends WP_CLI_Command {
 		$this->maybe_change_index_prefix( $assoc_args );
 		$this->connect_check();
 		$this->index_occurring();
-
-		if ( ! $this->put_mapping_helper( $args, $assoc_args ) ) {
-			exit( 1 );
-		}
+		$this->put_mapping_helper( $args, $assoc_args );
 	}
 
 	/**
@@ -286,9 +283,7 @@ class Command extends WP_CLI_Command {
 					if ( $result ) {
 						WP_CLI::success( esc_html__( 'Mapping sent', 'elasticpress' ) );
 					} else {
-						WP_CLI::error( esc_html__( 'Mapping failed', 'elasticpress' ), false );
-
-						return false;
+						WP_CLI::error( esc_html__( 'Mapping failed', 'elasticpress' ) );
 					}
 				}
 
@@ -322,9 +317,7 @@ class Command extends WP_CLI_Command {
 				if ( $result ) {
 					WP_CLI::success( esc_html__( 'Mapping sent', 'elasticpress' ) );
 				} else {
-					WP_CLI::error( esc_html__( 'Mapping failed', 'elasticpress' ), false );
-
-					return false;
+					WP_CLI::error( esc_html__( 'Mapping failed', 'elasticpress' ) );
 				}
 			}
 		}
@@ -359,9 +352,7 @@ class Command extends WP_CLI_Command {
 			if ( $result ) {
 				WP_CLI::success( esc_html__( 'Mapping sent', 'elasticpress' ) );
 			} else {
-				WP_CLI::error( esc_html__( 'Mapping failed', 'elasticpress' ), false );
-
-				return false;
+				WP_CLI::error( esc_html__( 'Mapping failed', 'elasticpress' ) );
 			}
 		}
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -19,7 +19,9 @@ use ElasticPress\Elasticsearch as Elasticsearch;
 use ElasticPress\Indexables as Indexables;
 
 if ( ! defined( 'ABSPATH' ) ) {
+	// @codeCoverageIgnoreStart
 	exit; // Exit if accessed directly.
+	// @codeCoverageIgnoreEnd
 }
 
 /**
@@ -622,7 +624,7 @@ class Command extends WP_CLI_Command {
 		if ( SIGINT === $signal_no ) {
 			$this->delete_transient();
 			WP_CLI::log( esc_html__( 'Indexing cleaned up.', 'elasticpress' ) );
-			exit;
+			WP_CLI::halt();
 		}
 	}
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -582,6 +582,8 @@ class Command extends WP_CLI_Command {
 		add_action( 'ep_epio_wp_cli_set_autosuggest', [ $autosuggest_feature, 'epio_send_autosuggest_public_request' ] );
 
 		do_action( 'ep_epio_wp_cli_set_autosuggest', $args, $assoc_args );
+
+		WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );
 	}
 
 	/**
@@ -1331,7 +1333,7 @@ class Command extends WP_CLI_Command {
 		if ( ! $result ) {
 			$this->delete_transient();
 
-			exit( 1 );
+			WP_CLI::error( esc_html__( 'Mapping Failed.', 'elasticpress' ) );
 		}
 	}
 

--- a/includes/classes/DeprecatedCommand.php
+++ b/includes/classes/DeprecatedCommand.php
@@ -11,7 +11,9 @@ namespace ElasticPress;
 use \WP_CLI as WP_CLI;
 
 if ( ! defined( 'ABSPATH' ) ) {
+	// @codeCoverageIgnoreStart
 	exit; // Exit if accessed directly.
+	// @codeCoverageIgnoreEnd
 }
 
 /**

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -1139,6 +1139,7 @@ class IndexHelper {
 	 * @since 4.0.0
 	 */
 	public function clear_index_meta() {
+		$this->index_meta = false;
 		Utils\delete_option( 'ep_index_meta', false );
 	}
 

--- a/includes/classes/Indexables.php
+++ b/includes/classes/Indexables.php
@@ -35,8 +35,14 @@ class Indexables {
 		$this->registered_indexables[ $indexable->slug ] = $indexable;
 	}
 
-	public function deregister( Indexable $indexable ) {
-		unset( $this->registered_indexables[ $indexable->slug ] );
+	/**
+	 * Unregister an indexable instance
+	 *
+	 * @param  string $slug Indexable type slug.
+	 * @since 4.4.1
+	 */
+	public function unregister( $slug ) {
+		unset( $this->registered_indexables[ $slug ] );
 	}
 
 	/**

--- a/includes/classes/Indexables.php
+++ b/includes/classes/Indexables.php
@@ -35,6 +35,10 @@ class Indexables {
 		$this->registered_indexables[ $indexable->slug ] = $indexable;
 	}
 
+	public function deregister( Indexable $indexable ) {
+		unset( $this->registered_indexables[ $indexable->slug ] );
+	}
+
 	/**
 	 * Get an indexable instance given a slug
 	 *

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -199,7 +199,7 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringContainsString( 'Adding post mapping', $output );
 		$this->assertStringContainsString( 'Mapping sent', $output );
 
-		Indexables::factory()->deregister( new ElasticPress\Indexable\Comment\Comment() );
+		Indexables::factory()->unregister( 'comment' );
 	}
 
 	/**
@@ -233,7 +233,7 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringNotContainsString( 'Adding post mapping for site 2', $output );
 		$this->assertStringContainsString( 'Mapping sent', $output );
 
-		Indexables::factory()->deregister( new ElasticPress\Indexable\Comment\Comment() );
+		Indexables::factory()->unregister( 'comment' );
 	}
 
 	/**
@@ -281,7 +281,7 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringContainsString( 'Adding user mapping', $output );
 		$this->assertStringContainsString( 'Mapping sent', $output );
 
-		Indexables::factory()->deregister( new ElasticPress\Indexable\User\User() );
+		Indexables::factory()->unregister( 'user' );
 	}
 
 	/**
@@ -419,6 +419,8 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringContainsString( 'Sync complete', $output );
 		$this->assertStringContainsString( 'Total time elapsed', $output );
 		$this->assertStringContainsString( 'Done!', $output );
+
+		Indexables::factory()->unregister( 'comment' );
 	}
 
 	/**
@@ -445,6 +447,8 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringContainsString( 'Sync complete', $output );
 		$this->assertStringContainsString( 'Total time elapsed', $output );
 		$this->assertStringContainsString( 'Done!', $output );
+
+		Indexables::factory()->unregister( 'comment' );
 	}
 
 	/**
@@ -453,6 +457,10 @@ class TestCommands extends BaseTestCase {
 	 * @since 4.4.1
 	 */
 	public function testSyncWithSetupFlag() {
+
+		// activate comments feature
+		ElasticPress\Features::factory()->activate_feature( 'comments' );
+		ElasticPress\Features::factory()->setup_features();
 
 		$this->ep_factory->post->create_many( 10 );
 		$this->ep_factory->comment->create_many( 10, [ 'comment_post_ID' => $this->ep_factory->post->create() ] );
@@ -470,6 +478,7 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringContainsString( 'Total time elapsed', $output );
 		$this->assertStringContainsString( 'Done!', $output );
 
+		Indexables::factory()->unregister( 'comment' );
 	}
 
 	/**
@@ -495,7 +504,7 @@ class TestCommands extends BaseTestCase {
 		$this->assertStringNotContainsString( 'Indexing comments', $output );
 		$this->assertStringContainsString( 'Sync complete', $output );
 
-		Indexables::factory()->deregister( new ElasticPress\Indexable\Comment\Comment() );
+		Indexables::factory()->unregister( 'comment' );
 	}
 
 	/**

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -2,6 +2,7 @@
 /**
  * Test WP-CLI commands.
  *
+ * @since 4.4.1
  * @package elasticpress
  */
 
@@ -24,8 +25,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Setup each test.
-	 *
-	 * @since 4.4.1
 	 */
 	public function set_up() {
 		$this->command = new Command();
@@ -39,9 +38,15 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		ob_clean();
+		parent::tear_down();
+	}
+
+	/**
 	 * Test activate-feature command can activate feature.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testActivateFeature() {
 
@@ -53,8 +58,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test activate-feature throws warning when feature needs re-index.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testActivateFeatureThrowWarnings() {
 
@@ -67,8 +70,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test activate-feature command throws error when feature is already activated.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testActivateFeatureWhenFeatureIsAlreadyActivated() {
 
@@ -79,8 +80,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test activate-feature command throws error when feature is not registered.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testActivateFeatureForInvalidFeature() {
 
@@ -91,8 +90,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test activate-feature command throws error when requirement is not met.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testActivateFeatureWhenRequirementIsNotMet() {
 
@@ -103,8 +100,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test deactivate-feature command can deactivate feature.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testDeactivateFeature() {
 
@@ -117,8 +112,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test deactivate-feature command throws error when feature is already deactivated.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testDeactivateFeatureWhenFeatureIsAlreadyDeactivated() {
 
@@ -129,8 +122,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test deactivate-feature command throws error when feature is not registered.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testDeactivateFeatureForInvalidFeature() {
 
@@ -141,8 +132,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test list-features command can list all active features.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testListFeature() {
 
@@ -155,8 +144,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test list-features command can list all features.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testListFeatureAll() {
 
@@ -169,8 +156,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test put-mapping command can put mapping for active features.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testPutMapping() {
 
@@ -184,8 +169,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test put-mapping command can put mapping for specific indexable.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testPutMappingWithIndexablesFlag() {
 
@@ -206,7 +189,6 @@ class TestCommands extends BaseTestCase {
 	 * Test put-mapping command can put mapping for network-wide.
 	 *
 	 * @group skip-on-single-site
-	 * @since 4.4.1
 	 */
 	public function testPutMappingForNetworkWide() {
 
@@ -238,8 +220,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test put-mapping command throws error if mapping failed.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testPutMappingThrowErrorIfMappingFailed() {
 
@@ -252,8 +232,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test put-mapping command throws error if mapping failed for network-wide.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testPutMappingForNetworkWideThrowErrorIfMappingFailed() {
 
@@ -266,8 +244,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test put-mapping command can put mapping for global indexables.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testPutMappingForGlobalIndexables() {
 
@@ -286,8 +262,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test get-mapping command returns mapping.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testGetMapping() {
 
@@ -322,8 +296,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test get-cluster-indices command returns cluster indices.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testGetClusterIndices() {
 
@@ -344,8 +316,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test get-indices command returns indices information.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testGetIndices() {
 
@@ -368,12 +338,10 @@ class TestCommands extends BaseTestCase {
 	 * Test recreate-network-alias command can create aliases.
 	 *
 	 * @group skip-on-single-site
-	 * @since 4.4.1
 	 */
 	public function testReCreateNetworkAlias() {
 
-		$command = new Command();
-		$command->recreate_network_alias( [], [] );
+		$this->command->recreate_network_alias( [], [] );
 
 		$output = $this->getActualOutputForAssertion();
 		$this->assertStringContainsString( 'Recreating post network alias…', $output );
@@ -384,22 +352,19 @@ class TestCommands extends BaseTestCase {
 	 * Test recreate-network-alias command can create aliases.
 	 *
 	 * @group skip-on-multi-site
-	 * @since 4.4.1
 	 */
 
 	public function testReCreateNetworkAliasOnSingleSite() {
 
 		$this->expectExceptionMessage( 'ElasticPress is not network activated.' );
 
-		$command = new Command();
-		$command->recreate_network_alias( [], [] );
+		$this->command->recreate_network_alias( [], [] );
 	}
 
 	/**
 	 * Test sync command can sync content.
 	 *
 	 * @group skip-on-multi-site
-	 * @since 4.4.1
 	 */
 	public function testSync() {
 
@@ -427,7 +392,6 @@ class TestCommands extends BaseTestCase {
 	 * Test sync command can sync content.
 	 *
 	 * @group skip-on-single-site
-	 * @since 4.4.1
 	 */
 	public function testSyncOnNetwork() {
 
@@ -453,8 +417,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command with setup flag.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncWithSetupFlag() {
 
@@ -483,8 +445,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command with indexables flag.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncWithIndexablesFlag() {
 
@@ -511,7 +471,6 @@ class TestCommands extends BaseTestCase {
 	 * Test sync command with include flag.
 	 *
 	 * @group skip-on-multi-site
-	 * @since 4.4.1
 	 */
 	public function testSyncWithIncludeFlag() {
 
@@ -528,7 +487,6 @@ class TestCommands extends BaseTestCase {
 	 * Test sync command with include flag.
 	 *
 	 * @group skip-on-single-site
-	 * @since 4.4.1
 	 */
 	public function testSyncWithIncludeFlagForNetwork() {
 
@@ -543,8 +501,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command with per-page flag.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncWithPerPageFlag() {
 
@@ -560,8 +516,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command with post-type flag.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncWithPostTypeFlag() {
 
@@ -577,8 +531,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command with ep-prefix flag.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncWithEPPrefixFlag() {
 
@@ -593,8 +545,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command with ep-host flag.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncWithEPHostFlag() {
 
@@ -605,8 +555,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command can ask for confirmation when setup flag is set
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncAskForConfirmationWhenSetupIsPassed() {
 
@@ -617,8 +565,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test sync command throws error if mapping failed.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSyncThrowsErrorIfMappingFailed() {
 
@@ -638,8 +584,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test status command returns status information.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testStatus() {
 
@@ -653,8 +597,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test delete-index command ask for confirmation.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testDeleteIndexAskForConfirmation() {
 
@@ -665,8 +607,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test delete-index command can delete index.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testDeleteIndex() {
 
@@ -698,8 +638,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test delete-index command also delete global index.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testDeleteIndexGlobal() {
 
@@ -716,7 +654,6 @@ class TestCommands extends BaseTestCase {
 	 *  Test delete-index command can delete all the indexes if network-wide flag is set.
 	 *
 	 * @group skip-on-single-site
-	 * @since 4.4.1
 	 */
 	public function testDeleteIndexForNetwork() {
 
@@ -742,7 +679,6 @@ class TestCommands extends BaseTestCase {
 	 * Test delete-index command can delete all the indexes if network-wide flag is set.
 	 *
 	 * @group skip-on-single-site
-	 * @since 4.4.1
 	 */
 	public function testClearSync() {
 
@@ -754,8 +690,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test get-ongoing-sync-status command returns ongoing sync status.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testGetOnGoingSyncStatus() {
 
@@ -767,8 +701,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test get-last-sync command returns last sync information.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testGetLastSync() {
 
@@ -780,8 +712,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test get-last-cli-sync command returns last cli sync information.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testGetLastCliSync() {
 
@@ -799,8 +729,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test stop-sync command can stop indexing.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testStopSync() {
 
@@ -821,8 +749,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test set-search-algorithm-version command can set search algorithm version.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSetSearchAlgorithmVersion() {
 
@@ -845,8 +771,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test set-search-algorithm-version command throws an error if no version is provided.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSetSearchAlgorithmVersionWithOutVersion() {
 
@@ -857,8 +781,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test get-search-algorithm-version returns the algorithm version.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testGetSearchAlgorithmVersion() {
 
@@ -882,8 +804,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test request command can make a request to Elasticsearch.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testRequest() {
 
@@ -923,8 +843,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test request command throws an error if request fails.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testRequestThrowsError() {
 
@@ -945,8 +863,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test settings-reset command delete all settings.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSettingsReset() {
 
@@ -958,8 +874,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test settings-reset command ask for confirmation.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testSettingsResetAskForConfirmation() {
 
@@ -970,8 +884,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test stats command.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testStats() {
 
@@ -984,8 +896,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test epio-set-autosuggest command.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testEPioSetAutosuggest() {
 
@@ -999,8 +909,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test epio-set-autosuggest command throws an error if autosuggest is not enabled.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testEPioSetAutosuggestThrowsError() {
 
@@ -1011,8 +919,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test `should_interrupt_sync` method.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testShouldInterruptSync() {
 
@@ -1027,8 +933,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test commands throws an error when host is not set.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testThrowsErrorWhenHostIsNotSet() {
 
@@ -1042,8 +946,6 @@ class TestCommands extends BaseTestCase {
 
 	/**
 	 * Test commands throws an error if indexing is already happening.
-	 *
-	 * @since 4.4.1
 	 */
 	public function testThrowsErrorIfIndexingIsAlreadyHappening() {
 

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -424,6 +424,9 @@ class TestCommands extends BaseTestCase {
 		ElasticPress\Features::factory()->activate_feature( 'comments' );
 		ElasticPress\Features::factory()->setup_features();
 
+		// without these dummy content, the sync command gets failed because the static variable
+		// https://github.com/10up/ElasticPress/blob/4.0.0/includes/classes/Indexable/Post/Post.php#L173
+		// holds the old value.
 		$this->ep_factory->post->create_many( 10 );
 		$this->ep_factory->comment->create_many( 10, [ 'comment_post_ID' => $this->ep_factory->post->create() ] );
 
@@ -956,4 +959,106 @@ class TestCommands extends BaseTestCase {
 
 		$this->command->sync( [], [] );
 	}
+
+	/**
+	 * Test commands throws deprecated warning.
+	 *
+	 *  @expectedDeprecated get-indexes
+	 */
+	public function testGetIndexesThrowsDeprecatedWarning() {
+
+		$this->command->get_indexes( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'This command is deprecated. Please use get-indices instead.', $output );
+	}
+
+	 /**
+	  * Test commands throws deprecated warning.
+	  *
+	  *  @expectedDeprecated get-cluster-indexes
+	  */
+	public function testGetClusterIndexesThrowsDeprecatedWarning() {
+
+		$this->command->get_cluster_indexes( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'This command is deprecated. Please use get-cluster-indices instead.', $output );
+	}
+
+	 /**
+	  * Test commands throws deprecated warning.
+	  *
+	  *  @expectedDeprecated index
+	  */
+	public function testIndexThrowsDeprecatedWarning() {
+
+		// activate comments feature
+		ElasticPress\Features::factory()->activate_feature( 'comments' );
+		ElasticPress\Features::factory()->setup_features();
+
+		// without these dummy content, the sync command gets failed because the static variable
+		// https://github.com/10up/ElasticPress/blob/4.0.0/includes/classes/Indexable/Post/Post.php#L173
+		// holds the old value.
+		$this->ep_factory->post->create_many( 10 );
+		$this->ep_factory->comment->create_many( 10, [ 'comment_post_ID' => $this->ep_factory->post->create() ] );
+
+		$this->command->index( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'This command is deprecated. Please use sync instead.', $output );
+	}
+
+	 /**
+	  * Test commands throws deprecated warning.
+	  *
+	  *  @expectedDeprecated clear-index
+	  */
+	public function testClearIndexThrowsDeprecatedWarning() {
+
+		$this->command->clear_index( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'This command is deprecated. Please use clear-sync instead.', $output );
+	}
+
+	 /**
+	  * Test commands throws deprecated warning.
+	  *
+	  *  @expectedDeprecated get-indexing-status
+	  */
+	public function testGetIndexingStatusThrowsDeprecatedWarning() {
+
+		$this->command->get_indexing_status( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'This command is deprecated. Please use get-ongoing-sync-status instead.', $output );
+	}
+
+	 /**
+	  * Test commands throws deprecated warning.
+	  *
+	  *  @expectedDeprecated get-last-cli-index
+	  */
+	public function testGetLastCliIndexThrowsDeprecatedWarning() {
+
+		$this->command->get_last_cli_index( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'This command is deprecated. Please use get-last-cli-sync instead.', $output );
+	}
+
+	 /**
+	  * Test commands throws deprecated warning.
+	  *
+	  *  @expectedDeprecated stop-indexing
+	  */
+	public function testStopIndexingThrowsDeprecatedWarning() {
+
+		$this->command->stop_indexing( [], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'This command is deprecated. Please use stop-sync instead.', $output );
+	}
+
 }

--- a/tests/php/includes/classes/mock/class-wp-cli.php
+++ b/tests/php/includes/classes/mock/class-wp-cli.php
@@ -91,4 +91,12 @@ class WP_CLI {
 		throw new Exception( $message );
 	}
 
+	/**
+	 * Halt script execution
+	 *
+	 * @param integer $return_code Exit code to return.
+	 */
+	public static function halt( $return_code = 0 ) {
+	}
+
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the new tests for the WP CLI commands. With this change, the coverage of commands is reached to 90%. 

I made one change in the `put_mapping_helper` instead of returning false when the error happens. I update that with `WP_CLI::error` so it stops the execution as soon as an error occurs. 

Also, this particular line https://github.com/10up/ElasticPress/blob/5d2dd65a0554a8d7dc157c4ad40a9b145a78520c/includes/classes/Command.php#L1338 fixes this issue https://github.com/10up/ElasticPress/issues/3198. 


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3198  #3054

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New test for WP CLI Commands
> Fixed - Sync command exits without any error message if mapping fails


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy, @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
