### PR TITLE
New X-ElasticPress-Request-ID header

### DIFF
--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -37,6 +37,7 @@ const Context = createContext();
  * @param {string} props.apiHost API Host.
  * @param {object} props.argsSchema Schema describing supported args.
  * @param {string} props.authorization Authorization header.
+ * @param {string} props.requestIdBase Base of Requests IDs.
  * @param {WPElement} props.children Component children.
  * @param {string} props.paramPrefix Prefix used to set and parse URL parameters.
  * @returns {WPElement} Component.
@@ -45,6 +46,7 @@ export const ApiSearchProvider = ({
 	apiEndpoint,
 	apiHost,
 	authorization,
+	requestIdBase,
 	argsSchema,
 	children,
 	paramPrefix,
@@ -82,7 +84,7 @@ export const ApiSearchProvider = ({
 	/**
 	 * Set up fetch method.
 	 */
-	const fetchResults = useFetchResults(apiHost, apiEndpoint, authorization);
+	const fetchResults = useFetchResults(apiHost, apiEndpoint, authorization, requestIdBase);
 
 	/**
 	 * Set up the reducer.

--- a/assets/js/api-search/src/hooks.js
+++ b/assets/js/api-search/src/hooks.js
@@ -38,8 +38,9 @@ export const useFetchResults = (apiHost, apiEndpoint, Authorization, requestIdBa
 			Authorization,
 		};
 
-		if (requestIdBase) {
-			headers['X-ElasticPress-Request-ID'] = generateRequestId(requestIdBase);
+		const requestId = generateRequestId(requestIdBase);
+		if (requestId) {
+			headers['X-ElasticPress-Request-ID'] = requestId;
 		}
 
 		request.current = fetch(url, {

--- a/assets/js/api-search/src/hooks.js
+++ b/assets/js/api-search/src/hooks.js
@@ -4,14 +4,20 @@
 import { useCallback, useRef } from '@wordpress/element';
 
 /**
+ * Internal dependencies.
+ */
+import { generateRequestId } from '../../utils/helpers';
+
+/**
  * Get a callback function for retrieving search results.
  *
  * @param {string} apiHost API host.
  * @param {string} apiEndpoint API endpoint.
  * @param {string} Authorization Authorization header.
+ * @param {string} requestIdBase Base of Request IDs.
  * @returns {Function} Function for retrieving search results.
  */
-export const useFetchResults = (apiHost, apiEndpoint, Authorization) => {
+export const useFetchResults = (apiHost, apiEndpoint, Authorization, requestIdBase = '') => {
 	const abort = useRef(new AbortController());
 	const request = useRef(null);
 
@@ -27,12 +33,18 @@ export const useFetchResults = (apiHost, apiEndpoint, Authorization) => {
 		abort.current.abort();
 		abort.current = new AbortController();
 
+		const headers = {
+			Accept: 'application/json',
+			Authorization,
+		};
+
+		if (requestIdBase) {
+			headers['X-ElasticPress-Request-ID'] = generateRequestId(requestIdBase);
+		}
+
 		request.current = fetch(url, {
 			signal: abort.current.signal,
-			headers: {
-				Accept: 'application/json',
-				Authorization,
-			},
+			headers,
 		})
 			.then((response) => {
 				return response.json();
@@ -49,5 +61,5 @@ export const useFetchResults = (apiHost, apiEndpoint, Authorization) => {
 		return request.current;
 	};
 
-	return useCallback(fetchResults, [apiHost, apiEndpoint, Authorization]);
+	return useCallback(fetchResults, [apiHost, apiEndpoint, Authorization, requestIdBase]);
 };

--- a/assets/js/autosuggest/index.js
+++ b/assets/js/autosuggest/index.js
@@ -15,6 +15,7 @@ import {
 	replaceGlobally,
 	debounce,
 	domReady,
+	generateRequestId,
 } from '../utils/helpers';
 
 const { epas } = window;
@@ -190,6 +191,12 @@ async function esSearch(query, searchTerm) {
 	// only applies headers if using ep.io endpoint
 	if (epas.addSearchTermHeader) {
 		fetchConfig.headers['EP-Search-Term'] = encodeURI(searchTerm);
+	}
+
+	// only add a request ID if using ep.io endpoint
+	const requestId = generateRequestId(epas?.requestIdBase || '');
+	if (requestId) {
+		fetchConfig.headers['X-ElasticPress-Request-ID'] = requestId;
 	}
 
 	try {

--- a/assets/js/instant-results/config.js
+++ b/assets/js/instant-results/config.js
@@ -19,6 +19,7 @@ const {
 	postTypeLabels,
 	taxonomyLabels,
 	termCount,
+	requestIdBase,
 } = window.epInstantResults;
 
 /**
@@ -74,4 +75,5 @@ export {
 	sortOptions,
 	taxonomyLabels,
 	termCount,
+	requestIdBase,
 };

--- a/assets/js/instant-results/index.js
+++ b/assets/js/instant-results/index.js
@@ -7,7 +7,7 @@ import { render } from '@wordpress/element';
  * Internal dependencies.
  */
 import { ApiSearchProvider } from '../api-search';
-import { apiEndpoint, apiHost, argsSchema, paramPrefix } from './config';
+import { apiEndpoint, apiHost, argsSchema, paramPrefix, requestIdBase } from './config';
 import Modal from './apps/modal';
 
 /**
@@ -22,6 +22,7 @@ const init = () => {
 			apiHost={apiHost}
 			argsSchema={argsSchema}
 			paramPrefix={paramPrefix}
+			requestIdBase={requestIdBase}
 		>
 			<Modal />
 		</ApiSearchProvider>,

--- a/assets/js/utils/helpers.js
+++ b/assets/js/utils/helpers.js
@@ -1,4 +1,14 @@
 /**
+ * WordPress dependencies.
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * External dependencies.
+ */
+import { v4 as uuidv4 } from 'uuid';
+
+/**
  * Simple throttling function for waiting a set amount of time after the last keypress
  * So we don't overload the server with too many requests at once
  *
@@ -154,4 +164,25 @@ export const domReady = (callback) => {
 
 	// DOMContentLoaded has not fired yet, delay callback until then.
 	document.addEventListener('DOMContentLoaded', callback);
+};
+
+/**
+ * Generate a Request ID for autosuggest
+ *
+ * @param {string} requestIdBase - base for request ID generation
+ * @returns {string} Request ID
+ */
+export const generateRequestId = (requestIdBase) => {
+	const uuid = uuidv4().replaceAll('-', '');
+
+	/**
+	 * Filter the request ID used for an autosuggest request.
+	 *
+	 * @filter ep.Autosuggest.requestId
+	 * @since 4.5.0
+	 *
+	 * @param {string} requestId The Request ID.
+	 * @returns {string} New Request ID.
+	 */
+	return applyFilters('ep.requestId', requestIdBase + uuid);
 };

--- a/assets/js/woocommerce/admin/orders/config.js
+++ b/assets/js/woocommerce/admin/orders/config.js
@@ -10,6 +10,7 @@ const {
 	dateFormat,
 	statusLabels,
 	timeFormat,
+	requestIdBase,
 } = window.epWooCommerceAdminOrders;
 
 export {
@@ -21,4 +22,5 @@ export {
 	dateFormat,
 	statusLabels,
 	timeFormat,
+	requestIdBase,
 };

--- a/assets/js/woocommerce/admin/orders/index.js
+++ b/assets/js/woocommerce/admin/orders/index.js
@@ -18,6 +18,7 @@ import {
 	dateFormat,
 	statusLabels,
 	timeFormat,
+	requestIdBase,
 } from './config';
 
 /**
@@ -41,6 +42,7 @@ const init = () => {
 			apiHost={apiHost}
 			argsSchema={argsSchema}
 			authorization={authorization}
+			requestIdBase={requestIdBase}
 			defaultIsOn
 		>
 			<App

--- a/bin/es-docker/elasticsearch.yml
+++ b/bin/es-docker/elasticsearch.yml
@@ -4,4 +4,4 @@ http.host: 0.0.0.0
 http.cors.enabled : true
 http.cors.allow-origin : "*"
 http.cors.allow-methods : OPTIONS, HEAD, GET, POST, PUT, DELETE
-http.cors.allow-headers : X-Requested-With,X-Auth-Token,Content-Type, Content-Length
+http.cors.allow-headers : X-Requested-With,X-Auth-Token,x-elasticpress-request-id,Content-Type,Content-Length

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -627,6 +627,11 @@ class Elasticsearch {
 			// phpcs:enable
 		}
 
+		$request_id = Utils\generate_request_id();
+		if ( ! empty( $request_id ) ) {
+			$headers['X-ElasticPress-Request-ID'] = $request_id;
+		}
+
 		/**
 		 * Filter Elasticsearch request headers
 		 *

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -458,6 +458,7 @@ class Autosuggest extends Feature {
 			'http_headers'        => apply_filters( 'ep_autosuggest_http_headers', [] ),
 			'triggerAnalytics'    => ! empty( $settings['trigger_ga_event'] ),
 			'addSearchTermHeader' => false,
+			'requestIdBase'       => Utils\get_request_id_base(),
 		];
 
 		if ( Utils\is_epio() ) {

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -317,6 +317,7 @@ class InstantResults extends Feature {
 				'paramPrefix'    => 'ep-',
 				'postTypeLabels' => $this->get_post_type_labels(),
 				'termCount'      => $this->settings['term_count'],
+				'requestIdBase'  => Utils\get_request_id_base(),
 			)
 		);
 	}

--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -145,6 +145,7 @@ class Orders {
 				'dateFormat'    => wc_date_format(),
 				'statusLabels'  => wc_get_order_statuses(),
 				'timeFormat'    => wc_time_format(),
+				'requestIdBase' => Utils\get_request_id_base(),
 			)
 		);
 	}

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -268,12 +268,17 @@ class QueryLogger {
 			}
 		}
 
+		$request_id = ( ! empty( $query['args']['headers'] ) && ! empty( $query['args']['headers']['X-ElasticPress-Request-ID'] ) ) ?
+			$query['args']['headers']['X-ElasticPress-Request-ID'] :
+			null;
+
 		$status = wp_remote_retrieve_response_code( $query['request'] );
 		$result = json_decode( wp_remote_retrieve_body( $query['request'] ), true );
 
 		$formatted_log = [
 			'wp_url'      => home_url( add_query_arg( [ $_GET ], $wp->request ) ), // phpcs:ignore WordPress.Security.NonceVerification
 			'es_req'      => $query['args']['method'] . ' ' . $query['url'],
+			'request_id'  => $request_id ?? '',
 			'timestamp'   => current_time( 'timestamp' ),
 			'query_time'  => $query_time,
 			'wp_args'     => $query['query_args'] ?? [],

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -58,6 +58,7 @@ class FailedQueries extends Report {
 		$labels = [
 			'wp_url'      => esc_html__( 'Page URL', 'elasticpress' ),
 			'es_req'      => esc_html__( 'Elasticsearch Request', 'elasticpress' ),
+			'request_id'  => esc_html__( 'Request ID', 'elasticpress' ),
 			'timestamp'   => esc_html__( 'Time', 'elasticpress' ),
 			'query_time'  => esc_html__( 'Time Spent (ms)', 'elasticpress' ),
 			'wp_args'     => esc_html__( 'WP Query Args', 'elasticpress' ),

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -689,3 +689,45 @@ function get_sync_url( bool $do_sync = false ) : string {
 		network_admin_url( $page ) :
 		admin_url( $page );
 }
+
+/**
+ * Generate a common prefix to be used while generating a request ID.
+ *
+ * Uses the return of `get_index_prefix()` by default.
+ *
+ * @since 4.5.0
+ * @return string
+ */
+function get_request_id_base() {
+	/**
+	 * Filter the base of requests IDs. Uses the return of `get_index_prefix()` by default.
+	 *
+	 * @hook ep_request_id_base
+	 * @since 4.5.0
+	 * @param {string} $request_id_base Request ID base
+	 * @return {string} New Request ID base
+	 */
+	return apply_filters( 'ep_request_id_base', str_replace( '-', '', get_index_prefix() ) );
+}
+
+/**
+ * Generate a Request ID.
+ *
+ * The function concatenates the indices prefix to a random UUID4.
+ *
+ * @since 4.5.0
+ * @return string
+ */
+function generate_request_id() : string {
+	$uuid = str_replace( '-', '', wp_generate_uuid4() );
+
+	/**
+	 * Filter the ID generated to identify a request.
+	 *
+	 * @hook ep_request_id
+	 * @since 4.5.0
+	 * @param {string} $request_id Request ID. By default formed by the indices prefix and a random UUID4.
+	 * @return {string} New Request ID
+	 */
+	return apply_filters( 'ep_request_id', get_request_id_base() . $uuid );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "focus-trap-react": "^8.8.2",
         "react-beautiful-dnd": "^11.0.5",
         "react-slider": "^1.3.1",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@4tw/cypress-drag-drop": "^2.2.1",
@@ -2336,6 +2336,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cypress/xvfb": {
@@ -18093,6 +18102,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -19748,8 +19766,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -22155,6 +22174,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "@cypress/xvfb": {
@@ -33291,6 +33318,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -34514,7 +34549,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "focus-trap-react": "^8.8.2",
     "react-beautiful-dnd": "^11.0.5",
     "react-slider": "^1.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.0"
   },
   "overrides": {
     "eslint-plugin-jsdoc": "^39.4.0"

--- a/tests/cypress/integration/features/autosuggest.cy.js
+++ b/tests/cypress/integration/features/autosuggest.cy.js
@@ -13,7 +13,14 @@ describe('Autosuggest Feature', () => {
 	it('Can see post in autosuggest list', () => {
 		cy.visit('/');
 
+		cy.intercept('*-post-*').as('apiRequest');
+
 		cy.get('.wp-block-search__input').type('Markup: HTML Tags and Formatting');
+
+		cy.wait('@apiRequest')
+			.its('request.headers')
+			.should('have.property', 'x-elasticpress-request-id');
+
 		cy.get('.ep-autosuggest').should(($autosuggestList) => {
 			// eslint-disable-next-line no-unused-expressions
 			expect($autosuggestList).to.be.visible;

--- a/tests/cypress/integration/features/autosuggest.cy.js
+++ b/tests/cypress/integration/features/autosuggest.cy.js
@@ -13,13 +13,16 @@ describe('Autosuggest Feature', () => {
 	it('Can see post in autosuggest list', () => {
 		cy.visit('/');
 
-		cy.intercept('*-post-*').as('apiRequest');
+		cy.intercept({
+			url: /(_search|autosuggest)$/,
+			headers: {
+				'X-ElasticPress-Request-ID': /[0-9a-f]{32}$/,
+			},
+		}).as('apiRequest');
 
 		cy.get('.wp-block-search__input').type('Markup: HTML Tags and Formatting');
 
-		cy.wait('@apiRequest')
-			.its('request.headers')
-			.should('have.property', 'x-elasticpress-request-id');
+		cy.wait('@apiRequest');
 
 		cy.get('.ep-autosuggest').should(($autosuggestList) => {
 			// eslint-disable-next-line no-unused-expressions

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -125,7 +125,10 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('.ep-search-modal').as('searchModal').should('be.visible'); // Should be visible immediatly
 				cy.url().should('include', 'search=blog');
 
-				cy.wait('@apiRequest');
+				cy.wait('@apiRequest')
+					.its('request.headers')
+					.should('have.property', 'x-elasticpress-request-id');
+
 				cy.get('@searchModal').should('contain.text', 'blog');
 				// Show the number of results
 				cy.get('@searchModal').find('.ep-search-results__title').contains(/\d+/);

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -114,7 +114,12 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 			it('Can see instant results elements, URL changes, reload, and update after changing search term', () => {
 				cy.maybeEnableFeature('instant-results');
 
-				cy.intercept('*search=blog*').as('apiRequest');
+				cy.intercept({
+					url: '*search=blog*',
+					headers: {
+						'X-ElasticPress-Request-ID': /[0-9a-f]{32}$/,
+					},
+				}).as('apiRequest');
 
 				cy.visit('/');
 
@@ -125,9 +130,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('.ep-search-modal').as('searchModal').should('be.visible'); // Should be visible immediatly
 				cy.url().should('include', 'search=blog');
 
-				cy.wait('@apiRequest')
-					.its('request.headers')
-					.should('have.property', 'x-elasticpress-request-id');
+				cy.wait('@apiRequest');
 
 				cy.get('@searchModal').should('contain.text', 'blog');
 				// Show the number of results

--- a/tests/cypress/support/global-hooks.js
+++ b/tests/cypress/support/global-hooks.js
@@ -14,6 +14,7 @@ before(() => {
 		if ( ! $is_epio ) {
 			$host            = \\ElasticPress\\Utils\\get_host();
 			$host            = str_replace( '172.17.0.1', 'localhost', $host );
+			$host            = str_replace( 'host.docker.internal', 'localhost', $host );
 			$index_name      = \\ElasticPress\\Indexables::factory()->get( 'post' )->get_index_name();
 			$as_endpoint_url = $host . $index_name . '/_search';
 			

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -8,6 +8,7 @@
 namespace ElasticPressTest;
 
 use ElasticPress;
+use ElasticPress\Utils;
 
 /**
  * Dashboard test class
@@ -215,5 +216,58 @@ class TestUtils extends BaseTestCase {
 		} else {
 			$this->assertStringContainsString( 'wp-admin/admin.php?page=elasticpress-sync&do_sync', $sync_url );
 		}
+	}
+
+	/**
+	 * Test the `get_request_id_base` function
+	 * 
+	 * @since 4.5.0
+	 */
+	public function testGetRequestIdBase() {
+		/**
+		 * Use the `ep_index_prefix` filter so `get_index_prefix()` can return something.
+		 */
+		$custom_index_prefix = function() {
+			return 'custom-prefix';
+		};
+		add_filter( 'ep_index_prefix', $custom_index_prefix );
+		$this->assertEquals( 'customprefix', Utils\get_request_id_base() ); // `-` are removed
+
+		/**
+		 * Test the `ep_request_id_base` filter
+		 */
+		$custom_request_id_base = function( $base ) {
+			return $base . '-plus';
+		};
+		add_filter( 'ep_request_id_base', $custom_request_id_base );
+		$this->assertEquals( 'customprefix-plus', Utils\get_request_id_base() );
+	}
+
+	/**
+	 * Test the `generate_request_id` function
+	 *
+	 * @since 4.5.0
+	 */
+	public function testGenerateRequestId() {
+		$this->assertMatchesRegularExpression( '/[0-9a-f]{32}/', Utils\generate_request_id() );
+
+		/**
+		 * Use the `ep_request_id_base` filter so `get_request_id_base()` can return something.
+		 */
+		$custom_request_id_base = function() {
+			return 'indexprefix';
+		};
+		add_filter( 'ep_request_id_base', $custom_request_id_base );
+		$this->assertMatchesRegularExpression( '/indexprefix[0-9a-f]{32}/', Utils\generate_request_id() );
+
+		/**
+		 * Test the `ep_request_id` filter
+		 */
+		$custom_request_id = function( $request_id ) {
+			$this->assertMatchesRegularExpression( '/indexprefix[0-9a-f]{32}/', $request_id );
+			return 'totally-new-request-id';
+		};
+		add_filter( 'ep_request_id', $custom_request_id );
+		$this->assertEquals( 'totally-new-request-id', Utils\generate_request_id() );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3305

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Requests now have a new header called X-ElasticPress-Request-ID to help with debugging.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia, @dustinrue 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
