### PR TITLE
Exclude dist directory from PHP linting

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,4 +19,5 @@
   <rule ref="WordPress.WP.PostsPerPage.posts_per_page_posts_per_page">
       <exclude-pattern>/tests/*.php</exclude-pattern>
   </rule>
+  <exclude-pattern>dist/</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
When we run the `composer lint-fix` command, the php linter tries to fix the PHP files in the `dist` directory. The `dist` directory is already in the gitignore so we don't need to check the linting issue there. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Run `composer lint-fix` command and it should not check the PHP files in the `dist` directory

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Exclude dist directory from the PHP linting


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
