### PR TITLE
[WP-CLI] add --force flag to sync command

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -728,7 +728,12 @@ class Command extends WP_CLI_Command {
 		$force_option = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
 		if ( $setup_option ) {
-			WP_CLI::confirm( esc_html__( 'Indexing with setup option needs to delete Elasticsearch index first, are you sure you want to delete your Elasticsearch index?', 'elasticpress' ), $assoc_args );
+			$message = sprintf(
+				/* translators: ElasticPress.io or Elasticsearch */
+				esc_html__( 'Syncing with the --setup option will delete your existing index in %s. Are you sure you want to delete your Elasticsearch index', 'elasticpress' ),
+				Utils\is_epio() ? 'ElasticPress.io' : 'Elasticsearch'
+			);
+			WP_CLI::confirm( $message, $assoc_args );
 		}
 
 		if ( $force_option ) {

--- a/tests/cypress/integration/wp-cli.cy.js
+++ b/tests/cypress/integration/wp-cli.cy.js
@@ -127,6 +127,17 @@ describe('WP-CLI Commands', { tags: '@slow' }, () => {
 
 			cy.deactivatePlugin('fake-log-messages');
 		});
+
+		it('Can stop ongoing syncs with the --force flag', () => {
+			// mock the sync process
+			cy.wpCliEval(
+				`update_option('ep_index_meta', [ 'indexing' => true ] ); set_transient('ep_sync_interrupted', true);`,
+			);
+
+			cy.wpCli('wp elasticpress sync --force --yes')
+				.its('stdout')
+				.should('contain', 'Sync cleared');
+		});
 	});
 
 	it('Can delete the index of current blog if user runs wp elasticpress delete-index', () => {

--- a/tests/cypress/integration/wp-cli.cy.js
+++ b/tests/cypress/integration/wp-cli.cy.js
@@ -366,7 +366,7 @@ describe('WP-CLI Commands', { tags: '@slow' }, () => {
 
 		cy.wpCli('wp elasticpress stop-sync').its('stdout').should('contain', 'Done');
 
-		cy.wpCli('wp elasticpress clear-sync').its('stdout').should('contain', 'Index cleared');
+		cy.wpCli('wp elasticpress clear-sync').its('stdout').should('contain', 'Sync cleared');
 	});
 
 	it('can send an HTTP request to Elasticsearch', () => {

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -640,6 +640,38 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
+	 * Test sync command with the force flag.
+	 *
+	 * @since 4.6.0
+	 */
+	public function testSyncWithForceFlag() {
+		// mock indexing
+		add_filter( 'ep_is_indexing', '__return_true' );
+
+		$this->command->sync(
+			[],
+			[
+				'force' => true,
+				'yes'   => true,
+			]
+		);
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Sync cleared.', $output );
+	}
+
+	/**
+	 * Test sync command can ask for confirmation when force flag is set
+	 *
+	 * @since 4.6.0
+	 */
+	public function testSyncAskForConfirmationWhenForceIsPassed() {
+		$this->expectExceptionMessage( 'Are you sure you want to stop any other ongoing sync?' );
+
+		$this->command->sync( [], [ 'force' => true ] );
+	}
+
+	/**
 	 * Test status command returns status information.
 	 */
 	public function testStatus() {
@@ -733,7 +765,7 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
-	 * Test delete-index command can delete all the indexes if network-wide flag is set.
+	 * Test the clear-sync command
 	 *
 	 * @group skip-on-single-site
 	 */
@@ -742,7 +774,7 @@ class TestCommands extends BaseTestCase {
 		$this->command->clear_sync( [], [] );
 
 		$output = $this->getActualOutputForAssertion();
-		$this->assertStringContainsString( 'Index cleared.', $output );
+		$this->assertStringContainsString( 'Sync cleared.', $output );
 	}
 
 	/**

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -609,8 +609,7 @@ class TestCommands extends BaseTestCase {
 	 * Test sync command can ask for confirmation when setup flag is set
 	 */
 	public function testSyncAskForConfirmationWhenSetupIsPassed() {
-
-		$this->expectExceptionMessage( 'Indexing with setup option needs to delete Elasticsearch index first, are you sure you want to delete your Elasticsearch index?' );
+		$this->expectExceptionMessage( 'Syncing with the --setup option will delete your existing index in Elasticsearch. Are you sure you want to delete your Elasticsearch index' );
 
 		$this->command->sync( [], [ 'setup' => true ] );
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3327

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - --force flag to the sync WP-CLI command, to stop any other ongoing syncs

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @tomjn 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
