### PR TITLE
Require the utils file in the uninstaller

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,7 +76,8 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}"
         ./bin/wp-env-cli tests-wordpress "cp -r wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"
 
@@ -144,6 +145,7 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}"
         ./bin/wp-env-cli tests-wordpress "cp -r wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,8 +76,8 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network" || true
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}" || true
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
 
   cypress_epio:
@@ -144,6 +144,6 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network" || true
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}" || true
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,7 +76,7 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "cp wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
+        ./bin/wp-env-cli tests-wordpress "cp -r wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"
 
   cypress_epio:
@@ -143,5 +143,5 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "cp wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
+        ./bin/wp-env-cli tests-wordpress "cp -r wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -72,6 +72,13 @@ jobs:
       if: always()
       run: cd bin/es-docker/ && docker-compose down
 
+    - name: Test plugin uninstall
+      if: always()
+      run: |
+        PLUGIN_NAME=$(basename "$PWD")
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
+
   cypress_epio:
     name: Cypress - EP.io
     runs-on: ubuntu-latest
@@ -131,3 +138,10 @@ jobs:
         PLUGIN_NAME=$(basename "$PWD")
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin activate ${PLUGIN_NAME} --network"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root elasticpress-tests delete-all-indices"
+
+    - name: Test plugin uninstall
+      if: always()
+      run: |
+        PLUGIN_NAME=$(basename "$PWD")
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,7 +76,8 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network" || true
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}" || true
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
 
   cypress_epio:
@@ -143,5 +144,6 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network" || true
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}" || true
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,9 +76,7 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
-        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}"
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME} --deactivate"
 
   cypress_epio:
     name: Cypress - EP.io
@@ -144,6 +142,4 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
-        ! ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME}"
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME} --deactivate"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,6 +76,7 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
         ./bin/wp-env-cli tests-wordpress "cp -r wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"
 
@@ -143,5 +144,6 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
         ./bin/wp-env-cli tests-wordpress "cp -r wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -77,7 +77,7 @@ jobs:
       run: |
         PLUGIN_NAME=$(basename "$PWD")
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME} --deactivate"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
 
   cypress_epio:
     name: Cypress - EP.io
@@ -144,4 +144,4 @@ jobs:
       run: |
         PLUGIN_NAME=$(basename "$PWD")
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME} --deactivate"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,6 +76,7 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME} --deactivate"
 
   cypress_epio:
@@ -142,4 +143,5 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
         ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME} --deactivate"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -76,8 +76,8 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
+        ./bin/wp-env-cli tests-wordpress "cp wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"
 
   cypress_epio:
     name: Cypress - EP.io
@@ -143,5 +143,5 @@ jobs:
       if: always()
       run: |
         PLUGIN_NAME=$(basename "$PWD")
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate ${PLUGIN_NAME} --network"
-        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ${PLUGIN_NAME}"
+        ./bin/wp-env-cli tests-wordpress "cp wp-content/plugins/${PLUGIN_NAME} wp-content/plugins/ep-delete"
+        ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin uninstall ep-delete"

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,6 +10,10 @@
 
 use ElasticPress\Utils;
 
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/includes/utils.php';
+
 /**
  * Class EP_Uninstaller
  */


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixes an error while uninstalling the plugin:

Fatal error: Uncaught Error: Call to undefined function ElasticPress\Utils\get_capability() in /var/www/html/wp-content/plugins/elasticpress/uninstall.php:225

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Install and activate the plugin, then run `wp plugin uninstall elasticpress`

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fatal error during plugin uninstall


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
