### PR TITLE
Orders autosuggest: Report status and WooCommerce class attribute

### DIFF
--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -14,6 +14,8 @@ use ElasticPress\Indexables as Indexables;
 use ElasticPress\IndexHelper;
 use ElasticPress\Utils as Utils;
 
+use function ElasticPress\Utils\is_epio;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -22,6 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * WooCommerce feature class
  */
 class WooCommerce extends Feature {
+	/**
+	 * If enabled, receive the Orders object instance
+	 *
+	 * @since 4.5.0
+	 * @var null|Orders
+	 */
+	public $orders = null;
+
 	/**
 	 * Initialize feature setting it's config
 	 *
@@ -836,6 +846,12 @@ class WooCommerce extends Feature {
 		if ( ! function_exists( 'WC' ) ) {
 			return;
 		}
+
+		if ( apply_filters( 'ep_woocommerce_enable_orders_autosuggest', false && is_epio() ) ) {
+			$this->orders = new Orders();
+			$this->orders->setup();
+		}
+
 		add_action( 'ep_formatted_args', [ $this, 'price_filter' ], 10, 3 );
 		add_filter( 'ep_sync_insert_permissions_bypass', [ $this, 'bypass_order_permissions_check' ], 10, 2 );
 		add_filter( 'ep_integrate_search_queries', [ $this, 'blacklist_coupons' ], 10, 2 );

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -8,13 +8,11 @@
 
 namespace ElasticPress\Feature\WooCommerce;
 
-use ElasticPress\Feature as Feature;
-use ElasticPress\FeatureRequirementsStatus as FeatureRequirementsStatus;
-use ElasticPress\Indexables as Indexables;
+use ElasticPress\Feature;
+use ElasticPress\FeatureRequirementsStatus;
+use ElasticPress\Indexables;
 use ElasticPress\IndexHelper;
-use ElasticPress\Utils as Utils;
-
-use function ElasticPress\Utils\is_epio;
+use ElasticPress\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -847,11 +847,6 @@ class WooCommerce extends Feature {
 			return;
 		}
 
-		if ( apply_filters( 'ep_woocommerce_enable_orders_autosuggest', false && is_epio() ) ) {
-			$this->orders = new Orders();
-			$this->orders->setup();
-		}
-
 		add_action( 'ep_formatted_args', [ $this, 'price_filter' ], 10, 3 );
 		add_filter( 'ep_sync_insert_permissions_bypass', [ $this, 'bypass_order_permissions_check' ], 10, 2 );
 		add_filter( 'ep_integrate_search_queries', [ $this, 'blacklist_coupons' ], 10, 2 );

--- a/includes/classes/StatusReport/ElasticPressIo.php
+++ b/includes/classes/StatusReport/ElasticPressIo.php
@@ -39,6 +39,7 @@ class ElasticPressIo extends Report {
 		$groups = [
 			$this->get_autosuggest_group(),
 			$this->get_instant_results_group(),
+			$this->get_orders_search_group(),
 		];
 
 		return array_values( array_filter( $groups ) );
@@ -144,9 +145,54 @@ class ElasticPressIo extends Report {
 	}
 
 	/**
+	 * Process the ElasticPress.io Orders Search templates.
+	 *
+	 * @since 4.5.0
+	 * @return array
+	 */
+	protected function get_orders_search_group() : array {
+		$woocommerce_feature = \ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );
+
+		if ( ! $woocommerce_feature->is_active() ) {
+			return [];
+		}
+
+		if ( ! $woocommerce_feature->orders ) {
+			return [];
+		}
+
+		$title  = __( 'Orders Search Template', 'elasticpress' );
+		$fields = [];
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$sites = Utils\get_sites();
+
+			foreach ( $sites as $site ) {
+				if ( ! Utils\is_site_indexable( $site['blog_id'] ) ) {
+					continue;
+				}
+
+				switch_to_blog( $site['blog_id'] );
+
+				$field  = $this->get_orders_search_field();
+				$fields = array_merge( $fields, $field );
+
+				restore_current_blog();
+			}
+		} else {
+			$fields = $this->get_orders_search_field();
+		}
+
+		return [
+			'title'  => $title,
+			'fields' => $fields,
+		];
+	}
+
+	/**
 	 * Process the ElasticPress.io Instant Results template.
 	 *
-	 * @return array|null
+	 * @return array
 	 */
 	protected function get_instant_results_field() : array {
 		$index = Indexables::factory()->get( 'post' )->get_index_name();
@@ -157,6 +203,39 @@ class ElasticPressIo extends Report {
 
 		$feature  = new InstantResults\InstantResults();
 		$template = $feature->epio_get_search_template();
+
+		if ( is_wp_error( $template ) ) {
+			return [
+				$index => [
+					'label' => $index,
+					'value' => $template->get_error_message(),
+				],
+			];
+		}
+
+		return [
+			$index => [
+				'label' => $index,
+				'value' => $template,
+			],
+		];
+	}
+
+	/**
+	 * Process the ElasticPress.io Orders Search template.
+	 *
+	 * @since 4.5.0
+	 * @return array
+	 */
+	protected function get_orders_search_field() : array {
+		$index = Indexables::factory()->get( 'post' )->get_index_name();
+
+		if ( ! $index ) {
+			return [];
+		}
+
+		$woocommerce_feature = \ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );
+		$template            = $woocommerce_feature->orders->get_search_template();
 
 		if ( is_wp_error( $template ) ) {
 			return [


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds Orders Autosuggest templates to the Report Status and add an attribute to the WooCommerce class to receive the Orders class instance when we have that setup.


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
To be added to the Orders autosuggest changelog entry.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
