### PR TITLE
Add a new ep_sync_args filter

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -69,7 +69,17 @@ class IndexHelper {
 		add_filter( 'wp_php_error_message', [ $this, 'wp_handle_index_error' ], 10, 2 );
 
 		$this->index_meta = Utils\get_indexing_status();
-		$this->args       = $args;
+
+		/**
+		 * Filter the sync arguments
+		 *
+		 * @since 4.5.0
+		 * @hook ep_sync_args
+		 * @param {array} $args Sync arguments
+		 * @param {array} $index_meta Current index meta
+		 * @return {array} New sync arguments
+		 */
+		$this->args = apply_filters( 'ep_sync_args', $args, $this->index_meta );
 
 		if ( false === $this->index_meta ) {
 			$this->build_index_meta();

--- a/tests/php/TestIndexHelper.php
+++ b/tests/php/TestIndexHelper.php
@@ -23,7 +23,7 @@ class TestIndexHelper extends BaseTestCase {
 		$index_helper = \ElasticPress\IndexHelper::factory();
 
 		$args = [
-			'method' => 'custom',
+			'method'        => 'custom',
 			'output_method' => function() {},
 		];
 

--- a/tests/php/TestIndexHelper.php
+++ b/tests/php/TestIndexHelper.php
@@ -12,6 +12,33 @@ namespace ElasticPressTest;
  * InderHelper test class
  */
 class TestIndexHelper extends BaseTestCase {
+
+	/**
+	 * Test if the ep_sync_args filter is applied in the full_index method
+	 *
+	 * @since 4.5.0
+	 * @group indexHelper
+	 */
+	public function testFullIndexEpSyncArgsFilter() {
+		$index_helper = \ElasticPress\IndexHelper::factory();
+
+		$args = [
+			'method' => 'custom',
+			'output_method' => function() {},
+		];
+
+		$change_args = function ( $filter_args, $index_meta ) use ( $args ) {
+			$this->assertFalse( $index_meta );
+			$this->assertSame( $filter_args, $args );
+			return $filter_args;
+		};
+		add_filter( 'ep_sync_args', $change_args, 10, 2 );
+
+		$index_helper->full_index( $args );
+
+		$this->assertEquals( 1, did_filter( 'ep_sync_args' ) );
+	}
+	
 	/**
 	 * Test get_index_default_per_page
 	 *

--- a/tests/php/TestIndexHelper.php
+++ b/tests/php/TestIndexHelper.php
@@ -36,7 +36,7 @@ class TestIndexHelper extends BaseTestCase {
 
 		$index_helper->full_index( $args );
 
-		$this->assertEquals( 1, did_filter( 'ep_sync_args' ) );
+		$this->assertGreaterThanOrEqual( 1, did_filter( 'ep_sync_args' ) );
 	}
 	
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds a new `ep_sync_args` filter that can be used to change the parameters sent when triggering a sync.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3239

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New `ep_sync_args` filter


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia and @nickchomey

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
