### PR TITLE
Fix React errors in WordPress 6.2

### DIFF
--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -280,29 +280,33 @@ export const ApiSearchProvider = ({
 	 *
 	 * @returns {void}
 	 */
-	const handleSearch = useCallback(async () => {
-		const { args, isOn, isPoppingState } = stateRef.current;
+	const handleSearch = useCallback(() => {
+		const handle = async () => {
+			const { args, isOn, isPoppingState } = stateRef.current;
 
-		if (!isPoppingState) {
-			pushState();
-		}
+			if (!isPoppingState) {
+				pushState();
+			}
 
-		if (!isOn) {
-			return;
-		}
+			if (!isOn) {
+				return;
+			}
 
-		const urlParams = getUrlParamsFromArgs(args, argsSchema);
+			const urlParams = getUrlParamsFromArgs(args, argsSchema);
 
-		setIsLoading(true);
+			setIsLoading(true);
 
-		const response = await fetchResults(urlParams);
+			const response = await fetchResults(urlParams);
 
-		if (!response) {
-			return;
-		}
+			if (!response) {
+				return;
+			}
 
-		setResults(response);
-		setIsLoading(false);
+			setResults(response);
+			setIsLoading(false);
+		};
+
+		handle();
 	}, [argsSchema, fetchResults, pushState]);
 
 	/**

--- a/assets/js/instant-results/components/common/checkbox.js
+++ b/assets/js/instant-results/components/common/checkbox.js
@@ -15,13 +15,24 @@ import { WPElement } from '@wordpress/element';
  * @returns {WPElement} Component element.
  */
 export default ({ count, disabled, id, label, onChange, ...props }) => {
+	/**
+	 * Handle change event if checkbox is not disabled.
+	 *
+	 * @param {Event} e Change event.
+	 */
+	const maybeOnChange = (e) => {
+		if (!disabled) {
+			onChange(e);
+		}
+	};
+
 	return (
 		<div className="ep-search-checkbox">
 			<input
 				aria-disabled={disabled}
 				className="ep-search-checkbox__input"
 				id={id}
-				onChange={!disabled ? onChange : null}
+				onChange={maybeOnChange}
 				type="checkbox"
 				{...props}
 			/>{' '}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Fixes two React errors, including one which causes a crash in React 18/WordPress 6.2. 

WordPress 6.2 will still display this console notice:
```
Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot
```
But Instant Results will continue to work.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3416

### How to test the Change
Instant Results should not crash instantly when used in WordPress 6.2.

### Changelog Entry
Fixed - A compatibility issue which prevented Instant Results from working in WordPress 6.2.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
