### PR TITLE
Only add Autosuggest health check info if feature is active.

### DIFF
--- a/includes/classes/Screen/HealthInfo.php
+++ b/includes/classes/Screen/HealthInfo.php
@@ -57,7 +57,7 @@ class HealthInfo {
 
 		$feature = Features::factory()->get_registered_feature( 'autosuggest' );
 
-		if ( ! $feature->is_active() ) {
+		if ( ! $feature || ! $feature->is_active() ) {
 			return $debug_info;
 		}
 

--- a/includes/classes/Screen/HealthInfo.php
+++ b/includes/classes/Screen/HealthInfo.php
@@ -55,6 +55,12 @@ class HealthInfo {
 			return $debug_info;
 		}
 
+		$feature = Features::factory()->get_registered_feature( 'autosuggest' );
+
+		if ( ! $feature->is_active() ) {
+			return $debug_info;
+		}
+
 		$epio_report = new \ElasticPress\StatusReport\ElasticPressIo();
 		$groups      = $epio_report->get_groups();
 		$first_group = reset( $groups );


### PR DESCRIPTION
### Description of the Change
Fixes an issue where the Autosuggest Site Health section would still appear, but with the wrong info, if the Autosuggest feature is not enabled.


### How to test the Change
In _Tools > Site Health_ the _ElasticPress.io - Autosuggest_ section should only appear when the Autosuggest feature is active, and only contain info relevant to Autosuggest.

### Changelog Entry
Fixed - An issue where the Autosuggest Site Health Info would contain incorrect information unrelated to Autosuggest.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
