### PR TITLE
Avoid applying meta ranges to aggregations

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -159,6 +159,11 @@ class Facets extends Feature {
 		}
 
 		/**
+		 * This flag is used to differentiate filters being applied to the query and to its aggregations.
+		 */
+		$query_args['ep_facet_adding_agg_filters'] = true;
+
+		/**
 		 * Filter WP query arguments that will be used to build the aggregations filter.
 		 *
 		 * The returned `$query_args` will be used to build the aggregations filter passing

--- a/tests/php/features/TestFacetTypeMetaRange.php
+++ b/tests/php/features/TestFacetTypeMetaRange.php
@@ -100,6 +100,13 @@ class TestFacetTypeMetaRange extends BaseTestCase {
 			],
 		];
 		$this->assertSame( $expected, $new_filters );
+
+		/**
+		 * If applying filters to the aggregations, we do not add the range as that would restrict
+		 * min and max to the selected values
+		 */
+		$new_filters = $this->facet_type->add_query_filters( [], [ 'ep_facet_adding_agg_filters' => true ] );
+		$this->assertSame( [], $new_filters );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
As stated in #3341, applying the range filter to the aggregation's filter restricts the field min and max in a way that is impossible to get back if a meta range is applied.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3341

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
To be added to the meta range changelog entry

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
