### PR TITLE
New ep_facet_should_check_if_allowed filter

### DIFF
--- a/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
@@ -96,7 +96,28 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 			return $filters;
 		}
 
-		$selected_range_filters = $all_selected_filters[ $this->get_filter_type() ];
+		/**
+		 * Filter if EP should only filter by fields selected in facets. Defaults to true.
+		 *
+		 * @since 4.5.1
+		 * @hook ep_facet_should_check_if_allowed
+		 * @param {bool} $should_check Whether it should or not check fields
+		 * @return {string} New value
+		 */
+		$should_check_if_allowed = apply_filters( 'ep_facet_should_check_if_allowed', true );
+		if ( $should_check_if_allowed ) {
+			$allowed_meta_fields = $this->get_facets_meta_fields();
+
+			$selected_range_filters = array_filter(
+				$all_selected_filters[ $this->get_filter_type() ],
+				function ( $meta_field ) use ( $allowed_meta_fields ) {
+					return in_array( $meta_field, $allowed_meta_fields, true );
+				},
+				ARRAY_FILTER_USE_KEY
+			);
+		} else {
+			$selected_range_filters = $all_selected_filters[ $this->get_filter_type() ];
+		}
 
 		$range_filters = [];
 		foreach ( $selected_range_filters as $field_name => $values ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR changes the way Meta fields Facets filter the results. Previously, it would be possible to filter simply by adding a parameter to the URL. Now, it will only filter results using meta fields selected in blocks.

Using `add_filter( 'ep_facet_should_check_if_allowed', '__return_false' );` makes EP use the old behavior.

### How to test the Change
Visit /?ep_meta_filter_<field>=<value> in a field that is not selected in a facet before and after checking out this PR.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Meta field facets now only filter based on fields selected on blocks. The new `ep_facet_should_check_if_allowed` filter reverts this behavior.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
