### PR TITLE
Fix #3325 Set the current post when indexing posts

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -420,7 +420,9 @@ class Post extends Indexable {
 	 * @return bool|array
 	 */
 	public function prepare_document( $post_id ) {
+		global $post;
 		$post = get_post( $post_id );
+		setup_postdata( $post );
 
 		if ( empty( $post ) ) {
 			return false;


### PR DESCRIPTION
### Description of the Change

When indexing a post, the content gets rendered, and shortcodes/blocks/etc may rely on the global `$post` variable to provide context that will be missing when performing an ES index.

In my case it was a block which did not handle the value being missing, but context dependent content would generate PHP warnings/errors or incorrect data

By setting the global `$post` and the current postdata, we can avoid some of these situations. This enabled indexing to continue locally where it would fail previously.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3325

### How to test the Change

In my case, I did not check the `postId` in the block context for presence and used it without verification. This lead to a fatal error which is avoided when using this PR

### Changelog Entry

> Fixed - Not setting the post context when indexing a post


### Credits

Props @tomjn 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
