### PR TITLE
Feature: Did you mean

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -117,6 +117,10 @@ function register_indexable_posts() {
 	);
 
 	Features::factory()->register_feature(
+		new Feature\DidYouMean\DidYouMean()
+	);
+
+	Features::factory()->register_feature(
 		new Feature\WooCommerce\WooCommerce()
 	);
 
@@ -164,10 +168,6 @@ function register_indexable_posts() {
 
 	Features::factory()->register_feature(
 		new Feature\Terms\Terms()
-	);
-
-	Features::factory()->register_feature(
-		new Feature\DidYouMean\DidYouMean()
 	);
 
 	/**

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -166,6 +166,10 @@ function register_indexable_posts() {
 		new Feature\Terms\Terms()
 	);
 
+	Features::factory()->register_feature(
+		new Feature\DidYouMean\DidYouMean()
+	);
+
 	/**
 	 * Register search algorithms
 	 */

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -468,6 +468,7 @@ class Elasticsearch {
 					'found_documents' => $total_hits,
 					'documents'       => $documents,
 					'aggregations'    => $response['aggregations'] ?? [],
+					'suggest'         => $response['suggest'] ?? [],
 				],
 				$response,
 				$query,

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -170,6 +170,7 @@ class DidYouMean extends Feature {
 		 * Filter the search analyzer use for the did you mean feature.
 		 *
 		 * @hook ep_search_suggestion_analyzer
+		 * @since 4.6.0
 		 * @param {array} $search_analyzer Search analyzer
 		 * @param {array} $formatted_args Formatted Elasticsearch query
 		 * @param {array} $args WP_Query arguments

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -334,12 +334,23 @@ class DidYouMean extends Feature {
 	/**
 	 * Return a message to the user when the original search term has no results and the user is redirected to the suggested term.
 	 *
+	 * @param WP_Query $query WP_Query object
+	 *
 	 * @return string|void
 	 */
-	public function get_original_search_term() {
+	public function get_original_search_term( $query = null ) {
 		global $wp_query;
 
-		if ( ! $wp_query->is_main_query() || ! $wp_query->is_search() ) {
+		$settings = $this->get_settings();
+		if ( empty( $settings['active'] ) ) {
+			return false;
+		}
+
+		if ( ! $query && $wp_query->is_main_query() && $wp_query->is_search() ) {
+			$query = $wp_query;
+		}
+
+		if ( ! is_a( $query, '\WP_Query' ) ) {
 			return;
 		}
 
@@ -361,7 +372,7 @@ class DidYouMean extends Feature {
 			<span class="no-result">%s</span><strong>%s</strong>
 			</div>',
 			esc_html__( 'Showing results for: ', 'elasticpress' ),
-			esc_html( $wp_query->query_vars['s'] ),
+			esc_html( $query->query_vars['s'] ),
 			esc_html__( 'No results for: ', 'elasticpress' ),
 			esc_html( $original_term )
 		);
@@ -374,16 +385,16 @@ class DidYouMean extends Feature {
 		 * @param {string} $html HTML output
 		 * @param {string} $search_term Suggested search term
 		 * @param {string} $original_term Original search term
-		 * @param {WP_Query} $wp_query WP_Query object
+		 * @param {WP_Query} $query WP_Query object
 		 * @return {string} New HTML output
 		 */
-		return apply_filters( 'ep_suggestion_original_search_term_html', $html, $wp_query->query_vars['s'], $original_term, $wp_query );
+		return apply_filters( 'ep_suggestion_original_search_term_html', $html, $query->query_vars['s'], $original_term, $query );
 	}
 
 	/**
 	 * Returns the suggestion
 	 *
-	 * @param WP_Query $query WP_Query object. Default set to false.
+	 * @param WP_Query $query WP_Query object
 	 * @return void
 	 */
 	public function the_output( $query = null ) {

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Did You Mean feature.
+ *
+ * @since   4.6.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress\Feature\DidYouMean;
+
+use ElasticPress\{Elasticsearch, Feature, FeatureRequirementsStatus, Features };
+
+/**
+ * Did You Mean feature class.
+ */
+class DidYouMean extends Feature {
+
+	/**
+	 * Initialize feature, setting it's config.
+	 */
+	public function __construct() {
+		$this->slug = 'did-you-mean';
+
+		$this->title = esc_html__( 'Did You Mean', 'elasticpress' );
+
+		$this->summary = __( '"Did You Mean" search feature provides alternative suggestions for misspelled or ambiguous search queries, enhancing search accuracy and user experience.', 'elasticpress' );
+
+		$this->requires_install_reindex = true;
+
+		$this->available_during_installation = true;
+
+		$this->default_settings = [
+			'search_behavior' => false,
+		];
+
+		parent::__construct();
+	}
+
+	/**
+	 * Setup search functionality.
+	 *
+	 * @return void
+	 */
+	public function setup() {
+		add_filter( 'ep_post_mapping', [ $this, 'add_mapping' ] );
+		add_filter( 'ep_post_formatted_args', [ $this, 'add_query_args' ], 10, 3 );
+		add_filter( 'ep_integrate_search_queries', [ $this, 'set_ep_suggestion' ], 10, 2 );
+		add_action( 'template_redirect', [ $this, 'automatically_redirect_user' ] );
+	}
+
+	/**
+	 * Output feature box long.
+	 *
+	 * @return void
+	 */
+	public function output_feature_box_long() {
+		?>
+		<p><?php esc_html_e( '"Did You Mean" search feature provides alternative suggestions for misspelled or ambiguous search queries, enhancing search accuracy and user experience.', 'elasticpress' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Add mapping.
+	 *
+	 * @param array $mapping Post mapping.
+	 */
+	public function add_mapping( $mapping ) : array {
+		// Shingle token filter.
+		$mapping['settings']['analysis']['filter']['shingle_filter'] = [
+			'type'             => 'shingle',
+			'min_shingle_size' => 2,
+			'max_shingle_size' => 3,
+		];
+
+		// Custom analyzer.
+		$mapping['settings']['analysis']['analyzer']['trigram'] = [
+			'type'      => 'custom',
+			'tokenizer' => 'standard',
+			'filter'    => [
+				'lowercase',
+				'shingle_filter',
+			],
+		];
+
+		if ( version_compare( Elasticsearch::factory()->get_elasticsearch_version(), '7.0', '<' ) ) {
+			$mapping['mappings']['post']['properties']['post_content']['fields'] = [
+				'shingle' => [
+					'type'     => 'text',
+					'analyzer' => 'trigram',
+				],
+			];
+		} else {
+			$mapping['mappings']['properties']['post_content']['fields'] = [
+				'shingle' => [
+					'type'     => 'text',
+					'analyzer' => 'trigram',
+				],
+			];
+		}
+
+		return $mapping;
+	}
+
+	/**
+	 * Return the suggested search term.
+	 *
+	 * @param WP_Query $query WP_Query object
+	 * @return string|false
+	 */
+	public function get_suggestion( $query = null ) {
+		global $wp_query;
+
+		$settings = $this->get_settings();
+		if ( empty( $settings['active'] ) ) {
+			return false;
+		}
+
+		if ( ! $query && $wp_query->is_main_query() && $wp_query->is_search() ) {
+			$query = $wp_query;
+		}
+
+		if ( ! is_a( $query, '\WP_Query' ) ) {
+			return false;
+		}
+
+		$term = $this->get_suggested_term( $query );
+		if ( empty( $term ) ) {
+			return false;
+		}
+
+		$html = sprintf( '<span class="ep-suggested-spell-term">%s: <a href="%s">%s</a>?</span>', esc_html__( 'Did you mean', 'elasticpress' ), get_search_link( $term ), $term );
+
+		$html .= $this->get_alternatives( $query );
+
+		/**
+		 * Filter the Did You Mean HTML output.
+		 *
+		 * @since 4.6.0
+		 * @hook ep_did_you_mean_suggestion_html
+		 * @param {string}   $html The HTML output.
+		 * @param {WP_Query} $query The WP_Query object.
+		 * @param {string}   $term The suggested term.
+		 * @return {string}  New $html value
+		 */
+		return apply_filters( 'ep_did_you_mean_suggestion_html', $html, $query, $term );
+	}
+
+	/**
+	 * If needed set the `suggest` to ES query clause.
+	 *
+	 * @param array $formatted_args Formatted Elasticsearch query.
+	 * @param array $args           WP_Query arguments
+	 * @param array $wp_query       WP_Query object
+	 */
+	public function add_query_args( $formatted_args, $args, $wp_query ) : array {
+		$search_analyzer = [
+			'phrase' => [
+				'field'            => 'post_content.shingle',
+				'max_errors'       => 2,
+				'direct_generator' => [
+					[
+						'field' => 'post_content.shingle',
+					],
+				],
+			],
+		];
+
+		/**
+		 * Filter the search analyzer use for the did you mean feature.
+		 *
+		 * @hook ep_search_suggestion_analyzer
+		 * @param {array} $search_analyzer Search analyzer
+		 * @param {array} $formatted_args Formatted Elasticsearch query
+		 * @param {array} $args WP_Query arguments
+		 * @param {WP_Query} $wp_query WP_Query object
+		 *
+		 * @return  {array} New search analyzer
+		 */
+		$search_analyzer = apply_filters( 'ep_search_suggestion_analyzer', $search_analyzer, $formatted_args, $args, $wp_query );
+
+		if ( ! empty( $args['s'] ) ) {
+			$formatted_args['suggest'] = array(
+				'text'          => $args['s'],
+				'ep_suggestion' => $search_analyzer,
+			);
+		}
+
+		return $formatted_args;
+	}
+
+	/**
+	 * Set the ep_suggestion flag to true if the query is a search query.
+	 *
+	 * @param bool     $enabled Whether to enable the search queries integration.
+	 * @param WP_Query $query   The WP_Query object.
+	 */
+	public function set_ep_suggestion( $enabled, $query ) : bool {
+		if ( $query->is_search() && ! empty( $query->query_vars['s'] ) ) {
+			$query->set( 'ep_suggestion', true );
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Returns requirements status of feature
+	 *
+	 * Requires the search feature to be activated
+	 */
+	public function requirements_status() : FeatureRequirementsStatus {
+		$features = Features::factory();
+		$search   = $features->get_registered_feature( 'search' );
+
+		if ( ! $search->is_active() ) {
+			return new FeatureRequirementsStatus( 2, esc_html__( 'This feature requires the "Post Search" feature to be enabled', 'elasticpress' ) );
+		}
+
+		return parent::requirements_status();
+	}
+
+	/**
+	 * Display feature settings.
+	 *
+	 * @return void
+	 */
+	public function output_feature_box_settings() {
+		$settings = $this->get_settings();
+		?>
+		<div class="field">
+			<div class="field-name status"><?php esc_html_e( 'Search Behavior when no result found.', 'elasticpress' ); ?></div>
+			<div class="input-wrap">
+				<label><input name="settings[search_behavior]" type="radio" <?php checked( ! (bool) $settings['search_behavior'] ); ?> value="0"><?php esc_html_e( 'Default', 'elasticpress' ); ?></label><br>
+				<label><input name="settings[search_behavior]" type="radio" <?php checked( $settings['search_behavior'], 'list' ); ?> value="list"><?php esc_html_e( 'Display all the suggestions', 'elasticpress' ); ?></label><br>
+				<label><input name="settings[search_behavior]" type="radio" <?php checked( $settings['search_behavior'], 'redirect' ); ?> value="redirect"><?php esc_html_e( 'Automatically redirects user to top suggestion', 'elasticpress' ); ?></label><br>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Returns the list of other suggestions
+	 *
+	 * @param WP_Query $query WP_Query object
+	 * @return string|boolean
+	 */
+	protected function get_alternatives( $query ) {
+		global $wp_query;
+
+		if ( ! $query && $wp_query->is_main_query() && $wp_query->is_search() ) {
+			$query = $wp_query;
+		}
+
+		if ( ! is_a( $query, '\WP_Query' ) ) {
+			return false;
+		}
+
+		$settings = $this->get_settings();
+
+		// If there are posts, we don't need to show the list of suggestions.
+		if ( 'list' !== $settings['search_behavior'] || $query->found_posts ) {
+			return '';
+		}
+
+		array_shift( $options );
+
+		if ( empty( $options ) ) {
+			return '';
+		}
+
+		$html  = '<div class="ep-spell-suggestions">';
+		$html .= esc_html__( 'Other suggestions:', 'elasticpress' );
+		$html .= '<ul class="ep-suggestions-list">';
+		foreach ( $options as $option ) {
+			$html .= sprintf( '<li><a href="%s">%s</a></li>', get_search_link( $option['text'] ), $option['text'] );
+		}
+		$html .= '</ul>';
+		$html .= '</div>';
+
+		return $html;
+
+	}
+
+	/**
+	 * Returns the top suggested term
+	 *
+	 * @param WP_Query $query WP_Query object
+	 * @return string|bool
+	 */
+	public function get_suggested_term( $query ) {
+		$options = $query->suggested_terms['options'] ?? [];
+		return ! empty( $options ) ? $options[0]['text'] : false;
+	}
+
+	/**
+	 * Redirect user to suggested search term if no results found and search_behavior is set to redirect.
+	 *
+	 * @return void
+	 */
+	public function automatically_redirect_user() {
+		global $wp_query;
+
+		if ( ! $wp_query->is_main_query() || ! $wp_query->is_search() ) {
+			return;
+		}
+
+		if ( $wp_query->found_posts ) {
+			return;
+		}
+
+		$settings = $this->get_settings();
+		if ( 'redirect' !== $settings['search_behavior'] ) {
+			return;
+		}
+
+		$term = $this->get_suggested_term( $wp_query );
+		if ( empty( $term ) ) {
+			return;
+		}
+
+		$url = get_search_link( $term );
+		wp_safe_redirect( $url );
+		exit;
+	}
+}

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -23,7 +23,7 @@ class DidYouMean extends Feature {
 
 		$this->title = esc_html__( 'Did You Mean', 'elasticpress' );
 
-		$this->summary = __( 'Recommend alternative search terms for misspelled queries or terms with no results', 'elasticpress' );
+		$this->summary = __( 'Recommend alternative search terms for misspelled queries or terms with no results.', 'elasticpress' );
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -23,7 +23,7 @@ class DidYouMean extends Feature {
 
 		$this->title = esc_html__( 'Did You Mean', 'elasticpress' );
 
-		$this->summary = __( '"Did You Mean" search feature provides alternative suggestions for misspelled or ambiguous search queries, enhancing search accuracy and user experience.', 'elasticpress' );
+		$this->summary = __( 'Recommend alternative search terms for misspelled queries or terms with no results', 'elasticpress' );
 
 		$this->requires_install_reindex = true;
 
@@ -217,7 +217,7 @@ class DidYouMean extends Feature {
 			return new FeatureRequirementsStatus( 2, esc_html__( 'This feature requires the "Post Search" feature to be enabled', 'elasticpress' ) );
 		}
 
-		return parent::requirements_status();
+		return new FeatureRequirementsStatus( 1 );
 	}
 
 	/**
@@ -231,7 +231,7 @@ class DidYouMean extends Feature {
 		<div class="field">
 			<div class="field-name status"><?php esc_html_e( 'Search behavior when no result is found', 'elasticpress' ); ?></div>
 			<div class="input-wrap">
-				<label><input name="settings[search_behavior]" type="radio" <?php checked( ! (bool) $settings['search_behavior'] ); ?> value="0"><?php esc_html_e( 'Display a top suggestion', 'elasticpress' ); ?></label><br>
+				<label><input name="settings[search_behavior]" type="radio" <?php checked( ! (bool) $settings['search_behavior'] ); ?> value="0"><?php esc_html_e( 'Display the top suggestion', 'elasticpress' ); ?></label><br>
 				<label><input name="settings[search_behavior]" type="radio" <?php checked( $settings['search_behavior'], 'list' ); ?> value="list"><?php esc_html_e( 'Display all the suggestions', 'elasticpress' ); ?></label><br>
 				<label><input name="settings[search_behavior]" type="radio" <?php checked( $settings['search_behavior'], 'redirect' ); ?> value="redirect"><?php esc_html_e( 'Automatically redirect the user to the top suggestion', 'elasticpress' ); ?></label><br>
 			</div>
@@ -334,7 +334,7 @@ class DidYouMean extends Feature {
 	/**
 	 * Return a message to the user when the original search term has no results and the user is redirected to the suggested term.
 	 *
-	 * @return string
+	 * @return string|void
 	 */
 	public function get_original_search_term() {
 		global $wp_query;
@@ -386,10 +386,10 @@ class DidYouMean extends Feature {
 	 * @param WP_Query $query WP_Query object. Default set to false.
 	 * @return void
 	 */
-	public function the_output( $query = false ) {
-		$html  = $this->get_original_search_term();
+	public function the_output( $query = null ) {
+		$html  = $this->get_original_search_term( $query );
 		$html .= $this->get_suggestion( $query );
 
-		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wp_kses_post( $html );
 	}
 }

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -332,7 +332,7 @@ class DidYouMean extends Feature {
 	}
 
 	/**
-	 * Display a message to the user when the original search term has no results and the user is redirected to the suggested term.
+	 * Return a message to the user when the original search term has no results and the user is redirected to the suggested term.
 	 *
 	 * @return string
 	 */
@@ -361,23 +361,23 @@ class DidYouMean extends Feature {
 			<span class="no-result">%s</span><strong>%s</strong>
 			</div>',
 			esc_html__( 'Showing results for: ', 'elasticpress' ),
-			esc_html( $original_term ),
+			esc_html( $wp_query->query_vars['s'] ),
 			esc_html__( 'No results for: ', 'elasticpress' ),
-			esc_html( $wp_query->query_vars['s'] )
+			esc_html( $original_term )
 		);
 
-		 /**
-		  * Filter the HTML output for the original search term.
-		  *
-		  * @since 4.6.0
-		  * @hook ep_suggestion_original_search_term_html
-		  * @param {string} $html HTML output
-		  * @param {string} $original_term Original search term
-		  * @param {string} $search_term Search term
-		  * @param {WP_Query} $wp_query WP_Query object
-		  * @return {string} New HTML output
-		  */
-		return apply_filters( 'ep_suggestion_original_search_term_html', $html, $original_term, $wp_query->query_vars['s'], $wp_query );
+		/**
+		 * Filter the HTML output for the original search term.
+		 *
+		 * @since 4.6.0
+		 * @hook ep_suggestion_original_search_term_html
+		 * @param string $html HTML output
+		 * @param string $search_term Suggested search term
+		 * @param string $original_term Original search term
+		 * @param WP_Query $wp_query WP_Query object
+		 * @return string New HTML output
+		 */
+		return apply_filters( 'ep_suggestion_original_search_term_html', $html, $wp_query->query_vars['s'], $original_term, $wp_query );
 	}
 
 	/**

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -169,14 +169,13 @@ class DidYouMean extends Feature {
 		/**
 		 * Filter the search analyzer use for the did you mean feature.
 		 *
-		 * @hook ep_search_suggestion_analyzer
 		 * @since 4.6.0
+		 * @hook ep_search_suggestion_analyzer
 		 * @param {array} $search_analyzer Search analyzer
 		 * @param {array} $formatted_args Formatted Elasticsearch query
 		 * @param {array} $args WP_Query arguments
 		 * @param {WP_Query} $wp_query WP_Query object
-		 *
-		 * @return  {array} New search analyzer
+		 * @return {array} New search analyzer
 		 */
 		$search_analyzer = apply_filters( 'ep_search_suggestion_analyzer', $search_analyzer, $formatted_args, $args, $wp_query );
 

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -130,19 +130,20 @@ class DidYouMean extends Feature {
 
 		$html = sprintf( '<span class="ep-suggested-spell-term">%s: <a href="%s">%s</a>?</span>', esc_html__( 'Did you mean', 'elasticpress' ), get_search_link( $term ), $term );
 
-		$html .= $this->get_alternatives( $query );
+		$html .= $this->get_alternatives_terms( $query );
+		$terms = $query->suggested_terms['options'] ?? [];
 
 		/**
-		 * Filter the Did You Mean HTML output.
+		 * Filter the did you mean suggested term HTML.
 		 *
 		 * @since 4.6.0
-		 * @hook ep_did_you_mean_suggestion_html
+		 * @hook ep_did_you_mean_suggested_term_html
 		 * @param {string}   $html The HTML output.
+		 * @param {array}    $terms All suggested terms.
 		 * @param {WP_Query} $query The WP_Query object.
-		 * @param {string}   $term The suggested term.
 		 * @return {string}  New $html value
 		 */
-		return apply_filters( 'ep_did_you_mean_suggestion_html', $html, $query, $term );
+		return apply_filters( 'ep_did_you_mean_suggestion_html', $html, $terms, $query );
 	}
 
 	/**
@@ -241,9 +242,9 @@ class DidYouMean extends Feature {
 	 * Returns the list of other suggestions
 	 *
 	 * @param WP_Query $query WP_Query object
-	 * @return string|boolean
+	 * @return string|false
 	 */
-	protected function get_alternatives( $query ) {
+	protected function get_alternatives_terms( $query ) {
 		global $wp_query;
 
 		if ( ! $query && $wp_query->is_main_query() && $wp_query->is_search() ) {
@@ -258,9 +259,10 @@ class DidYouMean extends Feature {
 
 		// If there are posts, we don't need to show the list of suggestions.
 		if ( 'list' !== $settings['search_behavior'] || $query->found_posts ) {
-			return '';
+			return false;
 		}
 
+		$options = $query->suggested_terms['options'] ?? [];
 		array_shift( $options );
 
 		if ( empty( $options ) ) {
@@ -277,7 +279,6 @@ class DidYouMean extends Feature {
 		$html .= '</div>';
 
 		return $html;
-
 	}
 
 	/**

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -142,7 +142,7 @@ class DidYouMean extends Feature {
 		 * @param {string}   $html The HTML output.
 		 * @param {array}    $terms All suggested terms.
 		 * @param {WP_Query} $query The WP_Query object.
-		 * @return {string}  New $html value
+		 * @return {string}  New HTML output
 		 */
 		return apply_filters( 'ep_suggestion_html', $html, $terms, $query );
 	}
@@ -371,11 +371,11 @@ class DidYouMean extends Feature {
 		 *
 		 * @since 4.6.0
 		 * @hook ep_suggestion_original_search_term_html
-		 * @param string $html HTML output
-		 * @param string $search_term Suggested search term
-		 * @param string $original_term Original search term
-		 * @param WP_Query $wp_query WP_Query object
-		 * @return string New HTML output
+		 * @param {string} $html HTML output
+		 * @param {string} $search_term Suggested search term
+		 * @param {string} $original_term Original search term
+		 * @param {WP_Query} $wp_query WP_Query object
+		 * @return {string} New HTML output
 		 */
 		return apply_filters( 'ep_suggestion_original_search_term_html', $html, $wp_query->query_vars['s'], $original_term, $wp_query );
 	}

--- a/includes/classes/FeatureRequirementsStatus.php
+++ b/includes/classes/FeatureRequirementsStatus.php
@@ -34,7 +34,7 @@ class FeatureRequirementsStatus {
 	 * Returns the status of a feature
 	 *
 	 * 0 is no issues
-	 * 1 is usable but there are warnngs
+	 * 1 is usable but there are warnings
 	 * 2 is not usable
 	 *
 	 * @var    int

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -371,6 +371,7 @@ class QueryIntegration {
 			$query->found_posts           = $found_documents;
 			$query->num_posts             = $query->found_posts;
 			$query->max_num_pages         = ceil( $found_documents / $query->get( 'posts_per_page' ) );
+			$query->suggested_terms       = isset( $ep_query['suggest']['ep_suggestion'] ) && isset( $ep_query['suggest']['ep_suggestion'][0] ) ? $ep_query['suggest']['ep_suggestion'][0] : [];
 			$query->elasticsearch_success = true;
 
 			// Determine how we should format the results from ES based on the fields parameter.

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -280,6 +280,5 @@ class TestDidYouMean extends BaseTestCase {
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 'Test post', $query->posts[0]->post_content );
-
 	}
 }

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -178,8 +178,8 @@ class TestDidYouMean extends BaseTestCase {
 		$expected_result = '<span class="ep-suggested-spell-term">Did you mean: test filter is working ?</span>';
 		add_filter(
 			'ep_did_you_mean_suggestion_html',
-			function( $html, $query, $term ) use ( $expected_result ) {
-				$this->assertEquals( 'test', $term );
+			function( $html, $terms, $query ) use ( $expected_result ) {
+				$this->assertEquals( 'test', $terms[0]['text'] );
 				$this->assertInstanceOf( '\WP_Query', $query );
 				return $expected_result;
 			},

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Test Did you mean feature.
+ *
+ * @since   4.6.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+/**
+ * Did you mean test class.
+ */
+class TestDidYouMean extends BaseTestCase {
+
+	/**
+	 * Setup each test.
+	 */
+	public function set_up() {
+		global $wpdb;
+		parent::set_up();
+		$wpdb->suppress_errors();
+
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+
+		wp_set_current_user( $admin_id );
+
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+		ElasticPress\Features::factory()->activate_feature( 'did-you-mean' );
+
+		ElasticPress\Features::factory()->setup_features();
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+
+		$this->setup_test_post_type();
+	}
+
+	/**
+	 * Test Feature properties.
+	 */
+	public function testConstruct() {
+		$instance = new ElasticPress\Feature\DidYouMean\DidYouMean();
+
+		$this->assertEquals( 'did-you-mean', $instance->slug );
+		$this->assertEquals( 'Did You Mean', $instance->title );
+		$this->assertTrue( $instance->requires_install_reindex );
+		$this->assertTrue( $instance->available_during_installation );
+		$this->assertTrue( $instance->is_visible() );
+		$this->assertSame( [ 'search_behavior' => false ], $instance->default_settings );
+	}
+
+	/**
+	 * Test Requirements status.
+	 */
+	public function testRequirementsStatus() {
+		$instance = new ElasticPress\Feature\DidYouMean\DidYouMean();
+		$status   = $instance->requirements_status();
+
+		$this->assertEquals( 0, $status->code );
+		$this->assertEquals( null, $status->message );
+	}
+
+	/**
+	 * Test Requirements status when search feature is not active.
+	 */
+	public function testRequirementsStatusWhenSearchFeatureIsNotActive() {
+		ElasticPress\Features::factory()->deactivate_feature( 'search' );
+
+		$instance = new ElasticPress\Feature\DidYouMean\DidYouMean();
+		$status   = $instance->requirements_status();
+
+		$this->assertEquals( 2, $status->code );
+		$this->assertEquals( 'This feature requires the &quot;Post Search&quot; feature to be enabled', $status->message );
+	}
+
+	/**
+	 * Tests that ES returns a suggestion when search term has a typo.
+	 */
+	public function testEsSearchSuggestion() {
+		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				's' => 'teet',
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 'test', $query->suggested_terms['options'][0]['text'] );
+	}
+
+	/**
+	 * Tests that ES returns a suggestion only for search queries.
+	 */
+	public function testEsSearchSuggestionOnlyIntegrateWithSearchQuery() {
+		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEmpty( $query->suggested_terms );
+	}
+
+	/**
+	 * Tests the get_suggestion method.
+	 */
+	public function testGetSearchSuggestionMethod() {
+		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				's' => 'teet',
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+
+		$expected = sprintf( '<span class="ep-suggested-spell-term">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
+		$this->assertEquals( $expected, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
+	}
+
+	/**
+	 * Tests that get_suggestion method returns suggestion only for main query.
+	 */
+	public function testGetSearchSuggestionMethodReturnsSuggestionForMainQuery() {
+		global $wp_the_query, $wp_query;
+
+		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$args  = [
+			's' => 'teet',
+		];
+		$query = new \WP_Query( $args );
+
+		// mock the query as main query
+		$wp_the_query = $query;
+		$wp_query     = $query;
+
+		$this->assertTrue( $query->elasticsearch_success );
+
+		$query = $query->query( $args );
+
+		$expected = sprintf( '<span class="ep-suggested-spell-term">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
+		$this->assertEquals( $expected, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion() );
+	}
+
+	/**
+	 * Tests that get_suggestion method returns false if other than WP_Query is passed.
+	 */
+	public function testGetSearchSuggestionMethodReturnsFalseIfOtherThanWpQueryIsPassed() {
+		$query = new \stdClass();
+		$this->assertFalse( ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
+	}
+
+	/**
+	 * Tests that get_suggestion method filter `ep_did_you_mean_suggestion_html`.
+	 */
+	public function testGetSearchSuggestionMethodFilter() {
+		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$expected_result = '<span class="ep-suggested-spell-term">Did you mean: test filter is working ?</span>';
+		add_filter(
+			'ep_did_you_mean_suggestion_html',
+			function( $html, $query, $term ) use ( $expected_result ) {
+				$this->assertEquals( 'test', $term );
+				$this->assertInstanceOf( '\WP_Query', $query );
+				return $expected_result;
+			},
+			10,
+			3
+		);
+
+		$query = new \WP_Query(
+			[
+				's' => 'teet',
+			]
+		);
+		$this->assertEquals( $expected_result, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
+	}
+
+	/**
+	 * Test Mapping for ES version 7 and above.
+	 */
+	public function testMapping() {
+		add_filter(
+			'ep_elasticsearch_version',
+			function() {
+				return '7.0';
+			}
+		);
+
+		$mapping = ElasticPress\Indexables::factory()->get( 'post' )->generate_mapping();
+
+		$expected_result = [
+			'shingle' =>
+			[
+				'type'     => 'text',
+				'analyzer' => 'trigram',
+			],
+		];
+		$this->assertSame( $expected_result, $mapping['mappings']['properties']['post_content']['fields'] );
+	}
+
+	/**
+	 * Test Mapping for ES version lower than 7.
+	 */
+	public function testMappingForESVersionLowerThanSeven() {
+		add_filter(
+			'ep_elasticsearch_version',
+			function() {
+				return '5.2.0';
+			}
+		);
+
+		$mapping = ElasticPress\Indexables::factory()->get( 'post' )->generate_mapping();
+
+		$expected_result = [
+			'shingle' =>
+			[
+				'type'     => 'text',
+				'analyzer' => 'trigram',
+			],
+		];
+		$this->assertSame( $expected_result, $mapping['mappings']['post']['properties']['post_content']['fields'] );
+	}
+}

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -292,17 +292,13 @@ class TestDidYouMean extends BaseTestCase {
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		$filter = function() {
-			return [
-				'did-you-mean' => [
-					'search_behavior' => 'redirect',
-					'active'          => true,
-				],
-			];
-		};
-
-		add_filter( 'pre_site_option_ep_feature_settings', $filter );
-		add_filter( 'pre_option_ep_feature_settings', $filter );
+		ElasticPress\Features::factory()->update_feature(
+			'did-you-mean',
+			[
+				'active'          => true,
+				'search_behavior' => 'redirect',
+			]
+		);
 
 		parse_str( 'ep_suggestion_original_term=Original Term', $_GET );
 
@@ -340,17 +336,13 @@ class TestDidYouMean extends BaseTestCase {
 			]
 		);
 
-		$filter = function() {
-			return [
-				'did-you-mean' => [
-					'search_behavior' => 'redirect',
-					'active'          => true,
-				],
-			];
-		};
-
-		add_filter( 'pre_site_option_ep_feature_settings', $filter );
-		add_filter( 'pre_option_ep_feature_settings', $filter );
+		ElasticPress\Features::factory()->update_feature(
+			'did-you-mean',
+			[
+				'active'          => true,
+				'search_behavior' => 'redirect',
+			]
+		);
 
 		parse_str( 'ep_suggestion_original_term=Original Term', $_GET );
 
@@ -381,17 +373,13 @@ class TestDidYouMean extends BaseTestCase {
 			]
 		);
 
-		$filter = function() {
-			return [
-				'did-you-mean' => [
-					'search_behavior' => 'redirect',
-					'active'          => true,
-				],
-			];
-		};
-
-		add_filter( 'pre_site_option_ep_feature_settings', $filter );
-		add_filter( 'pre_option_ep_feature_settings', $filter );
+		ElasticPress\Features::factory()->update_feature(
+			'did-you-mean',
+			[
+				'active'          => true,
+				'search_behavior' => 'redirect',
+			]
+		);
 
 		parse_str( 'ep_suggestion_original_term=Original Term', $_GET );
 

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -128,7 +128,7 @@ class TestDidYouMean extends BaseTestCase {
 
 		$this->assertTrue( $query->elasticsearch_success );
 
-		$expected = sprintf( '<span class="ep-suggested-spell-term">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
+		$expected = sprintf( '<span class="ep-spell-suggestion">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
 		$this->assertEquals( $expected, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
 	}
 
@@ -155,7 +155,7 @@ class TestDidYouMean extends BaseTestCase {
 
 		$query = $query->query( $args );
 
-		$expected = sprintf( '<span class="ep-suggested-spell-term">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
+		$expected = sprintf( '<span class="ep-spell-suggestion">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
 		$this->assertEquals( $expected, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion() );
 	}
 
@@ -168,16 +168,16 @@ class TestDidYouMean extends BaseTestCase {
 	}
 
 	/**
-	 * Tests that get_suggestion method filter `ep_did_you_mean_suggestion_html`.
+	 * Tests that get_suggestion method filter `ep_suggestion_html`.
 	 */
 	public function testGetSearchSuggestionMethodFilter() {
 		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-		$expected_result = '<span class="ep-suggested-spell-term">Did you mean: test filter is working ?</span>';
+		$expected_result = '<span class="ep-spell-suggestion">Did you mean: test filter is working ?</span>';
 		add_filter(
-			'ep_did_you_mean_suggestion_html',
+			'ep_suggestion_html',
 			function( $html, $terms, $query ) use ( $expected_result ) {
 				$this->assertEquals( 'test', $terms[0]['text'] );
 				$this->assertInstanceOf( '\WP_Query', $query );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the 'Did you mean' functionality just like other search engines have. The algorithm on ES will detect any typos in the search term and based on the result, the most preferred term will be disabled. To add the functionality to the search page, the user has to call the function `\ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion();`


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2089

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Enable the "Did You Mean" Feature
- Add the method `\ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion();` on theme search template.
- Search a term with typo

This feature includes a setting that applies when the search results yield no matches.

1) "Display all the suggestions": When this option is enabled, ElasticPress will display all suggested terms.
2) "Automatically redirects user to top suggestion": Enabling this option will automatically redirect the user to the top suggested term when there are no search results.


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - 'Did you mean' functionality when there is typo in search term


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
