### PR TITLE
Add support for post_parent__in and post_parent__not_in

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1422,19 +1422,21 @@ class Post extends Indexable {
 		 * these filters by its usual numeric indices (see the array_values() call below.)
 		 */
 		$filters = [
-			'tax_query'        => $this->parse_tax_queries( $args, $query ),
-			'post_parent'      => $this->parse_post_parent( $args ),
-			'post__in'         => $this->parse_post__in( $args ),
-			'post_name__in'    => $this->parse_post_name__in( $args ),
-			'post__not_in'     => $this->parse_post__not_in( $args ),
-			'category__not_in' => $this->parse_category__not_in( $args ),
-			'tag__not_in'      => $this->parse_tag__not_in( $args ),
-			'author'           => $this->parse_author( $args ),
-			'post_mime_type'   => $this->parse_post_mime_type( $args ),
-			'date'             => $this->parse_date( $args ),
-			'meta_query'       => $this->parse_meta_queries( $args ),
-			'post_type'        => $this->parse_post_type( $args ),
-			'post_status'      => $this->parse_post_status( $args ),
+			'tax_query'           => $this->parse_tax_queries( $args, $query ),
+			'post_parent'         => $this->parse_post_parent( $args ),
+			'post_parent__in'     => $this->parse_post_parent__in( $args ),
+			'post_parent__not_in' => $this->parse_post_parent__not_in( $args ),
+			'post__in'            => $this->parse_post__in( $args ),
+			'post_name__in'       => $this->parse_post_name__in( $args ),
+			'post__not_in'        => $this->parse_post__not_in( $args ),
+			'category__not_in'    => $this->parse_category__not_in( $args ),
+			'tag__not_in'         => $this->parse_tag__not_in( $args ),
+			'author'              => $this->parse_author( $args ),
+			'post_mime_type'      => $this->parse_post_mime_type( $args ),
+			'date'                => $this->parse_date( $args ),
+			'meta_query'          => $this->parse_meta_queries( $args ),
+			'post_type'           => $this->parse_post_type( $args ),
+			'post_status'         => $this->parse_post_status( $args ),
 		];
 
 		/**
@@ -1730,6 +1732,52 @@ class Post extends Indexable {
 				'must' => [
 					'term' => [
 						'post_parent' => (int) $args['post_parent'],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `post_parent__in` WP Query arg and transform it into an ES query clause.
+	 *
+	 * @since 4.5.0
+	 * @param array $args WP_Query arguments
+	 * @return array
+	 */
+	protected function parse_post_parent__in( $args ) {
+		if ( empty( $args['post_parent__in'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must' => [
+					'terms' => [
+						'post_parent' => array_values( (array) $args['post_parent__in'] ),
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `post_parent__not_in` WP Query arg and transform it into an ES query clause.
+	 *
+	 * @since 4.5.0
+	 * @param array $args WP_Query arguments
+	 * @return array
+	 */
+	protected function parse_post_parent__not_in( $args ) {
+		if ( empty( $args['post_parent__not_in'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must_not' => [
+					'terms' => [
+						'post_parent' => array_values( (array) $args['post_parent__not_in'] ),
 					],
 				],
 			],

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4357,6 +4357,29 @@ class TestPost extends BaseTestCase {
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( $parent_post, $query->posts[0] );
+
+		// Test post_parent__in and post_parent__not_in queries
+		$args = array(
+			's'               => 'findme',
+			'post_parent__in' => array( $parent_post ),
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+
+		$args = array(
+			's'                   => 'findme',
+			'post_parent__not_in' => array( $parent_post ),
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4378,8 +4378,8 @@ class TestPost extends BaseTestCase {
 		$query = new \WP_Query( $args );
 
 		$this->assertTrue( $query->elasticsearch_success );
-		$this->assertEquals( 1, $query->post_count );
-		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR will add the support for post_parent__in and post_parent__not_in
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #558 

### How to test the Change

- Create EP-integrated WP Queries with post_parent__in and post_parent__not_in args and notice that it should add the proper clause in ES and should return the proper results

<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Support for post_parent__in and post_parent__not_in


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
