### PR TITLE
Meta and Meta Range facets only available on WP 5.8+

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -50,10 +50,13 @@ class Facets extends Feature {
 		];
 
 		$types = [
-			'taxonomy'   => __NAMESPACE__ . '\Types\Taxonomy\FacetType',
-			'meta'       => __NAMESPACE__ . '\Types\Meta\FacetType',
-			'meta-range' => __NAMESPACE__ . '\Types\MetaRange\FacetType',
+			'taxonomy' => __NAMESPACE__ . '\Types\Taxonomy\FacetType',
 		];
+
+		if ( version_compare( get_bloginfo( 'version' ), '5.8', '>=' ) ) {
+			$types['meta']       = __NAMESPACE__ . '\Types\Meta\FacetType';
+			$types['meta-range'] = __NAMESPACE__ . '\Types\MetaRange\FacetType';
+		}
 
 		/**
 		 * Filter the Facet types available.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR adds a check for the WordPress version before making the Meta and Meta Range facets available, as they depend on a WordPress class only available in WP 5.8+

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3401

As testing this depends on the WP version, I've opened #3421 to have that done.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fatal error while syncing on older versions of WordPress


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @TorlockC 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
