### PR TITLE
Add Health Check Elasticsearch tests

### DIFF
--- a/includes/classes/HealthCheck/HealthCheckElasticsearch.php
+++ b/includes/classes/HealthCheck/HealthCheckElasticsearch.php
@@ -13,7 +13,9 @@ use ElasticPress\Utils as Utils;
 use ElasticPress\Elasticsearch as Elasticsearch;
 
 if ( ! defined( 'ABSPATH' ) ) {
+	// @codeCoverageIgnoreStart
 	exit; // Exit if accessed directly.
+	// @codeCoverageIgnoreEnd
 }
 
 /**

--- a/tests/php/TestHealthCheckElasticsearch.php
+++ b/tests/php/TestHealthCheckElasticsearch.php
@@ -43,7 +43,7 @@ class TestHealthCheckElasticsearch extends WP_Ajax_UnitTestCase {
 
 		$response = json_decode( $this->_last_response, true );
 
-		$this->assertEquals( true, $response['success'] );
+		$this->assertTrue( $response['success'] );
 		$this->assertEquals( 'Your site can connect to Elasticsearch.', $response['data']['label'] );
 		$this->assertEquals( 'good', $response['data']['status'] );
 		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );
@@ -68,14 +68,12 @@ class TestHealthCheckElasticsearch extends WP_Ajax_UnitTestCase {
 
 		$response = json_decode( $this->_last_response, true );
 
-		$this->assertEquals( true, $response['success'] );
+		$this->assertTrue( $response['success'] );
 		$this->assertEquals( 'Your site could not connect to Elasticsearch', $response['data']['label'] );
 		$this->assertEquals( 'critical', $response['data']['status'] );
 		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );
 		$this->assertEquals( 'red', $response['data']['badge']['color'] );
 		$this->assertEquals( 'The Elasticsearch host is not set.', $response['data']['description'] );
-
-		remove_filter( 'ep_host', '__return_empty_string' );
 	}
 
 	/**
@@ -96,14 +94,12 @@ class TestHealthCheckElasticsearch extends WP_Ajax_UnitTestCase {
 
 		$response = json_decode( $this->_last_response, true );
 
-		$this->assertEquals( true, $response['success'] );
+		$this->assertTrue( $response['success'] );
 		$this->assertEquals( 'Your site could not connect to Elasticsearch', $response['data']['label'] );
 		$this->assertEquals( 'critical', $response['data']['status'] );
 		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );
 		$this->assertEquals( 'red', $response['data']['badge']['color'] );
 		$this->assertEquals( 'Check if your Elasticsearch host URL is correct and you have the right access to the host.', $response['data']['description'] );
-
-		remove_filter( 'ep_elasticsearch_version', '__return_false' );
 	}
 
 	/**
@@ -128,7 +124,7 @@ class TestHealthCheckElasticsearch extends WP_Ajax_UnitTestCase {
 
 		$response = json_decode( $this->_last_response, true );
 
-		$this->assertEquals( true, $response['success'] );
+		$this->assertTrue( $response['success'] );
 		$this->assertEquals( 'Your site could not connect to Elasticsearch', $response['data']['label'] );
 		$this->assertEquals( 'critical', $response['data']['status'] );
 		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );

--- a/tests/php/TestHealthCheckElasticsearch.php
+++ b/tests/php/TestHealthCheckElasticsearch.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Test health check elasticsearch functionality.
+ *
+ * @since 4.4.1
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use WP_Ajax_UnitTestCase;
+use WPAjaxDieContinueException;
+
+/**
+ *  Health check elasticsearch test class
+ */
+class TestHealthCheckElasticsearch extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Test if the test is registered
+	 */
+	public function testIsRegistered() {
+		$tests = \WP_Site_Health::get_tests();
+
+		$this->assertArrayHasKey( 'elasticpress-health-check-elasticsearch', $tests['async'] );
+	}
+
+	/**
+	 * Test ajax output.
+	 */
+	public function testAjaxOutput() {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'health-check-elasticpress-health-check-elasticsearch' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertEquals( true, $response['success'] );
+		$this->assertEquals( 'Your site can connect to Elasticsearch.', $response['data']['label'] );
+		$this->assertEquals( 'good', $response['data']['status'] );
+		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );
+		$this->assertEquals( 'green', $response['data']['badge']['color'] );
+	}
+
+	/**
+	 * Test ajax output when host is not set.
+	 */
+	public function testAjaxOutPutWhenHostIsNotSet() {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		add_filter( 'ep_host', '__return_empty_string' );
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'health-check-elasticpress-health-check-elasticsearch' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertEquals( true, $response['success'] );
+		$this->assertEquals( 'Your site could not connect to Elasticsearch', $response['data']['label'] );
+		$this->assertEquals( 'critical', $response['data']['status'] );
+		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );
+		$this->assertEquals( 'red', $response['data']['badge']['color'] );
+		$this->assertEquals( 'The Elasticsearch host is not set.', $response['data']['description'] );
+
+		remove_filter( 'ep_host', '__return_empty_string' );
+	}
+
+	/**
+	 * Test ajax output when host is not valid.
+	 */
+	public function testAjaxOutPutWhenHostIsNotValid() {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		add_filter( 'ep_elasticsearch_version', '__return_false' );
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'health-check-elasticpress-health-check-elasticsearch' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertEquals( true, $response['success'] );
+		$this->assertEquals( 'Your site could not connect to Elasticsearch', $response['data']['label'] );
+		$this->assertEquals( 'critical', $response['data']['status'] );
+		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );
+		$this->assertEquals( 'red', $response['data']['badge']['color'] );
+		$this->assertEquals( 'Check if your Elasticsearch host URL is correct and you have the right access to the host.', $response['data']['description'] );
+
+		remove_filter( 'ep_elasticsearch_version', '__return_false' );
+	}
+
+	/**
+	 * Test ajax output when elasticpress.io host is not valid.
+	 */
+	public function testAjaxOutPutWhenEpioHostIsNotValid() {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$ep_host = function () {
+			return 'elasticpress.io/random-string';
+		};
+		add_filter( 'ep_host', $ep_host );
+		add_filter( 'ep_elasticsearch_version', '__return_false' );
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'health-check-elasticpress-health-check-elasticsearch' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertEquals( true, $response['success'] );
+		$this->assertEquals( 'Your site could not connect to Elasticsearch', $response['data']['label'] );
+		$this->assertEquals( 'critical', $response['data']['status'] );
+		$this->assertEquals( 'ElasticPress', $response['data']['badge']['label'] );
+		$this->assertEquals( 'red', $response['data']['badge']['color'] );
+		$this->assertEquals( 'Check if your credentials to ElasticPress.io host are correct.', $response['data']['description'] );
+
+		remove_filter( 'ep_host', $ep_host );
+		remove_filter( 'ep_elasticsearch_version', '__return_false' );
+	}
+}

--- a/tests/php/TestHealthCheckElasticsearch.php
+++ b/tests/php/TestHealthCheckElasticsearch.php
@@ -8,6 +8,7 @@
 
 namespace ElasticPressTest;
 
+use ElasticPress\Elasticsearch;
 use WP_Site_Health;
 use WP_Ajax_UnitTestCase;
 use WPAjaxDieContinueException;

--- a/tests/php/TestHealthCheckElasticsearch.php
+++ b/tests/php/TestHealthCheckElasticsearch.php
@@ -8,6 +8,7 @@
 
 namespace ElasticPressTest;
 
+use WP_Site_Health;
 use WP_Ajax_UnitTestCase;
 use WPAjaxDieContinueException;
 
@@ -20,7 +21,7 @@ class TestHealthCheckElasticsearch extends WP_Ajax_UnitTestCase {
 	 * Test if the test is registered
 	 */
 	public function testIsRegistered() {
-		$tests = \WP_Site_Health::get_tests();
+		$tests = WP_Site_Health::get_tests();
 
 		$this->assertArrayHasKey( 'elasticpress-health-check-elasticsearch', $tests['async'] );
 	}
@@ -135,5 +136,9 @@ class TestHealthCheckElasticsearch extends WP_Ajax_UnitTestCase {
 
 		remove_filter( 'ep_host', $ep_host );
 		remove_filter( 'ep_elasticsearch_version', '__return_false' );
+
+		// refetch the elasticsearch version. This is needed because this test has changed the value.
+		Elasticsearch::factory()->get_elasticsearch_version( true );
 	}
+
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the unit tests for the `HealthCheckElasticsearch` https://github.com/10up/ElasticPress/blob/4.4.0/includes/classes/HealthCheck/HealthCheckElasticsearch.php

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3054

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New unit tests for the `HealthCheckElasticsearch` class.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
