### PR TITLE
Add tests for status report

### DIFF
--- a/tests/php/TestStatusReport.php
+++ b/tests/php/TestStatusReport.php
@@ -404,6 +404,9 @@ class TestStatusReport extends BaseTestCase {
 
 		$this->assertSame( $expected_result, $report->get_groups()[0]['fields'] );
 		$this->assertEquals( 'Failed Queries', $report->get_title() );
+
+		// test the actions label
+		$this->assertEquals( 'Clear query log', $report->get_actions()[0]['label'] );
 	}
 
 	/**

--- a/tests/php/TestStatusReport.php
+++ b/tests/php/TestStatusReport.php
@@ -9,6 +9,7 @@
 namespace ElasticPressTest;
 
 use \ElasticPress\Screen\StatusReport;
+use \ElasticPress\Utils;
 
 /**
  * Test the Status Report class
@@ -66,5 +67,235 @@ class TestStatusReport extends BaseTestCase {
 			[ 'failed-queries', 'elasticpress', 'indices', 'last-sync', 'features' ],
 			array_keys( $reports )
 		);
+	}
+
+	/**
+	 * Tests the WordPress report.
+	 *
+	 * @group statusReport
+	 * @since x.x.x
+	 */
+	public function testWordPressReport() {
+		global $wp_version;
+
+		$report = new \ElasticPress\StatusReport\WordPress();
+
+		$expected_result = array(
+			array(
+				'title'  => 'WordPress Environment',
+				'fields' => array(
+					'wp_version'   => array(
+						'label' => 'WordPress Version',
+						'value' => $wp_version,
+					),
+					'home_url'     => array(
+						'label' => 'Home URL',
+						'value' => get_home_url(),
+					),
+					'site_url'     => array(
+						'label' => 'Site URL',
+						'value' => get_site_url(),
+					),
+					'is_multisite' => array(
+						'label' => 'Multisite',
+						'value' => is_multisite(),
+					),
+					'theme'        => array(
+						'label' => 'Theme',
+						'value' => sprintf( '%s (%s)', wp_get_theme()->get( 'Name' ), wp_get_theme()->get( 'Version' ) ),
+					),
+					'plugins'      => array(
+						'label' => 'Active Plugins',
+						'value' => '',
+					),
+					'revisions'    => array(
+						'label' => 'Revisions allowed',
+						'value' => WP_POST_REVISIONS === true ? 'all' : (int) WP_POST_REVISIONS,
+					),
+				),
+			),
+			array(
+				'title'  => 'Server Environment',
+				'fields' => array(
+					'php_version'  => array(
+						'label' => 'PHP Version',
+						'value' => phpversion(),
+					),
+					'memory_limit' => array(
+						'label' => 'Memory Limit',
+						'value' => WP_MEMORY_LIMIT,
+					),
+					'timeout'      => array(
+						'label' => 'Maximum Execution Time',
+						'value' => (int) ini_get( 'max_execution_time' ),
+					),
+				),
+			),
+		);
+
+		$this->assertSame( $expected_result, $report->get_groups() );
+		$this->assertEquals( 'WordPress', $report->get_title() );
+	}
+
+	/**
+	 * Tests the Last Sync report.
+	 *
+	 * @group statusReport
+	 * @since x.x.x
+	 */
+	public function testLastSyncReport() {
+		$report = new \ElasticPress\StatusReport\LastSync();
+
+		// Test when no last sync information is available
+		$this->assertEmpty( $report->get_groups() );
+
+		$start_time    = microtime( true );
+		$end_date_time = date_create( 'now', wp_timezone() );
+
+		$last_index                    = [];
+		$last_index['end_date_time']   = $end_date_time->format( DATE_ATOM );
+		$last_index['start_date_time'] = wp_date( DATE_ATOM, (int) $start_time );
+		$last_index['end_time_gmt']    = time();
+		$last_index['total_time']      = microtime( true ) - $start_time;
+		$last_index['method']          = 'cli';
+		$last_index['is_full_sync']    = 'Yes';
+		Utils\update_option( 'ep_last_index', $last_index );
+
+		$expected_result = array(
+			array(
+				'title'  => wp_date( 'Y/m/d g:i:s a', strtotime( $last_index['start_date_time'] ) ),
+				'fields' => array(
+					'method'          => array(
+						'label' => 'Method',
+						'value' => 'WP-CLI',
+					),
+					'is_full_sync'    => array(
+						'label' => 'Full Sync',
+						'value' => $last_index['is_full_sync'],
+					),
+					'start_date_time' => array(
+						'label' => 'Start Date Time',
+						'value' => wp_date( 'Y/m/d g:i:s a', strtotime( $last_index['start_date_time'] ) ),
+					),
+					'end_date_time'   => array(
+						'label' => 'End Date Time',
+						'value' => wp_date( 'Y/m/d g:i:s a', strtotime( $last_index['end_date_time'] ) ),
+					),
+					'total_time'      => array(
+						'label' => 'Total Time',
+						'value' => human_readable_duration( gmdate( 'H:i:s', ceil( $last_index['total_time'] ) ) ),
+					),
+				),
+			),
+		);
+
+		$this->assertSame( $expected_result, $report->get_groups() );
+		$this->assertEquals( 'Last Sync', $report->get_title() );
+
+		Utils\delete_option( 'ep_last_index' );
+	}
+
+	/**
+	 * Tests the Indices report.
+	 *
+	 * @group statusReport
+	 * @since x.x.x
+	 */
+	public function testIndicesReport() {
+		$report = new \ElasticPress\StatusReport\Indices();
+
+		$group         = $report->get_groups();
+		$expected_keys = [ 'health', 'status', 'index', 'uuid', 'pri', 'rep', 'docs.count', 'docs.deleted', 'store.size', 'pri.store.size', 'total_fields_limit' ];
+
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $group[0]['fields'] );
+		}
+
+		$this->assertEquals( 'Elasticsearch Indices', $report->get_title() );
+	}
+
+	/**
+	 * Tests the Indexable Content report.
+	 *
+	 * @group statusReport
+	 * @since x.x.x
+	 */
+	public function testIndexableContentReport() {
+		// set screen to status report
+		add_filter( 'ep_install_status', '__return_true' );
+		$_GET['page'] = 'elasticpress-status-report';
+		\ElasticPress\Screen::factory()->determine_screen();
+
+		$post_indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+		$post_types     = $post_indexable->get_indexable_post_types();
+
+		$posts_fields       = array();
+		$meta_fields        = array();
+		$distinct_meta_keys = array();
+
+		foreach ( $post_types as $post_type ) {
+			$this->ep_factory->post->create_many(
+				10,
+				array(
+					'post_type'  => $post_type,
+					'meta_input' => array(
+						'unique_meta_key_' . $post_type => 'foo',
+						'shared_meta_key'               => 'bar',
+					),
+				)
+			);
+
+			$post_type_obj                         = get_post_type_object( $post_type );
+			$posts_fields[ $post_type . '_count' ] = array(
+				'label' => sprintf( '%s (%s)', $post_type_obj->labels->name, $post_type ),
+				'value' => '10',
+			);
+
+			$meta_fields[ $post_type . '_meta_keys' ] = array(
+				'label'       => sprintf( '%s (%s) Meta Keys', $post_type_obj->labels->singular_name, $post_type ),
+				'description' => '',
+				'value'       => '2',
+			);
+
+			$distinct_meta_keys = array_merge( $distinct_meta_keys, array( 'unique_meta_key_' . $post_type, 'shared_meta_key' ) );
+		}
+
+		$meta_fields['total-all-post-types'] = array(
+			'label' => 'Total Distinct Meta Keys',
+			'value' => count( $post_types ) + 1,
+		);
+
+		$meta_fields['distinct-meta-keys'] = array(
+			'label' => 'Distinct Meta Keys',
+			'value' => wp_sprintf( '%l', array_unique( $distinct_meta_keys ) ),
+		);
+
+		$expected_result = array(
+			array(
+				'title'  => sprintf( '%1$s &mdash; %2$s', get_option( 'blogname' ), site_url() ),
+				'fields' => array_merge( $posts_fields, $meta_fields ),
+			),
+		);
+
+		$report = new \ElasticPress\StatusReport\IndexableContent();
+
+		$this->assertSame( $expected_result, $report->get_groups() );
+		$this->assertEquals( 'Elasticsearch Indices', $report->get_title() );
+	}
+
+
+	public function testFeatureReport() {
+		// deactivate all feature.
+		Utils\delete_option( 'ep_feature_settings');
+
+		// activate search feature.
+		\ElasticPress\Features::factory()->activate_feature( 'search' );
+
+		$report = new \ElasticPress\StatusReport\Features();
+		$groups = $report->get_groups();
+
+		$this->assertEquals( 1, count( $groups ) );
+		$this->assertEquals( 'Post Search', $groups[0]['title'] );
+		$this->assertEquals( 'Feature Settings', $report->get_title() );
 	}
 }

--- a/tests/php/TestStatusReport.php
+++ b/tests/php/TestStatusReport.php
@@ -73,7 +73,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests the WordPress report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testWordPressReport() {
 		global $wp_version;
@@ -141,7 +141,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests the Last Sync report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testLastSyncReport() {
 		$report = new \ElasticPress\StatusReport\LastSync();
@@ -199,7 +199,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests the Indices report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testIndicesReport() {
 		$report = new \ElasticPress\StatusReport\Indices();
@@ -218,7 +218,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests the Indexable Content report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testIndexableContentReport() {
 		// set screen to status report
@@ -287,7 +287,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests the Feature report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testFeatureReport() {
 		// deactivate all feature.
@@ -308,7 +308,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests the Failed Queries report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testFailedQueriesReport() {
 		$time_stamp = time();
@@ -413,7 +413,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests ElasticPress.io report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testElasticPressIoReport() {
 		\ElasticPress\Features::factory()->activate_feature( 'autosuggest' );
@@ -433,7 +433,7 @@ class TestStatusReport extends BaseTestCase {
 	 * Tests ElasticPress report.
 	 *
 	 * @group statusReport
-	 * @since x.x.x
+	 * @since 4.5.1
 	 */
 	public function testElasticPressReport() {
 		$report = new \ElasticPress\StatusReport\ElasticPress();


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the unit tests for the Status Report feature.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3218

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Unit tests for the Status Reports feature.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
