### PR TITLE
Fix: Fatal error undefined method  ElasticPress\IndexHelper::process_error_limit()

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -690,7 +690,7 @@ class IndexHelper {
 
 				$wp_error_messages = $return->get_error_messages();
 
-				$this->process_error_limit(
+				$this->maybe_process_error_limit(
 					count( $this->index_meta['current_sync_item']['errors'] ) + count( $wp_error_messages ),
 					count( $this->index_meta['current_sync_item']['errors'] ),
 					$wp_error_messages

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -738,7 +738,7 @@ class IndexHelper {
 	 * If the number of errors is less than or equal the limit, add the error message to the array (if it's not there).
 	 * Merges the new errors with the existing errors.
 	 *
-	 * @since  5.0.0
+	 * @since  4.5.1
 	 * @param int   $count Number of errors.
 	 * @param int   $num Number of errors to subtract from $limit.
 	 * @param array $errors Array of errors.
@@ -749,7 +749,7 @@ class IndexHelper {
 		/**
 		 * Filter the number of errors of a current sync that should be stored.
 		 *
-		 * @since  5.0.0
+		 * @since  4.5.1
 		 * @hook ep_current_sync_number_of_errors_stored
 		 * @param  {int} $number Number of errors to be logged.
 		 * @return {int} New value


### PR DESCRIPTION
…rror_limit()

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the sync command throw an error `Index failed: Uncaught Error: Call to undefined method ElasticPress\IndexHelper::process_error_limit()`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fatal error because of incorrect `maybe_process_error_limit` function name


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
