### PR TITLE
Failed Queries: Different message if no index is found

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1709,6 +1709,24 @@ class Elasticsearch {
 	}
 
 	/**
+	 * Return a comparison between which indices should be and are present in the ES server.
+	 *
+	 * @since 5.0.0
+	 * @return array Array with `missing_indices` and `present_indices` keys.
+	 */
+	public function get_indices_comparison() {
+		$all_index_names = $this->get_index_names();
+		$cluster_indices = $this->get_cluster_indices();
+
+		$cluster_index_names = wp_list_pluck( $cluster_indices, 'index' );
+
+		return [
+			'missing_indices' => array_diff( $all_index_names, $cluster_index_names ),
+			'present_indices' => array_intersect( $all_index_names, $cluster_index_names ),
+		];
+	}
+
+	/**
 	 * Given an index return its total fields limit
 	 *
 	 * @since 4.4.0

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -233,12 +233,6 @@ class QueryLogger {
 			return $notices;
 		}
 
-		$page = 'admin.php?page=elasticpress-status-report';
-
-		$status_report_url = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ?
-			network_admin_url( $page ) :
-			admin_url( $page );
-
 		$indices_comparison = Elasticsearch::factory()->get_indices_comparison();
 		$present_indices    = count( $indices_comparison['present_indices'] );
 
@@ -254,6 +248,12 @@ class QueryLogger {
 				)
 			);
 		} else {
+			$page = 'admin.php?page=elasticpress-status-report';
+
+			$status_report_url = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ?
+				network_admin_url( $page ) :
+				admin_url( $page );
+
 			$message = sprintf(
 				/* translators: Status Report URL */
 				__( 'Some ElasticPress queries failed in the last 24 hours. Please visit the <a href="%s">Status Report page</a> for more details.', 'elasticpress' ),

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -239,12 +239,29 @@ class QueryLogger {
 			network_admin_url( $page ) :
 			admin_url( $page );
 
-		$notices['has_failed_queries'] = [
-			'html'    => sprintf(
+		$indices_comparison = Elasticsearch::factory()->get_indices_comparison();
+		$present_indices    = count( $indices_comparison['present_indices'] );
+
+		if ( 0 === $present_indices ) {
+			$message = sprintf(
+				/* translators: %s: Sync page link. */
+				esc_html__( 'No Elasticsearch indices found. Please %s.', 'elasticpress' ),
+				sprintf(
+					'<a href="%1$s">%2$s</a>',
+					Utils\get_sync_url( true ),
+					esc_html__( 'sync your content', 'elasticpress' )
+				)
+			);
+		} else {
+			$message = sprintf(
 				/* translators: Status Report URL */
 				__( 'Some ElasticPress queries failed in the last 24 hours. Please visit the <a href="%s">Status Report page</a> for more details.', 'elasticpress' ),
 				$status_report_url . '#failed-queries'
-			),
+			);
+		}
+
+		$notices['has_failed_queries'] = [
+			'html'    => $message,
 			'type'    => 'warning',
 			'dismiss' => true,
 		];

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -245,7 +245,8 @@ class QueryLogger {
 		if ( 0 === $present_indices ) {
 			$message = sprintf(
 				/* translators: %s: Sync page link. */
-				esc_html__( 'No Elasticsearch indices found. Please %s.', 'elasticpress' ),
+				esc_html__( 'Your site\'s content is not synced with your %1$s. Please %2$s.', 'elasticpress' ),
+				Utils\is_epio() ? __( 'ElasticPress.io account', 'elasticpress' ) : __( 'Elasticsearch server', 'elasticpress' ),
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
 					Utils\get_sync_url( true ),

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -243,7 +243,7 @@ class QueryLogger {
 				Utils\is_epio() ? __( 'ElasticPress.io account', 'elasticpress' ) : __( 'Elasticsearch server', 'elasticpress' ),
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
-					Utils\get_sync_url( true ),
+					esc_url( Utils\get_sync_url( true ) ),
 					esc_html__( 'sync your content', 'elasticpress' )
 				)
 			);

--- a/includes/classes/Screen/Sync.php
+++ b/includes/classes/Screen/Sync.php
@@ -176,16 +176,8 @@ class Sync {
 
 		$ep_last_index = IndexHelper::factory()->get_last_index();
 
-		$sync_required   = false;
-		$all_index_names = Elasticsearch::factory()->get_index_names();
-		$cluster_indices = Elasticsearch::factory()->get_cluster_indices();
-
-		$cluster_index_names = wp_list_pluck( $cluster_indices, 'index' );
-		$synced_index_names  = array_intersect( $all_index_names, $cluster_index_names );
-
-		if ( $synced_index_names !== $all_index_names ) {
-			$sync_required = true;
-		}
+		$indices_comparison = Elasticsearch::factory()->get_indices_comparison();
+		$sync_required      = count( $indices_comparison['missing_indices'] ) > 0;
 
 		if ( ! empty( $ep_last_index ) && ! $sync_required ) {
 			$data['ep_last_sync_date']   = ! empty( $ep_last_index['end_date_time'] ) ? $ep_last_index['end_date_time'] : false;

--- a/tests/php/TestQueryLogger.php
+++ b/tests/php/TestQueryLogger.php
@@ -287,7 +287,7 @@ class TestQueryLogger extends BaseTestCase {
 		$this->assertArrayHasKey( 'has_failed_queries', $notices );
 
 		/**
-		 * No message
+		 * No message for users without the capability
 		 */
 		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $author_id );
@@ -298,6 +298,9 @@ class TestQueryLogger extends BaseTestCase {
 		wp_set_current_user( $admin_id );
 		$notices = $query_logger->maybe_add_notice( [] );
 		$this->assertArrayHasKey( 'has_failed_queries', $notices );
+
+		// Reset current screen
+		\ElasticPress\Screen::factory()->set_current_screen( null );
 	}
 
 	/**

--- a/tests/php/TestQueryLogger.php
+++ b/tests/php/TestQueryLogger.php
@@ -219,7 +219,6 @@ class TestQueryLogger extends BaseTestCase {
 		 */
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		grant_super_admin( $admin_id );
-
 		wp_set_current_user( $admin_id );
 
 		$query_logger = new QueryLogger();
@@ -230,13 +229,6 @@ class TestQueryLogger extends BaseTestCase {
 		add_filter( 'ep_query_logger_logs', $add_fake_log );
 
 		\ElasticPress\Screen::factory()->set_current_screen( 'features' );
-
-		/**
-		 * Generic check
-		 */
-		$notices = $query_logger->maybe_add_notice( [] );
-		$this->assertArrayHasKey( 'has_failed_queries', $notices );
-		$this->assertStringStartsWith( 'Some ElasticPress queries failed in the last 24 hours.', $notices['has_failed_queries']['html'] );
 
 		/**
 		 * Check messages when no indices are found
@@ -250,6 +242,14 @@ class TestQueryLogger extends BaseTestCase {
 		} else {
 			$this->assertStringContainsString( 'Elasticsearch server', $notices['has_failed_queries']['html'] );
 		}
+
+		/**
+		 * Generic check (we have at least one index present)
+		 */
+		\ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertArrayHasKey( 'has_failed_queries', $notices );
+		$this->assertStringStartsWith( 'Some ElasticPress queries failed in the last 24 hours.', $notices['has_failed_queries']['html'] );
 
 		/**
 		 * No message when no failed queries

--- a/tests/php/TestQueryLogger.php
+++ b/tests/php/TestQueryLogger.php
@@ -214,7 +214,90 @@ class TestQueryLogger extends BaseTestCase {
 	 * @group queryLogger
 	 */
 	public function testMaybeAddNotice() {
-		$this->markTestIncomplete();
+		/**
+		 * Initial setup
+		 */
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+
+		wp_set_current_user( $admin_id );
+
+		$query_logger = new QueryLogger();
+
+		$add_fake_log = function() {
+			return [ 'fake-log' ];
+		};
+		add_filter( 'ep_query_logger_logs', $add_fake_log );
+
+		\ElasticPress\Screen::factory()->set_current_screen( 'features' );
+
+		/**
+		 * Generic check
+		 */
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertArrayHasKey( 'has_failed_queries', $notices );
+		$this->assertStringStartsWith( 'Some ElasticPress queries failed in the last 24 hours.', $notices['has_failed_queries']['html'] );
+
+		/**
+		 * Check messages when no indices are found
+		 */
+		\ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertArrayHasKey( 'has_failed_queries', $notices );
+		$this->assertStringStartsWith( 'Your site&#039;s content is not synced with your', $notices['has_failed_queries']['html'] );
+		if ( \ElasticPress\Utils\is_epio() ) {
+			$this->assertStringContainsString( 'ElasticPress account', $notices['has_failed_queries']['html'] );
+		} else {
+			$this->assertStringContainsString( 'Elasticsearch server', $notices['has_failed_queries']['html'] );
+		}
+
+		/**
+		 * No message when no failed queries
+		 */
+		remove_filter( 'ep_query_logger_logs', $add_fake_log );
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertEmpty( $notices );
+		add_filter( 'ep_query_logger_logs', $add_fake_log );
+
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertArrayHasKey( 'has_failed_queries', $notices );
+
+		/**
+		 * No messages when dismissed
+		 */
+		add_filter( 'pre_site_option_ep_hide_has_failed_queries_notice', '__return_true' );
+		add_filter( 'pre_option_ep_hide_has_failed_queries_notice', '__return_true' );
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertEmpty( $notices );
+		remove_filter( 'pre_site_option_ep_hide_has_failed_queries_notice', '__return_true' );
+		remove_filter( 'pre_option_ep_hide_has_failed_queries_notice', '__return_true' );
+
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertArrayHasKey( 'has_failed_queries', $notices );
+
+		/**
+		 * No message when on status-report page
+		 */
+		\ElasticPress\Screen::factory()->set_current_screen( 'status-report' );
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertEmpty( $notices );
+		\ElasticPress\Screen::factory()->set_current_screen( 'features' );
+
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertArrayHasKey( 'has_failed_queries', $notices );
+
+		/**
+		 * No message
+		 */
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author_id );
+
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertEmpty( $notices );
+
+		wp_set_current_user( $admin_id );
+		$notices = $query_logger->maybe_add_notice( [] );
+		$this->assertArrayHasKey( 'has_failed_queries', $notices );
 	}
 
 	/**

--- a/tests/php/features/TestSearchOrdering.php
+++ b/tests/php/features/TestSearchOrdering.php
@@ -24,7 +24,6 @@ class TestSearchOrdering extends BaseTestCase {
 		parent::set_up();
 		$wpdb->suppress_errors();
 
-		\ElasticPress\setup_roles();
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 
 		wp_set_current_user( $admin_id );

--- a/tests/php/includes/classes/BaseTestCase.php
+++ b/tests/php/includes/classes/BaseTestCase.php
@@ -47,6 +47,9 @@ class BaseTestCase extends WP_UnitTestCase {
 	public function set_up() {
 
 		$this->setup_factory();
+
+		\ElasticPress\setup_roles();
+
 		parent::set_up();
 	}
 


### PR DESCRIPTION
### Description of the Change

If the Elasticsearch server does not have any index related to the current WordPress installation, the "Failed queries" message will be different, pointing the user to sync.

This PR also adds a new method called `get_indices_comparison()` to the Elasticsearch class. It returns an array of two arrays: a list of present indices, and a list of missing ones.

### How to test the Change
1. Enable more than one Indexable (Comments or Terms, for example)
2. Sync
3. Delete one index
4. See the old message
5. Delete all indices
6. See the new message

### Changelog Entry
> Changed - If no index is found, the failed queries message will be replaced with a prompt to sync


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
