### PR TITLE
Fix post_parent returning early if set to 0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,6 @@ jobs:
       with:
         php-version: '8.0'
         coverage: none
-      env:
-        debug: true 
 
     - name: Install dependencies
       run: composer install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,8 @@ jobs:
       with:
         php-version: '8.0'
         coverage: none
+      env:
+        debug: true 
 
     - name: Install dependencies
       run: composer install

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1720,7 +1720,7 @@ class Post extends Indexable {
 	 * @return array
 	 */
 	protected function parse_post_parent( $args ) {
-		$has_post_parent = isset( $args['post_parent'] ) && ( 0 === (int) $args['post_parent'] || ! empty( $args['post_parent'] ) );
+		$has_post_parent = isset( $args['post_parent'] ) && ( in_array( $args['post_parent'], [ 0, '0' ], true ) || ! empty( $args['post_parent'] ) );
 		if ( ! $has_post_parent || 'any' === strtolower( $args['post_parent'] ) ) {
 			return [];
 		}

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1720,7 +1720,8 @@ class Post extends Indexable {
 	 * @return array
 	 */
 	protected function parse_post_parent( $args ) {
-		if ( ! isset( $args['post_parent'] ) || 'any' === strtolower( $args['post_parent'] ) ) {
+		$has_post_parent = isset( $args['post_parent'] ) && ( $args['post_parent'] == 0 || ! empty( $args['post_parent'] ) );
+		if ( ! $has_post_parent || 'any' === strtolower( $args['post_parent'] ) ) {
 			return [];
 		}
 

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1720,7 +1720,7 @@ class Post extends Indexable {
 	 * @return array
 	 */
 	protected function parse_post_parent( $args ) {
-		$has_post_parent = isset( $args['post_parent'] ) && ( $args['post_parent'] == 0 || ! empty( $args['post_parent'] ) );
+		$has_post_parent = isset( $args['post_parent'] ) && ( 0 === (int) $args['post_parent'] || ! empty( $args['post_parent'] ) );
 		if ( ! $has_post_parent || 'any' === strtolower( $args['post_parent'] ) ) {
 			return [];
 		}

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1720,7 +1720,7 @@ class Post extends Indexable {
 	 * @return array
 	 */
 	protected function parse_post_parent( $args ) {
-		if ( empty( $args['post_parent'] ) || 'any' === strtolower( $args['post_parent'] ) ) {
+		if ( ! isset( $args['post_parent'] ) || 'any' === strtolower( $args['post_parent'] ) ) {
 			return [];
 		}
 
@@ -1728,7 +1728,7 @@ class Post extends Indexable {
 			'bool' => [
 				'must' => [
 					'term' => [
-						'post_parent' => $args['post_parent'],
+						'post_parent' => (int) $args['post_parent'],
 					],
 				],
 			],

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4368,6 +4368,17 @@ class TestPost extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
+
+		$args = array(
+			's'           => 'findme',
+			'post_parent' => 0,
+			'fields'      => 'ids',
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( $parent_post, $query->posts[0] );
 	}
 
 	/**


### PR DESCRIPTION
This is a simple takeover of #3196

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This change changes `empty( $args['post_parent'] )` to `! isset( $args['post_parent'] )` so any query or `pre_get_posts` (or similar) filter that sets `post_parent` to `0` will still work as expected.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3181

### How to test the Change
As seen in #3181, use a filter like the following on a hierarchical CPT to confirm the confirm child posts are actually removed.

```
add_action( 'pre_get_posts', function( $query ) {
	if ( is_admin() ) {
		return;
	}

	if ( ! $query->is_main_query() ) {
		return;
	}

	if ( ! $query->is_post_type_archive( 'things' ) ) {
		return;
	}

	$query->set( 'post_parent', 0 );
});
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Queries with `post_parent` set to `0` not working correctly

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JiveDig

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
