### PR TITLE
Make the meta range facet available + New block title

### DIFF
--- a/assets/js/blocks/facets/meta-range/block.json
+++ b/assets/js/blocks/facets/meta-range/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"title": "Facet by Meta Range (ElasticPress)",
+	"title": "Facet by Meta Range - Beta (ElasticPress)",
 	"textdomain": "elasticpress",
 	"name": "elasticpress/facet-meta-range",
 	"icon": "feedback",

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -50,8 +50,9 @@ class Facets extends Feature {
 		];
 
 		$types = [
-			'taxonomy' => __NAMESPACE__ . '\Types\Taxonomy\FacetType',
-			'meta'     => __NAMESPACE__ . '\Types\Meta\FacetType',
+			'taxonomy'   => __NAMESPACE__ . '\Types\Taxonomy\FacetType',
+			'meta'       => __NAMESPACE__ . '\Types\Meta\FacetType',
+			'meta-range' => __NAMESPACE__ . '\Types\MetaRange\FacetType',
 		];
 
 		/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR makes the meta range facet available without needing any extra code and also labels the block as Beta. As ElasticPress is already inside the parenthesis, I went with `Facet by Meta Range - Beta (ElasticPress)`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3347

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
To be added to the Meta Range Facet changelog entry

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
