### PR TITLE
PostSyncManager: Add missing kill_sync() to action_edited_term

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -554,6 +554,10 @@ class SyncManager extends SyncManagerAbstract {
 	 * @since  4.0.0
 	 */
 	public function action_edited_term( $term_id, $tt_id, $taxonomy ) {
+		if ( $this->kill_sync() ) {
+			return;
+		}
+
 		global $wpdb;
 
 		/**

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -554,11 +554,11 @@ class SyncManager extends SyncManagerAbstract {
 	 * @since  4.0.0
 	 */
 	public function action_edited_term( $term_id, $tt_id, $taxonomy ) {
+		global $wpdb;
+
 		if ( $this->kill_sync() ) {
 			return;
 		}
-
-		global $wpdb;
 
 		/**
 		 * Filter to whether skip a sync during autosave, defaults to true


### PR DESCRIPTION
### Description of the Change
We're missing `kill_sync()` in the `action_edited_term`, resulting in unexpected actions for it since it is not triggered (as we have a hook that calls it), like in the other ones e.g. `action_queue_meta_sync`


### Changelog Entry
Fixed action_edited_term to call kill_sync in SyncManager for post Indexable


### Credits
Props @rebeccahum 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
