### PR TITLE
Allow users to filter the number of results per page in Instant Results

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -24,6 +24,7 @@
         "wp-content/plugins/shorten-autosave.php": "./tests/cypress/wordpress-files/test-plugins/shorten-autosave.php",
         "wp-content/plugins/fake-log-messages.php": "./tests/cypress/wordpress-files/test-plugins/fake-log-messages.php",
         "wp-content/plugins/enable-debug-bar.php": "./tests/cypress/wordpress-files/test-plugins/enable-debug-bar.php",
+        "wp-content/plugins/filter-instant-results-per-page.php": "./tests/cypress/wordpress-files/test-plugins/filter-instant-results-per-page.php",
         "wp-content/uploads/content-example.xml": "./tests/cypress/wordpress-files/test-docs/content-example.xml"
       }
     }

--- a/docs/theme-integration.md
+++ b/docs/theme-integration.md
@@ -360,3 +360,16 @@ document.getElementById('search-blocks').addEventListener('click', () => {
 });
 </script>
 ```
+
+### Change the number of results per page
+
+As of ElasticPress 4.5.0 Instant Results will display the same number of results per page as the number of posts per page set in _Settings > Reading_. The `ep_instant_results_per_page` filter can be used to change the number of results per page independently of the number of posts per page:
+
+```
+add_filter(
+	'ep_instant_results_per_page',
+	function() {
+		return 12;
+	}
+);
+```

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -86,6 +86,7 @@ class InstantResults extends Feature {
 			'facets'        => 'post_type,category,post_tag',
 			'match_type'    => 'all',
 			'term_count'    => '1',
+			'per_page'      => get_option( 'posts_per_page', 6 ),
 		];
 
 		$settings = $this->get_settings() ? $this->get_settings() : array();
@@ -945,6 +946,15 @@ class InstantResults extends Feature {
 	 * @return array Search args schema.
 	 */
 	public function get_args_schema() {
+		/**
+		 * The number of resutls per page for Instant Results.
+		 *
+		 * @since 4.5.0
+		 * @hook ep_instant_results_per_page
+		 * @param {int} $per_page Results per page.
+		 */
+		$per_page = apply_filters( 'ep_instant_results_per_page', $this->settings['per_page'] );
+
 		$args = array(
 			'highlight' => array(
 				'type'          => 'string',
@@ -967,7 +977,7 @@ class InstantResults extends Feature {
 			),
 			'per_page'  => array(
 				'type'    => 'number',
-				'default' => 6,
+				'default' => absint( $per_page ),
 			),
 			'post_type' => array(
 				'type' => 'strings',

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -34,7 +34,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 	beforeEach(() => {
 		cy.deactivatePlugin(
-			'custom-instant-results-template open-instant-results-with-buttons',
+			'custom-instant-results-template open-instant-results-with-buttons filter-instant-results-per-page',
 			'wpCli',
 		);
 		cy.login();
@@ -222,6 +222,39 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				 */
 				cy.get('.my-custom-result').should('exist');
 				cy.get('.ep-search-result').should('not.exist');
+			});
+		});
+
+		it('Is possible to filter the number of results', () => {
+			/**
+			 * The number of results should match the posts per page
+			 * setting by default.
+			 */
+			cy.maybeEnableFeature('instant-results');
+			cy.visitAdminPage('options-reading.php');
+			cy.get('input[name="posts_per_page"]').then(($input) => {
+				const perPage = $input.val();
+
+				cy.visit('/');
+				cy.get('.wp-block-search').last().as('searchBlock');
+				cy.get('@searchBlock').find('input[type="search"]').type('block');
+				cy.get('@searchBlock').find('button').click();
+				cy.url().should('include', `per_page=${perPage}`);
+
+				/**
+				 * Activate test plugin with filter.
+				 */
+				cy.activatePlugin('filter-instant-results-per-page', 'wpCli');
+
+				/**
+				 * On searching the per_page parameter should reflect the
+				 * filtered value.
+				 */
+				cy.visit('/');
+				cy.get('.wp-block-search').last().as('searchBlock');
+				cy.get('@searchBlock').find('input[type="search"]').type('block');
+				cy.get('@searchBlock').find('button').click();
+				cy.url().should('include', 'per_page=3');
 			});
 		});
 	});

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -155,6 +155,39 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('#querylist').should('be.visible');
 			});
 
+			it('Is possible to filter the number of results', () => {
+				/**
+				 * The number of results should match the posts per page
+				 * setting by default.
+				 */
+				cy.maybeEnableFeature('instant-results');
+				cy.visitAdminPage('options-reading.php');
+				cy.get('input[name="posts_per_page"]').then(($input) => {
+					const perPage = $input.val();
+
+					cy.visit('/');
+					cy.get('.wp-block-search').last().as('searchBlock');
+					cy.get('@searchBlock').find('input[type="search"]').type('block');
+					cy.get('@searchBlock').find('button').click();
+					cy.url().should('include', `per_page=${perPage}`);
+
+					/**
+					 * Activate test plugin with filter.
+					 */
+					cy.activatePlugin('filter-instant-results-per-page', 'wpCli');
+
+					/**
+					 * On searching the per_page parameter should reflect the
+					 * filtered value.
+					 */
+					cy.visit('/');
+					cy.get('.wp-block-search').last().as('searchBlock');
+					cy.get('@searchBlock').find('input[type="search"]').type('block');
+					cy.get('@searchBlock').find('button').click();
+					cy.url().should('include', 'per_page=3');
+				});
+			});
+
 			it('Can filter results by price', () => {
 				/**
 				 * Add price range facet.
@@ -268,39 +301,6 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				 */
 				cy.get('.my-custom-result').should('exist');
 				cy.get('.ep-search-result').should('not.exist');
-			});
-		});
-
-		it('Is possible to filter the number of results', () => {
-			/**
-			 * The number of results should match the posts per page
-			 * setting by default.
-			 */
-			cy.maybeEnableFeature('instant-results');
-			cy.visitAdminPage('options-reading.php');
-			cy.get('input[name="posts_per_page"]').then(($input) => {
-				const perPage = $input.val();
-
-				cy.visit('/');
-				cy.get('.wp-block-search').last().as('searchBlock');
-				cy.get('@searchBlock').find('input[type="search"]').type('block');
-				cy.get('@searchBlock').find('button').click();
-				cy.url().should('include', `per_page=${perPage}`);
-
-				/**
-				 * Activate test plugin with filter.
-				 */
-				cy.activatePlugin('filter-instant-results-per-page', 'wpCli');
-
-				/**
-				 * On searching the per_page parameter should reflect the
-				 * filtered value.
-				 */
-				cy.visit('/');
-				cy.get('.wp-block-search').last().as('searchBlock');
-				cy.get('@searchBlock').find('input[type="search"]').type('block');
-				cy.get('@searchBlock').find('button').click();
-				cy.url().should('include', 'per_page=3');
 			});
 		});
 	});

--- a/tests/cypress/wordpress-files/test-plugins/filter-instant-results-per-page.php
+++ b/tests/cypress/wordpress-files/test-plugins/filter-instant-results-per-page.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Per Page
+ * Description: Filters the number of Instant Results per page for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ */
+
+add_filter( 'ep_instant_results_per_page', function() { return 3; } );


### PR DESCRIPTION
### Description of the Change
This PR does two things:

1. Sets the default number of results per page in Instant Results to match the number of posts per page as set in _Settings > Reading_. This is configured as the default value for a feature setting so that a UI could be supported in future.
2. Adds an `ep_instant_results_per_page` filter so developers can change the number of results per page in Instant Results.

Also included are a test for both of the above pieces of functionality and a section in the theme integration docs on using the filter.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3274

### How to test the Change
1. Activate Instant Results and perform a search. The number of results should match the number of posts per page as set in _Settings > Reading_.
2. Add code like `add_filter( 'ep_instant_results_per_page', function() { return 3; } );` and verify that the number of results per page matches the filtered value.

### Changelog Entry
> Added - An `ep_instant_results_per_page` filter for changing the number of results per page in Instant Results.
> Changed - The number of results per page in Instant Results now matches the site's posts per page setting.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
