### PR TITLE
Facets - Display term count

### DIFF
--- a/assets/js/blocks/facets/meta/block.json
+++ b/assets/js/blocks/facets/meta/block.json
@@ -15,6 +15,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"displayCount": {
+			"type": "boolean",
+			"default": false
+		},
 		"orderby": {
 			"type"   : "string",
 			"default": "count",

--- a/assets/js/blocks/facets/meta/edit.js
+++ b/assets/js/blocks/facets/meta/edit.js
@@ -5,6 +5,7 @@ import {
 	PanelBody,
 	RadioControl,
 	TextControl,
+	ToggleControl,
 	Spinner,
 	Placeholder,
 	SelectControl,
@@ -24,7 +25,7 @@ const FacetBlockEdit = (props) => {
 	const [metaKeys, setMetaKeys] = useState([]);
 	const [preview, setPreview] = useState('');
 	const [loading, setLoading] = useState(false);
-	const { searchPlaceholder, facet, orderby, order } = attributes;
+	const { searchPlaceholder, facet, displayCount, orderby, order } = attributes;
 
 	const blockProps = useBlockProps();
 
@@ -42,6 +43,7 @@ const FacetBlockEdit = (props) => {
 		const params = new URLSearchParams({
 			searchPlaceholder,
 			facet,
+			displayCount,
 			orderby,
 			order,
 		});
@@ -50,7 +52,7 @@ const FacetBlockEdit = (props) => {
 		})
 			.then((preview) => setPreview(preview))
 			.finally(() => setLoading(false));
-	}, [searchPlaceholder, facet, orderby, order]);
+	}, [searchPlaceholder, facet, displayCount, orderby, order]);
 
 	return (
 		<Fragment>
@@ -79,6 +81,11 @@ const FacetBlockEdit = (props) => {
 							})),
 						]}
 						onChange={(value) => setAttributes({ facet: value })}
+					/>
+					<ToggleControl
+						checked={displayCount}
+						onChange={(value) => setAttributes({ displayCount: value })}
+						label={__('Display Term Count', 'elasticpress')}
 					/>
 					<RadioControl
 						label={__('Order By', 'elasticpress')}

--- a/assets/js/blocks/facets/taxonomy/block.json
+++ b/assets/js/blocks/facets/taxonomy/block.json
@@ -11,6 +11,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"displayCount": {
+			"type": "boolean",
+			"default": false
+		},
 		"orderby": {
 			"type"   : "string",
 			"default": "count",

--- a/assets/js/blocks/facets/taxonomy/edit.js
+++ b/assets/js/blocks/facets/taxonomy/edit.js
@@ -4,6 +4,7 @@ import {
 	RadioControl,
 	SelectControl,
 	Spinner,
+	ToggleControl,
 	Placeholder,
 } from '@wordpress/components';
 import { Fragment, useEffect, useState, useCallback } from '@wordpress/element';
@@ -15,7 +16,7 @@ const FacetBlockEdit = (props) => {
 	const [taxonomies, setTaxonomies] = useState({});
 	const [preview, setPreview] = useState('');
 	const [loading, setLoading] = useState(false);
-	const { facet, orderby, order } = attributes;
+	const { facet, displayCount, orderby, order } = attributes;
 
 	const blockProps = useBlockProps();
 
@@ -32,6 +33,7 @@ const FacetBlockEdit = (props) => {
 		setLoading(true);
 		const params = new URLSearchParams({
 			facet,
+			displayCount,
 			orderby,
 			order,
 		});
@@ -40,7 +42,7 @@ const FacetBlockEdit = (props) => {
 		})
 			.then((preview) => setPreview(preview))
 			.finally(() => setLoading(false));
-	}, [facet, orderby, order]);
+	}, [facet, displayCount, orderby, order]);
 
 	return (
 		<Fragment>
@@ -56,6 +58,11 @@ const FacetBlockEdit = (props) => {
 							})),
 						]}
 						onChange={(value) => setAttributes({ facet: value })}
+					/>
+					<ToggleControl
+						checked={displayCount}
+						onChange={(value) => setAttributes({ displayCount: value })}
+						label={__('Display Term Count', 'elasticpress')}
 					/>
 					<RadioControl
 						label={__('Order By', 'elasticpress')}

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -167,13 +167,30 @@ abstract class Feature {
 	/**
 	 * Return feature settings
 	 *
-	 * @since  2.2.1
-	 * @return array|bool
+	 * @since  2.2.1, 4.5.0 started using default settings
+	 * @return array
 	 */
 	public function get_settings() {
-		$feature_settings = Utils\get_option( 'ep_feature_settings', [] );
+		$all_settings = Utils\get_option( 'ep_feature_settings', [] );
 
-		return ( ! empty( $feature_settings[ $this->slug ] ) ) ? $feature_settings[ $this->slug ] : false;
+		$feature_settings = ( ! empty( $all_settings[ $this->slug ] ) ) ? (array) $all_settings[ $this->slug ] : [];
+
+		$feature_settings = wp_parse_args( $feature_settings, $this->default_settings );
+
+		return $feature_settings;
+	}
+
+	/**
+	 * Return a specific setting of the feature
+	 *
+	 * @since 4.5.0
+	 * @param string $setting_name The setting name
+	 * @return mixed
+	 */
+	public function get_setting( string $setting_name ) {
+		$settings = $this->get_settings();
+
+		return isset( $settings[ $setting_name ] ) ? $settings[ $setting_name ] : null;
 	}
 
 	/**

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -46,8 +46,7 @@ class Facets extends Feature {
 		$this->requires_install_reindex = false;
 
 		$this->default_settings = [
-			'match_type'    => 'all',
-			'display_count' => 0,
+			'match_type' => 'all',
 		];
 
 		$types = [
@@ -131,13 +130,6 @@ class Facets extends Feature {
 				<label><input name="settings[match_type]" type="radio" <?php checked( $settings['match_type'], 'all' ); ?> value="all"><?php echo wp_kses_post( __( 'Show any content tagged to <strong>all</strong> selected terms', 'elasticpress' ) ); ?></label><br>
 				<label><input name="settings[match_type]" type="radio" <?php checked( $settings['match_type'], 'any' ); ?> value="any"><?php echo wp_kses_post( __( 'Show all content tagged to <strong>any</strong> selected term', 'elasticpress' ) ); ?></label>
 				<p class="field-description"><?php esc_html_e( '"All" will only show content that matches all facets. "Any" will show content that matches any facet.', 'elasticpress' ); ?></p>
-			</div>
-		</div>
-		<div class="field">
-			<div class="field-name status"><?php esc_html_e( 'Display Count', 'elasticpress' ); ?></div>
-			<div class="input-wrap">
-				<label><input name="settings[display_count]" type="radio" <?php checked( $settings['display_count'] ); ?> value="1"><?php esc_html_e( 'Enabled', 'elasticpress' ); ?></label><br>
-				<label><input name="settings[display_count]" type="radio" <?php checked( ! $settings['display_count'] ); ?> value="0"><?php esc_html_e( 'Disabled', 'elasticpress' ); ?></label>
 			</div>
 		</div>
 		<?php

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -46,7 +46,8 @@ class Facets extends Feature {
 		$this->requires_install_reindex = false;
 
 		$this->default_settings = [
-			'match_type' => 'all',
+			'match_type'    => 'all',
+			'display_count' => 0,
 		];
 
 		$types = [
@@ -130,6 +131,13 @@ class Facets extends Feature {
 				<label><input name="settings[match_type]" type="radio" <?php checked( $settings['match_type'], 'all' ); ?> value="all"><?php echo wp_kses_post( __( 'Show any content tagged to <strong>all</strong> selected terms', 'elasticpress' ) ); ?></label><br>
 				<label><input name="settings[match_type]" type="radio" <?php checked( $settings['match_type'], 'any' ); ?> value="any"><?php echo wp_kses_post( __( 'Show all content tagged to <strong>any</strong> selected term', 'elasticpress' ) ); ?></label>
 				<p class="field-description"><?php esc_html_e( '"All" will only show content that matches all facets. "Any" will show content that matches any facet.', 'elasticpress' ); ?></p>
+			</div>
+		</div>
+		<div class="field">
+			<div class="field-name status"><?php esc_html_e( 'Display Count', 'elasticpress' ); ?></div>
+			<div class="input-wrap">
+				<label><input name="settings[display_count]" type="radio" <?php checked( $settings['display_count'] ); ?> value="1"><?php esc_html_e( 'Enabled', 'elasticpress' ); ?></label><br>
+				<label><input name="settings[display_count]" type="radio" <?php checked( ! $settings['display_count'] ); ?> value="0"><?php esc_html_e( 'Disabled', 'elasticpress' ); ?></label>
 			</div>
 		</div>
 		<?php

--- a/includes/classes/Feature/Facets/Types/Meta/Block.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Block.php
@@ -51,6 +51,9 @@ class Block {
 					'searchPlaceholder' => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
+					'displayCount'      => [
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					],
 					'facet'             => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
@@ -168,6 +171,7 @@ class Block {
 		$attributes = $this->parse_attributes(
 			[
 				'searchPlaceholder' => $request->get_param( 'searchPlaceholder' ),
+				'displayCount'      => $request->get_param( 'displayCount' ),
 				'facet'             => $request->get_param( 'facet' ),
 				'orderby'           => $request->get_param( 'orderby' ),
 				'order'             => $request->get_param( 'order' ),
@@ -225,6 +229,7 @@ class Block {
 			[
 				'searchPlaceholder' => esc_html_x( 'Search', 'Facet by meta search placeholder', 'elasticpress' ),
 				'facet'             => '',
+				'displayCount'      => false,
 				'orderby'           => 'count',
 				'order'             => 'desc',
 

--- a/includes/classes/Feature/Facets/Types/Meta/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Renderer.php
@@ -26,6 +26,13 @@ class Renderer {
 	protected $meta_field = '';
 
 	/**
+	 * Whether the term count should be displayed or not.
+	 *
+	 * @var bool
+	 */
+	protected $display_count = false;
+
+	/**
 	 * Output the widget or block HTML.
 	 *
 	 * @param array $args     Widget args
@@ -61,6 +68,8 @@ class Renderer {
 
 		$selected_meta    = $this->get_selected_meta();
 		$selected_filters = $feature->get_selected();
+
+		$this->display_count = $feature->get_setting( 'display_count' );
 
 		/**
 		 * Get all the terms so we know if we should output the widget
@@ -182,6 +191,11 @@ class Renderer {
 			esc_url( $url )
 		);
 
+		$label = $value['name'];
+		if ( $this->display_count ) {
+			$label .= ' <span>(' . $value['count'] . ')</span>';
+		}
+
 		/**
 		 * Filter the label for an individual meta value.
 		 *
@@ -191,7 +205,7 @@ class Renderer {
 		 * @param {array}  $value Value array. It contains `value`, `name`, `count`, and `is_selected`.
 		 * @return {string} Individual facet meta value label.
 		 */
-		$label = apply_filters( 'ep_facet_meta_value_label', $value['name'], $value );
+		$label = apply_filters( 'ep_facet_meta_value_label', $label, $value );
 
 		/**
 		 * Filter the accessible label for an individual facet meta value link.

--- a/includes/classes/Feature/Facets/Types/Meta/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Renderer.php
@@ -46,7 +46,8 @@ class Renderer {
 			]
 		);
 
-		$this->meta_field = $instance['facet'];
+		$this->meta_field    = $instance['facet'];
+		$this->display_count = $instance['displayCount'];
 
 		if ( ! $this->should_render() ) {
 			return;
@@ -68,8 +69,6 @@ class Renderer {
 
 		$selected_meta    = $this->get_selected_meta();
 		$selected_filters = $feature->get_selected();
-
-		$this->display_count = $feature->get_setting( 'display_count' );
 
 		/**
 		 * Get all the terms so we know if we should output the widget

--- a/includes/classes/Feature/Facets/Types/Taxonomy/Block.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Block.php
@@ -48,13 +48,16 @@ class Block {
 				'permission_callback' => [ $this, 'check_facets_taxonomies_rest_permission' ],
 				'callback'            => [ $this, 'render_block_preview' ],
 				'args'                => [
-					'facet'   => [
+					'facet'        => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'orderby' => [
+					'displayCount' => [
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					],
+					'orderby'      => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'order'   => [
+					'order'        => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
@@ -189,9 +192,10 @@ class Block {
 
 		$attributes = $this->parse_attributes(
 			[
-				'facet'   => $request->get_param( 'facet' ),
-				'orderby' => $request->get_param( 'orderby' ),
-				'order'   => $request->get_param( 'order' ),
+				'facet'        => $request->get_param( 'facet' ),
+				'displayCount' => $request->get_param( 'displayCount' ),
+				'orderby'      => $request->get_param( 'orderby' ),
+				'order'        => $request->get_param( 'order' ),
 			]
 		);
 
@@ -229,9 +233,10 @@ class Block {
 		$attributes = wp_parse_args(
 			$attributes,
 			[
-				'facet'   => '',
-				'orderby' => 'count',
-				'order'   => 'desc',
+				'facet'        => '',
+				'displayCount' => '',
+				'orderby'      => 'count',
+				'order'        => 'desc',
 
 			]
 		);

--- a/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
@@ -53,8 +53,6 @@ class Renderer {
 
 		$feature = Features::factory()->get_registered_feature( 'facets' );
 
-		$this->display_count = $feature->get_setting( 'display_count' );
-
 		if ( $wp_query->get( 'ep_facet', false ) && ! $feature->is_facetable( $wp_query ) ) {
 			return false;
 		}
@@ -69,7 +67,8 @@ class Renderer {
 			return;
 		}
 
-		$taxonomy = $instance['facet'];
+		$taxonomy            = $instance['facet'];
+		$this->display_count = $instance['displayCount'];
 
 		if ( ! is_search() ) {
 

--- a/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
@@ -20,6 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Renderer {
 	/**
+	 * Whether the term count should be displayed or not.
+	 *
+	 * @var bool
+	 */
+	protected $display_count = false;
+
+	/**
 	 * Output the widget or block HTML.
 	 *
 	 * @param array $args     Widget args
@@ -45,6 +52,8 @@ class Renderer {
 		);
 
 		$feature = Features::factory()->get_registered_feature( 'facets' );
+
+		$this->display_count = $feature->get_setting( 'display_count' );
 
 		if ( $wp_query->get( 'ep_facet', false ) && ! $feature->is_facetable( $wp_query ) ) {
 			return false;
@@ -365,6 +374,11 @@ class Renderer {
 			esc_url( $url )
 		);
 
+		$label = $term->name;
+		if ( $this->display_count ) {
+			$label .= ' <span>(' . $term->count . ')</span>';
+		}
+
 		/**
 		 * Filter the label for an individual facet term.
 		 *
@@ -375,7 +389,7 @@ class Renderer {
 		 * @param {boolean} $selected Whether the term is selected.
 		 * @return {string} Individual facet term label.
 		 */
-		$label = apply_filters( 'ep_facet_widget_term_label', $term->name, $term, $selected );
+		$label = apply_filters( 'ep_facet_widget_term_label', $label, $term, $selected );
 
 		/**
 		 * Filter the accessible label for an individual facet term link.

--- a/tests/cypress/integration/features/custom-results.cy.js
+++ b/tests/cypress/integration/features/custom-results.cy.js
@@ -88,16 +88,23 @@ describe('Custom Results', () => {
 			})
 			.then(() => {
 				expect(searchResult.length).to.be.gt(0);
-				cy.get('#publish').click();
+				cy.get('#publish')
+					.click()
+					.then(() => {
+						/**
+						 * Give Elasticsearch some time to update the posts in custom results.
+						 */
+						// eslint-disable-next-line cypress/no-unnecessary-waiting
+						cy.wait(1000);
+						cy.visit(`?s=${searchTerm}`);
 
-				cy.visit(`?s=${searchTerm}`);
-
-				// verify the result of the search is in the same position.
-				cy.get(`article:nth-child(-n+${searchResult.length}) .entry-title`).each(
-					(post, index) => {
-						expect(post[0].innerText).to.equal(searchResult[index]);
-					},
-				);
+						// verify the result of the search is in the same position.
+						cy.get(`article:nth-child(-n+${searchResult.length}) .entry-title`).each(
+							(post, index) => {
+								expect(post[0].innerText).to.equal(searchResult[index]);
+							},
+						);
+					});
 			});
 	});
 });

--- a/tests/cypress/integration/features/facets.cy.js
+++ b/tests/cypress/integration/features/facets.cy.js
@@ -424,7 +424,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 			cy.get('.wp-block-elasticpress-facet').last().as('secondBlock');
 			cy.get('@firstBlock').find('input').should('have.attr', 'placeholder', 'Search Meta 1');
 			cy.get('@firstBlock')
-				.contains('.term', /\(\d*\)$/)
+				.contains('.term', /(^\(\d*\))$/)
 				.should('not.exist');
 
 			cy.get('@secondBlock')
@@ -432,7 +432,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 				.should('have.attr', 'placeholder', 'Search Meta 2');
 			cy.get('@secondBlock').find('.term').should('be.elementsSortedAlphabetically');
 			cy.get('@secondBlock')
-				.contains('.term', /(^\(\d*\))$/)
+				.contains('.term', /\(\d*\)$/)
 				.should('not.exist');
 
 			/**

--- a/tests/cypress/integration/features/facets.cy.js
+++ b/tests/cypress/integration/features/facets.cy.js
@@ -68,6 +68,18 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 		cy.get('@block').find('.term').should('be.elementsSortedAlphabetically');
 
 		/**
+		 * Verify the display count setting on the editor.
+		 */
+		cy.get('@block')
+			.contains('.term', /\(\d*\)$/)
+			.should('not.exist');
+		cy.get('.block-editor-block-inspector .components-form-toggle__input').click();
+		cy.wait('@blockPreview1');
+		cy.get('@block')
+			.contains('.term', /(^\(\d*\))$/)
+			.should('not.exist');
+
+		/**
 		 * Save widgets and visit the front page.
 		 */
 		cy.intercept('/wp-json/wp/v2/sidebars/*').as('sidebarsRest');
@@ -82,9 +94,14 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 		cy.get('.wp-block-elasticpress-facet').first().as('firstBlock');
 		cy.get('.wp-block-elasticpress-facet').last().as('secondBlock');
 		cy.get('@firstBlock').find('input').should('have.attr', 'placeholder', 'Search Categories');
+		cy.get('@firstBlock')
+			.contains('.term', /\(\d*\)$/)
+			.should('not.exist');
 		cy.get('@secondBlock').find('input').should('have.attr', 'placeholder', 'Search Tags');
 		cy.get('@secondBlock').find('.term').should('be.elementsSortedAlphabetically');
-
+		cy.get('@secondBlock')
+			.contains('.term', /(^\(\d*\))$/)
+			.should('not.exist');
 		/**
 		 * Typing in the input should filter the list of terms for that block
 		 * without affecting other blocks.
@@ -333,6 +350,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 			cy.openBlockSettingsSidebar();
 			cy.get('.block-editor-block-inspector input[type="text"]').clearThenType(
 				'Search Meta 1',
+				true,
 			);
 
 			cy.intercept(
@@ -348,6 +366,18 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 			cy.get('@block1').find('input').should('have.attr', 'placeholder', 'Search Meta 1');
 
 			/**
+			 * Verify the display count setting on the editor.
+			 */
+			cy.get('@block1')
+				.contains('.term', /\(\d*\)$/)
+				.should('not.exist');
+			cy.get('.block-editor-block-inspector .components-form-toggle__input').click();
+			cy.wait('@blockPreview1');
+			cy.get('@block1')
+				.contains('.term', /(^\(\d*\))$/)
+				.should('not.exist');
+
+			/**
 			 * Insert a second block.
 			 */
 			cy.openBlockInserter();
@@ -360,6 +390,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 			cy.openBlockSettingsSidebar();
 			cy.get('.block-editor-block-inspector input[type="text"]').clearThenType(
 				'Search Meta 2',
+				true,
 			);
 			cy.get('.block-editor-block-inspector select').select('meta_field_2');
 			cy.get('.block-editor-block-inspector input[type="radio"][value="name"]').click();
@@ -392,10 +423,17 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 			cy.get('.wp-block-elasticpress-facet').first().as('firstBlock');
 			cy.get('.wp-block-elasticpress-facet').last().as('secondBlock');
 			cy.get('@firstBlock').find('input').should('have.attr', 'placeholder', 'Search Meta 1');
+			cy.get('@firstBlock')
+				.contains('.term', /\(\d*\)$/)
+				.should('not.exist');
+
 			cy.get('@secondBlock')
 				.find('input')
 				.should('have.attr', 'placeholder', 'Search Meta 2');
 			cy.get('@secondBlock').find('.term').should('be.elementsSortedAlphabetically');
+			cy.get('@secondBlock')
+				.contains('.term', /(^\(\d*\))$/)
+				.should('not.exist');
 
 			/**
 			 * Typing in the input should filter the list of terms for that block

--- a/tests/php/TestFeatureActivation.php
+++ b/tests/php/TestFeatureActivation.php
@@ -252,6 +252,74 @@ class TestFeatureActivation extends BaseTestCase {
 	}
 
 	/**
+	 * Test the `get_settings` method
+	 *
+	 * @since 4.5.0
+	 */
+	public function testGetSettings() {
+		$feature = new FeatureTest();
+
+		$default_settings = [
+			'setting_1' => 123,
+			'setting_2' => false,
+		];
+
+		$feature->default_settings = $default_settings;
+
+		$this->assertEquals( $default_settings, $feature->get_settings() );
+
+		$new_values = [
+			'setting_1' => 456,
+			'setting_2' => true,
+			'setting_3' => 'custom_string',
+		];
+
+        $filter = function() use ( $new_values ) {
+            return [
+                'test' => $new_values,
+            ];
+        };
+		add_filter( 'pre_site_option_ep_feature_settings', $filter );
+		add_filter( 'pre_option_ep_feature_settings', $filter );
+
+		$this->assertEquals( $new_values, $feature->get_settings() );
+	}
+
+	/**
+	 * Test the `get_setting` method
+	 *
+	 * @since 4.5.0
+	 */
+	public function testGetSetting() {
+		$feature = new FeatureTest();
+
+		$feature->default_settings = [
+			'setting_1' => 123,
+			'setting_2' => false,
+		];
+
+		$this->assertEquals( 123, $feature->get_setting( 'setting_1' ) );
+		$this->assertFalse( $feature->get_setting( 'setting_2' ) );
+		$this->assertNull( $feature->get_setting( 'non_existent_setting' ) );
+
+        $filter = function() {
+            return [
+                'test' => [
+                    'setting_1' => 456,
+                    'setting_3' => 'new_string',
+                ],
+            ];
+        };
+		add_filter( 'pre_site_option_ep_feature_settings', $filter );
+		add_filter( 'pre_option_ep_feature_settings', $filter );
+
+		$this->assertEquals( 456, $feature->get_setting( 'setting_1' ) );
+		$this->assertFalse( $feature->get_setting( 'setting_2' ) );
+		$this->assertEquals( 'new_string', $feature->get_setting( 'setting_3' ) );
+		$this->assertNull( $feature->get_setting( 'non_existent_setting' ) );
+	}
+
+	/**
 	 * Wrapper for Features::handle_feature_activation() calls in admin context.
 	 *
 	 * To avoid unnecessary updates on the `ep_feature_requirement_statuses` option,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds a new toggle to both Facets blocks, so the user can display or not the term count in each facet. This PR also makes some small changes in the way one can get settings values from a feature:
- get_settings() now return default values as well
- A new get_setting() method was introduced

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3286

### How to test the Change
1. Create some facet blocks (taxonomy and meta)
2. Change the Display Term Count toggle to see it displaying or hiding the term count

### Changelog Entry
> Added - Option to display term counts in Facets blocks 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
