### PR TITLE
Remove legacy filter from WooCommerce Feature class

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -144,7 +144,7 @@ class WooCommerce extends Feature {
 	 * @return  array
 	 */
 	public function convert_post_object_to_id( $posts ) {
-		_doing_it_wrong( __METHOD__, 'This filter is removed from WooCommerce and will be removed from ElasticPress in a future release.', '4.5' );
+		_doing_it_wrong( __METHOD__, 'This filter was removed from WooCommerce and will be removed from ElasticPress in a future release.', '4.5.0' );
 		return $posts;
 	}
 
@@ -201,7 +201,7 @@ class WooCommerce extends Feature {
 	 * @return array
 	 */
 	public function disallow_duplicated_query( $value, $query ) {
-		_doing_it_wrong( __METHOD__, 'This filter is removed from WooCommerce and will be removed from ElasticPress in a future release.', '4.5' );
+		_doing_it_wrong( __METHOD__, 'This filter was removed from WooCommerce and will be removed from ElasticPress in a future release.', '4.5.0' );
 
 		return $value;
 	}

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -144,17 +144,8 @@ class WooCommerce extends Feature {
 	 * @return  array
 	 */
 	public function convert_post_object_to_id( $posts ) {
-		$new_posts = [];
-
-		foreach ( $posts as $post ) {
-			if ( is_object( $post ) ) {
-				$new_posts[] = $post->ID;
-			} else {
-				$new_posts[] = $post;
-			}
-		}
-
-		return $new_posts;
+		_doing_it_wrong( __METHOD__, 'This filter is removed from WooCommerce and will be removed from ElasticPress in a future release.', '4.5' );
+		return $posts;
 	}
 
 	/**
@@ -210,26 +201,9 @@ class WooCommerce extends Feature {
 	 * @return array
 	 */
 	public function disallow_duplicated_query( $value, $query ) {
-		global $pagenow;
-
-		$searchable_post_types = $this->get_admin_searchable_post_types();
-
-		/**
-		 * Make sure we're on edit.php in admin dashboard.
-		 */
-		if ( 'edit.php' !== $pagenow || ! is_admin() || ! in_array( $query->get( 'post_type' ), $searchable_post_types, true ) ) {
-			return $value;
-		}
-
-		/**
-		 * Check if EP API request was already done. If request was sent return its results.
-		 */
-		if ( isset( $query->elasticsearch_success ) && $query->elasticsearch_success ) {
-			return $query->posts;
-		}
+		_doing_it_wrong( __METHOD__, 'This filter is removed from WooCommerce and will be removed from ElasticPress in a future release.', '4.5' );
 
 		return $value;
-
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR removes the filters code that doesn't exist anymore in WooCommerce and EP. `woocommerce_layered_nav_query_post_ids` and `woocommerce_unfiltered_product_ids` was remove in WooCommerce 2.6.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Removed - Remove legacy filters `woocommerce_layered_nav_query_post_ids`, `woocommerce_unfiltered_product_ids` and `ep_wp_query_search_cached_posts` code


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
