### PR TITLE
Click first button from @block selection

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -15,6 +15,7 @@
       ],
       "mappings": {
         "wp-content/mu-plugins/unique-index-name.php": "./tests/cypress/wordpress-files/test-mu-plugins/unique-index-name.php",
+        "wp-content/mu-plugins/disable-welcome-guide.php": "./tests/cypress/wordpress-files/test-mu-plugins/disable-welcome-guide.php",
         "wp-content/plugins/cpt-and-custom-tax.php": "./tests/cypress/wordpress-files/test-plugins/cpt-and-custom-tax.php",
         "wp-content/plugins/custom-instant-results-template.php": "./tests/cypress/wordpress-files/test-plugins/custom-instant-results-template.php",
         "wp-content/plugins/fake-new-activation.php": "./tests/cypress/wordpress-files/test-plugins/fake-new-activation.php",

--- a/tests/cypress/integration/features/facets.cy.js
+++ b/tests/cypress/integration/features/facets.cy.js
@@ -33,6 +33,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 		 * Insert two Facets blocks.
 		 */
 		cy.openWidgetsPage();
+		cy.get('.components-modal__header button').click();
 		cy.openBlockInserter();
 		cy.getBlocksList().should('contain.text', 'Facet by Taxonomy (ElasticPress)');
 		cy.insertBlock('Facet by Taxonomy (ElasticPress)');

--- a/tests/cypress/integration/features/facets.cy.js
+++ b/tests/cypress/integration/features/facets.cy.js
@@ -662,7 +662,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 					'{leftArrow}{leftArrow}{leftArrow}{leftArrow}{leftArrow}{leftArrow}{leftArrow}{leftArrow}',
 				);
 			cy.get('@block').should('contain.text', '$9/day — $12/day');
-			cy.get('@block').get('button').click();
+			cy.get('@block').get('button').first().click();
 			cy.get('.post').should('have.length', 4);
 			cy.url().should('include', 'ep_meta_range_filter_numeric_meta_field_min=9');
 			cy.url().should('include', 'ep_meta_range_filter_numeric_meta_field_max=12');
@@ -681,7 +681,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 			cy.get('@thumbs').eq(0).type('{leftArrow}{leftArrow}');
 			cy.get('@thumbs').eq(1).type('{rightArrow}{rightArrow}');
 			cy.get('@block').should('contain.text', '$7/day — $14/day');
-			cy.get('@block').get('button').click();
+			cy.get('@block').get('button').first().click();
 			cy.url().should('include', 'ep_meta_range_filter_numeric_meta_field_min=7');
 			cy.url().should('include', 'ep_meta_range_filter_numeric_meta_field_max=14');
 			cy.get('.post').contains('Facet By Meta Range Post 14').should('exist');

--- a/tests/cypress/integration/features/facets.cy.js
+++ b/tests/cypress/integration/features/facets.cy.js
@@ -33,7 +33,6 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 		 * Insert two Facets blocks.
 		 */
 		cy.openWidgetsPage();
-		cy.get('.components-modal__header button').click();
 		cy.openBlockInserter();
 		cy.getBlocksList().should('contain.text', 'Facet by Taxonomy (ElasticPress)');
 		cy.insertBlock('Facet by Taxonomy (ElasticPress)');

--- a/tests/cypress/wordpress-files/test-mu-plugins/disable-welcome-guide.php
+++ b/tests/cypress/wordpress-files/test-mu-plugins/disable-welcome-guide.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Disable Welcome Guide
+ * Description: Disable Welcome Guide automatically on fresh WordPress install
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_action(
+	'enqueue_block_editor_assets',
+	function() {
+		wp_add_inline_script(
+			'wp-data',
+			"window.onload = function() {
+		wp.data.dispatch('core/preferences').set('core/edit-widgets', 'welcomeGuide', false);
+		}"
+		);
+	},
+	999
+);
+


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
This PR adds an MU plugin to ensure Welcome Guide is disabled from widgets page when running e2e tests.

Closes #3413

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Meta Range Facet Block e2e tests


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez, @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
