### PR TITLE
Set term_order as 0 in the facet field

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -744,7 +744,7 @@ class Post extends Indexable {
 			return $terms;
 		}
 		if ( ! isset( $terms[ $parent_term->term_id ] ) ) {
-			$terms[ $parent_term->term_id ] = $this->get_formatted_term( $term, $object_id );
+			$terms[ $parent_term->term_id ] = $this->get_formatted_term( $parent_term, $object_id );
 
 		}
 		return $this->get_parent_terms( $terms, $parent_term, $tax_name, $object_id );

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -715,16 +715,7 @@ class Post extends Indexable {
 
 			foreach ( $object_terms as $term ) {
 				if ( ! isset( $terms_dic[ $term->term_id ] ) ) {
-					$terms_dic[ $term->term_id ] = array(
-						'term_id'          => $term->term_id,
-						'slug'             => $term->slug,
-						'name'             => $term->name,
-						'parent'           => $term->parent,
-						'term_taxonomy_id' => $term->term_taxonomy_id,
-						'term_order'       => (int) $this->get_term_order( $term->term_taxonomy_id, $post->ID ),
-					);
-
-					$terms_dic[ $term->term_id ]['facet'] = wp_json_encode( $terms_dic[ $term->term_id ] );
+					$terms_dic[ $term->term_id ] = $this->get_formatted_term( $term, $post->ID );
 
 					if ( $allow_hierarchy ) {
 						$terms_dic = $this->get_parent_terms( $terms_dic, $term, $taxonomy->name, $post->ID );
@@ -753,19 +744,40 @@ class Post extends Indexable {
 			return $terms;
 		}
 		if ( ! isset( $terms[ $parent_term->term_id ] ) ) {
-			$terms[ $parent_term->term_id ] = array(
-				'term_id'          => $parent_term->term_id,
-				'slug'             => $parent_term->slug,
-				'name'             => $parent_term->name,
-				'parent'           => $parent_term->parent,
-				'term_taxonomy_id' => $parent_term->term_taxonomy_id,
-				'term_order'       => $this->get_term_order( $parent_term->term_taxonomy_id, $object_id ),
-			);
-
-			$terms[ $parent_term->term_id ]['facet'] = wp_json_encode( $terms[ $parent_term->term_id ] );
+			$terms[ $parent_term->term_id ] = $this->get_formatted_term( $term, $object_id );
 
 		}
 		return $this->get_parent_terms( $terms, $parent_term, $tax_name, $object_id );
+	}
+
+	/**
+	 * Given a term, format it to be appended to the post ES document.
+	 *
+	 * @since 4.5.0
+	 * @param \WP_Term $term    Term to be formatted
+	 * @param int      $post_id The post ID
+	 * @return array
+	 */
+	private function get_formatted_term( \WP_Term $term, int $post_id ) : array {
+		$formatted_term = [
+			'term_id'          => $term->term_id,
+			'slug'             => $term->slug,
+			'name'             => $term->name,
+			'parent'           => $term->parent,
+			'term_taxonomy_id' => $term->term_taxonomy_id,
+			'term_order'       => (int) $this->get_term_order( $term->term_taxonomy_id, $post_id ),
+		];
+
+		/**
+		 * As the name implies, the facet attribute is used to list all terms in facets.
+		 * As in facets, the term_order associated with a post does not matter, we set it as 0 here.
+		 * Note that this is set as 0 instead of simply removed to keep backward compatibility.
+		 */
+		$term_facet               = $formatted_term;
+		$term_facet['term_order'] = 0;
+		$formatted_term['facet']  = wp_json_encode( $term_facet );
+
+		return $formatted_term;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR sets the term_order in the facet field as 0 in all terms associated with a post. This is needed because Instant Results use that field in its aggregation and as different term_order(s) produce different entries, IR ends up with duplicated entries.

It is set as 0 instead of simply unset so it doesn't break any solution that is accounting for that field's presence.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3329

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Duplicate terms listed in Instant Results facets


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
