### PR TITLE
Add clear link to Facet by Meta Range block.

### DIFF
--- a/assets/js/blocks/facets/meta-range/components/range-facet.js
+++ b/assets/js/blocks/facets/meta-range/components/range-facet.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Range facet component.
  *
  * @param {object} props Props.
+ * @param {string} props.clearUrl Clear filter URL.
  * @param {number} props.min Minimum value.
  * @param {number} props.max Maximum value.
  * @param {string} props.prefix Value prefix.
@@ -20,7 +21,7 @@ import { __ } from '@wordpress/i18n';
  * @param {number[]} props.value Currnet value.
  * @returns {WPElement} Component element.
  */
-export default ({ min, max, prefix, suffix, value, ...props }) => {
+export default ({ clearUrl, min, max, prefix, suffix, value, ...props }) => {
 	return (
 		<div className="ep-range-facet">
 			<div className="ep-range-facet__slider">
@@ -46,6 +47,7 @@ export default ({ min, max, prefix, suffix, value, ...props }) => {
 				{suffix}
 			</div>
 			<div className="ep-range-facet__action">
+				{clearUrl ? <a href={clearUrl}>{__('Clear', 'elasticpress')}</a> : null}{' '}
 				<button type="submit">{__('Filter', 'elasticpress')}</button>
 			</div>
 		</div>

--- a/assets/js/blocks/facets/meta-range/view.js
+++ b/assets/js/blocks/facets/meta-range/view.js
@@ -47,6 +47,11 @@ const App = ({ max, min }) => {
 	const suffix = useMemo(() => min.dataset.suffix, [min]);
 
 	/**
+	 * Clear URL.
+	 */
+	const clearUrl = useMemo(() => (min.value !== '' ? min.form.action : null), [min]);
+
+	/**
 	 * Handle change.
 	 *
 	 * @param {Array} value Value range.
@@ -72,6 +77,7 @@ const App = ({ max, min }) => {
 	 */
 	return (
 		<RangeFacet
+			clearUrl={clearUrl}
 			max={maxAgg}
 			min={minAgg}
 			prefix={prefix}

--- a/includes/classes/Feature/Facets/Types/MetaRange/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Renderer.php
@@ -67,6 +67,7 @@ class Renderer {
 
 		$all_selected_filters = (array) $feature->get_selected();
 		$selected_filters     = $all_selected_filters[ $facet_type->get_filter_type() ] ?? [];
+
 		foreach ( $selected_filters as $filter => $values ) {
 			if ( $this->meta_field !== $filter ) {
 				continue;
@@ -76,10 +77,13 @@ class Renderer {
 			$selected_max_value = $values['_max'] ?? null;
 			unset( $all_selected_filters[ $facet_type->get_filter_type() ][ $filter ] );
 		}
-		$form_action = wp_parse_url( $feature->build_query_url( $all_selected_filters ) );
-		wp_parse_str( $form_action['query'] ?? '', $filter_fields );
+
+		$form_action = $feature->build_query_url( $all_selected_filters );
+		$action_url  = wp_parse_url( $form_action );
+
+		wp_parse_str( $action_url['query'] ?? '', $filter_fields );
 		?>
-		<form class="ep-facet-meta-range">
+		<form action="<?php echo esc_url( $form_action ); ?>" class="ep-facet-meta-range">
 			<input type="hidden" data-prefix="<?php echo esc_attr( $instance['prefix'] ); ?>" data-suffix="<?php echo esc_attr( $instance['suffix'] ); ?>" name="<?php echo esc_attr( $min_field_name ); ?>" min="<?php echo absint( $min ); ?>" max="<?php echo absint( $max ); ?>" value="<?php echo esc_attr( $selected_min_value ); ?>">
 			<input type="hidden" name="<?php echo esc_attr( $max_field_name ); ?>" min="<?php echo absint( $min ); ?>" max="<?php echo absint( $max ); ?>" value="<?php echo esc_attr( $selected_max_value ); ?>">
 


### PR DESCRIPTION
### Description of the Change
While implementing tests I discovered an issue where it wasn't possible to clear the Facet by Range filter, as adjusting the range to the full range was still applying a filter for any posts with that custom field. This PR adds a Clear link to the Facet by Meta Range block which clears the range filter entirely.

### How to test the Change
1. Add the Facet by Meta Range block.
2. View an archive of posts with some posts containing the field used for the range, and some not. All posts should be displayed.
3. Apply the range filter without any changes. Only posts with the field should be show.
4. A clear link should appear on the Facet by Meta Range block. Clicking it should show all posts again.

### Changelog Entry
N/A.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
