### PR TITLE
Cleanup Autosuggest description and change title for autosuggest and instant results

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1186,3 +1186,9 @@ p.ep-totals-data {
 	font-size: 3em;
 	margin-top: 22px;
 }
+
+.feature-epio-logo {
+	margin-left: 5px;
+	max-width: 110px;
+	vertical-align: middle;
+}

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -1189,6 +1189,5 @@ p.ep-totals-data {
 
 .feature-epio-logo {
 	margin-left: 5px;
-	max-width: 110px;
 	vertical-align: middle;
 }

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -352,7 +352,6 @@ abstract class Feature {
 	 * @return string
 	 */
 	public function get_epio_logo() : string {
-
-		return sprintf( '<img class="feature-epio-logo" src="%s">', esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ) );
+		return sprintf( '<img class="feature-epio-logo" alt="elasticpress.io-logo" src="%s">', esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ) );
 	}
 }

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -344,4 +344,15 @@ abstract class Feature {
 
 		<?php
 	}
+
+	/**
+	 * Returns the ElasticPress.io logo.
+	 *
+	 * @since 4.4.1
+	 * @return string
+	 */
+	public function get_epio_logo() : string {
+
+		return sprintf( '<img class="feature-epio-logo" src="%s">', esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ) );
+	}
 }

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -38,6 +38,14 @@ abstract class Feature {
 	public $title;
 
 	/**
+	 * Short title
+	 *
+	 * @var string
+	 * @since 4.4.1
+	 */
+	public $short_title;
+
+	/**
 	 * Feature summary
 	 *
 	 * @var string
@@ -353,5 +361,29 @@ abstract class Feature {
 	 */
 	public function get_epio_logo() : string {
 		return sprintf( '<img class="feature-epio-logo" alt="ElasticPresss.io logo" src="%s" width="110" height="20">', esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ) );
+	}
+
+	/**
+	 * Returns the feature title.
+	 *
+	 * @since 4.4.1
+	 * @return string
+	 */
+	public function get_title() : string {
+		return $this->title;
+	}
+
+	/**
+	 * Returns the feature short title.
+	 *
+	 * @since 4.4.1
+	 * @return string
+	 */
+	public function get_short_title() : string {
+		if ( ! empty( $this->short_title ) ) {
+			return $this->short_title;
+		}
+
+		return $this->get_title();
 	}
 }

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -352,6 +352,6 @@ abstract class Feature {
 	 * @return string
 	 */
 	public function get_epio_logo() : string {
-		return sprintf( '<img class="feature-epio-logo" alt="elasticpress.io-logo" src="%s">', esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ) );
+		return sprintf( '<img class="feature-epio-logo" alt="ElasticPresss.io logo" src="%s" width="110" height="20">', esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ) );
 	}
 }

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -42,6 +42,8 @@ class Autosuggest extends Feature {
 
 		$this->title = $this->get_title();
 
+		$this->short_title = esc_html__( 'Autosuggest', 'elasticpress' );
+
 		$this->summary = __( 'Suggest relevant content as text is entered into the search field.', 'elasticpress' );
 
 		$this->docs_url = __( 'https://elasticpress.zendesk.com/hc/en-us/articles/360050447492-Configuring-ElasticPress-via-the-Plugin-Dashboard#autosuggest', 'elasticpress' );
@@ -857,6 +859,7 @@ class Autosuggest extends Feature {
 			<?php
 			$epio_link                = 'https://elasticpress.io';
 			$epio_autosuggest_kb_link = 'https://elasticpress.zendesk.com/hc/en-us/articles/360055402791';
+			$status_report_link       = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? network_admin_url( 'admin.php?page=elasticpress-status-report' ) : admin_url( 'admin.php?page=elasticpress-status-report' );
 
 			printf(
 				/* translators: 1: <a> tag (ElasticPress.io); 2. </a>; 3: <a> tag (KB article); 4. </a>; 5: <a> tag (Site Health Debug Section); 6. </a>; */
@@ -865,7 +868,7 @@ class Autosuggest extends Feature {
 				'</a>',
 				'<a href="' . esc_url( $epio_autosuggest_kb_link ) . '">',
 				'</a>',
-				'<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
+				'<a href="' . esc_url( $status_report_link ) . '">',
 				'</a>'
 			);
 			?>
@@ -905,7 +908,7 @@ class Autosuggest extends Feature {
 	 * @since 4.4.1
 	 * @return string
 	 */
-	protected function get_title() : string {
+	public function get_title() : string {
 		if ( ! Utils\is_epio() ) {
 			return esc_html__( 'Autosuggest', 'elasticpress' );
 		}

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -911,7 +911,7 @@ class Autosuggest extends Feature {
 			return esc_html__( 'Autosuggest', 'elasticpress' );
 		}
 
-		/* translators: 1. Feature name;  */
+		/* translators: 1. elasticpress.io logo;  */
 		return sprintf( esc_html__( 'Autosuggest By %s', 'elasticpress' ), $this->get_epio_logo() );
 	}
 }

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -40,7 +40,7 @@ class Autosuggest extends Feature {
 	public function __construct() {
 		$this->slug = 'autosuggest';
 
-		$this->title = esc_html__( 'Autosuggest', 'elasticpress' );
+		$this->title = esc_html__( 'Autosuggest By ElasticPress.io', 'elasticpress' );
 
 		$this->summary = __( 'Suggest relevant content as text is entered into the search field.', 'elasticpress' );
 
@@ -855,11 +855,9 @@ class Autosuggest extends Feature {
 			<div class="field-name status"><?php esc_html_e( 'Connection', 'elasticpress' ); ?></div>
 			<div class="input-wrap">
 				<?php
-				$epio_link                = '';
+				$epio_link                = 'https://elasticpress.io';
 				$epio_autosuggest_kb_link = 'https://elasticpress.zendesk.com/hc/en-us/articles/360055402791';
 
-				// If WordPress 5.2+, show debug in Health Check. Otherwise, show it if WP_DEBUG is enabled.
-				if ( version_compare( $wp_version, '5.2', '>=' ) || 0 === stripos( $wp_version, '5.2-' ) ) {
 					printf(
 						/* translators: 1: <a> tag (ElasticPress.io); 2. </a>; 3: <a> tag (KB article); 4. </a>; 5: <a> tag (Site Health Debug Section); 6. </a>; */
 						esc_html__( 'You are directly connected to %1$sElasticPress.io%2$s, ensuring the most performant Autosuggest experience. %3$sLearn more about what this means%4$s or %5$sclick here for debug information%6$s.', 'elasticpress' ),
@@ -870,45 +868,12 @@ class Autosuggest extends Feature {
 						'<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
 						'</a>'
 					);
-				} else {
-					printf(
-						/* translators: 1: <a> tag (ElasticPress.io); 2. </a>; 3: <a> tag (KB article); 4. </a>; */
-						esc_html__( 'You are directly connected to %1$sElasticPress.io%2$s, ensuring the most performant Autosuggest experience. %1$sLearn more about what this means%2$s.', 'elasticpress' ),
-						'<a href="' . esc_url( $epio_link ) . '">',
-						'</a>',
-						'<a href="' . esc_url( $epio_autosuggest_kb_link ) . '">',
-						'</a>'
-					);
-
-					if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
-						?>
-						<p><?php esc_html_e( 'These are the allowed parameters stored in ElasticPress.io', 'elasticpress' ); ?></p>
-						<?php
-						$allowed_params = wp_parse_args(
-							$allowed_params,
-							[
-								'postTypes'    => [],
-								'postStatus'   => [],
-								'searchFields' => [],
-								'returnFields' => '',
-							]
-						);
-
-						$fields = [
-							wp_sprintf( esc_html__( 'Post Types: %l', 'elasticpress' ), $allowed_params['postTypes'] ),
-							wp_sprintf( esc_html__( 'Post Status: %l', 'elasticpress' ), $allowed_params['postStatus'] ),
-							wp_sprintf( esc_html__( 'Search Fields: %l', 'elasticpress' ), $allowed_params['searchFields'] ),
-							/* translators: List of files allowed to be returned wrapped by var_export() */
-							wp_sprintf( esc_html__( 'Returned Fields: %s', 'elasticpress' ), var_export( $allowed_params['returnFields'], true ) ), // phpcs:ignore
-						];
-
-						echo implode( '<br>', $fields ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					}
-				}
 				?>
-				<p>
-					<img width="150" src="<?php echo esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ); ?>">
-				</p>
+				<!-- <p>
+					<a href="<?php echo esc_attr( $epio_link ); ?>" class="autosuggest-epio-logo">
+						<img width="150" src="<?php echo esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ); ?>">
+					</a>
+				</p> -->
 			</div>
 		</div>
 		<?php

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -858,16 +858,16 @@ class Autosuggest extends Feature {
 			$epio_link                = 'https://elasticpress.io';
 			$epio_autosuggest_kb_link = 'https://elasticpress.zendesk.com/hc/en-us/articles/360055402791';
 
-				printf(
-					/* translators: 1: <a> tag (ElasticPress.io); 2. </a>; 3: <a> tag (KB article); 4. </a>; 5: <a> tag (Site Health Debug Section); 6. </a>; */
-					esc_html__( 'You are directly connected to %1$sElasticPress.io%2$s, ensuring the most performant Autosuggest experience. %3$sLearn more about what this means%4$s or %5$sclick here for debug information%6$s.', 'elasticpress' ),
-					'<a href="' . esc_url( $epio_link ) . '">',
-					'</a>',
-					'<a href="' . esc_url( $epio_autosuggest_kb_link ) . '">',
-					'</a>',
-					'<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
-					'</a>'
-				);
+			printf(
+				/* translators: 1: <a> tag (ElasticPress.io); 2. </a>; 3: <a> tag (KB article); 4. </a>; 5: <a> tag (Site Health Debug Section); 6. </a>; */
+				esc_html__( 'You are directly connected to %1$sElasticPress.io%2$s, ensuring the most performant Autosuggest experience. %3$sLearn more about what this means%4$s or %5$sclick here for debug information%6$s.', 'elasticpress' ),
+				'<a href="' . esc_url( $epio_link ) . '">',
+				'</a>',
+				'<a href="' . esc_url( $epio_autosuggest_kb_link ) . '">',
+				'</a>',
+				'<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
+				'</a>'
+			);
 			?>
 			</div>
 		</div>
@@ -906,7 +906,6 @@ class Autosuggest extends Feature {
 	 * @return string
 	 */
 	protected function get_title() : string {
-
 		if ( ! Utils\is_epio() ) {
 			return esc_html__( 'Autosuggest', 'elasticpress' );
 		}

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -40,7 +40,7 @@ class Autosuggest extends Feature {
 	public function __construct() {
 		$this->slug = 'autosuggest';
 
-		$this->title = esc_html__( 'Autosuggest By ElasticPress.io', 'elasticpress' );
+		$this->title = $this->get_title();
 
 		$this->summary = __( 'Suggest relevant content as text is entered into the search field.', 'elasticpress' );
 
@@ -854,26 +854,21 @@ class Autosuggest extends Feature {
 		<div class="field js-toggle-feature" data-feature="<?php echo esc_attr( $this->slug ); ?>">
 			<div class="field-name status"><?php esc_html_e( 'Connection', 'elasticpress' ); ?></div>
 			<div class="input-wrap">
-				<?php
-				$epio_link                = 'https://elasticpress.io';
-				$epio_autosuggest_kb_link = 'https://elasticpress.zendesk.com/hc/en-us/articles/360055402791';
+			<?php
+			$epio_link                = 'https://elasticpress.io';
+			$epio_autosuggest_kb_link = 'https://elasticpress.zendesk.com/hc/en-us/articles/360055402791';
 
-					printf(
-						/* translators: 1: <a> tag (ElasticPress.io); 2. </a>; 3: <a> tag (KB article); 4. </a>; 5: <a> tag (Site Health Debug Section); 6. </a>; */
-						esc_html__( 'You are directly connected to %1$sElasticPress.io%2$s, ensuring the most performant Autosuggest experience. %3$sLearn more about what this means%4$s or %5$sclick here for debug information%6$s.', 'elasticpress' ),
-						'<a href="' . esc_url( $epio_link ) . '">',
-						'</a>',
-						'<a href="' . esc_url( $epio_autosuggest_kb_link ) . '">',
-						'</a>',
-						'<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
-						'</a>'
-					);
-				?>
-				<!-- <p>
-					<a href="<?php echo esc_attr( $epio_link ); ?>" class="autosuggest-epio-logo">
-						<img width="150" src="<?php echo esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ); ?>">
-					</a>
-				</p> -->
+				printf(
+					/* translators: 1: <a> tag (ElasticPress.io); 2. </a>; 3: <a> tag (KB article); 4. </a>; 5: <a> tag (Site Health Debug Section); 6. </a>; */
+					esc_html__( 'You are directly connected to %1$sElasticPress.io%2$s, ensuring the most performant Autosuggest experience. %3$sLearn more about what this means%4$s or %5$sclick here for debug information%6$s.', 'elasticpress' ),
+					'<a href="' . esc_url( $epio_link ) . '">',
+					'</a>',
+					'<a href="' . esc_url( $epio_autosuggest_kb_link ) . '">',
+					'</a>',
+					'<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
+					'</a>'
+				);
+			?>
 			</div>
 		</div>
 		<?php
@@ -904,4 +899,19 @@ class Autosuggest extends Feature {
 		return $allowed_params;
 	}
 
+	/**
+	 * Returns the title.
+	 *
+	 * @since 4.4.1
+	 * @return string
+	 */
+	protected function get_title() : string {
+
+		if ( ! Utils\is_epio() ) {
+			return esc_html__( 'Autosuggest', 'elasticpress' );
+		}
+
+		/* translators: 1. Feature name;  */
+		return sprintf( esc_html__( 'Autosuggest By %s', 'elasticpress' ), $this->get_epio_logo() );
+	}
 }

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -1004,7 +1004,7 @@ class InstantResults extends Feature {
 			return esc_html__( 'Instant Results', 'elasticpress' );
 		}
 
-		/* translators: 1. Feature name;  */
+		/* translators: 1. elasticpress.io logo;  */
 		return sprintf( esc_html__( 'Instant Results By %s', 'elasticpress' ), $this->get_epio_logo() );
 	}
 }

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -69,6 +69,8 @@ class InstantResults extends Feature {
 
 		$this->title = $this->get_title();
 
+		$this->short_title = esc_html__( 'Instant Results', 'elasticpress' );
+
 		$this->summary = __( 'Search forms display results instantly after submission. A modal opens that populates results by querying ElasticPress directly.', 'elasticpress' );
 
 		$this->docs_url = __( 'https://elasticpress.zendesk.com/hc/en-us/articles/360050447492-Configuring-ElasticPress-via-the-Plugin-Dashboard#instant-results', 'elasticpress' );
@@ -998,7 +1000,7 @@ class InstantResults extends Feature {
 	 * @since 4.4.1
 	 * @return string
 	 */
-	protected function get_title() : string {
+	public function get_title() : string {
 		if ( ! Utils\is_epio() ) {
 			return esc_html__( 'Instant Results', 'elasticpress' );
 		}

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -67,7 +67,7 @@ class InstantResults extends Feature {
 	public function __construct() {
 		$this->slug = 'instant-results';
 
-		$this->title = esc_html__( 'Instant Results', 'elasticpress' );
+		$this->title = $this->get_title();
 
 		$this->summary = __( 'Search forms display results instantly after submission. A modal opens that populates results by querying ElasticPress directly.', 'elasticpress' );
 
@@ -992,4 +992,19 @@ class InstantResults extends Feature {
 		return $args;
 	}
 
+	/**
+	 * Returns the title.
+	 *
+	 * @since 4.4.1
+	 * @return string
+	 */
+	protected function get_title() : string {
+
+		if ( ! Utils\is_epio() ) {
+			return esc_html__( 'Instant Results', 'elasticpress' );
+		}
+
+		/* translators: 1. Feature name;  */
+		return sprintf( esc_html__( 'Instant Results By %s', 'elasticpress' ), $this->get_epio_logo() );
+	}
 }

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -999,7 +999,6 @@ class InstantResults extends Feature {
 	 * @return string
 	 */
 	protected function get_title() : string {
-
 		if ( ! Utils\is_epio() ) {
 			return esc_html__( 'Instant Results', 'elasticpress' );
 		}

--- a/includes/partials/dashboard-page.php
+++ b/includes/partials/dashboard-page.php
@@ -64,7 +64,7 @@ $index_meta = Utils\get_option( 'ep_index_meta', [] );
 			<div class="<?php if ( $feature->requires_install_reindex && defined( 'EP_DASHBOARD_SYNC' ) && ! EP_DASHBOARD_SYNC ) : ?>dash-sync-disabled<?php endif; ?> ep-feature ep-feature-<?php echo esc_attr( $feature->slug ); ?> <?php echo esc_attr( $feature_classes ); ?>">
 				<div class="postbox">
 					<h2 class="hndle">
-						<span><?php echo esc_html( $feature->title ); ?><img width="150" src="<?php echo esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ); ?>"></span>
+						<span><?php echo wp_kses_post( $feature->title ); ?></span>
 						<button aria-expanded="false" type="button" class="settings-button"><?php esc_html_e( 'settings', 'elasticpress' ); ?></button>
 					</h2>
 

--- a/includes/partials/dashboard-page.php
+++ b/includes/partials/dashboard-page.php
@@ -64,7 +64,7 @@ $index_meta = Utils\get_option( 'ep_index_meta', [] );
 			<div class="<?php if ( $feature->requires_install_reindex && defined( 'EP_DASHBOARD_SYNC' ) && ! EP_DASHBOARD_SYNC ) : ?>dash-sync-disabled<?php endif; ?> ep-feature ep-feature-<?php echo esc_attr( $feature->slug ); ?> <?php echo esc_attr( $feature_classes ); ?>">
 				<div class="postbox">
 					<h2 class="hndle">
-						<span><?php echo esc_html( $feature->title ); ?></span>
+						<span><?php echo esc_html( $feature->title ); ?><img width="150" src="<?php echo esc_url( plugins_url( '/images/logo-elasticpress-io.svg', EP_FILE ) ); ?>"></span>
 						<button aria-expanded="false" type="button" class="settings-button"><?php esc_html_e( 'settings', 'elasticpress' ); ?></button>
 					</h2>
 

--- a/includes/partials/dashboard-page.php
+++ b/includes/partials/dashboard-page.php
@@ -64,7 +64,7 @@ $index_meta = Utils\get_option( 'ep_index_meta', [] );
 			<div class="<?php if ( $feature->requires_install_reindex && defined( 'EP_DASHBOARD_SYNC' ) && ! EP_DASHBOARD_SYNC ) : ?>dash-sync-disabled<?php endif; ?> ep-feature ep-feature-<?php echo esc_attr( $feature->slug ); ?> <?php echo esc_attr( $feature_classes ); ?>">
 				<div class="postbox">
 					<h2 class="hndle">
-						<span><?php echo wp_kses_post( $feature->title ); ?></span>
+						<span><?php echo wp_kses_post( $feature->get_title() ); ?></span>
 						<button aria-expanded="false" type="button" class="settings-button"><?php esc_html_e( 'settings', 'elasticpress' ); ?></button>
 					</h2>
 

--- a/includes/partials/install-page.php
+++ b/includes/partials/install-page.php
@@ -105,7 +105,7 @@ $skip_index_url = remove_query_arg( 'ep-skip-features', $skip_install_url );
 												name="features[]"
 												value="<?php echo esc_attr( $feature->slug ); ?>"
 												<?php checked( $should_be_checked ); ?>>
-											<?php echo esc_html( $feature->title ); ?>
+											<?php echo esc_html( $feature->get_short_title() ); ?>
 										</label>
 										<?php if ( $feature->summary ) : ?>
 											<span class="a11y-tip a11y-tip--no-delay">


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR updates the titles for the Autosuggest and Instant Results feature if the ElasticPress is connected with ep.io. Also it removed the old checks from the autosuggest description. 

<img width="787" alt="image" src="https://user-images.githubusercontent.com/7139602/207604928-141ea5ab-726c-4c80-b2a7-86995a263403.png">


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3191 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Update title for Autosuggest and Instant results feature, if connected to ep.io


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia @NV607FOX 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
