### PR TITLE
Prevent doubled requests

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -899,7 +899,7 @@ class Autosuggest extends Feature {
 				break;
 			}
 
-			// Send to EP.io what should be accepted as values by autosuggest and try to get them again.
+			// Send to EP.io what should be autosuggest's allowed values and try to get them again.
 			$this->epio_send_autosuggest_public_request( true );
 		}
 

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -894,9 +894,13 @@ class Autosuggest extends Feature {
 				break;
 			}
 
-			if ( empty( $allowed_params ) ) {
-				$this->epio_send_autosuggest_public_request( true );
+			// We have what we need, no need to retry.
+			if ( ! empty( $allowed_params ) ) {
+				break;
 			}
+
+			// Send to EP.io what should be accepted as values by autosuggest and try to get them again.
+			$this->epio_send_autosuggest_public_request( true );
 		}
 
 		return $allowed_params;

--- a/includes/classes/Screen.php
+++ b/includes/classes/Screen.php
@@ -44,6 +44,14 @@ class Screen {
 	public $health_info_screen;
 
 	/**
+	 * Status report instance
+	 *
+	 * @var Screen\StatusReport
+	 * @since  4.5.0
+	 */
+	public $status_report;
+
+	/**
 	 * Initialize class
 	 *
 	 * @since 3.0

--- a/includes/classes/Screen/StatusReport.php
+++ b/includes/classes/Screen/StatusReport.php
@@ -19,6 +19,14 @@ defined( 'ABSPATH' ) || exit;
  */
 class StatusReport {
 	/**
+	 * The formatted/processed reports.
+	 *
+	 * @since 4.5.0
+	 * @var array
+	 */
+	protected $formatted_reports = [];
+
+	/**
 	 * Initialize class
 	 */
 	public function setup() {
@@ -45,22 +53,10 @@ class StatusReport {
 			true
 		);
 
-		$reports = $this->get_reports();
-		$reports = array_map(
-			function( $report ) {
-				return [
-					'actions' => $report->get_actions(),
-					'groups'  => $report->get_groups(),
-					'title'   => $report->get_title(),
-				];
-			},
-			$reports
-		);
-
 		wp_localize_script(
 			'ep_admin_status_report_scripts',
 			'epStatusReport',
-			$reports
+			$this->get_formatted_reports()
 		);
 
 		$style_deps = Utils\get_asset_info( 'status-report-styles', 'dependencies' );
@@ -128,13 +124,13 @@ class StatusReport {
 	 * Render all reports (HTML and Copy & Paste button)
 	 */
 	public function render_reports() {
-		$reports = $this->get_reports();
+		$reports = $this->get_formatted_reports();
 
 		$copy_paste_output = [];
 
 		foreach ( $reports as $report ) {
-			$title  = $report->get_title();
-			$groups = $report->get_groups();
+			$title  = $report['title'];
+			$groups = $report['groups'];
 
 			$copy_paste_output[] = $this->render_copy_paste_report( $title, $groups );
 		}
@@ -150,6 +146,30 @@ class StatusReport {
 			</span>
 		</p>
 		<?php
+	}
+
+	/**
+	 * Process and format the reports, then store them in the `formatted_reports` attribute.
+	 *
+	 * @since 4.5.0
+	 * @return array
+	 */
+	protected function get_formatted_reports() : array {
+		if ( empty( $this->formatted_reports ) ) {
+			$reports = $this->get_reports();
+
+			$this->formatted_reports = array_map(
+				function( $report ) {
+					return [
+						'actions' => $report->get_actions(),
+						'groups'  => $report->get_groups(),
+						'title'   => $report->get_title(),
+					];
+				},
+				$reports
+			);
+		}
+		return $this->formatted_reports;
 	}
 
 	/**

--- a/includes/partials/status-report-page.php
+++ b/includes/partials/status-report-page.php
@@ -6,11 +6,9 @@
  * @package elasticpress
  */
 
-use ElasticPress\Screen\StatusReport;
-
 defined( 'ABSPATH' ) || exit;
 
-$status_report = new StatusReport();
+$status_report = \ElasticPress\Screen::factory()->status_report;
 
 require_once __DIR__ . '/header.php';
 ?>


### PR DESCRIPTION
### Description of the Change
Visiting the Status Report page will make all the ES requests twice. This PR addresses this problem, using the same instance of the StatusReport page and storing the processed/formatted reports in an attribute.

### How to test the Change
1. Install Query Monitor
2. Visit the Status Report page and look at the HTTP API Calls
3. Checkout this PR
4. See the numbers cut in half

### Changelog Entry
> Fixed - Status Report page firing requests to ES twice.


### Credits
Props @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
