### PR TITLE
Support filtering Instant Results args schema.

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -25,6 +25,7 @@
         "wp-content/plugins/fake-log-messages.php": "./tests/cypress/wordpress-files/test-plugins/fake-log-messages.php",
         "wp-content/plugins/enable-debug-bar.php": "./tests/cypress/wordpress-files/test-plugins/enable-debug-bar.php",
         "wp-content/plugins/filter-instant-results-per-page.php": "./tests/cypress/wordpress-files/test-plugins/filter-instant-results-per-page.php",
+        "wp-content/plugins/filter-instant-results-args-schema.php": "./tests/cypress/wordpress-files/test-plugins/filter-instant-results-args-schema.php",
         "wp-content/uploads/content-example.xml": "./tests/cypress/wordpress-files/test-docs/content-example.xml"
       }
     }

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -956,7 +956,7 @@ class InstantResults extends Feature {
 		 */
 		$per_page = apply_filters( 'ep_instant_results_per_page', $this->settings['per_page'] );
 
-		$args = array(
+		$args_schema = array(
 			'highlight' => array(
 				'type'          => 'string',
 				'default'       => $this->settings['highlight_tag'],
@@ -999,10 +999,24 @@ class InstantResults extends Feature {
 
 		foreach ( $selected_facets as $key ) {
 			if ( isset( $available_facets[ $key ] ) ) {
-				$args = array_merge( $args, $available_facets[ $key ]['args'] );
+				$args_schema = array_merge( $args_schema, $available_facets[ $key ]['args'] );
 			}
 		}
-		return $args;
+
+		/**
+		 * The schema defining the API arguments used by Instant Results.
+		 *
+		 * The argument schema is used to configure the APISearchProvider
+		 * component used by Instant Results, and should conform to what is
+		 * supported by the API being used. The Instant Results UI expects
+		 * the default list of arguments to be available, so caution is advised
+		 * when adding or removing arguments.
+		 *
+		 * @since 4.5.1
+		 * @hook ep_instant_results_args_schema
+		 * @param {array} $args_schema Results per page.
+		 */
+		return apply_filters( 'ep_instant_results_args_schema', $args_schema );
 	}
 
 	/**

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -35,7 +35,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 	beforeEach(() => {
 		cy.deactivatePlugin(
-			'custom-instant-results-template open-instant-results-with-buttons filter-instant-results-per-page',
+			'custom-instant-results-template open-instant-results-with-buttons filter-instant-results-per-page filter-instant-results-args-schema',
 			'wpCli',
 		);
 		cy.login();
@@ -308,6 +308,34 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('.my-custom-result').should('exist');
 				cy.get('.ep-search-result').should('not.exist');
 			});
+		});
+
+		it('Is possible to filter the arguments schema', () => {
+			/**
+			 * The number of results should match the posts per page
+			 * setting by default.
+			 */
+			cy.maybeEnableFeature('instant-results');
+			cy.intercept('*search=block*').as('apiRequest');
+
+			/**
+			 * Activate test plugin.
+			 */
+			cy.activatePlugin('filter-instant-results-args-schema', 'wpCli');
+
+			/**
+			 * Perform a search.
+			 */
+			cy.visit('/');
+			cy.get('.wp-block-search').last().as('searchBlock');
+			cy.get('@searchBlock').find('input[type="search"]').type('block');
+			cy.get('@searchBlock').find('button').click();
+			cy.wait('@apiRequest');
+
+			/**
+			 * Results should be sorted by date.
+			 */
+			cy.get('.ep-search-sort :selected').should('contain.text', 'Date, newest to oldest');
 		});
 	});
 });

--- a/tests/cypress/wordpress-files/test-plugins/filter-instant-results-args-schema.php
+++ b/tests/cypress/wordpress-files/test-plugins/filter-instant-results-args-schema.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Argument Schema
+ * Description: Filters the Instant Results arguments schema for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_filter(
+	'ep_instant_results_args_schema',
+	function( $args_schema ) {
+		$args_schema['orderby']['default'] = 'date';
+
+		return $args_schema;
+	}
+);


### PR DESCRIPTION
### Description of the Change
Adds `ep_instant_results_args_schema` filter for filtering Instant Results arguments schema.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3385

### How to test the Change
Adding this code should change the default sorting of results.

```
add_filter(
	'ep_instant_results_args_schema',
	function( $args_schema ) {
		$args_schema['orderby']['default'] = 'date';

		return $args_schema;
	}
);
```

### Changelog Entry
Added - `ep_instant_results_args_schema` filter for filtering Instant Results arguments schema.> Changed - Existing functionality.

### Credits
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
