### PR TITLE
Ngram fields for orders autosuggest

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -160,44 +160,25 @@ class Autosuggest extends Feature {
 	 * @return array
 	 */
 	public function mapping( $mapping ) {
-		$mapping['settings']['analysis']['analyzer']['edge_ngram_analyzer'] = array(
-			'type'      => 'custom',
-			'tokenizer' => 'standard',
-			'filter'    => array(
-				'lowercase',
-				'edge_ngram',
-			),
-		);
+		$post_indexable = Indexables::factory()->get( 'post' );
 
+		$mapping = $post_indexable->add_ngram_analyzer( $mapping );
+		$mapping = $post_indexable->add_term_suggest_field( $mapping );
+
+		// Note the assignment by reference below.
 		if ( version_compare( Elasticsearch::factory()->get_elasticsearch_version(), '7.0', '<' ) ) {
-			$text_type = $mapping['mappings']['post']['properties']['post_content']['type'];
-
-			$mapping['mappings']['post']['properties']['post_title']['fields']['suggest'] = array(
-				'type'            => $text_type,
-				'analyzer'        => 'edge_ngram_analyzer',
-				'search_analyzer' => 'standard',
-			);
-
-			$mapping['mappings']['post']['properties']['term_suggest'] = array(
-				'type'            => $text_type,
-				'analyzer'        => 'edge_ngram_analyzer',
-				'search_analyzer' => 'standard',
-			);
+			$mapping_properties = &$mapping['mappings']['post']['properties'];
 		} else {
-			$text_type = $mapping['mappings']['properties']['post_content']['type'];
-
-			$mapping['mappings']['properties']['post_title']['fields']['suggest'] = array(
-				'type'            => $text_type,
-				'analyzer'        => 'edge_ngram_analyzer',
-				'search_analyzer' => 'standard',
-			);
-
-			$mapping['mappings']['properties']['term_suggest'] = array(
-				'type'            => $text_type,
-				'analyzer'        => 'edge_ngram_analyzer',
-				'search_analyzer' => 'standard',
-			);
+			$mapping_properties = &$mapping['mappings']['properties'];
 		}
+
+		$text_type = $mapping_properties['post_content']['type'];
+
+		$mapping_properties['post_title']['fields']['suggest'] = array(
+			'type'            => $text_type,
+			'analyzer'        => 'edge_ngram_analyzer',
+			'search_analyzer' => 'standard',
+		);
 
 		return $mapping;
 	}

--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -440,7 +440,7 @@ class Orders {
 	 * @return array
 	 */
 	public function filter_term_suggest( $post_args ) {
-		if ( 'shop_order' !== $post_args['post_type'] ) {
+		if ( empty( $post_args['post_type'] ) || 'shop_order' !== $post_args['post_type'] ) {
 			return $post_args;
 		}
 

--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -449,22 +449,29 @@ class Orders {
 		}
 
 		/**
-		 * Add the post ID as a meta (text) field, so we can freely search on it.
+		 * Add the order number as a meta (text) field, so we can freely search on it.
 		 */
-		$post_args['meta']['order_post_id'][] = [
-			'raw'   => $post_args['ID'],
-			'value' => $post_args['ID'],
+		$order_id = $post_args['ID'];
+		if ( function_exists( 'wc_get_order' ) ) {
+			$order = wc_get_order( $post_args['ID'] );
+			if ( $order && is_a( $order, 'WC_Order' ) && method_exists( $order, 'get_order_number' ) ) {
+				$order_id = $order->get_order_number();
+			}
+		}
+
+		$post_args['meta']['order_number'] = [
+			[
+				'raw'   => $order_id,
+				'value' => $order_id,
+			],
 		];
 
 		$suggest = [];
 
 		$fields_to_ngram = [
-			'_order_key',
 			'_billing_email',
 			'_billing_last_name',
 			'_billing_first_name',
-			'_shipping_first_name',
-			'_shipping_last_name',
 		];
 
 		foreach ( $fields_to_ngram as $field_to_ngram ) {
@@ -509,15 +516,12 @@ class Orders {
 
 		if ( $is_orders_search_template ) {
 			$search_fields = [
-				'meta.order_post_id.value',
+				'meta.order_number.value',
 				'term_suggest',
 				'meta' => [
-					'_order_key',
 					'_billing_email',
 					'_billing_last_name',
 					'_billing_first_name',
-					'_shipping_first_name',
-					'_shipping_last_name',
 				],
 			];
 		}

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -1270,4 +1270,24 @@ abstract class Indexable {
 	 * @since 4.5.0
 	 */
 	public function setup() {}
+
+	/**
+	 * Given a mapping, add the ngram analyzer to it
+	 *
+	 * @since 4.5.0
+	 * @param array $mapping The mapping
+	 * @return array
+	 */
+	public function add_ngram_analyzer( array $mapping ) : array {
+		$mapping['settings']['analysis']['analyzer']['edge_ngram_analyzer'] = array(
+			'type'      => 'custom',
+			'tokenizer' => 'standard',
+			'filter'    => array(
+				'lowercase',
+				'edge_ngram',
+			),
+		);
+
+		return $mapping;
+	}
 }

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -2754,4 +2754,31 @@ class Post extends Indexable {
 
 		return $meta_keys;
 	}
+
+	/**
+	 * Add a `term_suggest` field to the mapping.
+	 *
+	 * This method assumes the `edge_ngram_analyzer` analyzer was already added to the mapping.
+	 *
+	 * @since 4.5.0
+	 * @param array $mapping The mapping array
+	 * @return array
+	 */
+	public function add_term_suggest_field( array $mapping ) : array {
+		if ( version_compare( Elasticsearch::factory()->get_elasticsearch_version(), '7.0', '<' ) ) {
+			$mapping_properties = &$mapping['mappings']['post']['properties'];
+		} else {
+			$mapping_properties = &$mapping['mappings']['properties'];
+		}
+
+		$text_type = $mapping_properties['post_content']['type'];
+
+		$mapping_properties['term_suggest'] = array(
+			'type'            => $text_type,
+			'analyzer'        => 'edge_ngram_analyzer',
+			'search_analyzer' => 'standard',
+		);
+
+		return $mapping;
+	}
 }

--- a/tests/php/features/TestWooCommerceOrders.php
+++ b/tests/php/features/TestWooCommerceOrders.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Test woocommerce orders feature
+ *
+ * @since 4.5.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+/**
+ * WC Orders test class
+ */
+class TestWooCommerceOrders extends TestWooCommerce {
+	public $woocommerce_feature;
+
+	public $orders;
+
+	/**
+	 * Setup each test.
+	 *
+	 * @group WooCommerceOrders
+	 */
+	public function set_up() {
+		parent::set_up();
+		ElasticPress\Features::factory()->activate_feature( 'protected_content' );
+		ElasticPress\Features::factory()->activate_feature( 'woocommerce' );
+
+		$this->woocommerce_feature = ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );
+		if ( empty( $this->woocommerce_feature->orders ) ) {
+			$this->woocommerce_feature->orders = new \ElasticPress\Feature\WooCommerce\Orders;
+		}
+
+		ElasticPress\Features::factory()->setup_features();
+
+		$this->orders = $this->woocommerce_feature->orders;
+	}
+
+	/**
+	 * Test the `filter_term_suggest` method
+	 *
+	 * @group WooCommerceOrders
+	 */
+	public function testFilterTermSuggest() {
+		$order = [
+			'ID'        => 123,
+			'post_type' => 'shop_order',
+			'meta'      => [
+				'_order_key'           => [
+					[ 'value' => '_order_key_example', ],
+				],
+				'_billing_email'       => [
+					[ 'value' => '_billing_email_example', ],
+				],
+				'_billing_last_name'   => [
+					[ 'value' => '_billing_last_name_example', ],
+				],
+				'_billing_first_name'  => [
+					[ 'value' => '_billing_first_name_example', ],
+				],
+				'_shipping_first_name' => [
+					[ 'value' => '_shipping_first_name_example', ],
+				],
+				'_shipping_last_name'  => [
+					[ 'value' => '_shipping_last_name_example', ],
+				],
+			]
+		];
+
+		$order_with_suggest = $this->orders->filter_term_suggest( $order );
+
+		$this->assertArrayHasKey( 'term_suggest', $order_with_suggest );
+		$this->assertContains( '_order_key_example', $order_with_suggest['term_suggest'] );
+		$this->assertContains( '_billing_email_example', $order_with_suggest['term_suggest'] );
+		$this->assertContains( '_billing_last_name_example', $order_with_suggest['term_suggest'] );
+		$this->assertContains( '_billing_first_name_example', $order_with_suggest['term_suggest'] );
+		$this->assertContains( '_shipping_first_name_example', $order_with_suggest['term_suggest'] );
+		$this->assertContains( '_shipping_last_name_example', $order_with_suggest['term_suggest'] );
+
+		$this->assertSame( [ 'raw' => 123, 'value' => 123 ], $order_with_suggest['meta']['order_post_id'][0] );
+
+		unset( $order['post_type'] );
+		$order_with_suggest = $this->orders->filter_term_suggest( $order );
+		$this->assertArrayNotHasKey( 'term_suggest', $order_with_suggest );
+
+		$order['post_type'] = 'not_shop_order';
+		$order_with_suggest = $this->orders->filter_term_suggest( $order );
+		$this->assertArrayNotHasKey( 'term_suggest', $order_with_suggest );
+
+		$order['post_type'] = 'shop_order';
+		unset( $order['meta'] );
+		$order_with_suggest = $this->orders->filter_term_suggest( $order );
+		$this->assertArrayNotHasKey( 'term_suggest', $order_with_suggest );
+	}
+
+	/**
+	 * Test the `mapping` method with the ES 7 mapping
+	 *
+	 * @group WooCommerceOrders
+	 */
+	public function testMappingEs7() {
+		$original_mapping = [
+			'mappings' => [
+				'properties' => [
+					'post_content' => [ 'type' => 'text' ],
+				]
+			]
+		];
+		$changed_mapping = $this->orders->mapping( $original_mapping );
+
+		$expected_mapping = [
+			'mappings' => [
+				'properties' => [
+					'post_content' => [ 'type' => 'text' ],
+					'term_suggest' => [
+						'type'            => 'text',
+						'analyzer'        => 'edge_ngram_analyzer',
+						'search_analyzer' => 'standard',
+					],
+				]
+			],
+			'settings' => [
+				'analysis' => [
+					'analyzer' => [
+						'edge_ngram_analyzer' => [
+							'type'      => 'custom',
+							'tokenizer' => 'standard',
+							'filter'    => [
+								'lowercase',
+								'edge_ngram',
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame( $expected_mapping, $changed_mapping );
+	}
+
+	/**
+	 * Test the `mapping` method with the ES 5 mapping
+	 *
+	 * @group WooCommerceOrders
+	 */
+	public function testMappingEs5() {
+		$change_es_version = function() {
+			return '5.6';
+		};
+		add_filter( 'ep_elasticsearch_version', $change_es_version );
+
+		$original_mapping = [
+			'mappings' => [
+				'post' => [
+					'properties' => [
+						'post_content' => [ 'type' => 'text' ],
+					],
+				],
+			],
+		];
+
+		$changed_mapping = $this->orders->mapping( $original_mapping );
+
+		$expected_mapping = [
+			'mappings' => [
+				'post' => [
+					'properties' => [
+						'post_content' => [ 'type' => 'text' ],
+						'term_suggest' => [
+							'type'            => 'text',
+							'analyzer'        => 'edge_ngram_analyzer',
+							'search_analyzer' => 'standard',
+						],
+					],
+				],
+			],
+			'settings' => [
+				'analysis' => [
+					'analyzer' => [
+						'edge_ngram_analyzer' => [
+							'type'      => 'custom',
+							'tokenizer' => 'standard',
+							'filter'    => [
+								'lowercase',
+								'edge_ngram',
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame( $expected_mapping, $changed_mapping );
+	}
+
+	/**
+	 * Test the `set_search_fields` method
+	 *
+	 * @group WooCommerceOrders
+	 */
+	public function testSetSearchFields() {
+
+	}
+}

--- a/tests/php/features/TestWooCommerceOrders.php
+++ b/tests/php/features/TestWooCommerceOrders.php
@@ -13,7 +13,7 @@ use ElasticPress;
 /**
  * WC Orders test class
  */
-class TestWooCommerceOrders extends TestWooCommerce {
+class TestWooCommerceOrders extends BaseTestCase {
 	public $woocommerce_feature;
 
 	public $orders;

--- a/tests/php/features/TestWooCommerceOrders.php
+++ b/tests/php/features/TestWooCommerceOrders.php
@@ -201,6 +201,45 @@ class TestWooCommerceOrders extends TestWooCommerce {
 	 * @group WooCommerceOrders
 	 */
 	public function testSetSearchFields() {
+		$original_search_fields = [ 'old_search_field', ];
+		
+		$wp_query = new \WP_Query(
+			[
+				'ep_integrate'             => true,
+				'ep_order_search_template' => false,
+				'post_type'                => 'shop_order',
+				's'                        => '{{ep_placeholder}}',
+			]
+		);
 
+		$changed_search_fields = $this->orders->set_search_fields( $original_search_fields, $wp_query );
+
+		$this->assertSame( $original_search_fields, $changed_search_fields );
+
+		$wp_query = new \WP_Query(
+			[
+				'ep_integrate'             => true,
+				'ep_order_search_template' => true,
+				'post_type'                => 'shop_order',
+				's'                        => '{{ep_placeholder}}',
+			]
+		);
+
+		$changed_search_fields = $this->orders->set_search_fields( $original_search_fields, $wp_query );
+
+		$expected_fields = [
+			'meta.order_post_id.value',
+			'term_suggest',
+			'meta' => [
+				'_order_key',
+				'_billing_email',
+				'_billing_last_name',
+				'_billing_first_name',
+				'_shipping_first_name',
+				'_shipping_last_name',
+			],
+		];
+
+		$this->assertSame( $expected_fields, $changed_search_fields );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR introduces the code needed so orders autosuggest start using ngram fields. As autosuggest and the orders autosuggest have some intersection between fields and mapping changes, the common code was moved to the indexable and post indexable classes.

It is done by adding a `term_suggest` field to all orders, filled with all fields we want to be searchable.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3281 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Add this to the orders autosuggest PRs list


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
