### PR TITLE
Fix the display of the token field in Feature settings.

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -370,10 +370,6 @@ h2.ep-list-features {
 		margin: 0.25em 0 0.5em;
 	}
 
-	& div {
-		padding-top: 5px;
-	}
-
 	& > label,
 	& .field-name {
 		box-sizing: border-box;
@@ -386,6 +382,7 @@ h2.ep-list-features {
 	& .input-wrap {
 		display: block;
 		float: right;
+		padding-top: 5px;
 		width: 75%;
 	}
 
@@ -413,7 +410,7 @@ h2.ep-list-features {
 	}
 
 	& .components-form-token-field__input-container {
-		padding: 2px 4px;
+		border-color: #8c8f94;
 	}
 }
 


### PR DESCRIPTION
### Description of the Change
A recent version of WordPress seems to have adjusted the styling of the token field component which caused some display issues in our implementation for the Instant Results feature settings. This fixes those issues.

### How to test the Change
In Features > Instant Results the Facets field should appear without causing horizontal scrolling and without padding causing extra whitespace.

### Changelog Entry
Fixed - An issue with the styling of the Instant Results Facets field.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
