### PR TITLE
Update the "no response" automatic message

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -22,9 +22,6 @@ jobs:
           responseRequiredLabel: "reporter feedback" # Label indicating that a response from the original author is required
           closeComment: >
             This issue has been automatically closed because there has been no response
-            to our request for more information. With only the
-            information that is currently in the issue, we don't have enough information
-            to take action. Please reach out if you have or find the answers we need so
-            that we can investigate further. See [this blog post on bug reports and the
-            importance of repro steps](https://www.lee-dohm.com/2015/01/04/writing-good-bug-reports/)
-            for more information about the kind of information that may be helpful.
+            to our request for more information in the past 3 days. With only the
+            information that is currently available, we are unable to take further action on this ticket. Please reach out if you have found or find the answers we need so
+            that we can investigate further. When the information is ready, you can re-open this ticket to share it with us.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Automated message sent in GitHub issues after 3 days of inactivity.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @brandwaffle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
