### PR TITLE
Remove unnecessary remove_filters from the unit tests

### DIFF
--- a/tests/php/TestAdminNotices.php
+++ b/tests/php/TestAdminNotices.php
@@ -299,8 +299,6 @@ class TestAdminNotices extends BaseTestCase {
 
 		$notices = ElasticPress\AdminNotices::factory()->get_notices();
 
-		remove_filter( 'ep_elasticsearch_version', $es_version );
-
 		$this->assertEquals( 1, count( $notices ) );
 		$this->assertTrue( ! empty( $notices['es_above_compat'] ) );
 	}
@@ -337,8 +335,6 @@ class TestAdminNotices extends BaseTestCase {
 		ElasticPress\AdminNotices::factory()->process_notices();
 
 		$notices = ElasticPress\AdminNotices::factory()->get_notices();
-
-		remove_filter( 'ep_elasticsearch_version', $es_version );
 
 		$this->assertEquals( 1, count( $notices ) );
 		$this->assertTrue( ! empty( $notices['es_below_compat'] ) );

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -33,7 +33,6 @@ class TestCommands extends BaseTestCase {
 		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		delete_option( 'ep_active_features' );
 		parent::set_up();
 	}
 

--- a/tests/php/TestFeatureActivation.php
+++ b/tests/php/TestFeatureActivation.php
@@ -50,8 +50,6 @@ class TestFeatureActivation extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 

--- a/tests/php/TestInstaller.php
+++ b/tests/php/TestInstaller.php
@@ -107,8 +107,6 @@ class TestInstaller extends BaseTestCase {
 		$install_status = ElasticPress\Installer::factory()->get_install_status();
 
 		$this->assertEquals( 2, $install_status );
-
-		remove_all_filters( 'ep_host' );
 	}
 
 	/**

--- a/tests/php/TestScreen.php
+++ b/tests/php/TestScreen.php
@@ -116,8 +116,6 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'settings', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 
 	/**
@@ -139,8 +137,6 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'install', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 
 	/**
@@ -162,8 +158,6 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'settings', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 
 	/**
@@ -185,8 +179,6 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'dashboard', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 
 	/**
@@ -208,8 +200,6 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'install', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 
 	/**
@@ -231,8 +221,6 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'install', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 
 	/**
@@ -255,8 +243,6 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'install', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 
 	/**
@@ -279,7 +265,5 @@ class TestScreen extends BaseTestCase {
 		ElasticPress\Screen::factory()->determine_screen();
 
 		$this->assertEquals( 'dashboard', ElasticPress\Screen::factory()->get_current_screen() );
-
-		remove_filter( 'ep_install_status', $set_install_status );
 	}
 }

--- a/tests/php/TestSearchAlgorithm.php
+++ b/tests/php/TestSearchAlgorithm.php
@@ -50,8 +50,6 @@ class TestSearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $this->stub->get_query( 'indexable', '', [], [] );
 		$this->assertEquals( [ 'changed' ], $query );
-
-		remove_filter( 'ep_indexable_formatted_args_query', $test_filter );
 	}
 
 	/**
@@ -72,7 +70,5 @@ class TestSearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $this->stub->get_query( 'post', '', [], [] );
 		$this->assertEquals( [ 'changed' ], $query );
-
-		remove_filter( 'ep_formatted_args_query', $test_filter );
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -38,7 +38,7 @@ function load_plugin() {
 	$host = getenv( 'EP_HOST' );
 
 	if ( empty( $host ) ) {
-		$host = 'http://ep-mu.test/__elasticsearch';
+		$host = 'http://127.0.0.1:9200';
 	}
 
 	update_option( 'ep_host', $host );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -38,7 +38,7 @@ function load_plugin() {
 	$host = getenv( 'EP_HOST' );
 
 	if ( empty( $host ) ) {
-		$host = 'http://127.0.0.1:9200';
+		$host = 'http://ep-mu.test/__elasticsearch';
 	}
 
 	update_option( 'ep_host', $host );

--- a/tests/php/features/TestAutosuggest.php
+++ b/tests/php/features/TestAutosuggest.php
@@ -36,8 +36,6 @@ class TestAutosuggest extends BaseTestCase {
 		$this->setup_test_post_type();
 
 		set_current_screen( 'front' );
-
-		delete_option( 'ep_active_features' );
 	}
 
 	/**
@@ -111,8 +109,6 @@ class TestAutosuggest extends BaseTestCase {
         $this->assertArrayHasKey( 'type', $mapping['mappings']['post']['properties']['post_title']['fields']['suggest'] );
         $this->assertArrayHasKey( 'analyzer', $mapping['mappings']['post']['properties']['post_title']['fields']['suggest'] );
         $this->assertArrayHasKey( 'search_analyzer', $mapping['mappings']['post']['properties']['post_title']['fields']['suggest'] );
-
-        remove_filter( 'ep_elasticsearch_version', $change_es_version );
     }
 
     public function testMappingES7() {
@@ -132,8 +128,6 @@ class TestAutosuggest extends BaseTestCase {
         $this->assertArrayHasKey( 'type', $mapping['mappings']['properties']['post_title']['fields']['suggest'] );
         $this->assertArrayHasKey( 'analyzer', $mapping['mappings']['properties']['post_title']['fields']['suggest'] );
         $this->assertArrayHasKey( 'search_analyzer', $mapping['mappings']['properties']['post_title']['fields']['suggest'] );
-
-        remove_filter( 'ep_elasticsearch_version', $change_es_version );
     }
 
     public function testSetFuzziness() {
@@ -182,9 +176,6 @@ class TestAutosuggest extends BaseTestCase {
 
         $this->get_feature()->enqueue_scripts();
         $this->assertTrue( wp_script_is( 'elasticpress-autosuggest' ) );
-
-        remove_filter( 'pre_site_option_ep_feature_settings', $filter );
-        remove_filter( 'pre_option_ep_feature_settings', $filter );
     }
 
     public function testGenerateSearchQuery() {
@@ -208,8 +199,6 @@ class TestAutosuggest extends BaseTestCase {
 		$query = $this->get_feature()->generate_search_query();
 		$this->assertStringContainsString( 'lorem-ipsum', $query['body'] );
 
-		remove_filter( 'ep_autosuggest_query_placeholder', $test_placeholder_filter );
-
 		/**
 		 * Test the `ep_autosuggest_query_placeholder` filter.
 		 */
@@ -221,9 +210,6 @@ class TestAutosuggest extends BaseTestCase {
 
 		$query = $this->get_feature()->generate_search_query();
 		$this->assertStringContainsString( 'my-custom-post-type', $query['body'] );
-
-		remove_filter( 'ep_term_suggest_post_type', $test_post_type_filter );
-
 		/**
 		 * Test the `ep_term_suggest_post_status` filter.
 		 */
@@ -235,8 +221,6 @@ class TestAutosuggest extends BaseTestCase {
 
 		$query = $this->get_feature()->generate_search_query();
 		$this->assertStringContainsString( 'trash', $query['body'] );
-
-		remove_filter( 'ep_term_suggest_post_status', $test_post_status_filter );
 
 		/**
 		 * Test the `ep_term_suggest_post_status` filter.
@@ -250,8 +234,6 @@ class TestAutosuggest extends BaseTestCase {
 
 		$query = $this->get_feature()->generate_search_query();
 		$this->assertStringContainsString( '1234', $query['body'] );
-
-		remove_filter( 'ep_autosuggest_query_args', $test_args_filter );
     }
 
     public function testReturnEmptyPosts() {
@@ -269,8 +251,6 @@ class TestAutosuggest extends BaseTestCase {
 
         $this->assertArrayHasKey( 'hello', $this->get_feature()->apply_autosuggest_weighting( [] ) );
         $this->assertContains( 'world', $this->get_feature()->apply_autosuggest_weighting( [] ) );
-
-        remove_filter( 'ep_weighting_configuration_for_autosuggest', $filter );
     }
 
     public function testRequirementsStatus() {

--- a/tests/php/features/TestComments.php
+++ b/tests/php/features/TestComments.php
@@ -37,8 +37,6 @@ class TestComments extends BaseTestCase {
 		$this->setup_test_post_type();
 
 		set_current_screen( 'front' );
-
-		delete_option( 'ep_active_features' );
 	}
 
 	/**
@@ -54,8 +52,6 @@ class TestComments extends BaseTestCase {
 
 		set_current_screen();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
     }
 

--- a/tests/php/features/TestDocuments.php
+++ b/tests/php/features/TestDocuments.php
@@ -36,8 +36,6 @@ class TestDocuments extends BaseTestCase {
 		$this->setup_test_post_type();
 
 		set_current_screen( 'front' );
-
-		delete_option( 'ep_active_features' );
 	}
 
 	/**
@@ -53,8 +51,6 @@ class TestDocuments extends BaseTestCase {
 
 		set_current_screen();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 

--- a/tests/php/features/TestFacet.php
+++ b/tests/php/features/TestFacet.php
@@ -39,8 +39,6 @@ class TestFacet extends BaseTestCase {
 		$facets->types['test_custom'] = $facet_type;
 
 		$facets->setup();
-
-		remove_filter( 'ep_facet_types', $register_facet_type );
 	}
 
 	/**

--- a/tests/php/features/TestFacetTypeMeta.php
+++ b/tests/php/features/TestFacetTypeMeta.php
@@ -55,7 +55,6 @@ class TestFacetTypeMeta extends BaseTestCase {
 		};
 		add_filter( 'ep_facet_meta_filter_name', $change_filter_name );
 		$this->assertEquals( 'ep_meta_filter__', $facet_type->get_filter_name() );
-		remove_filter( 'ep_facet_meta_filter_name', $change_filter_name );
 	}
 
 	/**
@@ -81,7 +80,6 @@ class TestFacetTypeMeta extends BaseTestCase {
 		};
 		add_filter( 'ep_facet_meta_filter_type', $change_filter_type );
 		$this->assertEquals( 'meta_', $facet_type->get_filter_type() );
-		remove_filter( 'ep_facet_meta_filter_type', $change_filter_type );
 	}
 
 	/**
@@ -139,10 +137,6 @@ class TestFacetTypeMeta extends BaseTestCase {
 		$with_aggs = $facet_type->set_wp_query_aggs( [] );
 		$this->assertSame( 5, $with_aggs['ep_meta_filter_new_meta_key_1']['terms']['size'] );
 		$this->assertSame( 10000, $with_aggs['ep_meta_filter_new_meta_key_2']['terms']['size'] );
-
-		remove_filter( 'ep_facet_meta_size', $change_meta_bucket_size );
-
-		remove_filter( 'ep_facet_meta_fields', $set_facet_meta_field );
 	}
 
 	/**
@@ -206,8 +200,6 @@ class TestFacetTypeMeta extends BaseTestCase {
 
 		$this->assertEqualsCanonicalizing( [ 'foo', 'bar', 'foobar' ], $meta_values_1 );
 		$this->assertEqualsCanonicalizing( [ 'lore', 'ipsu' ], $meta_values_2 );
-
-		remove_filter( 'ep_facet_meta_custom_meta_values', $change_meta_values );
 	}
 
 	/**
@@ -319,7 +311,5 @@ class TestFacetTypeMeta extends BaseTestCase {
 		// test sanitize_text_field runs when filter is applied.
 		$expected_result = sanitize_title( $test_meta );
 		$this->assertArrayHasKey( $expected_result, $selected['meta']['new_meta_key_1']['terms'] );
-
-		remove_filter( 'ep_facet_default_sanitize_callback', $sanitize_function );
 	}
 }

--- a/tests/php/features/TestFacetTypeMetaRenderer.php
+++ b/tests/php/features/TestFacetTypeMetaRenderer.php
@@ -106,7 +106,5 @@ class TestFacetTypeMetaRenderer extends BaseTestCase {
 		add_filter( 'ep_facet_meta_value_html', $change_html, 10, 3 );
 
 		$this->assertEquals( '<p>Completely custom made element</p>', $renderer->get_meta_value_html( $value, $url )  );
-
-		remove_filter( 'ep_facet_meta_value_html', $change_html );
 	}
 }

--- a/tests/php/features/TestFacetTypeTaxonomy.php
+++ b/tests/php/features/TestFacetTypeTaxonomy.php
@@ -37,7 +37,6 @@ class TestFacetTypeTaxonomy extends BaseTestCase {
 		};
 		add_filter( 'ep_facet_filter_name', $change_filter_name );
 		$this->assertEquals( 'ep_filter__', $facet_type->get_filter_name() );
-		remove_filter( 'ep_facet_filter_name', $change_filter_name );
 	}
 
 	/**
@@ -63,7 +62,6 @@ class TestFacetTypeTaxonomy extends BaseTestCase {
 		};
 		add_filter( 'ep_facet_filter_type', $change_filter_type );
 		$this->assertEquals( 'taxonomies_', $facet_type->get_filter_type() );
-		remove_filter( 'ep_facet_filter_type', $change_filter_type );
 	}
 
 	/**
@@ -96,8 +94,6 @@ class TestFacetTypeTaxonomy extends BaseTestCase {
 
 		$facetable_taxonomies = array_keys( $facet_type->get_facetable_taxonomies() );
 		$this->assertNotContains( 'category', $facetable_taxonomies );
-
-		remove_filter( 'ep_facet_include_taxonomies', $change_facetable_taxonomies );
 	}
 
 	/**
@@ -150,8 +146,6 @@ class TestFacetTypeTaxonomy extends BaseTestCase {
 		$with_aggs = $facet_type->set_wp_query_aggs( [] );
 		$this->assertSame( 5, $with_aggs['category']['terms']['size'] );
 		$this->assertSame( 10000, $with_aggs['post_tag']['terms']['size'] );
-
-		remove_filter( 'ep_facet_taxonomies_size', $change_tax_bucket_size );
 	}
 
 	/**
@@ -233,7 +227,5 @@ class TestFacetTypeTaxonomy extends BaseTestCase {
 		// test sanitize_text_field runs when filter is applied.
 		$expected_result = sanitize_text_field( $test_taxonomy );
 		$this->assertArrayHasKey( $expected_result, $selected['taxonomies']['taxonomy']['terms'] );
-
-		remove_filter( 'ep_facet_sanitize_callback', $sanitize_function );
 	}
 }

--- a/tests/php/features/TestProtectedContent.php
+++ b/tests/php/features/TestProtectedContent.php
@@ -35,8 +35,6 @@ class TestProtectedContent extends BaseTestCase {
 		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->sync_queue = [];
 
 		$this->setup_test_post_type();
-
-		delete_option( 'ep_active_features' );
 	}
 
 	/**
@@ -48,8 +46,6 @@ class TestProtectedContent extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 
 		set_current_screen( 'front' );

--- a/tests/php/features/TestRelatedPosts.php
+++ b/tests/php/features/TestRelatedPosts.php
@@ -35,8 +35,6 @@ class TestRelatedPosts extends BaseTestCase {
 		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->sync_queue = [];
 
 		$this->setup_test_post_type();
-
-		delete_option( 'ep_active_features' );
 	}
 
 	/**
@@ -47,8 +45,6 @@ class TestRelatedPosts extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 
@@ -95,8 +91,6 @@ class TestRelatedPosts extends BaseTestCase {
 		$related = ElasticPress\Features::factory()->get_registered_feature( 'related_posts' )->find_related( $post_id, 1 );
 		$this->assertEquals( 1, count( $related ) );
 		$this->assertTrue( isset( $related[0] ) && isset( $related[0]->elasticsearch ) );
-
-		remove_filter( 'ep_find_related_args', array( $this, 'find_related_posts_filter' ), 10, 1 );
 	}
 
 	/**

--- a/tests/php/features/TestSearch.php
+++ b/tests/php/features/TestSearch.php
@@ -44,8 +44,6 @@ class TestSearch extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 

--- a/tests/php/features/TestSearchOrdering.php
+++ b/tests/php/features/TestSearchOrdering.php
@@ -322,8 +322,6 @@ class TestSearchOrdering extends BaseTestCase {
 		add_filter( 'pre_insert_term', $create_term_failed );
 
 		$this->assertFalse( $this->get_feature()->create_or_return_custom_result_term( 'test' ) );
-
-		remove_filter( 'pre_insert_term', $create_term_failed );
 	}
 
 	public function testExcludeCustomResultsWeightingFields() {
@@ -441,8 +439,6 @@ class TestSearchOrdering extends BaseTestCase {
 		$request = new \WP_REST_Request( 'GET', '/elasticpress/v1/pointer_preview' );
 		$response = $wp_rest_server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
-
-		remove_filter( 'rest_url', [ $this, 'filter_rest_url_for_leading_slash' ], 10, 2 );
 	}
 
 	/**

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -46,8 +46,6 @@ class TestSynonyms extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 

--- a/tests/php/features/TestWeighting.php
+++ b/tests/php/features/TestWeighting.php
@@ -45,8 +45,6 @@ class TestWeighting extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 		update_option( 'elasticpress_weighting', [] );
 	}
@@ -338,8 +336,6 @@ class TestWeighting extends BaseTestCase {
 		$this->assertFalse( $this->get_weighting_feature()->post_type_has_fields( 'page' ) );
 		$this->assertTrue( $this->get_weighting_feature()->post_type_has_fields( 'test' ) );
 		$this->assertFalse( $this->get_weighting_feature()->post_type_has_fields( 'test-2' ) );
-
-		remove_filter( 'ep_weighting_configuration_for_search', $function );
 	}
 
 	public function testDoWeightingWithQueryContainsSearchFields() {

--- a/tests/php/features/TestWooCommerce.php
+++ b/tests/php/features/TestWooCommerce.php
@@ -35,8 +35,6 @@ class TestWooCommerce extends BaseTestCase {
 		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->sync_queue = [];
 
 		$this->setup_test_post_type();
-
-		delete_option( 'ep_active_features' );
 	}
 
 	/**
@@ -48,8 +46,6 @@ class TestWooCommerce extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 
@@ -349,7 +345,5 @@ class TestWooCommerce extends BaseTestCase {
 			$query->query_vars['search_fields'],
 			[ 'post_title', 'post_content' ]
 		);
-
-		remove_filter( 'ep_woocommerce_admin_products_list_search_fields', $search_fields_function );
 	}
 }

--- a/tests/php/indexables/TestComment.php
+++ b/tests/php/indexables/TestComment.php
@@ -56,8 +56,6 @@ class TestComment extends BaseTestCase {
 
 		$this->deleteAllComments();
 
-		// Make sure no one attached to this.
-		remove_filter( 'ep_sync_comments_allow_hierarchy', array( $this, 'ep_allow_multiple_level_comments_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 
@@ -279,8 +277,6 @@ class TestComment extends BaseTestCase {
 		$comments = $comments_query->get_comments();
 
 		$this->assertEquals( 2, count( $comments ) );
-
-		remove_filter( 'ep_max_results_window', $return_2 );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -1449,8 +1449,6 @@ class TestPost extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 2, $query->post_count );
 		$this->assertEquals( 2, $query->found_posts );
-
-		remove_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10 );
 	}
 
 	/**
@@ -1491,8 +1489,6 @@ class TestPost extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 3, $query->post_count );
 		$this->assertEquals( 3, $query->found_posts );
-
-		remove_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10 );
 	}
 
 	/**
@@ -1552,9 +1548,6 @@ class TestPost extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
-
-		remove_filter( 'ep_indexable_post_types', array( $this, 'addAttachmentPostType' ) );
-		remove_filter( 'ep_indexable_post_status', array( $this, 'addAttachmentPostStatus' ) );
 	}
 
 	/**
@@ -1743,8 +1736,6 @@ class TestPost extends BaseTestCase {
 		$this->assertContains( $post_id_1, $post_ids );
 		$this->assertContains( $post_id_1, $post_ids );
 		$this->assertNotContains( $post_id_0, $post_ids );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -1790,8 +1781,6 @@ class TestPost extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -2418,8 +2407,6 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 'Ordertest 222', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertest 111', $query->posts[1]->post_title );
 		$this->assertEquals( 'ordertesr', $query->posts[2]->post_title );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -2510,8 +2497,6 @@ class TestPost extends BaseTestCase {
 
 			$i++;
 		}
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -2542,8 +2527,6 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertest', $query->posts[0]->post_title );
 		$this->assertEquals( 'ordertet', $query->posts[1]->post_title );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -2604,8 +2587,6 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertest', $query->posts[0]->post_title );
 		$this->assertEquals( 'Ordertet', $query->posts[1]->post_title );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -2638,8 +2619,6 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 2, $query->found_posts );
 		$this->assertEquals( 'ordertestt', $query->posts[0]->post_title );
 		$this->assertEquals( 'Ordertest', $query->posts[1]->post_title );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -3667,7 +3646,6 @@ class TestPost extends BaseTestCase {
 			$this->assertNull( $post['post_modified_gmt'] );
 		}
 		$this->assertNotNull( $post );
-		remove_filter( 'ep_indexable_post_status', array( $this, 'mock_indexable_post_status' ), 10 );
 	}
 
 	/**
@@ -6525,8 +6503,6 @@ class TestPost extends BaseTestCase {
 
 		$last_filter = end( $args['post_filter']['bool']['must'] );
 		$this->assertSame( [ 'my_custom_field.raw' => 'my_custom_value' ], $last_filter['term'] );
-
-		remove_filter( 'ep_post_filters', $add_es_filter );
 	}
 
 	/**
@@ -6703,8 +6679,6 @@ class TestPost extends BaseTestCase {
 			remove_filter( 'ep_fallback_elasticsearch_version', $version_callback );
 			remove_filter( 'ep_post_mapping_file', $assert_callback );
 		}
-
-		remove_filter( 'ep_elasticsearch_version', '__return_false' );
 	}
 
 	/**
@@ -7510,8 +7484,6 @@ class TestPost extends BaseTestCase {
 
 		$search_algorithm = $post_indexable->get_search_algorithm( '', [], [] );
 		$this->assertSame( $version_35, $search_algorithm );
-
-		remove_filter( 'ep_post_search_algorithm', $set_version_35 );
 	}
 
 	/**
@@ -7650,9 +7622,6 @@ class TestPost extends BaseTestCase {
 
 		$this->assertEquals( 'test content', $query->posts[0]->post_content );
 		$this->assertEquals( 'test title', $query->posts[0]->post_title );
-
-		remove_filter( 'ep_highlight_should_add_clause', '__return_false' );
-
 	}
 
 	/**

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -1111,8 +1111,6 @@ class TestPostMultisite extends BaseTestCase {
 		$this->assertSame( 2, $query->found_posts );
 
 		$this->cleanUpSites( $sites );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**
@@ -1180,8 +1178,6 @@ class TestPostMultisite extends BaseTestCase {
 		$this->assertSame( 2, $query->found_posts );
 
 		$this->cleanUpSites( $sites );
-
-		remove_filter( 'ep_search_algorithm_version', array( $this, 'set_algorithm_34' ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -99,8 +99,6 @@ class TestTerm extends BaseTestCase {
 
 		$this->deleteAllTerms();
 
-		// Make sure no one attached to this.
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 
@@ -1396,8 +1394,6 @@ class TestTerm extends BaseTestCase {
 
 		$prepared_meta = $term->prepare_meta( $term_id );
 
-		remove_filter( 'ep_prepare_term_meta_allowed_protected_keys', $callback );
-
 		$this->assertSame( '123', $prepared_meta['_custom_protected_key'][0] );
 	}
 
@@ -1537,7 +1533,6 @@ class TestTerm extends BaseTestCase {
 			remove_filter( 'ep_term_mapping_file', $assert_callback );
 		}
 
-		remove_filter( 'ep_elasticsearch_version', '__return_false' );
 	}
 
 	/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -139,8 +139,6 @@ class TestUser extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 
-		// make sure no one attached to this
-		remove_filter( 'ep_sync_terms_allow_hierarchy', array( $this, 'ep_allow_multiple_level_terms_sync' ), 100 );
 		$this->fired_actions = array();
 	}
 
@@ -1472,7 +1470,7 @@ class TestUser extends BaseTestCase {
 		foreach ( $user_query->results as $user ) {
 			$user_order[] = $user->user_login;
 		}
-		
+
 		$this->assertTrue( $user_query->query_vars['elasticsearch_success'] );
 		$this->assertEquals( $expected_user_order, $user_order );
 	}

--- a/tests/php/searchAlgorithms/TestDefaultSearchAlgorithm.php
+++ b/tests/php/searchAlgorithms/TestDefaultSearchAlgorithm.php
@@ -32,7 +32,7 @@ class TestDefaultSearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 	 */
 	public function testGetQuery() {
 		$default = new DefaultAlgorithm();
-		
+
 		$search_term   = 'search_term';
 		$search_fields = [ 'post_title', 'post_content' ];
 
@@ -85,16 +85,14 @@ class TestDefaultSearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $default->get_query( 'indexable', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][2]['multi_match']['fuzziness'] );
-
-		remove_filter( 'ep_indexable_fuzziness_arg', $test_filter );
 	}
 
 	/**
 	 * Test filters with posts
-	 * 
+	 *
 	 * As posts also apply the legacy filters, these tests assure code honors the value of the newer filters
 	 *
-	 * @see https://github.com/10up/ElasticPress/issues/3033 
+	 * @see https://github.com/10up/ElasticPress/issues/3033
 	 * @group searchAlgorithms
 	 */
 	public function testPostFilters() {
@@ -134,8 +132,6 @@ class TestDefaultSearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $default->get_query( 'post', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][2]['multi_match']['fuzziness'] );
-
-		remove_filter( 'ep_post_fuzziness_arg', $test_filter );
 	}
 
 	/**
@@ -183,8 +179,6 @@ class TestDefaultSearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $default->get_query( 'post', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][2]['multi_match']['fuzziness'] );
-
-		remove_filter( 'ep_fuzziness_arg', $test_filter );
 	}
 
 	/**

--- a/tests/php/searchAlgorithms/TestVersion_350SearchAlgorithm.php
+++ b/tests/php/searchAlgorithms/TestVersion_350SearchAlgorithm.php
@@ -32,7 +32,7 @@ class TestVersion_350SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 	 */
 	public function testGetQuery() {
 		$basic = new Version_350();
-		
+
 		$search_term   = 'search_term';
 		$search_fields = [ 'post_title', 'post_content' ];
 
@@ -65,16 +65,14 @@ class TestVersion_350SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $basic->get_query( 'indexable', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][0]['multi_match']['boost'] );
-
-		remove_filter( 'ep_indexable_match_phrase_boost', $test_filter );
 	}
 
 	/**
 	 * Test filters with posts
-	 * 
+	 *
 	 * As posts also apply the legacy filters, these tests assure code honors the value of the newer filters
 	 *
-	 * @see https://github.com/10up/ElasticPress/issues/3033 
+	 * @see https://github.com/10up/ElasticPress/issues/3033
 	 * @group searchAlgorithms
 	 */
 	public function testPostFilters() {
@@ -94,8 +92,6 @@ class TestVersion_350SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][0]['multi_match']['boost'] );
-
-		remove_filter( 'ep_post_match_phrase_boost', $test_filter );
 	}
 
 	/**
@@ -121,8 +117,6 @@ class TestVersion_350SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][0]['multi_match']['boost'] );
-
-		remove_filter( 'ep_match_phrase_boost', $test_filter );
 	}
 
 	/**

--- a/tests/php/searchAlgorithms/TestVersion_400SearchAlgorithm.php
+++ b/tests/php/searchAlgorithms/TestVersion_400SearchAlgorithm.php
@@ -32,7 +32,7 @@ class TestVersion_400SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 	 */
 	public function testGetQuery() {
 		$basic = new Version_400();
-		
+
 		$search_term   = 'search_term';
 		$search_fields = [ 'post_title', 'post_content' ];
 
@@ -95,16 +95,14 @@ class TestVersion_400SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $basic->get_query( 'indexable', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][2]['multi_match']['boost'] );
-
-		remove_filter( 'ep_indexable_match_cross_fields_boost', $test_filter );
 	}
 
 	/**
 	 * Test filters with posts
-	 * 
+	 *
 	 * As posts also apply the legacy filters, these tests assure code honors the value of the newer filters
 	 *
-	 * @see https://github.com/10up/ElasticPress/issues/3033 
+	 * @see https://github.com/10up/ElasticPress/issues/3033
 	 * @group searchAlgorithms
 	 */
 	public function testPostFilters() {
@@ -154,8 +152,6 @@ class TestVersion_400SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][2]['multi_match']['boost'] );
-
-		remove_filter( 'ep_post_match_cross_fields_boost', $test_filter );
 	}
 
 	/**
@@ -214,8 +210,6 @@ class TestVersion_400SearchAlgorithm extends \ElasticPressTest\BaseTestCase {
 
 		$query = $basic->get_query( 'post', $search_term, $search_fields, [] );
 		$this->assertEquals( 1234, $query['bool']['should'][2]['multi_match']['boost'] );
-
-		remove_filter( 'ep_match_cross_fields_boost', $test_filter );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR removes the unneeded `remove_filters` from the unit tests

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3217

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Removed - unwanted remove_filters from the unit tests


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
