### PR TITLE
Use WP_Query argument for facetable queries.

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -248,6 +248,10 @@ class Facets extends Feature {
 			return true;
 		}
 
+		if ( $query->get( 'ep_is_facetable' ) ) {
+			return true;
+		}
+
 		if ( is_admin() || is_feed() ) {
 			return false;
 		}

--- a/includes/classes/Feature/Facets/Types/Meta/Block.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Block.php
@@ -164,8 +164,6 @@ class Block {
 	public function render_block_preview( $request ) {
 		global $wp_query;
 
-		add_filter( 'ep_is_facetable', '__return_true' );
-
 		$search = Features::factory()->get_registered_feature( 'search' );
 
 		$attributes = $this->parse_attributes(
@@ -188,8 +186,9 @@ class Block {
 
 		$wp_query = new \WP_Query(
 			[
-				'post_type' => $search->get_searchable_post_types(),
-				'per_page'  => 1,
+				'ep_is_facetable' => true,
+				'post_type'       => $search->get_searchable_post_types(),
+				'per_page'        => 1,
 			]
 		);
 

--- a/includes/classes/Feature/Facets/Types/MetaRange/Block.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Block.php
@@ -128,10 +128,6 @@ class Block {
 	 * @return string
 	 */
 	public function render_block_preview( $request ) {
-		global $wp_query;
-
-		add_filter( 'ep_is_facetable', '__return_true' );
-
 		$search = \ElasticPress\Features::factory()->get_registered_feature( 'search' );
 
 		$attributes = $this->parse_attributes(
@@ -149,10 +145,11 @@ class Block {
 			}
 		);
 
-		$wp_query = new \WP_Query(
+		$query = new \WP_Query(
 			[
-				'post_type' => $search->get_searchable_post_types(),
-				'per_page'  => 1,
+				'ep_is_facetable' => true,
+				'post_type'       => $search->get_searchable_post_types(),
+				'per_page'        => 1,
 			]
 		);
 

--- a/includes/classes/Feature/Facets/Types/Taxonomy/Block.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Block.php
@@ -179,14 +179,13 @@ class Block {
 	public function render_block_preview( $request ) {
 		global $wp_query;
 
-		add_filter( 'ep_is_facetable', '__return_true' );
-
 		$search = Features::factory()->get_registered_feature( 'search' );
 
 		$wp_query = new \WP_Query(
 			[
-				'post_type' => $search->get_searchable_post_types(),
-				'per_page'  => 1,
+				'ep_is_facetable' => true,
+				'post_type'       => $search->get_searchable_post_types(),
+				'per_page'        => 1,
 			]
 		);
 


### PR DESCRIPTION
### Description of the Change
The current facet blocks use the `ep_is_facetable` filter to enabled faceting for queries used to create the block previews. This can be unreliable if the preview query spawns any other queries as the aggregations from those queries may be used instead. By using an argument on the query instead faceting can be reliably enabled only on the specific queries needed.

### How to test the Change
- Face block previews should continue to work as expected.
- The Facet by Range block should no longer display the "Is this a numeric field?" error if a numeric field is selected.

### Changelog Entry
- Fixed - An issue where Facet block previews may be missing or inaccurate.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
