### PR TITLE
Sanitize meta query

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -2001,9 +2001,8 @@ class Post extends Indexable {
 		 *
 		 * @since 1.3
 		 */
-		$meta_queries     = ( ! empty( $args['meta_query'] ) ) ? $args['meta_query'] : [];
-		$this->meta_query = new \WP_Meta_Query();
-		$meta_queries     = $this->meta_query->sanitize_query( $meta_queries );
+		$meta_queries = ( ! empty( $args['meta_query'] ) ) ? $args['meta_query'] : [];
+		$meta_queries = ( new \WP_Meta_Query() )->sanitize_query( $meta_queries );
 
 		/**
 		 * Todo: Support meta_type

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -2001,7 +2001,9 @@ class Post extends Indexable {
 		 *
 		 * @since 1.3
 		 */
-		$meta_queries = ( ! empty( $args['meta_query'] ) ) ? $args['meta_query'] : [];
+		$meta_queries     = ( ! empty( $args['meta_query'] ) ) ? $args['meta_query'] : [];
+		$this->meta_query = new \WP_Meta_Query();
+		$meta_queries     = $this->meta_query->sanitize_query( $meta_queries );
 
 		/**
 		 * Todo: Support meta_type

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -3232,12 +3232,12 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
-	 * Test an advanced meta filter query with integer key
+	 * Test the sanitization of an empty meta query
 	 *
 	 * @since 4.5.0
 	 * @group post
 	 */
-	public function testMetaQueryIntegerKey() {
+	public function testMetaQueryEmptySanitization() {
 		$this->ep_factory->post->create(
 			array(
 				'post_content' => 'the post content findme',

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -3238,7 +3238,6 @@ class TestPost extends BaseTestCase {
 	 * @group post
 	 */
 	public function testMetaQueryIntegerKey() {
-		$this->ep_factory->post->create( array( 'post_content' => 'the post content findme' ), array( 'test_key' => 'value1' ) );
 		$this->ep_factory->post->create(
 			array(
 				'post_content' => 'the post content findme',
@@ -3270,8 +3269,8 @@ class TestPost extends BaseTestCase {
 		$query = new \WP_Query( $args );
 
 		$this->assertTrue( $query->elasticsearch_success );
-		$this->assertEquals( 3, $query->post_count );
-		$this->assertEquals( 3, $query->found_posts );
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -3232,6 +3232,49 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test an advanced meta filter query with integer key
+	 *
+	 * @since 4.5.0
+	 * @group post
+	 */
+	public function testMetaQueryIntegerKey() {
+		$this->ep_factory->post->create( array( 'post_content' => 'the post content findme' ), array( 'test_key' => 'value1' ) );
+		$this->ep_factory->post->create(
+			array(
+				'post_content' => 'the post content findme',
+				'meta_input'   => array(
+					'test_key'  => 'value1',
+					'test_key2' => 'value',
+				),
+			)
+		);
+		$this->ep_factory->post->create(
+			array(
+				'post_content' => 'post content findme',
+				'meta_input'   => array(
+					'test_key'  => 'value',
+					'test_key2' => 'value2',
+					'test_key3' => 'value',
+				),
+			)
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+		$args = array(
+			's'          => 'findme',
+			'meta_query' => array(
+				0 => array(),
+			),
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 3, $query->post_count );
+		$this->assertEquals( 3, $query->found_posts );
+	}
+
+	/**
 	 * Test a query that searches and filters by a meta value like the query
 	 *
 	 * @since 1.5


### PR DESCRIPTION
<!---->

### Description of the Change
This PR uses the WP Core sanitize_query method to sanitize the meta_query to resolve the `[bool] query does not support [must]` issue
<!--
Sanitize the meta query using the core's sanitization method

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3226 

### How to test the Change

- Install Debug bar and Debug Bar ElasticPress
- Enable the query logging in the EP settings.
- Add a meta query with an integer key and see that the query does not show the error in the debug bar.
- Example query:
```
new WP_Query(
		array(
			'posts_per_page' => 5,
			'no_found_rows' => true,
			'post_status' => 'publish',
			'meta_query' => array( 0 => array() ),
			'ep_integrate' => true,

		)
	);

```
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Sanitization of Meta Query

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
