### PR TITLE
Fix: 'sites' => 'current' doesn't work as expected

### DIFF
--- a/includes/classes/Indexable/Comment/QueryIntegration.php
+++ b/includes/classes/Indexable/Comment/QueryIntegration.php
@@ -123,15 +123,17 @@ class QueryIntegration {
 		$site__not_in = [];
 
 		if ( ! empty( $query->query_vars['sites'] ) ) {
-
 			_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
-			$site__in = (array) $query->query_vars['sites'];
-			$scope    = 'all' === $query->query_vars['sites'] ? 'all' : $site__in;
 		}
 
-		if ( ! empty( $query->query_vars['site__in'] ) ) {
-			$site__in = (array) $query->query_vars['site__in'];
-			$scope    = 'all' === $query->query_vars['site__in'] ? 'all' : $site__in;
+		if ( ! empty( $query->query_vars['site__in'] ) || ! empty( $query->query_vars['sites'] ) ) {
+			$site__in = ! empty( $query->query_vars['site__in'] ) ? (array) $query->query_vars['site__in'] : (array) $query->query_vars['sites'];
+
+			if ( in_array( 'all', $site__in, true ) ) {
+				$scope = 'all';
+			} elseif ( in_array( 'current', $site__in, true ) ) {
+				$site__in = (array) get_current_blog_id();
+			}
 		}
 
 		if ( ! empty( $query->query_vars['site__not_in'] ) ) {

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -280,16 +280,17 @@ class QueryIntegration {
 			$site__not_in = '';
 
 			if ( ! empty( $query_vars['sites'] ) ) {
-
 				_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
-				$site__in = (array) $query_vars['sites'];
-				$scope    = 'all' === $query_vars['sites'] ? 'all' : $site__in;
 			}
 
-			if ( ! empty( $query_vars['site__in'] ) ) {
+			if ( ! empty( $query_vars['site__in'] ) || ! empty( $query_vars['sites'] ) ) {
+				$site__in = ! empty( $query_vars['site__in'] ) ? (array) $query_vars['site__in'] : (array) $query_vars['sites'];
 
-				$site__in = (array) $query_vars['site__in'];
-				$scope    = 'all' === $query_vars['site__in'] ? 'all' : $site__in;
+				if ( in_array( 'all', $site__in, true ) ) {
+					$scope = 'all';
+				} elseif ( in_array( 'current', $site__in, true ) ) {
+					$site__in = (array) get_current_blog_id();
+				}
 			}
 
 			if ( ! empty( $query_vars['site__not_in'] ) ) {

--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -94,15 +94,17 @@ class QueryIntegration {
 			$site__not_in = [];
 
 			if ( ! empty( $query->query_vars['sites'] ) ) {
-
 				_deprecated_argument( __FUNCTION__, '4.4.0', esc_html__( 'sites is deprecated. Use site__in instead.', 'elasticpress' ) );
-				$site__in = (array) $query->query_vars['sites'];
-				$scope    = 'all' === $query->query_vars['sites'] ? 'all' : $site__in;
 			}
 
-			if ( ! empty( $query->query_vars['site__in'] ) ) {
-				$site__in = (array) $query->query_vars['site__in'];
-				$scope    = 'all' === $query->query_vars['site__in'] ? 'all' : $site__in;
+			if ( ! empty( $query->query_vars['site__in'] ) || ! empty( $query->query_vars['sites'] ) ) {
+				$site__in = ! empty( $query->query_vars['site__in'] ) ? (array) $query->query_vars['site__in'] : (array) $query->query_vars['sites'];
+
+				if ( in_array( 'all', $site__in, true ) ) {
+					$scope = 'all';
+				} elseif ( in_array( 'current', $site__in, true ) ) {
+					$site__in = (array) get_current_blog_id();
+				}
 			}
 
 			if ( ! empty( $query->query_vars['site__not_in'] ) ) {

--- a/tests/php/indexables/TestCommentMultisite.php
+++ b/tests/php/indexables/TestCommentMultisite.php
@@ -268,7 +268,7 @@ class TestCommentMultisite extends BaseTestCase {
 	/**
 	 * Test Comment Query with the deprecated `sites` param and with value `current`
 	 *
-	 * @since 4.4.0
+	 * @since 4.4.1
 	 * @expectedDeprecated maybe_filter_query
 	 */
 	public function testCommentQueryWithDeprecatedSitesParamWithValueCurrent() {
@@ -289,7 +289,6 @@ class TestCommentMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		// switch the blog
 		switch_to_blog( $sites[1]['blog_id'] );
 
 		$query = new \WP_Comment_Query(
@@ -311,7 +310,7 @@ class TestCommentMultisite extends BaseTestCase {
 	/**
 	 * Test Comment Query with the `site__in` param and with value `current`
 	 *
-	 * @since 4.4.0
+	 * @since 4.4.1
 	 */
 	public function testCommentQueryWithSiteInParamWithValueCurrent() {
 
@@ -331,7 +330,6 @@ class TestCommentMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		// switch the blog
 		switch_to_blog( $sites[1]['blog_id'] );
 
 		$query = new \WP_Comment_Query(

--- a/tests/php/indexables/TestCommentMultisite.php
+++ b/tests/php/indexables/TestCommentMultisite.php
@@ -265,4 +265,88 @@ class TestCommentMultisite extends BaseTestCase {
 		$this->assertEquals( 9, count( $query->get_comments() ) );
 	}
 
+	/**
+	 * Test Comment Query with the deprecated `sites` param and with value `current`
+	 *
+	 * @since 4.4.0
+	 * @expectedDeprecated maybe_filter_query
+	 */
+	public function testCommentQueryWithDeprecatedSitesParamWithValueCurrent() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$post_id = $this->ep_factory->post->create();
+			$this->ep_factory->comment->create_many( 3, array( 'comment_post_ID' => $post_id ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		// switch the blog
+		switch_to_blog( $sites[1]['blog_id'] );
+
+		$query = new \WP_Comment_Query(
+			array(
+				'ep_integrate' => true,
+				'sites'        => 'current',
+			)
+		);
+
+		$comments = $query->get_comments();
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 3, count( $comments ) );
+
+		foreach ( $comments as $comment ) {
+			$this->assertEquals( $sites[1]['blog_id'], $comment->site_id );
+		}
+	}
+
+	/**
+	 * Test Comment Query with the `site__in` param and with value `current`
+	 *
+	 * @since 4.4.0
+	 */
+	public function testCommentQueryWithSiteInParamWithValueCurrent() {
+
+		$sites = ElasticPress\Utils\get_sites();
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$post_id = $this->ep_factory->post->create();
+			$this->ep_factory->comment->create_many( 3, array( 'comment_post_ID' => $post_id ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		// switch the blog
+		switch_to_blog( $sites[1]['blog_id'] );
+
+		$query = new \WP_Comment_Query(
+			array(
+				'ep_integrate' => true,
+				'site__in'     => 'current',
+			)
+		);
+
+		$comments = $query->get_comments();
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 3, count( $comments ) );
+
+		foreach ( $comments as $comment ) {
+			$this->assertEquals( $sites[1]['blog_id'], $comment->site_id );
+		}
+	}
 }

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -1946,9 +1946,8 @@ class TestPostMultisite extends BaseTestCase {
 		foreach ( $sites as $site ) {
 			switch_to_blog( $site['blog_id'] );
 
-			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
+			$this->ep_factory->post->create( 2, array( 'post_content' => 'findme' ) );
 			$this->ep_factory->post->create();
-			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
 
 			ElasticPress\Elasticsearch::factory()->refresh_indices();
 
@@ -1958,38 +1957,21 @@ class TestPostMultisite extends BaseTestCase {
 		switch_to_blog( $sites[1]['blog_id'] );
 
 		$args = array(
-			's'     => 'findme ' . $sites[1]['blog_id'],
+			's'     => 'findme',
 			'sites' => 'current',
 		);
 
 		$query = new \WP_Query( $args );
+		$posts = $query->posts;
 
 		$this->assertTrue( $query->elasticsearch_success );
-
 		$this->assertEquals( $query->post_count, 2 );
 		$this->assertEquals( $query->found_posts, 2 );
 
-
-		while ( $query->have_posts() ) {
-			$query->the_post();
-
-			global $post;
-
-			$wp_post = get_post( get_the_ID() );
-
-			$this->assertEquals( $post->post_title, get_the_title() );
-			$this->assertEquals( $post->post_content, get_the_content() );
-			$this->assertEquals( $post->post_date, $wp_post->post_date );
-			$this->assertEquals( $post->post_modified, $wp_post->post_modified );
-			$this->assertEquals( $post->post_date_gmt, $wp_post->post_date_gmt );
-			$this->assertEquals( $post->post_modified_gmt, $wp_post->post_modified_gmt );
-			$this->assertEquals( $post->post_name, $wp_post->post_name );
-			$this->assertEquals( $post->post_parent, $wp_post->post_parent );
-			$this->assertEquals( $post->post_excerpt, $wp_post->post_excerpt );
-			$this->assertEquals( $post->site_id, get_current_blog_id() );
+		foreach ( $posts as $post ) {
+			$this->assertEquals( $post->site_id, $sites[1]['blog_id'] );
 		}
 
-		wp_reset_postdata();
 		$this->cleanUpSites( $sites );
 	}
 
@@ -1997,7 +1979,7 @@ class TestPostMultisite extends BaseTestCase {
 	/**
 	 * Test a simple post content search with `site__in` parameter and with value `current`.
 	 *
-	 * @since 4.4.0
+	 * @since 4.4.1
 	 * @group testMultipleTests
 	 */
 	public function testWPQuerySearchContentWithDeprecatedSiteInParamWithValueCurrent() {
@@ -2012,9 +1994,8 @@ class TestPostMultisite extends BaseTestCase {
 		foreach ( $sites as $site ) {
 			switch_to_blog( $site['blog_id'] );
 
-			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
+			$this->ep_factory->post->create_many( 2, array( 'post_content' => 'findme' ) );
 			$this->ep_factory->post->create();
-			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
 
 			ElasticPress\Elasticsearch::factory()->refresh_indices();
 
@@ -2024,38 +2005,21 @@ class TestPostMultisite extends BaseTestCase {
 		switch_to_blog( $sites[1]['blog_id'] );
 
 		$args = array(
-			's'     => 'findme ' . $sites[1]['blog_id'],
+			's'        => 'findme',
 			'site__in' => 'current',
 		);
 
 		$query = new \WP_Query( $args );
+		$posts = $query->posts;
 
 		$this->assertTrue( $query->elasticsearch_success );
-
 		$this->assertEquals( $query->post_count, 2 );
 		$this->assertEquals( $query->found_posts, 2 );
 
-
-		while ( $query->have_posts() ) {
-			$query->the_post();
-
-			global $post;
-
-			$wp_post = get_post( get_the_ID() );
-
-			$this->assertEquals( $post->post_title, get_the_title() );
-			$this->assertEquals( $post->post_content, get_the_content() );
-			$this->assertEquals( $post->post_date, $wp_post->post_date );
-			$this->assertEquals( $post->post_modified, $wp_post->post_modified );
-			$this->assertEquals( $post->post_date_gmt, $wp_post->post_date_gmt );
-			$this->assertEquals( $post->post_modified_gmt, $wp_post->post_modified_gmt );
-			$this->assertEquals( $post->post_name, $wp_post->post_name );
-			$this->assertEquals( $post->post_parent, $wp_post->post_parent );
-			$this->assertEquals( $post->post_excerpt, $wp_post->post_excerpt );
-			$this->assertEquals( $post->site_id, get_current_blog_id() );
+		foreach ( $posts as $post ) {
+			$this->assertEquals( $post->site_id, $sites[1]['blog_id'] );
 		}
 
-		wp_reset_postdata();
 		$this->cleanUpSites( $sites );
 	}
 

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -1926,6 +1926,140 @@ class TestPostMultisite extends BaseTestCase {
 		$this->cleanUpSites( $sites );
 	}
 
+
+	/**
+	 * Test a simple post content search with deprecated `sites` parameter and with value `current`
+	 *
+	 * @since 4.4.1
+	 * @expectedDeprecated get_es_posts
+	 * @group testMultipleTests
+	 */
+	public function testWPQuerySearchContentWithDeprecatedSitesParamWithValueCurrent() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
+			$this->ep_factory->post->create();
+			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			restore_current_blog();
+		}
+
+		switch_to_blog( $sites[1]['blog_id'] );
+
+		$args = array(
+			's'     => 'findme ' . $sites[1]['blog_id'],
+			'sites' => 'current',
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+
+		$this->assertEquals( $query->post_count, 2 );
+		$this->assertEquals( $query->found_posts, 2 );
+
+
+		while ( $query->have_posts() ) {
+			$query->the_post();
+
+			global $post;
+
+			$wp_post = get_post( get_the_ID() );
+
+			$this->assertEquals( $post->post_title, get_the_title() );
+			$this->assertEquals( $post->post_content, get_the_content() );
+			$this->assertEquals( $post->post_date, $wp_post->post_date );
+			$this->assertEquals( $post->post_modified, $wp_post->post_modified );
+			$this->assertEquals( $post->post_date_gmt, $wp_post->post_date_gmt );
+			$this->assertEquals( $post->post_modified_gmt, $wp_post->post_modified_gmt );
+			$this->assertEquals( $post->post_name, $wp_post->post_name );
+			$this->assertEquals( $post->post_parent, $wp_post->post_parent );
+			$this->assertEquals( $post->post_excerpt, $wp_post->post_excerpt );
+			$this->assertEquals( $post->site_id, get_current_blog_id() );
+		}
+
+		wp_reset_postdata();
+		$this->cleanUpSites( $sites );
+	}
+
+
+	/**
+	 * Test a simple post content search with `site__in` parameter and with value `current`.
+	 *
+	 * @since 4.4.0
+	 * @group testMultipleTests
+	 */
+	public function testWPQuerySearchContentWithDeprecatedSiteInParamWithValueCurrent() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
+			$this->ep_factory->post->create();
+			$this->ep_factory->post->create( array( 'post_content' => 'findme ' . $site['blog_id'] ) );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			restore_current_blog();
+		}
+
+		switch_to_blog( $sites[1]['blog_id'] );
+
+		$args = array(
+			's'     => 'findme ' . $sites[1]['blog_id'],
+			'site__in' => 'current',
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+
+		$this->assertEquals( $query->post_count, 2 );
+		$this->assertEquals( $query->found_posts, 2 );
+
+
+		while ( $query->have_posts() ) {
+			$query->the_post();
+
+			global $post;
+
+			$wp_post = get_post( get_the_ID() );
+
+			$this->assertEquals( $post->post_title, get_the_title() );
+			$this->assertEquals( $post->post_content, get_the_content() );
+			$this->assertEquals( $post->post_date, $wp_post->post_date );
+			$this->assertEquals( $post->post_modified, $wp_post->post_modified );
+			$this->assertEquals( $post->post_date_gmt, $wp_post->post_date_gmt );
+			$this->assertEquals( $post->post_modified_gmt, $wp_post->post_modified_gmt );
+			$this->assertEquals( $post->post_name, $wp_post->post_name );
+			$this->assertEquals( $post->post_parent, $wp_post->post_parent );
+			$this->assertEquals( $post->post_excerpt, $wp_post->post_excerpt );
+			$this->assertEquals( $post->site_id, get_current_blog_id() );
+		}
+
+		wp_reset_postdata();
+		$this->cleanUpSites( $sites );
+	}
+
+
 	/**
 	 * Tests WP Query returns the data from all sites except one.
 	 *

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -1946,7 +1946,7 @@ class TestPostMultisite extends BaseTestCase {
 		foreach ( $sites as $site ) {
 			switch_to_blog( $site['blog_id'] );
 
-			$this->ep_factory->post->create( 2, array( 'post_content' => 'findme' ) );
+			$this->ep_factory->post->create_many( 2, array( 'post_content' => 'findme' ) );
 			$this->ep_factory->post->create();
 
 			ElasticPress\Elasticsearch::factory()->refresh_indices();
@@ -1974,7 +1974,6 @@ class TestPostMultisite extends BaseTestCase {
 
 		$this->cleanUpSites( $sites );
 	}
-
 
 	/**
 	 * Test a simple post content search with `site__in` parameter and with value `current`.
@@ -2022,7 +2021,6 @@ class TestPostMultisite extends BaseTestCase {
 
 		$this->cleanUpSites( $sites );
 	}
-
 
 	/**
 	 * Tests WP Query returns the data from all sites except one.

--- a/tests/php/indexables/TestTermMultisite.php
+++ b/tests/php/indexables/TestTermMultisite.php
@@ -372,4 +372,93 @@ class TestTermMultisite extends BaseTestCase {
 		$this->assertEquals( 4, count( $query->get_terms() ) );
 
 	}
+
+	/**
+	 * Test WP Term Query with the deprecated `sites` param and with value `current`
+	 *
+	 * @since 4.4.1
+	 * @expectedDeprecated maybe_filter_query
+	 */
+	public function testTermQuerySearchWithDeprecatedSitesParamAndValueCurrent() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create_many( 4 );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		// switch the site.
+		switch_to_blog( $sites[1]['blog_id'] );
+
+		// test for only current site.
+		$args  = array(
+			'sites'        => 'current',
+			'taxonomy'     => 'category',
+			'hide_empty'   => false,
+			'ep_integrate' => true,
+		);
+		$query = new \WP_Term_Query( $args );
+		$terms = $query->get_terms();
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 4, count( $terms ) );
+
+		foreach ( $terms as $term ) {
+			$this->assertEquals( $sites[1]['blog_id'], $term->site_id );
+		}
+	}
+
+	/**
+	 * Test WP Term Query with the `site__in` param and with value `current`
+	 *
+	 * @since 4.4.1
+	 */
+	public function testTermQuerySearchWithSiteInParamAndValueCurrent() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+
+			$this->ep_factory->category->create_many( 4 );
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+			restore_current_blog();
+		}
+
+		// switch the site.
+		switch_to_blog( $sites[1]['blog_id'] );
+
+		// test for only current site.
+		$args  = array(
+			'site__in'     => 'current',
+			'taxonomy'     => 'category',
+			'hide_empty'   => false,
+			'ep_integrate' => true,
+		);
+		$query = new \WP_Term_Query( $args );
+		$terms = $query->get_terms();
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 4, count( $terms ) );
+
+		foreach ( $terms as $term ) {
+			$this->assertEquals( $sites[1]['blog_id'], $term->site_id );
+		}
+	}
 }

--- a/tests/php/indexables/TestTermMultisite.php
+++ b/tests/php/indexables/TestTermMultisite.php
@@ -397,7 +397,6 @@ class TestTermMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		// switch the site.
 		switch_to_blog( $sites[1]['blog_id'] );
 
 		// test for only current site.
@@ -441,7 +440,6 @@ class TestTermMultisite extends BaseTestCase {
 			restore_current_blog();
 		}
 
-		// switch the site.
 		switch_to_blog( $sites[1]['blog_id'] );
 
 		// test for only current site.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the ` 'sites' => 'current'` doesn't work after as expected. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3225 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Run the below query on the multisite and it should only returns the post of current site 
```

		$query = new \WP_Query(
			array(
				's'  => 'site',
				'sites' => 'current',
			)
		);
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - 'sites' => 'current' doesn't work 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez @anders-naslund @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
