### PR TITLE
Use only the body to build the cache key

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -628,7 +628,7 @@ class Autosuggest extends Feature {
 		// But only fire this if we have object caching as otherwise this comes with a performance penalty.
 		// If we do not have object caching we cache only one value for 5 minutes in a transient.
 		if ( wp_using_ext_object_cache() ) {
-			$cache_key = md5( wp_json_encode( $query['url'] ) . wp_json_encode( $args ) );
+			$cache_key = md5( wp_json_encode( $query['url'] ) . wp_json_encode( $args['body'] ) );
 			$request   = wp_cache_get( $cache_key, 'ep_autosuggest' );
 			if ( false === $request ) {
 				$request = wp_remote_request( $query['url'], $args );


### PR DESCRIPTION
### Description of the Change

Since we've introduced the Request ID header, autosuggest won't cache the authenticated request anymore, as we were using the entire request (including headers) to create the cache key. This PR changes that to use just the query body.

### How to test the Change

1. Set external object cache
2. Load a page, see the _search request for autosuggest
3. Reload the page, the authenticated request should have 0ms

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Authenticated requests for autosuggest were not being properly cached while using external object cache.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
