### PR TITLE
Use error logging limit for current_sync_item too

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -699,6 +699,7 @@ class IndexHelper {
 
 			if ( is_wp_error( $return ) ) {
 				$this->index_meta['current_sync_item']['failed'] += count( $queued_items );
+
 				$wp_error_messages = $return->get_error_messages();
 
 				if ( count( $this->index_meta['current_sync_item']['errors'] ) + count( $wp_error_messages ) > $logged_errors ) {
@@ -713,7 +714,7 @@ class IndexHelper {
 					}
 				}
 
-				$this->index_meta['current_sync_item']['errors']  = array_merge( $this->index_meta['current_sync_item']['errors'], $wp_error_messages );
+				$this->index_meta['current_sync_item']['errors'] = array_merge( $this->index_meta['current_sync_item']['errors'], $wp_error_messages );
 
 				$this->output( implode( "\n", $wp_error_messages ), 'warning' );
 			} elseif ( count( $failed_objects ) ) {

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -685,15 +685,54 @@ class IndexHelper {
 				}
 			}
 
+			/**
+			 * Filter the number of errors of a sync that should be stored.
+			 *
+			 * @since  4.2.0
+			 * @hook ep_sync_number_of_errors_stored
+			 * @param  {int} $number Number of errors to be logged.
+			 * @return {int} New value
+			 */
+			$logged_errors = (int) apply_filters( 'ep_sync_number_of_errors_stored', 50 );
+
+			$error_store_msg = 'Reached maximum number of errors to store';
+
 			if ( is_wp_error( $return ) ) {
 				$this->index_meta['current_sync_item']['failed'] += count( $queued_items );
-				$this->index_meta['current_sync_item']['errors']  = array_merge( $this->index_meta['current_sync_item']['errors'], $return->get_error_messages() );
+				$wp_error_messages = $return->get_error_messages();
 
-				$this->output( implode( "\n", $return->get_error_messages() ), 'warning' );
+				if ( count( $this->index_meta['current_sync_item']['errors'] ) + count( $wp_error_messages ) > $logged_errors ) {
+					$diff = $logged_errors - count( $this->index_meta['current_sync_item']['errors'] );
+					if ( $diff > 0 ) {
+						$wp_error_messages = array_slice( $wp_error_messages, 0, $diff );
+					} else {
+						$wp_error_messages = [];
+						if ( end( $this->index_meta['current_sync_item']['errors'] ) !== $error_store_msg ) {
+							$this->index_meta['current_sync_item']['errors'][] = $error_store_msg;
+						}
+					}
+				}
+
+				$this->index_meta['current_sync_item']['errors']  = array_merge( $this->index_meta['current_sync_item']['errors'], $wp_error_messages );
+
+				$this->output( implode( "\n", $wp_error_messages ), 'warning' );
 			} elseif ( count( $failed_objects ) ) {
 				$errors_output = $this->output_index_errors( $failed_objects );
 
 				$this->index_meta['current_sync_item']['synced'] += count( $queued_items ) - count( $failed_objects );
+
+				if ( $this->index_meta['current_sync_item']['failed'] + count( $failed_objects ) > $logged_errors ) {
+					$diff = $logged_errors - $this->index_meta['current_sync_item']['failed'];
+					if ( $diff > 0 ) {
+						$errors_output = array_slice( $errors_output, 0, $diff );
+					} else {
+						$errors_output = [];
+						if ( end( $this->index_meta['current_sync_item']['errors'] ) !== $error_store_msg ) {
+							$this->index_meta['current_sync_item']['errors'][] = $error_store_msg;
+						}
+					}
+				}
+
 				$this->index_meta['current_sync_item']['failed'] += count( $failed_objects );
 				$this->index_meta['current_sync_item']['errors']  = array_merge( $this->index_meta['current_sync_item']['errors'], $errors_output );
 

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -685,18 +685,6 @@ class IndexHelper {
 				}
 			}
 
-			/**
-			 * Filter the number of errors of a current sync that should be stored.
-			 *
-			 * @since  5.0.0
-			 * @hook ep_current_sync_number_of_errors_stored
-			 * @param  {int} $number Number of errors to be logged.
-			 * @return {int} New value
-			 */
-			$logged_errors = (int) apply_filters( 'ep_current_sync_number_of_errors_stored', 50 );
-
-			$error_store_msg = __( 'Reached maximum number of errors to store', 'elasticpress' );
-
 			if ( is_wp_error( $return ) ) {
 				$this->index_meta['current_sync_item']['failed'] += count( $queued_items );
 
@@ -705,8 +693,7 @@ class IndexHelper {
 				$this->process_error_limit(
 					count( $this->index_meta['current_sync_item']['errors'] ) + count( $wp_error_messages ),
 					count( $this->index_meta['current_sync_item']['errors'] ),
-					$wp_error_messages,
-					$logged_errors
+					$wp_error_messages
 				);
 
 				$this->output( implode( "\n", $wp_error_messages ), 'warning' );
@@ -718,8 +705,7 @@ class IndexHelper {
 				$this->maybe_process_error_limit(
 					$this->index_meta['current_sync_item']['failed'] + count( $failed_objects ),
 					$this->index_meta['current_sync_item']['failed'],
-					$errors_output,
-					$logged_errors
+					$errors_output
 				);
 
 				$this->index_meta['current_sync_item']['failed'] += count( $failed_objects );
@@ -750,14 +736,25 @@ class IndexHelper {
 	/**
 	 * If the number of errors is greater than the limit, slice the array to the limit.
 	 * If the number of errors is less than or equal the limit, add the error message to the array (if it's not there).
+	 * Merges the new errors with the existing errors.
 	 *
+	 * @since  5.0.0
 	 * @param int   $count Number of errors.
 	 * @param int   $num Number of errors to subtract from $limit.
 	 * @param array $errors Array of errors.
-	 * @param int   $limit Limit of errors.
 	 */
-	protected function maybe_process_error_limit( $count, $num, $errors, $limit ) {
+	protected function maybe_process_error_limit( $count, $num, $errors ) {
 		$error_store_msg = __( 'Reached maximum number of errors to store', 'elasticpress' );
+
+		/**
+		 * Filter the number of errors of a current sync that should be stored.
+		 *
+		 * @since  5.0.0
+		 * @hook ep_current_sync_number_of_errors_stored
+		 * @param  {int} $number Number of errors to be logged.
+		 * @return {int} New value
+		 */
+		$limit = (int) apply_filters( 'ep_current_sync_number_of_errors_stored', 50 );
 
 		if ( $limit > 0 && $count > $limit ) {
 			$diff = $limit - $num;


### PR DESCRIPTION
### Description of the Change
The `ep_index_meta` option gets too large if there are many posts that fail to index. It happens at https://github.com/10up/ElasticPress/blob/0f32025fb439c6ba04fe343cd106ebd4ed6d5743/includes/classes/IndexHelper.php#L698

For example, running an index with lots of errors and then while that is happening, I grab the `ep_index_meta` option:
```
 'synced' => 0,
    'skipped' => 0,
    'failed' => 1022,
    'errors' =>
    array (
      0 => '1289 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      1 => '1288 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      2 => '1287 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      3 => '1286 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
...
      74 => '1215 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      75 => '1214 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      76 => '...
```

It'd be nice to limit it the same way we do it at https://github.com/10up/ElasticPress/blob/0f32025fb439c6ba04fe343cd106ebd4ed6d5743/includes/classes/IndexHelper.php#L744-L750 to prevent site instability.

### How to test the Change
1) In my case, I used bad mapping to trigger the error and created a bunch of posts to index with a category:
```
{"mappings":{"dynamic_templates":[{"template_meta":{"path_match":"post_meta.*","mapping":{"fields":{"{name}":{"type":"text"},"raw":{"ignore_above":10922,"type":"keyword"}},"path":"full","type":"text"}}},{"template_meta_types":{"path_match":"meta.*","mapping":{"path":"full","properties":{"date":{"format":"yyyy-MM-dd","type":"date"},"datetime":{"format":"yyyy-MM-dd HH:mm:ss","type":"date"},"boolean":{"type":"boolean"},"double":{"type":"double"},"raw":{"ignore_above":10922,"type":"keyword"},"time":{"format":"HH:mm:ss","type":"date"},"value":{"type":"text","fields":{"raw":{"ignore_above":10922,"type":"keyword"},"sortable":{"normalizer":"lowerasciinormalizer","ignore_above":10922,"type":"keyword"}}},"long":{"type":"long"}},"type":"object"}}},{"template_terms":{"path_match":"terms.*","mapping":{"path":"full","properties":{"parent":{"type":"long"},"name":{"type":"text","fields":{"raw":{"type":"keyword"},"sortable":{"normalizer":"lowerasciinormalizer","type":"keyword"}}},"term_taxonomy_id":{"type":"long"},"term_order":{"type":"long"},"term_id":{"type":"long"},"slug":{"type":"keyword"}},"type":"object"}}},{"term_suggest":{"path_match":"term_suggest_*","mapping":{"analyzer":"default","type":"completion"}}}],"date_detection":false,"properties":{"ID":{"type":"long"},"comment_count":{"type":"long"},"comment_status":{"type":"text","fields":{"keyword":{"type":"keyword","ignore_above":256}}},"date_gmt_terms":{"properties":{"day":{"type":"integer"},"dayofweek":{"type":"integer"},"dayofweek_iso":{"type":"integer"},"dayofyear":{"type":"integer"},"hour":{"type":"integer"},"m":{"type":"integer"},"minute":{"type":"integer"},"month":{"type":"integer"},"second":{"type":"integer"},"week":{"type":"integer"},"year":{"type":"integer"}}},"date_terms":{"properties":{"day":{"type":"integer"},"dayofweek":{"type":"integer"},"dayofweek_iso":{"type":"integer"},"dayofyear":{"type":"integer"},"hour":{"type":"integer"},"m":{"type":"integer"},"minute":{"type":"integer"},"month":{"type":"integer"},"second":{"type":"integer"},"week":{"type":"integer"},"year":{"type":"integer"}}},"guid":{"type":"keyword"},"menu_order":{"type":"long"},"meta":{"type":"object"},"modified_date_gmt_terms":{"properties":{"day":{"type":"integer"},"dayofweek":{"type":"integer"},"dayofweek_iso":{"type":"integer"},"dayofyear":{"type":"integer"},"hour":{"type":"integer"},"m":{"type":"integer"},"minute":{"type":"integer"},"month":{"type":"integer"},"second":{"type":"integer"},"week":{"type":"integer"},"year":{"type":"integer"}}},"modified_date_terms":{"properties":{"day":{"type":"integer"},"dayofweek":{"type":"integer"},"dayofweek_iso":{"type":"integer"},"dayofyear":{"type":"integer"},"hour":{"type":"integer"},"m":{"type":"integer"},"minute":{"type":"integer"},"month":{"type":"integer"},"second":{"type":"integer"},"week":{"type":"integer"},"year":{"type":"integer"}}},"permalink":{"type":"keyword"},"ping_status":{"type":"text","fields":{"keyword":{"type":"keyword","ignore_above":256}}},"post_author":{"properties":{"display_name":{"type":"text","fields":{"raw":{"type":"keyword"},"sortable":{"type":"keyword","normalizer":"lowerasciinormalizer"}}},"id":{"type":"long"},"login":{"type":"text","fields":{"raw":{"type":"keyword"},"sortable":{"type":"keyword","normalizer":"lowerasciinormalizer"}}},"raw":{"type":"keyword"}}},"post_content":{"type":"text"},"post_content_filtered":{"type":"text"},"post_date":{"type":"date","format":"yyyy-MM-dd HH:mm:ss"},"post_date_gmt":{"type":"date","format":"yyyy-MM-dd HH:mm:ss"},"post_excerpt":{"type":"text"},"post_id":{"type":"long"},"post_meta":{"type":"object"},"post_mime_type":{"type":"keyword"},"post_modified":{"type":"date","format":"yyyy-MM-dd HH:mm:ss"},"post_modified_gmt":{"type":"date","format":"yyyy-MM-dd HH:mm:ss"},"post_name":{"type":"text","fields":{"post_name":{"type":"text"},"raw":{"type":"keyword","ignore_above":10922}}},"post_parent":{"type":"long"},"post_status":{"type":"keyword"},"post_title":{"type":"text","fields":{"post_title":{"type":"text","analyzer":"standard"},"raw":{"type":"keyword","ignore_above":10922},"sortable":{"type":"keyword","ignore_above":10922,"normalizer":"lowerasciinormalizer"}}},"post_type":{"type":"text","fields":{"post_type":{"type":"text"},"raw":{"type":"keyword"}}},"terms":{"properties":{"category":{"properties":{"name":{"type":"text","fields":{"raw":{"type":"keyword"},"sortable":{"type":"keyword","normalizer":"lowerasciinormalizer"}}},"parent":{"type":"long"},"slug":{"type":"keyword"},"term_id":{"type":"long"},"term_order":{"type":"long"},"term_taxonomy_id":{"type":"long"}}}}}}}}
```
2) I created a bunch of posts and a category called `test-category`
3) I bulk assigned a lot of them the category `test-category`
4) I started an index with `wp elasticpress index --per-page=4` and watched it get over 50, and then did on a separate screen `wp option get ep_index_meta`:
```
array (
  'method' => 'cli',
  'put_mapping' => false,
  'offset' => 356,
  'pagination_method' => 'id_range',
  'start' => true,
  'sync_stack' =>
  array (
  ),
  'network_alias' =>
  array (
  ),
  'start_time' => 1679419485.275893,
  'start_date_time' => '2023-03-21T17:24:45+00:00',
  'totals' =>
  array (
    'total' => 0,
    'synced' => 0,
    'skipped' => 0,
    'failed' => 0,
    'total_time' => 0,
    'errors' =>
    array (
    ),
  ),
  'current_sync_item' =>
  array (
    'url' => 'http://es-site.vipdev.lndo.site',
    'blog_id' => 1,
    'indexable' => 'post',
    'put_mapping' => false,
    'found_items' => 2203,
    'total' => 2203,
    'synced' => 0,
    'skipped' => 0,
    'failed' => 356,
    'errors' =>
    array (
      0 => '2309 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      1 => '2308 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      2 => '2307 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      3 => '2306 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      4 => '2305 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      5 => '2304 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      6 => '2303 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      7 => '2302 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      8 => '2301 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      9 => '2300 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      10 => '2299 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      11 => '2298 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      12 => '2297 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      13 => '2296 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      14 => '2295 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      15 => '2294 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      16 => '2293 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      17 => '2292 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      18 => '2291 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      19 => '2290 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      20 => '2289 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      21 => '2288 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      22 => '2287 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      23 => '2286 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      24 => '2285 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      25 => '2284 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      26 => '2283 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      27 => '2282 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      28 => '2281 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      29 => '2280 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      30 => '2279 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      31 => '2278 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      32 => '2277 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      33 => '2276 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      34 => '2275 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      35 => '2274 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      36 => '2273 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      37 => '2272 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      38 => '2271 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      39 => '2270 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      40 => '2269 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      41 => '2268 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      42 => '2267 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      43 => '2266 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      44 => '2265 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      45 => '2264 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      46 => '2263 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      47 => '2262 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      48 => '2261 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      49 => '2260 (Post): [mapper_parsing_exception] object mapping for [terms.category.facet] tried to parse field [facet] as object, but found a concrete value',
      50 => 'Reached maximum number of errors to store',
    ),
    'last_processed_object_id' => 1954,
  ),
  'from' => 354,
  'found_items' => 2203,
)
```

### Changelog Entry
> Fixed - ep_index_meta option blowing up on an indexing process with many errors


### Credits
Props @rebeccahum 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
