### PR TITLE
Change disabling method to avoid losing focus on facets

### DIFF
--- a/assets/js/instant-results/components/common/checkbox.js
+++ b/assets/js/instant-results/components/common/checkbox.js
@@ -6,17 +6,25 @@ import { WPElement } from '@wordpress/element';
 /**
  * Checkbox component.
  *
- * @param {Option} props       Component props.
+ * @param {Option} props Component props.
  * @param {string} props.count Checkbox count.
- * @param {string} props.id    Checkbox ID.
+ * @param {string} props.id Checkbox ID.
  * @param {string} props.label Checkbox label.
+ * @param {Function} props.onChange Change event handler.
  *
  * @returns {WPElement} Component element.
  */
-export default ({ count, id, label, ...props }) => {
+export default ({ count, disabled, id, label, onChange, ...props }) => {
 	return (
 		<div className="ep-search-checkbox">
-			<input className="ep-search-checkbox__input" id={id} type="checkbox" {...props} />{' '}
+			<input
+				aria-disabled={disabled}
+				className="ep-search-checkbox__input"
+				id={id}
+				onChange={!disabled ? onChange : null}
+				type="checkbox"
+				{...props}
+			/>{' '}
 			<label className="ep-search-checkbox__label" htmlFor={id}>
 				{label} {count && <span className="ep-search-checkbox__count">{count}</span>}
 			</label>


### PR DESCRIPTION
### Description of the Change
When facets are used in Instant Results the facet option checkboxes are disabled during loading to avoid a situation where the user selects two mutually incompatible options. This was being done using the `disabled` attribute, but the problem was that when this attribute was applied the checkboxes lost focus, meaning that keyboard users would lose their position. 

This PR changes the checkbox to instead use `aria-disabled` for indicating the disabled status and to check the disabled status inside the onChange callback. This still prevents the user selecting mutually incompatible filters, but without losing keyboard focus on the checkbox,

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3201

### How to test the Change
1. Perform an Instant Results search.
2. Navigate to a facet checkbox with the keyboard and make a selection with Space.
3. After the new results are loaded attempt to navigate to the next or previous facet option. You should navigate to the expected element.
4. Attempt to quickly select two filter options. Once loading has started after selecting the first option it should not be possible to select another option until loading has finished.

### Changelog Entry
Fixed - An issue where keyboard focus on a facet option was lost upon selection.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
