### PR TITLE
WIP: always get a default weighting configuration when calling get_we…

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -181,6 +181,12 @@ class Weighting {
 	 * @return array
 	 */
 	public function get_weighting_configuration() {
+		foreach ( Features::factory()->get_registered_feature( 'search' )->get_searchable_post_types() as $post_type ) {
+			$defaults[ $post_type ] = $this->get_post_type_default_settings( $post_type );
+		}
+
+		$saved_weights = get_option( 'elasticpress_weighting', [] );
+
 		/**
 		 * Filter weighting configuration
 		 *
@@ -188,7 +194,7 @@ class Weighting {
 		 * @param  {array} $config Current configuration
 		 * @return  {array} New configuration
 		 */
-		return apply_filters( 'ep_weighting_configuration', get_option( 'elasticpress_weighting', [] ) );
+		return apply_filters( 'ep_weighting_configuration', wp_parse_args($saved_weights, $defaults ) );
 	}
 
 	/**


### PR DESCRIPTION
…ighting_configuration()

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3132 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
