### PR TITLE
Renaming "exclude from search"

### DIFF
--- a/assets/js/search/editor/plugins/exclude-from-search.js
+++ b/assets/js/search/editor/plugins/exclude-from-search.js
@@ -20,7 +20,11 @@ export default () => {
 	return (
 		<PluginPostStatusInfo>
 			<CheckboxControl
-				label={__('Exclude from search', 'elasticpress')}
+				label={__('Exclude from search results', 'elasticpress')}
+				help={__(
+					"Excludes this post from the results of your site's search form while ElasticPress is active.",
+					'elasticpress',
+				)}
 				checked={ep_exclude_from_search}
 				onChange={onChange}
 			/>

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -771,7 +771,8 @@ class Search extends Feature {
 		?>
 		<div class="misc-pub-section">
 			<input id="ep_exclude_from_search" name="ep_exclude_from_search" type="checkbox" value="1" <?php checked( get_post_meta( get_the_ID(), 'ep_exclude_from_search', true ) ); ?>>
-			<label for="ep_exclude_from_search"><?php esc_html_e( 'Exclude from Search', 'elasticpress' ); ?></label>
+			<label for="ep_exclude_from_search"><?php esc_html_e( 'Exclude from search results', 'elasticpress' ); ?></label>
+			<p class="howto"><?php esc_html_e( 'Excludes this post from the results of your site\'s search form while ElasticPress is active.', 'elasticpress' ); ?></p>
 			<?php wp_nonce_field( 'save-exclude-from-search', 'ep-exclude-from-search-nonce' ); ?>
 		</div>
 		<?php


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR updates the `exclude from search` text.


**Gutenberg**
<img width="278" alt="image" src="https://user-images.githubusercontent.com/7139602/208028659-6a6b48cb-3b81-4142-ac74-36aab19493f7.png">

**Classic Editor**
<img width="278" alt="image" src="https://user-images.githubusercontent.com/7139602/208028611-69700b4b-7a1c-459b-8ffa-15a992831451.png">


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3203 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Update "exclude from search" text

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @anjulahettige  @burhandodhy @felipeelia @JakePT 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
