### PR TITLE
Prevent using the EP if query has unsuported orderby

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -807,7 +807,14 @@ class Search extends Feature {
 			'parent',
 		];
 
-		if ( in_array( $query->get( 'orderby' ), $unsupported_orderby, true ) ) {
+		$orderby = $query->get( 'orderby' );
+		if ( is_array( $orderby ) ) {
+			$orderby = array_keys( $orderby );
+		} else {
+			$orderby = explode( ' ', $orderby );
+		}
+
+		if ( array_intersect( $orderby, $unsupported_orderby ) ) {
 			return true;
 		}
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -796,6 +796,10 @@ class Search extends Feature {
 	 * @since 4.5
 	 */
 	public function skip_query_integration( $skip, $query ) {
+		if ( $query instanceof \WP_Query ) {
+			return $skip;
+		}
+
 		$unsupported_orderby = [
 			'post__in',
 			'post_name__in',

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -791,8 +791,8 @@ class Search extends Feature {
 	/**
 	 * If WP_Query has unsupported orderby, skip ES query integration and use the WP query instead.
 	 *
-	 * @param bool $skip Whether to skip ES query integration
-	  * @param \WP_Query $query WP_Query object
+	 * @param bool      $skip Whether to skip ES query integration
+	 * @param \WP_Query $query WP_Query object
 	 * @since 4.5
 	 */
 	function skip_query_integration( $skip, $query ) {
@@ -800,7 +800,7 @@ class Search extends Feature {
 			'post__in',
 			'post_name__in',
 			'post_parent__in',
-			'parent'
+			'parent',
 		];
 
 		if ( in_array( $query->get( 'orderby' ), $unsupported_orderby, true ) ) {

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -795,7 +795,7 @@ class Search extends Feature {
 	 * @param \WP_Query $query WP_Query object
 	 * @since 4.5
 	 */
-	function skip_query_integration( $skip, $query ) {
+	public function skip_query_integration( $skip, $query ) {
 		$unsupported_orderby = [
 			'post__in',
 			'post_name__in',

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -794,6 +794,8 @@ class Search extends Feature {
 	 * @param bool      $skip Whether to skip ES query integration
 	 * @param \WP_Query $query WP_Query object
 	 * @since 4.5
+	 *
+	 * @return bool
 	 */
 	public function skip_query_integration( $skip, $query ) {
 		if ( ! $query instanceof \WP_Query ) {

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -796,7 +796,7 @@ class Search extends Feature {
 	 * @since 4.5
 	 */
 	public function skip_query_integration( $skip, $query ) {
-		if ( $query instanceof \WP_Query ) {
+		if ( ! $query instanceof \WP_Query ) {
 			return $skip;
 		}
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -807,14 +807,14 @@ class Search extends Feature {
 			'parent',
 		];
 
-		$orderby = $query->get( 'orderby' );
-		if ( is_array( $orderby ) ) {
-			$orderby = array_keys( $orderby );
-		} else {
-			$orderby = explode( ' ', $orderby );
+		$orderby = is_string( $query->get( 'orderby' ) ) ? explode( ' ', $query->get( 'orderby' ) ) : $query->get( 'orderby', 'date' );
+
+		$parse_orderby = array();
+		foreach ( $orderby as $key => $value ) {
+			$parse_orderby[] = is_string( $key ) ? $key : $value;
 		}
 
-		if ( array_intersect( $orderby, $unsupported_orderby ) ) {
+		if ( array_intersect( $parse_orderby, $unsupported_orderby ) ) {
 			return true;
 		}
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -110,6 +110,7 @@ class Search extends Feature {
 		add_filter( 'ep_post_filters', [ $this, 'exclude_posts_from_search' ], 10, 3 );
 		add_action( 'post_submitbox_misc_actions', [ $this, 'output_exclude_from_search_setting' ] );
 		add_action( 'edit_post', [ $this, 'save_exclude_from_search_meta' ], 10, 2 );
+		add_filter( 'ep_skip_query_integration', [ $this, 'skip_query_integration' ], 10, 2 );
 	}
 
 
@@ -785,5 +786,27 @@ class Search extends Feature {
 		$exclude_from_search = isset( $_POST['ep_exclude_from_search'] ) ? true : false;
 
 		update_post_meta( $post_id, 'ep_exclude_from_search', $exclude_from_search );
+	}
+
+	/**
+	 * If WP_Query has unsupported orderby, skip ES query integration and use the WP query instead.
+	 *
+	 * @param bool $skip Whether to skip ES query integration
+	  * @param \WP_Query $query WP_Query object
+	 * @since 4.5
+	 */
+	function skip_query_integration( $skip, $query ) {
+		$unsupported_orderby = [
+			'post__in',
+			'post_name__in',
+			'post_parent__in',
+			'parent'
+		];
+
+		if ( in_array( $query->get( 'orderby' ), $unsupported_orderby, true ) ) {
+			return true;
+		}
+
+		return $skip;
 	}
 }

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -793,8 +793,8 @@ class Search extends Feature {
 	 *
 	 * @param bool      $skip Whether to skip ES query integration
 	 * @param \WP_Query $query WP_Query object
-	 * @since 4.5
 	 *
+	 * @since 4.5
 	 * @return bool
 	 */
 	public function skip_query_integration( $skip, $query ) {

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -8371,6 +8371,15 @@ class TestPost extends BaseTestCase {
 		);
 		$this->assertNull( $query->elasticsearch_success );
 
+		// test for post__in with fallback to a title and without orders.
+		$query = new \WP_Query(
+			array(
+				'orderby'      => array( 'post__in', 'title'),
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
+
 		// test for post_name__in
 		$query = new \WP_Query(
 			array(

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -8353,6 +8353,24 @@ class TestPost extends BaseTestCase {
 		);
 		$this->assertNull( $query->elasticsearch_success );
 
+		// test for post__in with fallback to a title
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'post__in title',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
+
+		// test for post__in with fallback to a title and with different sort orders
+		$query = new \WP_Query(
+			array(
+				'orderby'      => array( 'post__in' => 'DESC', 'title' => 'ASC' ),
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
+
 		// test for post_name__in
 		$query = new \WP_Query(
 			array(

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -8337,4 +8337,39 @@ class TestPost extends BaseTestCase {
 		$ep_post = ElasticPress\Indexables::factory()->get( 'post' )->get( $product_id );
 		$this->assertArrayHasKey( '_thumbnail_id', $ep_post['meta'] );
 	}
+
+	/**
+	 * Test that query with unsupported orderby does not use EP.
+	 *
+	 * @since 4.5.0
+	 */
+	public function testQueryWithUnSupportedOrderByDoesNotUseEP() {
+		// test for post__in
+		$query = new \WP_Query( array(
+			'orderby' => 'post__in',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull( $query->elasticsearch_success  );
+
+		// test for post_name__in
+		$query = new \WP_Query( array(
+			'orderby' => 'post_name__in',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull( $query->elasticsearch_success  );
+
+		// test for post_parent__in
+		$query = new \WP_Query( array(
+			'orderby' => 'post_parent__in',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull(  $query->elasticsearch_success  );
+
+		// test for parent
+		$query = new \WP_Query( array(
+			'orderby' => 'parent',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull(  $query->elasticsearch_success  );
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -8345,31 +8345,39 @@ class TestPost extends BaseTestCase {
 	 */
 	public function testQueryWithUnSupportedOrderByDoesNotUseEP() {
 		// test for post__in
-		$query = new \WP_Query( array(
-			'orderby' => 'post__in',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull( $query->elasticsearch_success  );
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'post__in',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
 
 		// test for post_name__in
-		$query = new \WP_Query( array(
-			'orderby' => 'post_name__in',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull( $query->elasticsearch_success  );
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'post_name__in',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
 
 		// test for post_parent__in
-		$query = new \WP_Query( array(
-			'orderby' => 'post_parent__in',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull(  $query->elasticsearch_success  );
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'post_parent__in',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
 
 		// test for parent
-		$query = new \WP_Query( array(
-			'orderby' => 'parent',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull(  $query->elasticsearch_success  );
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'parent',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR prevents WordPress to use Elasticsearch if the Query does have unsupported orderby value

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3272 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Set the orderby => 'post__in' in WP_Query.
2. Check the query should not use Elasticsearch.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Prevent using the Elasticsearch if query has unsupported orderby



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
