### PR TITLE
Fix: Uncaught ArgumentCountError: Too few arguments to function WP_CLI::halt()

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -644,7 +644,7 @@ class Command extends WP_CLI_Command {
 		if ( SIGINT === $signal_no ) {
 			$this->delete_transient();
 			WP_CLI::log( esc_html__( 'Indexing cleaned up.', 'elasticpress' ) );
-			WP_CLI::halt();
+			WP_CLI::halt( 0 );
 		}
 	}
 
@@ -1140,7 +1140,7 @@ class Command extends WP_CLI_Command {
 		if ( $should_interrupt_sync ) {
 			WP_CLI::line( esc_html__( 'Sync was interrupted', 'elasticpress' ) );
 			$this->delete_transient_on_int( 2 );
-			WP_CLI::halt();
+			WP_CLI::halt( 0 );
 		}
 	}
 

--- a/tests/php/includes/classes/mock/class-wp-cli.php
+++ b/tests/php/includes/classes/mock/class-wp-cli.php
@@ -96,7 +96,7 @@ class WP_CLI {
 	 *
 	 * @param integer $return_code Exit code to return.
 	 */
-	public static function halt( $return_code = 0 ) {
+	public static function halt( $return_code ) {
 	}
 
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR resolves the issue where canceling the sync with Ctrl+C results in an error. This issue originally arose after the https://github.com/10up/ElasticPress/pull/3202 change. The main problem was that `WP_CLI::halt` was expecting the error code as an argument. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Run the CLI command `wp elasticpress sync --setup --yes`
- Forcefully cancel the sync with `Ctrl+C`

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fix: Uncaught ArgumentCountError: Too few arguments to function WP_CLI::halt()


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
