### PR TITLE
Exclude non-searchable post types from facet post types.

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -837,6 +837,7 @@ class InstantResults extends Feature {
 
 			$post_types = Features::factory()->get_registered_feature( 'search' )->get_searchable_post_types();
 			$post_types = array_intersect( $post_types, $taxonomy->object_type );
+			$post_types = array_values( $post_types );
 
 			$facets[ $name ] = array(
 				'type'       => 'taxonomy',

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -835,9 +835,12 @@ class InstantResults extends Feature {
 				$slug
 			);
 
+			$post_types = Features::factory()->get_registered_feature( 'search' )->get_searchable_post_types();
+			$post_types = array_intersect( $post_types, $taxonomy->object_type );
+
 			$facets[ $name ] = array(
 				'type'       => 'taxonomy',
-				'post_types' => $taxonomy->object_type,
+				'post_types' => $post_types,
 				'labels'     => array(
 					'admin'    => $admin_label,
 					'frontend' => $labels->singular_name,

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -35,7 +35,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 	beforeEach(() => {
 		cy.deactivatePlugin(
-			'custom-instant-results-template open-instant-results-with-buttons filter-instant-results-per-page',
+			'custom-instant-results-template open-instant-results-with-buttons filter-instant-results-per-page cpt-and-custom-tax',
 			'wpCli',
 		);
 		cy.login();
@@ -112,6 +112,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 			 * Can change the URL when search term is changed
 			 */
 			it('Can see instant results elements, URL changes, reload, and update after changing search term', () => {
+				cy.activatePlugin('cpt-and-custom-tax', 'wpCli');
 				cy.maybeEnableFeature('instant-results');
 
 				cy.intercept({
@@ -121,6 +122,25 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 					},
 				}).as('apiRequest');
 
+				/**
+				 * Add product category facet to test the labelling of facets
+				 * with the same name.
+				 */
+				cy.intercept('**/wp-admin/admin-ajax.php*').as('ajaxRequest');
+				cy.visitAdminPage('admin.php?page=elasticpress');
+				cy.get('.ep-feature-instant-results .settings-button').click();
+				cy.get('.ep-feature-instant-results .components-form-token-field__input').type(
+					'cat{downArrow}{enter}',
+				);
+				cy.get('.ep-feature-instant-results .components-form-token-field__input').type(
+					'prod{downArrow}{enter}{esc}',
+				);
+				cy.get('.ep-feature-instant-results .button-primary').click();
+				cy.wait('@ajaxRequest');
+
+				/**
+				 * Perform a search.
+				 */
 				cy.visit('/');
 
 				cy.get('.wp-block-search').last().as('searchBlock');
@@ -135,6 +155,14 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('@searchModal').should('contain.text', 'blog');
 				// Show the number of results
 				cy.get('@searchModal').find('.ep-search-results__title').contains(/\d+/);
+
+				/**
+				 * The Category facet should specify its searchable post types.
+				 */
+				cy.get('.ep-search-panel__button').contains('Category').as('categoryFacet');
+				cy.get('@categoryFacet').should('contain', 'Posts');
+				cy.get('@categoryFacet').should('contain', 'Movies');
+				cy.get('@categoryFacet').should('not.contain', 'Albums');
 
 				cy.get('.ep-search-sidebar #ep-search-post-type-post')
 					.click()

--- a/tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php
+++ b/tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php
@@ -12,7 +12,7 @@
 namespace ElasticPress\Tests\E2e;
 
 /**
- * Create a CPT called "Movies".
+ * Create a CPT called "Movies" and a non-searchable CPT called "Group".
  */
 function create_post_type() {
 	register_post_type(
@@ -24,6 +24,21 @@ function create_post_type() {
 			],
 			'public'      => true,
 			'has_archive' => true,
+			'taxonomies'  => [ 'category' ],
+		]
+	);
+
+	register_post_type(
+		'group',
+		[
+			'labels'              => [
+				'name'          => __( 'Albums' ),
+				'singular_name' => __( 'Album' ),
+			],
+			'exclude_from_search' => true,
+			'has_archive'         => true,
+			'public'              => true,
+			'taxonomies'          => [ 'category' ],
 		]
 	);
 }


### PR DESCRIPTION
### Description of the Change
Fixes an issue where Instant Results facets have post types that are not publicly searchable, which causes an error when Instant Results attempts to print the labels for those post types, as only labels for publicly searchable post types are provided.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
Fixed - An issue where Instant Results would crash when using taxonomies as facets that are attached to both searchable and non-searchable post types.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
