### PR TITLE
Use the elasticpress-facets style by handle

### DIFF
--- a/assets/js/blocks/facets/meta-range/block.json
+++ b/assets/js/blocks/facets/meta-range/block.json
@@ -16,5 +16,5 @@
 		"html": false
 	},
 	"editorScript": "ep-facets-meta-range-block-script",
-	"style": "file:/../../../../../dist/css/facets-styles.css"
+	"style": "elasticpress-facets"
 }

--- a/assets/js/blocks/facets/meta/block.json
+++ b/assets/js/blocks/facets/meta/block.json
@@ -30,5 +30,5 @@
 		"html": false
 	},
 	"editorScript": "ep-facets-meta-block-script",
-	"style": "file:/../../../../../dist/css/facets-styles.css"
+	"style": "elasticpress-facets"
 }

--- a/assets/js/blocks/facets/taxonomy/block.json
+++ b/assets/js/blocks/facets/taxonomy/block.json
@@ -26,5 +26,5 @@
 		"html": false
 	},
 	"editorScript": "ep-facets-block-script",
-	"style": "file:/../../../../../dist/css/facets-styles.css"
+	"style": "elasticpress-facets"
 }

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -104,6 +104,7 @@ class Facets extends Feature {
 		add_action( 'ep_valid_response', [ $this, 'get_aggs' ], 10, 4 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'front_scripts' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'front_scripts' ] );
 		add_action( 'ep_feature_box_settings_facets', [ $this, 'settings' ], 10, 1 );
 		add_filter( 'ep_post_formatted_args', [ $this, 'set_agg_filters' ], 10, 3 );
 		add_action( 'pre_get_posts', [ $this, 'facet_query' ] );


### PR DESCRIPTION
### Description of the Change

As stated in #3287, we add the same style several times for Facets blocks. We already have that same CSS file already registered with the `elasticpress-facets` handle, so this PR uses that instead.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3287

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Facets styles not enqueued more than once

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
