### PR TITLE
Fix the output of put-mapping errors

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -290,7 +290,7 @@ class Command extends WP_CLI_Command {
 							sprintf(
 								/* translators: Error message */
 								esc_html__( 'Mapping failed: %s', 'elasticpress' ),
-								$result->get_error_message()
+								Utils\get_elasticsearch_error_reason( $result->get_error_message() )
 							)
 						);
 					}
@@ -330,7 +330,7 @@ class Command extends WP_CLI_Command {
 						sprintf(
 							/* translators: Error message */
 							esc_html__( 'Mapping failed: %s', 'elasticpress' ),
-							$result->get_error_message()
+							Utils\get_elasticsearch_error_reason( $result->get_error_message() )
 						)
 					);
 				}
@@ -371,7 +371,7 @@ class Command extends WP_CLI_Command {
 					sprintf(
 						/* translators: Error message */
 						esc_html__( 'Mapping failed: %s', 'elasticpress' ),
-						$result->get_error_message()
+						Utils\get_elasticsearch_error_reason( $result->get_error_message() )
 					)
 				);
 			}

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -1337,8 +1337,11 @@ class IndexHelper {
 
 		switch ( $context ) {
 			case 'mapping':
-				/* translators: Error message */
-				$message  = sprintf( esc_html__( 'Mapping failed: %s', 'elasticpress' ), $error['message'] );
+				$message = sprintf(
+					/* translators: Error message */
+					esc_html__( 'Mapping failed: %s', 'elasticpress' ),
+					Utils\get_elasticsearch_error_reason( $error['message'] )
+				);
 				$message .= "\n";
 				$message .= esc_html__( 'Mapping has failed, which will cause ElasticPress search results to be incorrect. Please click `Delete all Data and Start a Fresh Sync` to retry mapping.', 'elasticpress' );
 				break;

--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -146,15 +146,7 @@ class FailedQueries extends Report {
 	 * @return array The error in index 0, solution in index 1
 	 */
 	public function analyze_log( $log ) {
-		$error = '';
-
-		if ( ! empty( $log['result']['error'] ) && ! empty( $log['result']['error']['root_cause'][0]['reason'] ) ) {
-			$error = $log['result']['error']['root_cause'][0]['reason'];
-		}
-
-		if ( ! empty( $log['result']['errors'] ) && ! empty( $log['result']['items'] ) && ! empty( $log['result']['items'][0]['index']['error']['reason'] ) ) {
-			$error = $log['result']['items'][0]['index']['error']['reason'];
-		}
+		$error = Utils\get_elasticsearch_error_reason( $log );
 
 		$solution = ( ! empty( $error ) ) ?
 			$this->maybe_suggest_solution_for_es( $error ) :

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -787,3 +787,34 @@ function generate_request_id() : string {
 	 */
 	return apply_filters( 'ep_request_id', get_request_id_base() . $uuid );
 }
+
+/**
+ * Given an Elasticsearch response, try to find an error message.
+ *
+ * @since 4.6.0
+ * @param mixed $response The Elasticsearch response
+ * @return string
+ */
+function get_elasticsearch_error_reason( $response ) : string {
+	if ( is_string( $response ) ) {
+		return $response;
+	}
+
+	if ( ! is_array( $response ) ) {
+		return var_export( $response, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions
+	}
+
+	if ( ! empty( $response['reason'] ) ) {
+		return $response['reason'];
+	}
+
+	if ( ! empty( $response['result']['error'] ) && ! empty( $response['result']['error']['root_cause'][0]['reason'] ) ) {
+		return $response['result']['error']['root_cause'][0]['reason'];
+	}
+
+	if ( ! empty( $response['result']['errors'] ) && ! empty( $response['result']['items'] ) && ! empty( $response['result']['items'][0]['index']['error']['reason'] ) ) {
+		return $response['result']['items'][0]['index']['error']['reason'];
+	}
+
+	return '';
+}

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -329,4 +329,59 @@ class TestUtils extends BaseTestCase {
 
 		$this->assertSame( $expected, Utils\get_post_map_capabilities() );
 	}
+
+	/**
+	 * Test the `get_elasticsearch_error_reason` function
+	 *
+	 * @since 4.6.0
+	 */
+	public function testGetElasticsearchErrorReason() {
+		// Strings should be returned without any change
+		$this->assertSame( 'Some message', Utils\get_elasticsearch_error_reason( 'Some message' ) );
+
+		// Objects will be returned after passing through var_export()
+		$object = (object) [ 'attribute' => 'this will be an object' ];
+		$return = Utils\get_elasticsearch_error_reason( $object );
+		$this->assertIsString( $return );
+		$this->assertStringContainsString( 'attribute', $return );
+		$this->assertStringContainsString( 'this will be an object', $return );
+
+		// `reason` in the array root
+		$reason_root = [ 'reason' => 'Error reason' ];
+		$this->assertSame( 'Error reason', Utils\get_elasticsearch_error_reason( $reason_root ) );
+
+		// array with `error`
+		$reason_in_single_error_array = [
+			'result' => [
+				'error' => [
+					'root_cause' => [
+						[
+							'reason' => 'Error reason',
+						],
+					],
+				],
+			],
+		];
+		$this->assertSame( 'Error reason', Utils\get_elasticsearch_error_reason( $reason_in_single_error_array ) );
+
+		// array with `errors`
+		$reason_in_errors_array = [
+			'result' => [
+				'error' => [
+					'root_cause' => [
+						[
+							'reason' => 'Error reason',
+						],
+					],
+				],
+			],
+		];
+		$this->assertSame( 'Error reason', Utils\get_elasticsearch_error_reason( $reason_in_errors_array ) );
+
+		// For something that is an array but does not have a format of an error, return an empty string
+		$not_an_error = [
+			'results' => [ 1, 2, 3 ],
+		];
+		$this->assertSame( '', Utils\get_elasticsearch_error_reason( $not_an_error ) );
+	}
 }

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -367,10 +367,15 @@ class TestUtils extends BaseTestCase {
 		// array with `errors`
 		$reason_in_errors_array = [
 			'result' => [
-				'error' => [
-					'root_cause' => [
-						[
-							'reason' => 'Error reason',
+				'errors' => [
+					'some error',
+				],
+				'items'  => [
+					[
+						'index' => [
+							'error' => [
+								'reason' => 'Error reason',
+							],
 						],
 					],
 				],


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Currently, if the put-mapping operation returns an error, the message returned says `Mapping failed: Array`. This PR fixes that introducing a general function that gets an Elasticsearch response and returns the error reason in it (if any.)

### How to test the Change
Add the following snippet to your codebase and run `wp elasticpress sync --setup`, `wp elasticpress put-mapping`, or sync via the UI:
```php
add_filter(
	'ep_post_mapping',
	function ( $mapping ) {
		$mapping['mappings']['properties']['post_title']['index_options'] = 'something_wrong';
		return $mapping;
	}
);
```

### Changelog Entry
> Fixed - Display the error message returned by Elasticsearch if a mapping operation fails.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
