### PR TITLE
Keep taxonomy query parameters in Facets URLs

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -513,6 +513,21 @@ class Facets extends Feature {
 	public function get_allowed_query_args() {
 		$args = array( 's', 'post_type', 'orderby' );
 
+		// Retrieve all registered query variables for public taxonomies
+		$taxonomies = get_taxonomies( [ 'public' => true ], 'objects' );
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( $taxonomy->query_var ) {
+				$args[] = $taxonomy->query_var;
+			}
+		}
+		/**
+		 * To keep backward compatibility, WordPress uses  `'cat'` for default categories.
+		 * It also allows access using the `?taxonomy=<tax>&term=<term>` format.
+		 *
+		 * @see get_term_link()
+		 */
+		$args = array_merge( $args, [ 'cat', 'taxonomy', 'term' ] );
+
 		/**
 		 * Filter allowed query args
 		 *

--- a/tests/php/features/TestFacet.php
+++ b/tests/php/features/TestFacet.php
@@ -319,6 +319,45 @@ class TestFacet extends BaseTestCase {
 	}
 
 	/**
+	 * Test get_allowed_query_args
+	 *
+	 * @since 4.5.1
+	 * @group facets
+	 */
+	public function testGetAllowedQueryArgs() {
+		$facet_feature = Features::factory()->get_registered_feature( 'facets' );
+
+		$default_allowed_args = [
+			// Default:
+			's',
+			'post_type',
+			'orderby',
+			// Taxonomy related:
+			'cat',
+			'category_name',
+			'post_format',
+			'product_cat',
+			'product_tag',
+			'tag',
+			'taxonomy',
+			'term',
+		];
+
+		$this->assertEqualsCanonicalizing( $default_allowed_args, $facet_feature->get_allowed_query_args() );
+
+		/**
+		 * Test the `ep_facet_allowed_query_args` filter
+		 */
+		$add_allowed_query_arg = function ( $allowed ) {
+			$allowed[] = 'test';
+			return $allowed;
+		};
+		add_filter( 'ep_facet_allowed_query_args', $add_allowed_query_arg );
+
+		$this->assertEqualsCanonicalizing( array_merge( $default_allowed_args, [ 'test' ] ), $facet_feature->get_allowed_query_args() );
+	}
+
+	/**
 	 * Utilitary function for the testGetSelected test.
 	 *
 	 * Private as it is super specific and not likely to be extended.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This is #3397 with tests and additional comments

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/ElasticPress/issues/3360

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Facets removing taxonomy parameters in the URL when not using pretty permalinks.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
