### PR TITLE
Allow menu_order to be negative

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -453,7 +453,7 @@ class Post extends Indexable {
 		$comment_count     = absint( $post->comment_count );
 		$comment_status    = $post->comment_status;
 		$ping_status       = $post->ping_status;
-		$menu_order        = absint( $post->menu_order );
+		$menu_order        = (int) $post->menu_order;
 
 		/**
 		 * Filter to ignore invalid dates

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -8637,4 +8637,33 @@ class TestPost extends BaseTestCase {
 
 		$this->assertSame( $expected_mapping, $changed_mapping );
 	}
+
+	/**
+	 * Test negative `menu_order` values.
+	 *
+	 * @since 4.6.0
+	 * @group post
+	 * @see https://github.com/10up/ElasticPress/issues/3440#issuecomment-1545446291
+	 */
+	public function testNegativeMenuOrder() {
+		$post_negative = $this->ep_factory->post->create( array( 'menu_order' => -2 ) );
+		$post_positive = $this->ep_factory->post->create( array( 'menu_order' => 1 ) );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			array(
+				'ep_integrate' => true,
+				'fields'       => 'ids',
+				'post_type'    => 'post',
+				'order'        => 'ASC',
+				'orderby'      => 'menu_order',
+			)
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 2, count( $query->posts ) );
+		$this->assertEquals( $post_negative, $query->posts[0] );
+		$this->assertEquals( $post_positive, $query->posts[1] );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
As pointed out in [this comment](https://github.com/10up/ElasticPress/issues/3440#issuecomment-1545446291), ElasticPress is not storing negative menu_order values but making them positive instead. This PR addresses this issue.

### How to test the Change
Create a product (or any post), give it a negative menu_order value, check Debug Bar EP and see the menu_order stored as a positive number

### Changelog Entry
> Fixed - Negative menu_order values being transformed into positive numbers.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia and @navidabdi

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
