### PR TITLE
Fixes bugs from word delimiter graph filter

### DIFF
--- a/includes/mappings/comment/7-0.php
+++ b/includes/mappings/comment/7-0.php
@@ -93,8 +93,7 @@ return [
 					'max_shingle_size' => 5,
 				],
 				'ewp_word_delimiter' => [
-					'type'              => 'word_delimiter_graph',
-					'preserve_original' => true,
+					'type' => 'word_delimiter_graph',
 				],
 				'ewp_snowball'       => [
 					'type'     => 'snowball',

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -110,8 +110,7 @@ return array(
 					'max_shingle_size' => 5,
 				),
 				'ewp_word_delimiter' => array(
-					'type'              => 'word_delimiter_graph',
-					'preserve_original' => true,
+					'type' => 'word_delimiter_graph',
 				),
 				'ewp_snowball'       => array(
 					'type'     => 'snowball',

--- a/includes/mappings/term/7-0.php
+++ b/includes/mappings/term/7-0.php
@@ -49,8 +49,7 @@ return [
 					'max_shingle_size' => 5,
 				],
 				'ewp_word_delimiter' => [
-					'type'              => 'word_delimiter_graph',
-					'preserve_original' => true,
+					'type' => 'word_delimiter_graph',
 				],
 				'ewp_snowball'       => [
 					'type'     => 'snowball',

--- a/includes/mappings/user/7-0.php
+++ b/includes/mappings/user/7-0.php
@@ -93,8 +93,7 @@ return array(
 					'max_shingle_size' => 5,
 				),
 				'ewp_word_delimiter' => array(
-					'type'              => 'word_delimiter_graph',
-					'preserve_original' => true,
+					'type' => 'word_delimiter_graph',
 				),
 				'ewp_snowball'       => array(
 					'type'     => 'snowball',


### PR DESCRIPTION
### Description of the Change

This removes the [`preserve_original` option for the `word_delimiter_graph` token filter](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-word-delimiter-graph-tokenfilter.html#word-delimiter-graph-tokenfilter-preserve-original). As noted in the ES docs:

> Setting this parameter to true produces multi-position tokens, which are not supported by indexing.
> 
> If this parameter is true, avoid using this filter in an index analyzer or use the [flatten_graph](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-flatten-graph-tokenfilter.html) filter after this filter to make the token stream suitable for indexing.

As it was set, this was producing multi-position tokens, which could lead to unexpected results and, potentially, indexing errors. Where I observed this specifically was using a [`search_as_you_type` field](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-as-you-type.html). This uses shingle token filters to create 2- and 3-gram sub-fields. Combined with `word_delimiter_graph.preserve_original = true`, if the field text is a word like "WordPress", and the analyzed token count is <= the gram size, the tokens can end up with a negative token position and indexing fails.

For what it's worth, I tried using `flatten_graph` as the docs suggest as a workaround, and that didn't work 🤷.

### How to test the Change

To replicate the error in isolation:

```js
PUT sayt-demo
{
  "settings": {
    "analysis": {
      "filter": {
        "word_delimiter": {
          "type": "word_delimiter_graph",
          "preserve_original": true
        }
      },
      "analyzer": {
        "default": {
          "tokenizer": "standard",
          "filter": [
            "word_delimiter"
          ]
        }
      }
    }
  },
  "mappings": {
    "properties": {
      "test": {
        "type": "search_as_you_type"
      }
    }
  }
}

PUT sayt-demo/_doc/1?refresh
{
  "test": "WordPress"
}

RESPONSE:
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "first position increment must be > 0 (got 0) for field 'test._2gram'"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "first position increment must be > 0 (got 0) for field 'test._2gram'"
  },
  "status" : 400
}

GET /sayt-demo/_analyze
{
  "field": "test._2gram",
  "text": "WordPress"
}

RESPONSE:
{
  "tokens" : [
    {
      "token" : "Word Press",
      "start_offset" : 0,
      "end_offset" : 9,
      "type" : "shingle",
      "position" : -1
    }
  ]
}
```

Observe that when removing `"preserve_original": true`, the document indexes as expected and the position is correctly calculated as 0, not -1.



### Changelog Entry

> Fixed - Potential indexing error due to `word_delimiter_graph.preserve_original: true`, which Elastic notes should not be set for analysis during indexing.


### Credits

Props @mboynes, @dlh01


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
