### PR TITLE
Fix missing currency for price range facet.

### DIFF
--- a/assets/css/instant-results/result.css
+++ b/assets/css/instant-results/result.css
@@ -37,6 +37,7 @@
 
 	& img {
 		display: block;
+		height: auto;
 		margin: 0;
 		width: 100%;
 	}

--- a/assets/js/instant-results/components/facets/price-range-facet.js
+++ b/assets/js/instant-results/components/facets/price-range-facet.js
@@ -8,6 +8,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { useApiSearch } from '../../../api-search';
+import { currencyCode } from '../../config';
 import { formatPrice } from '../../utilities';
 import Panel from '../common/panel';
 import RangeSlider from '../common/range-slider';
@@ -49,8 +50,15 @@ export default ({ defaultIsOpen, label }) => {
 	/**
 	 * Current minimum and maximum prices, formatted.
 	 */
-	const currentMaxPrice = formatPrice(currentMaxValue, { maximumFractionDigits: 0 });
-	const currentMinPrice = formatPrice(currentMinValue, { maximumFractionDigits: 0 });
+	const currentMaxPrice = formatPrice(currentMaxValue, {
+		maximumFractionDigits: 0,
+		currency: currencyCode,
+	});
+
+	const currentMinPrice = formatPrice(currentMinValue, {
+		maximumFractionDigits: 0,
+		currency: currencyCode,
+	});
 
 	/**
 	 * Applied minimum and maximum values.
@@ -61,8 +69,8 @@ export default ({ defaultIsOpen, label }) => {
 	/**
 	 * Applied minimum and maximum prices, formatted.
 	 */
-	const maxPrice = formatPrice(maxValue, { maximumFractionDigits: 0 });
-	const minPrice = formatPrice(minValue, { maximumFractionDigits: 0 });
+	const maxPrice = formatPrice(maxValue, { maximumFractionDigits: 0, currency: currencyCode });
+	const minPrice = formatPrice(minValue, { maximumFractionDigits: 0, currency: currencyCode });
 
 	/**
 	 * Handle completed slider change.

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -18,6 +18,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 	}
 
 	before(() => {
+		cy.deactivatePlugin('woocommerce', 'wpCli');
 		cy.deactivatePlugin('classic-widgets', 'wpCli');
 		createSearchWidget();
 
@@ -62,6 +63,8 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 	describe('Instant Results Available', () => {
 		before(() => {
+			cy.activatePlugin('woocommerce');
+
 			if (!isEpIo) {
 				cy.activatePlugin('elasticpress-proxy');
 			}
@@ -150,6 +153,49 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 				cy.get('#wpadminbar li#wp-admin-bar-debug-bar').click();
 				cy.get('#querylist').should('be.visible');
+			});
+
+			it('Can filter results by price', () => {
+				/**
+				 * Add price range facet.
+				 */
+				cy.maybeEnableFeature('instant-results');
+				cy.visitAdminPage('admin.php?page=elasticpress');
+				cy.intercept('/wp-admin/admin-ajax.php*').as('ajaxRequest');
+				cy.get('.ep-feature-instant-results .settings-button').click();
+				cy.get('.ep-feature-instant-results .components-form-token-field__input').type(
+					'{backspace}{backspace}price{downArrow}{enter}{esc}',
+				);
+				cy.get('.ep-feature-instant-results .button-primary').click();
+				cy.wait('@ajaxRequest');
+
+				/**
+				 * Perform a search.
+				 */
+				cy.visit('/');
+				cy.intercept('*search=ergonomic*').as('apiRequest');
+				cy.get('.wp-block-search').last().as('searchBlock');
+				cy.get('@searchBlock').find('input[type="search"]').type('ergonomic');
+				cy.get('@searchBlock').find('button').click();
+				cy.get('.ep-search-modal').should('be.visible');
+				cy.wait('@apiRequest');
+				cy.get('.ep-search-result').should('have.length', 3);
+
+				/**
+				 * Adjusting the price range facet should filter results by price.
+				 */
+				cy.get('.ep-search-range-slider__thumb-0').as('priceThumb');
+				cy.get('@priceThumb').type('{rightArrow}');
+				cy.wait('@apiRequest');
+				cy.url().should('include', 'min_price=420');
+				cy.get('.ep-search-result').should('have.length', 2);
+
+				/**
+				 * Clearing the filter should return the unfiltered results.
+				 */
+				cy.get('.ep-search-tokens button').contains('420').click();
+				cy.wait('@apiRequest');
+				cy.get('.ep-search-result').should('have.length', 3);
 			});
 
 			it('Is possible to manually open Instant Results with a plugin', () => {


### PR DESCRIPTION
### Description of the Change
Fixes an issue in Instant Results where a currency was not used when formatting prices, which would cause Instant Results to crash when the price range facet was used. Also includes tests for the price range facet.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3279

### How to test the Change
1. Activate WooCommerce.
2. Activate Instant Results.
3. Add Price range to the Instant Results facets.
4. Sync.
5. Perform a search for products.
6. Instant Results should function as expected, and the price range facet should work as expected.

### Changelog Entry
_N/A, fixes an issue that does not exist in a release version_.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
