### PR TITLE
EP.io messages adjustments

### DIFF
--- a/includes/classes/ElasticPressIo.php
+++ b/includes/classes/ElasticPressIo.php
@@ -19,6 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ElasticPressIo {
 	/**
+	 * Name of the transient that stores EP.io messages
+	 */
+	const MESSAGES_TRANSIENT_NAME = 'ep_elasticpress_io_messages';
+
+	/**
 	 * Return singleton instance of class
 	 *
 	 * @return object
@@ -39,18 +44,33 @@ class ElasticPressIo {
 	 * @return array ElasticPress.io messages.
 	 */
 	public function get_endpoint_messages() {
-		$transient = 'ep_elasticpress_io_messages';
-		$messages  = get_transient( $transient );
+		if ( ! Utils\is_epio() ) {
+			return [];
+		}
 
+		$messages = get_transient( self::MESSAGES_TRANSIENT_NAME );
 		if ( false !== $messages ) {
 			return $messages;
 		}
 
 		$response = \ElasticPress\Elasticsearch::factory()->remote_request( 'endpoint-messages' );
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( is_wp_error( $response ) || 200 !== $response_code ) {
+			return [];
+		}
+
 		$messages = (array) json_decode( wp_remote_retrieve_body( $response ), true );
 
-		set_transient( $transient, $messages, HOUR_IN_SECONDS );
+		set_transient( self::MESSAGES_TRANSIENT_NAME, $messages, HOUR_IN_SECONDS );
 
 		return $messages;
+	}
+
+	/**
+	 * Delete cached messages.
+	 */
+	public function delete_endpoint_messages() {
+		delete_transient( self::MESSAGES_TRANSIENT_NAME );
 	}
 }

--- a/includes/classes/ElasticPressIo.php
+++ b/includes/classes/ElasticPressIo.php
@@ -41,15 +41,17 @@ class ElasticPressIo {
 	/**
 	 * Get messages from ElasticPress.io.
 	 *
+	 * @param bool $skip_cache Whether to fetch the API or use the cached messages. Defaults to false, i.e., use cache.
 	 * @return array ElasticPress.io messages.
 	 */
-	public function get_endpoint_messages() {
+	public function get_endpoint_messages( $skip_cache = false ) : array {
 		if ( ! Utils\is_epio() ) {
 			return [];
 		}
 
-		$messages = get_transient( self::MESSAGES_TRANSIENT_NAME );
-		if ( false !== $messages ) {
+		$transient = 'ep_elasticpress_io_messages';
+		$messages  = get_transient( $transient );
+		if ( ! $skip_cache && false !== $messages ) {
 			return $messages;
 		}
 
@@ -62,15 +64,8 @@ class ElasticPressIo {
 
 		$messages = (array) json_decode( wp_remote_retrieve_body( $response ), true );
 
-		set_transient( self::MESSAGES_TRANSIENT_NAME, $messages, HOUR_IN_SECONDS );
+		set_transient( $transient, $messages, HOUR_IN_SECONDS );
 
 		return $messages;
-	}
-
-	/**
-	 * Delete cached messages.
-	 */
-	public function delete_endpoint_messages() {
-		delete_transient( self::MESSAGES_TRANSIENT_NAME );
 	}
 }

--- a/includes/classes/StatusReport/ElasticPressIo.php
+++ b/includes/classes/StatusReport/ElasticPressIo.php
@@ -228,8 +228,11 @@ class ElasticPressIo extends Report {
 	 * @since 4.5.0
 	 */
 	public function get_messages() : array {
-		$messages = \ElasticPress\ElasticPressIo::factory()->get_endpoint_messages();
-		$messages = array_values( $messages );
+		$elasticpress_io = \ElasticPress\ElasticPressIo::factory();
+
+		$elasticpress_io->delete_endpoint_messages();
+
+		$messages = array_values( $elasticpress_io->get_endpoint_messages() );
 
 		return $messages;
 	}

--- a/includes/classes/StatusReport/ElasticPressIo.php
+++ b/includes/classes/StatusReport/ElasticPressIo.php
@@ -228,11 +228,8 @@ class ElasticPressIo extends Report {
 	 * @since 4.5.0
 	 */
 	public function get_messages() : array {
-		$elasticpress_io = \ElasticPress\ElasticPressIo::factory();
-
-		$elasticpress_io->delete_endpoint_messages();
-
-		$messages = array_values( $elasticpress_io->get_endpoint_messages() );
+		$messages = \ElasticPress\ElasticPressIo::factory()->get_endpoint_messages( true );
+		$messages = array_values( $messages );
 
 		return $messages;
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -58,14 +58,15 @@ class EP_Uninstaller {
 	 * @var array
 	 */
 	protected $transients = [
+		'ep_autosuggest_query_request_cache',
+		'ep_elasticpress_io_messages',
+		'ep_es_info',
 		'ep_es_info_response_code',
 		'ep_es_info_response_error',
-		'logging_ep_es_info',
-		'ep_wpcli_sync_interrupted',
-		'ep_wpcli_sync',
-		'ep_es_info',
-		'ep_autosuggest_query_request_cache',
 		'ep_meta_field_keys',
+		'ep_wpcli_sync',
+		'ep_wpcli_sync_interrupted',
+		'logging_ep_es_info',
 	];
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR addresses a few things:
- Non-EP.io users will not fetch messages anymore
- Failed requests will not be interpreted as messages anymore
- While visiting the Status Report page, new messages will always be fetched
- The transient will be deleted on uninstall

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3375

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
To be added to the EP.io message system changelog entry


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
