### PR TITLE
Add E2E tests for orders autosuggest

### DIFF
--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -405,7 +405,7 @@ class Orders {
 		$endpoint = $this->get_token_endpoint();
 		$response = Elasticsearch::factory()->remote_request( $endpoint, [ 'method' => 'POST' ] );
 
-		if ( is_wp_error( $response ) ) {
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return false;
 		}
 

--- a/tests/cypress/README.md
+++ b/tests/cypress/README.md
@@ -39,3 +39,7 @@ Run `sudo apt update && sudo apt install libatk1.0-0 libatk-bridge2.0-0 libcups2
 #### `Command was killed with SIGILL (Invalid machine instruction)`
 
 Make sure you have `xvfb` installed
+
+### Running tests with ElasticPress.io
+
+To run tests locally using an ElasticPress.io endpoint, in place of running `npm run cypress:setup` during setup, run: `./bin/setup-cypress-env.sh --ep-host="https://" --es-shield="username:password" --ep-index-prefix="username"`, with the arguments populated with the details for your ElasticPress.io endpoint.

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -1,3 +1,4 @@
+/* global isEpIo */
 // eslint-disable-next-line jest/valid-describe-callback
 describe('WooCommerce Feature', { tags: '@slow' }, () => {
 	const userData = {
@@ -296,6 +297,143 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 				});
 
 			cy.setPerIndexCycle();
+		});
+	});
+
+	/**
+	 * Test the Orders Autosuggest feature.
+	 */
+	context('Orders Autosuggest', () => {
+		before(() => {
+			cy.activatePlugin('woocommerce', 'wpCli');
+			cy.login();
+			cy.maybeEnableFeature('woocommerce');
+			cy.maybeDisableFeature('protected_content');
+		});
+
+		it('Will require a sync when enabling Orders Autosuggest', () => {
+			cy.visitAdminPage('admin.php?page=elasticpress');
+
+			/**
+			 * Enable the feature.
+			 */
+			cy.get('.ep-feature-woocommerce .settings-button').click();
+
+			if (!isEpIo) {
+				cy.get('.ep-feature-woocommerce [name="settings[orders]"][value="1"]').should(
+					'be.disabled',
+				);
+				return;
+			}
+
+			cy.get('.ep-feature-woocommerce [name="settings[orders]"][value="1"]').click();
+			cy.get('.ep-feature-woocommerce .button-primary').click();
+
+			/**
+			 * Accept the prompt asking to sync.
+			 */
+			cy.on('window:confirm', () => {
+				return true;
+			});
+
+			/**
+			 * Syncing should complete.
+			 */
+			cy.get('.ep-sync-panel').last().as('syncPanel');
+			cy.get('@syncPanel').find('.components-form-toggle').click();
+			cy.get('@syncPanel')
+				.find('.ep-sync-messages', { timeout: Cypress.config('elasticPressIndexTimeout') })
+				.should('contain.text', 'Mapping sent')
+				.should('contain.text', 'Sync complete');
+		});
+
+		it('Will show a navigable list of suggested results when searching orders', () => {
+			cy.visitAdminPage('edit.php?post_type=shop_order');
+
+			/**
+			 * Prepare aliases.
+			 */
+			cy.intercept('*api/v1/search/orders*').as('apiRequest');
+			cy.get('#posts-filter .ep-combobox__input').as('input');
+			cy.get('#posts-filter .screen-reader.text').as('description');
+			cy.get('#posts-filter .ep-combobox__list').as('listbox');
+			cy.get('#posts-filter .button').as('submit');
+
+			if (!isEpIo) {
+				cy.get('@listbox').should('not.exist');
+				return;
+			}
+
+			/**
+			 * Search for "Antwon". 3 suggestions should appear.
+			 */
+			cy.get('@input').type('Antwon');
+			cy.wait('@apiRequest');
+			cy.get('@input').should('have.attr', 'aria-expanded', 'true');
+			cy.get('@description').should('contain.text', '3 suggestions available');
+			cy.get('@listbox').should('be.visible');
+			cy.get('@listbox').children().should('have.length', 3);
+
+			/**
+			 * It should be possible to navigate suggestions with the arrow
+			 * keys. Navigating past the beginning or end of the list should
+			 * loop around to the opposite side of the list.
+			 */
+			cy.get('@input').type('{downArrow}');
+			cy.get('@listbox').children.eq(0).should('have.attr', 'aria-selected', 'true');
+			cy.get('@input').type('{downArrow}{downArrow}');
+			cy.get('@listbox').children.eq(2).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children.eq(0).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@input').type('{downArrow}');
+			cy.get('@listbox').children.eq(0).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children.eq(2).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@input').type('{upArrow}');
+			cy.get('@listbox').children.eq(2).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children.eq(0).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@input').type('{upArrow}');
+			cy.get('@listbox').children.eq(1).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children.eq(2).should('not.have.attr', 'aria-selected', 'true');
+
+			/**
+			 * Pressing escape should hide the listbox and pressing an arrow
+			 * key should bring it back.
+			 */
+			cy.get('@input').type('{esc}');
+			cy.get('@listbox').should('not.be.visible');
+			cy.get('@input').type('{downArrow}');
+			cy.get('@listbox').should('be.visible');
+			cy.get('@listbox').children.eq(0).should('have.attr', 'aria-selected', 'true');
+
+			/**
+			 * Moving focus away from the input should hide the listbox.
+			 * Returning focus should bring it back.
+			 */
+			cy.get('@submit').focus();
+			cy.get('@listbox').should('not.be.visible');
+			cy.get('@input').focus();
+			cy.get('@listbox').should('be.visible');
+
+			/**
+			 * Partial name searches should still match.
+			 */
+			cy.get('@input').type('{backspace}{backspace}');
+			cy.wait('@apiRequest');
+			cy.get('@listbox').children().should('have.length', 3);
+
+			/**
+			 * Pressing enter on a selected item should navigate to that order.
+			 */
+			cy.get('@input').type('{downArrow}{downArrow}{enter}');
+			cy.url().should('include', 'post.php?post=');
+
+			/**
+			 * Clicking a suggestion should also navigate to that order.
+			 */
+			cy.visitAdminPage('edit.php?post_type=shop_order');
+			cy.get('@input').type('Antwon');
+			cy.wait('@apiRequest');
+			cy.get('@listbox').children().eq(1).click();
+			cy.url().should('include', 'post.php?post=');
 		});
 	});
 });

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -351,6 +351,14 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			cy.visitAdminPage('edit.php?post_type=shop_order');
 
 			/**
+			 * The combobox will not render if not using ElasticPress.io.
+			 */
+			if (!isEpIo) {
+				cy.get('#posts-filter .ep-combobox__input').should('not.exist');
+				return;
+			}
+
+			/**
 			 * Prepare aliases.
 			 */
 			cy.intercept('*api/v1/search/orders*').as('apiRequest');
@@ -359,14 +367,9 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			cy.get('#posts-filter .ep-combobox__list').as('listbox');
 			cy.get('#posts-filter .button').as('submit');
 
-			if (!isEpIo) {
-				cy.get('@listbox').should('not.exist');
-				return;
-			}
-
 			/**
 			 * Search for "Antwon". 3 suggestions should appear.
-			 */
+			*/
 			cy.get('@input').type('Antwon');
 			cy.wait('@apiRequest');
 			cy.get('@input').should('have.attr', 'aria-expanded', 'true');

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -361,7 +361,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			/**
 			 * Prepare aliases.
 			 */
-			cy.intercept('*api/v1/search/orders*').as('apiRequest');
+			cy.intercept('**/api/v1/search/orders/*').as('apiRequest');
 			cy.get('#posts-filter .ep-combobox__input').as('input');
 			cy.get('#posts-filter .screen-reader-text').as('description');
 			cy.get('#posts-filter .ep-combobox__list').as('listbox');

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -383,19 +383,19 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			 * loop around to the opposite side of the list.
 			 */
 			cy.get('@input').type('{downArrow}');
-			cy.get('@listbox').children.eq(0).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(0).should('have.attr', 'aria-selected', 'true');
 			cy.get('@input').type('{downArrow}{downArrow}');
-			cy.get('@listbox').children.eq(2).should('have.attr', 'aria-selected', 'true');
-			cy.get('@listbox').children.eq(0).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(2).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(0).should('not.have.attr', 'aria-selected', 'true');
 			cy.get('@input').type('{downArrow}');
-			cy.get('@listbox').children.eq(0).should('have.attr', 'aria-selected', 'true');
-			cy.get('@listbox').children.eq(2).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(0).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(2).should('not.have.attr', 'aria-selected', 'true');
 			cy.get('@input').type('{upArrow}');
-			cy.get('@listbox').children.eq(2).should('have.attr', 'aria-selected', 'true');
-			cy.get('@listbox').children.eq(0).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(2).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(0).should('not.have.attr', 'aria-selected', 'true');
 			cy.get('@input').type('{upArrow}');
-			cy.get('@listbox').children.eq(1).should('have.attr', 'aria-selected', 'true');
-			cy.get('@listbox').children.eq(2).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(1).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(2).should('not.have.attr', 'aria-selected', 'true');
 
 			/**
 			 * Pressing escape should hide the listbox and pressing an arrow
@@ -405,7 +405,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			cy.get('@listbox').should('not.be.visible');
 			cy.get('@input').type('{downArrow}');
 			cy.get('@listbox').should('be.visible');
-			cy.get('@listbox').children.eq(0).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(0).should('have.attr', 'aria-selected', 'true');
 
 			/**
 			 * Moving focus away from the input should hide the listbox.

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -369,7 +369,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 
 			/**
 			 * Search for "Antwon". 3 suggestions should appear.
-			*/
+			 */
 			cy.get('@input').type('Antwon');
 			cy.wait('@apiRequest');
 			cy.get('@input').should('have.attr', 'aria-expanded', 'true');

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -363,7 +363,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			 */
 			cy.intercept('*api/v1/search/orders*').as('apiRequest');
 			cy.get('#posts-filter .ep-combobox__input').as('input');
-			cy.get('#posts-filter .screen-reader.text').as('description');
+			cy.get('#posts-filter .screen-reader-text').as('description');
 			cy.get('#posts-filter .ep-combobox__list').as('listbox');
 			cy.get('#posts-filter .button').as('submit');
 

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -363,9 +363,9 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			 */
 			cy.intercept('**/api/v1/search/orders/*').as('apiRequest');
 			cy.get('#posts-filter .ep-combobox__input').as('input');
-			cy.get('#posts-filter .screen-reader-text').as('description');
+			cy.get('#posts-filter .ep-combobox > .screen-reader-text').as('description');
 			cy.get('#posts-filter .ep-combobox__list').as('listbox');
-			cy.get('#posts-filter .button').as('submit');
+			cy.get('#posts-filter .search-box .button').as('submit');
 
 			/**
 			 * Search for "Antwon". 3 suggestions should appear.
@@ -373,9 +373,9 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			cy.get('@input').type('Antwon');
 			cy.wait('@apiRequest');
 			cy.get('@input').should('have.attr', 'aria-expanded', 'true');
-			cy.get('@description').should('contain.text', '3 suggestions available');
+			cy.get('@description').should('contain.text', '4 suggestions available');
 			cy.get('@listbox').should('be.visible');
-			cy.get('@listbox').children().should('have.length', 3);
+			cy.get('@listbox').children().should('have.length', 4);
 
 			/**
 			 * It should be possible to navigate suggestions with the arrow
@@ -384,18 +384,18 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			 */
 			cy.get('@input').type('{downArrow}');
 			cy.get('@listbox').children().eq(0).should('have.attr', 'aria-selected', 'true');
-			cy.get('@input').type('{downArrow}{downArrow}');
-			cy.get('@listbox').children().eq(2).should('have.attr', 'aria-selected', 'true');
+			cy.get('@input').type('{downArrow}{downArrow}{downArrow}');
+			cy.get('@listbox').children().eq(3).should('have.attr', 'aria-selected', 'true');
 			cy.get('@listbox').children().eq(0).should('not.have.attr', 'aria-selected', 'true');
 			cy.get('@input').type('{downArrow}');
 			cy.get('@listbox').children().eq(0).should('have.attr', 'aria-selected', 'true');
-			cy.get('@listbox').children().eq(2).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(3).should('not.have.attr', 'aria-selected', 'true');
 			cy.get('@input').type('{upArrow}');
-			cy.get('@listbox').children().eq(2).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(3).should('have.attr', 'aria-selected', 'true');
 			cy.get('@listbox').children().eq(0).should('not.have.attr', 'aria-selected', 'true');
 			cy.get('@input').type('{upArrow}');
-			cy.get('@listbox').children().eq(1).should('have.attr', 'aria-selected', 'true');
-			cy.get('@listbox').children().eq(2).should('not.have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(2).should('have.attr', 'aria-selected', 'true');
+			cy.get('@listbox').children().eq(3).should('not.have.attr', 'aria-selected', 'true');
 
 			/**
 			 * Pressing escape should hide the listbox and pressing an arrow
@@ -421,7 +421,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			 */
 			cy.get('@input').type('{backspace}{backspace}');
 			cy.wait('@apiRequest');
-			cy.get('@listbox').children().should('have.length', 3);
+			cy.get('@listbox').children().should('have.length', 4);
 
 			/**
 			 * Pressing enter on a selected item should navigate to that order.


### PR DESCRIPTION
### Description of the Change
Adds E2E tests for Orders Autosuggest.

Tests:

- That enabling Orders Autosuggest requires a reindex.
- That suggestions appear when searching Orders.
- That suggestions can be navigated with the keyboard.
- The suggestions can be opened by pressing the clicking or pressing the enter key on suggestions.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3282

### How to test the Change
Tests should pass on GitHub.

### Changelog Entry
See #3175

### Credits
@JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
