### PR TITLE
Add custom capability for managing ElasticPress

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -254,7 +254,7 @@ function setup_roles() {
 
 	$role->add_cap( Utils\get_capability() );
 }
-add_action( 'init', __NAMESPACE__ . '\\setup_roles' );
+register_activation_hook( __FILE__, __NAMESPACE__ . '\setup_roles' );
 
 /**
  * Fires after Elasticpress plugin is loaded

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -246,6 +246,17 @@ function setup_misc() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\setup_misc' );
 
 /**
+ * Set up role(s) with EP capability
+ */
+function setup_roles() {
+	// add custom capabilities to admin role
+	$role = get_role( 'administrator' );
+
+	$role->add_cap( Utils\get_capability() );
+}
+add_action( 'init', __NAMESPACE__ . '\\setup_roles' );
+
+/**
  * Fires after Elasticpress plugin is loaded
  *
  * @since  2.0

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -172,7 +172,7 @@ class Synonyms {
 			'elasticpress',
 			esc_html__( 'ElasticPress Synonyms', 'elasticpress' ),
 			esc_html__( 'Synonyms', 'elasticpress' ),
-			'manage_options',
+			Utils\get_capability(),
 			'elasticpress-synonyms',
 			[ $this, 'admin_page' ]
 		);
@@ -249,7 +249,7 @@ class Synonyms {
 			'show_ui'            => false,
 			'show_in_menu'       => false,
 			'query_var'          => true,
-			'capability_type'    => 'post',
+			'capabilities'       => Utils\get_post_map_capabilities(),
 			'has_archive'        => false,
 			'hierarchical'       => false,
 			'menu_position'      => 100,

--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -199,7 +199,7 @@ class Weighting {
 			'elasticpress',
 			esc_html__( 'ElasticPress Search Fields & Weighting', 'elasticpress' ),
 			esc_html__( 'Search Fields & Weighting', 'elasticpress' ),
-			'manage_options',
+			Utils\get_capability(),
 			'elasticpress-weighting',
 			[ $this, 'render_settings_page' ]
 		);
@@ -339,7 +339,7 @@ class Weighting {
 			return;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( Utils\get_capability() ) ) {
 			return;
 		}
 

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -36,11 +36,6 @@ class SearchOrdering extends Feature {
 	const TAXONOMY_NAME = 'ep_custom_result';
 
 	/**
-	 * Capability required to manage.
-	 */
-	const CAPABILITY = 'manage_options';
-
-	/**
 	 * Initialize feature setting it's config
 	 *
 	 * @since  3.0
@@ -215,7 +210,7 @@ class SearchOrdering extends Feature {
 			'elasticpress',
 			esc_html__( 'Custom Results', 'elasticpress' ),
 			esc_html__( 'Custom Results', 'elasticpress' ),
-			self::CAPABILITY,
+			Utils\get_capability(),
 			'edit.php?post_type=' . self::POST_TYPE_NAME
 		);
 	}
@@ -297,7 +292,7 @@ class SearchOrdering extends Feature {
 			'show_in_menu'         => $menu,
 			'query_var'            => true,
 			'rewrite'              => array( 'slug' => 'ep-pointer' ),
-			'capability_type'      => 'post',
+			'capabilities'         => Utils\get_post_map_capabilities(),
 			'has_archive'          => false,
 			'hierarchical'         => false,
 			'menu_position'        => 100,
@@ -697,7 +692,7 @@ class SearchOrdering extends Feature {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'handle_pointer_search' ],
 				'permission_callback' => function() {
-					return current_user_can( self::CAPABILITY );
+					return current_user_can( Utils\get_capability() );
 				},
 				'args'                => [
 					's' => [
@@ -717,7 +712,7 @@ class SearchOrdering extends Feature {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'handle_pointer_preview' ],
 				'permission_callback' => function() {
-					return current_user_can( self::CAPABILITY );
+					return current_user_can( Utils\get_capability() );
 				},
 				'args'                => [
 					's' => [

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -36,6 +36,15 @@ class SearchOrdering extends Feature {
 	const TAXONOMY_NAME = 'ep_custom_result';
 
 	/**
+	 * Capability required to manage.
+	 *
+	 * This will be removed in future versions of ElasticPress. Please use `Utils\get_capability()` instead.
+	 *
+	 * @deprecated 4.5.0
+	 */
+	const CAPABILITY = 'elasticpress_manage';
+
+	/**
 	 * Initialize feature setting it's config
 	 *
 	 * @since  3.0

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -47,6 +47,7 @@ class Upgrades {
 			'3.6.6' => [ 'upgrade_3_6_6', 'init' ],
 			'4.2.2' => [ 'upgrade_4_2_2', 'init' ],
 			'4.4.0' => [ 'upgrade_4_4_0', 'init' ],
+			'4.5.0' => [ 'upgrade_4_5_0', 'init' ],
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ] );
@@ -189,6 +190,17 @@ class Upgrades {
 	 */
 	public function upgrade_4_4_0() {
 		Utils\delete_option( 'ep_prefix' );
+	}
+
+	/**
+	 * Upgrade routine of v4.5.0.
+	 *
+	 * Add the ElasticPress capability to admins
+	 *
+	 * @see https://github.com/10up/ElasticPress/pull/3313
+	 */
+	public function upgrade_4_5_0() {
+		setup_roles();
 	}
 
 	/**

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -297,22 +297,11 @@ function filter_plugin_action_links( $plugin_actions, $plugin_file ) {
 function maybe_notice( $force = false ) {
 	// Admins only.
 	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		if ( ! is_super_admin() ) {
+		if ( ! is_super_admin() || ! is_network_admin() ) {
 			return false;
 		}
 	} else {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
-		}
-	}
-
-	// If in network mode, don't output notice in admin and vice-versa.
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		if ( ! is_network_admin() ) {
-			return false;
-		}
-	} else {
-		if ( is_network_admin() ) {
+		if ( is_network_admin() || ! current_user_can( Utils\get_capability() ) ) {
 			return false;
 		}
 	}
@@ -377,7 +366,7 @@ function action_wp_ajax_ep_notice_dismiss() {
 		exit;
 	}
 
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if ( ! current_user_can( Utils\get_capability() ) ) {
 		wp_send_json_error();
 		exit;
 	}
@@ -663,7 +652,7 @@ function resolve_screen() {
  * @return void
  */
 function action_admin_menu() {
-	$capability = 'manage_options';
+	$capability = Utils\get_capability();
 
 	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 		$capability = 'manage_network';

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -652,11 +652,7 @@ function resolve_screen() {
  * @return void
  */
 function action_admin_menu() {
-	$capability = Utils\get_capability();
-
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		$capability = 'manage_network';
-	}
+	$capability = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ? Utils\get_network_capability() : Utils\get_capability();
 
 	add_menu_page(
 		'ElasticPress',

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -52,6 +52,34 @@ function get_epio_credentials() {
 }
 
 /**
+ * Get WP capability needed for a user to interact with ElasticPress in the admin
+ *
+ * @return string
+ */
+function get_capability() {
+	return apply_filters( 'ep_capability', 'elasticpress_manage' );
+}
+
+/**
+ * Get mapped capabilities for post types
+ *
+ * @return string
+ */
+function get_post_map_capabilities() {
+	$capability = get_capability();
+
+	return [
+		'edit_post'          => $capability,
+		'edit_posts'         => $capability,
+		'edit_others_posts'  => $capability,
+		'publish_posts'      => $capability,
+		'read_post'          => $capability,
+		'read_private_posts' => $capability,
+		'delete_post'        => $capability,
+	];
+}
+
+/**
  * Get shield credentials
  *
  * @since  3.0

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -54,18 +54,46 @@ function get_epio_credentials() {
 /**
  * Get WP capability needed for a user to interact with ElasticPress in the admin
  *
+ * @since 4.5.0
  * @return string
  */
-function get_capability() {
-	return apply_filters( 'ep_capability', 'elasticpress_manage' );
+function get_capability() : string {
+	/**
+	 * Filter the WP capability needed to interact with ElasticPress in the admin
+	 *
+	 * @since 4.5.0
+	 * @hook ep_capability
+	 * @param  {bool} $capability Capability name. Defaults to `'elasticpress_manage'`
+	 * @return {bool} New capability value
+	 */
+	return apply_filters( 'ep_capability', 'manage_elasticpress' );
+}
+
+/**
+ * Get WP capability needed for a user to interact with ElasticPress in the network admin
+ *
+ * @since 4.5.0
+ * @return string
+ */
+function get_network_capability() : string {
+	/**
+	 * Filter the WP capability needed to interact with ElasticPress in the network admin
+	 *
+	 * @since 4.5.0
+	 * @hook ep_capability
+	 * @param  {bool} $capability Capability name. Defaults to `'manage_network_elasticpress'`
+	 * @return {bool} New capability value
+	 */
+	return apply_filters( 'ep_network_capability', 'manage_network_elasticpress' );
 }
 
 /**
  * Get mapped capabilities for post types
  *
- * @return string
+ * @since 4.5.0
+ * @return array
  */
-function get_post_map_capabilities() {
+function get_post_map_capabilities() : array {
 	$capability = get_capability();
 
 	return [

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -80,7 +80,7 @@ function get_network_capability() : string {
 	 * Filter the WP capability needed to interact with ElasticPress in the network admin
 	 *
 	 * @since 4.5.0
-	 * @hook ep_capability
+	 * @hook ep_network_capability
 	 * @param  {bool} $capability Capability name. Defaults to `'manage_network_elasticpress'`
 	 * @return {bool} New capability value
 	 */

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -270,4 +270,63 @@ class TestUtils extends BaseTestCase {
 		add_filter( 'ep_request_id', $custom_request_id );
 		$this->assertEquals( 'totally-new-request-id', Utils\generate_request_id() );
 	}
+
+	/**
+	 * Test the `get_capability` function
+	 *
+	 * @since 4.5.0
+	 */
+	public function testGetCapability() {
+		$this->assertSame( 'manage_elasticpress', Utils\get_capability() );
+
+		/**
+		 * Test the `ep_capability` filter.
+		 */
+		$change_cap_name = function( $cap ) {
+			$this->assertSame( 'manage_elasticpress', $cap );
+			return 'custom_manage_ep';
+		};
+		add_filter( 'ep_capability', $change_cap_name );
+
+		$this->assertSame( 'custom_manage_ep', Utils\get_capability() );
+	}
+
+	/**
+	 * Test the `get_network_capability` function
+	 *
+	 * @since 4.5.0
+	 */
+	public function testGetNetworkCapability() {
+		$this->assertSame( 'manage_network_elasticpress', Utils\get_network_capability() );
+
+		/**
+		 * Test the `ep_network_capability` filter.
+		 */
+		$change_cap_name = function( $cap ) {
+			$this->assertSame( 'manage_network_elasticpress', $cap );
+			return 'custom_manage_network_ep';
+		};
+		add_filter( 'ep_network_capability', $change_cap_name );
+
+		$this->assertSame( 'custom_manage_network_ep', Utils\get_network_capability() );
+	}
+
+	/**
+	 * Test the `get_post_map_capabilities` function
+	 *
+	 * @since 4.5.0
+	 */
+	public function testGetPostMapCapabilities() {
+		$expected = [
+			'edit_post'          => 'manage_elasticpress',
+			'edit_posts'         => 'manage_elasticpress',
+			'edit_others_posts'  => 'manage_elasticpress',
+			'publish_posts'      => 'manage_elasticpress',
+			'read_post'          => 'manage_elasticpress',
+			'read_private_posts' => 'manage_elasticpress',
+			'delete_post'        => 'manage_elasticpress',
+		];
+
+		$this->assertSame( $expected, Utils\get_post_map_capabilities() );
+	}
 }

--- a/tests/php/features/TestSearchOrdering.php
+++ b/tests/php/features/TestSearchOrdering.php
@@ -103,12 +103,10 @@ class TestSearchOrdering extends BaseTestCase {
 	}
 
 	public function testAdminMenu() {
-		$site_url = trailingslashit( get_option( 'siteurl' ) );
-
 		add_menu_page(
 			'ElasticPress',
 			'ElasticPress',
-			'manage_options',
+			\ElasticPress\Utils\get_capability(),
 			'elasticpress'
 		);
 

--- a/tests/php/features/TestSearchOrdering.php
+++ b/tests/php/features/TestSearchOrdering.php
@@ -24,6 +24,7 @@ class TestSearchOrdering extends BaseTestCase {
 		parent::set_up();
 		$wpdb->suppress_errors();
 
+		\ElasticPress\setup_roles();
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 
 		wp_set_current_user( $admin_id );
@@ -440,11 +441,11 @@ class TestSearchOrdering extends BaseTestCase {
 	}
 
 	/**
-	 * Test API endpoints are accessible for users with `manage_options` capability.
+	 * Test API endpoints are accessible for users with `manage_elasticpress` capability.
 	 *
 	 * @since 4.4.0
 	 */
-	public function testUserWithManageOptionsCapabilityCanAccessAPI() {
+	public function testUserWithManageElasticPressCapabilityCanAccessAPI() {
 
 		global $wp_rest_server;
 		/** @var WP_REST_Server $wp_rest_server */
@@ -472,13 +473,13 @@ class TestSearchOrdering extends BaseTestCase {
 	}
 
 	/**
-	 * Test API endpoints are not accessible for users without `manage_options` capability.
+	 * Test API endpoints are not accessible for users without `manage_elasticpress` capability.
 	 *
 	 * @since 4.4.0
 	 */
-	public function testUserWithOutManageOptionsCapabilityCanNotAccessAPI() {
+	public function testUserWithOutManageElasticPressCapabilityCanNotAccessAPI() {
 
-		// Set current user without `manage_options` capability.
+		// Set current user without `manage_elasticpress` capability.
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		global $wp_rest_server;

--- a/tests/php/features/TestWeighting.php
+++ b/tests/php/features/TestWeighting.php
@@ -8,6 +8,7 @@
 namespace ElasticPressTest;
 
 use ElasticPress;
+use \ElasticPress\Utils;
 
 /**
  * Weighting test class

--- a/tests/php/features/TestWeighting.php
+++ b/tests/php/features/TestWeighting.php
@@ -175,7 +175,7 @@ class TestWeighting extends BaseTestCase {
 		add_menu_page(
 			'ElasticPress',
 			'ElasticPress',
-			'manage_options',
+			Utils\get_capability(),
 			'elasticpress'
 		);
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,6 +8,8 @@
  * @since   1.7
  */
 
+use ElasticPress\Utils;
+
 /**
  * Class EP_Uninstaller
  */
@@ -95,6 +97,7 @@ class EP_Uninstaller {
 
 		// Uninstall ElasticPress.
 		$this->clean_options_and_transients();
+		$this->remove_elasticpress_capability();
 	}
 
 	/**
@@ -179,6 +182,16 @@ class EP_Uninstaller {
 			$this->delete_related_posts_transients();
 			$this->delete_total_fields_limit_transients();
 		}
+	}
+
+	/**
+	 * Remove the ElasticPress' capability
+	 *
+	 * @since 4.5.0
+	 */
+	protected function remove_elasticpress_capability() {
+		$role = get_role( 'administrator' );
+		$role->remove_cap( Utils\get_capability() );
 	}
 
 	/**


### PR DESCRIPTION
This adds a new capability for managing ElasticPress and adds it to the admin role.

The point of this change is it allows people to add the capability to non-admins. Right now, that's not possible since everything goes off of `manage_options`.


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
