### PR TITLE
Only use allowed protected key is found

### DIFF
--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -7956,7 +7956,6 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( 5, $query->post_count );
 	}
 
-
 	/**
 	 * Tests get_distinct_meta_field_keys_db
 	 *
@@ -7969,7 +7968,13 @@ class TestPost extends BaseTestCase {
 		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
 
 		$meta_keys = $wpdb->get_col( "SELECT DISTINCT meta_key FROM {$wpdb->postmeta} ORDER BY meta_key" );
-		$this->assertSame( $meta_keys, $indexable->get_distinct_meta_field_keys_db() );
+		$this->assertSame( $meta_keys, $indexable->get_distinct_meta_field_keys_db( true ) );
+
+		// Make sure it works if no allowed protected key is found
+		add_filter( 'ep_prepare_meta_allowed_protected_keys', '__return_empty_array' );
+		$this->assertSame( $meta_keys, $indexable->get_distinct_meta_field_keys_db( true ) );
+		$this->assertEmpty( $wpdb->last_error );
+		remove_filter( 'ep_prepare_meta_allowed_protected_keys', '__return_empty_array' );
 
 		/**
 		 * Test the `ep_post_pre_meta_keys_db` filter
@@ -7983,7 +7988,7 @@ class TestPost extends BaseTestCase {
 		$num_queries = $wpdb->num_queries;
 		$this->assertGreaterThan( 0, $num_queries );
 
-		$this->assertSame( [ 'totally_custom_key' ], $indexable->get_distinct_meta_field_keys_db() );
+		$this->assertSame( [ 'totally_custom_key' ], $indexable->get_distinct_meta_field_keys_db( true ) );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
 
 		remove_filter( 'ep_post_pre_meta_keys_db', $return_custom_array );
@@ -7996,7 +8001,7 @@ class TestPost extends BaseTestCase {
 		};
 		add_filter( 'ep_post_meta_keys_db', $return_custom_array );
 
-		$this->assertSame( array_merge( $meta_keys, [ 'custom_key' ] ), $indexable->get_distinct_meta_field_keys_db() );
+		$this->assertSame( array_merge( $meta_keys, [ 'custom_key' ] ), $indexable->get_distinct_meta_field_keys_db( true ) );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
This PR fixes a bug introduced in #3215 that happens when no allowed protected key is found.

### Changelog Entry
To be added to the `Detection of indexable meta fields when...` line + props to @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
