### PR TITLE
Better handling of request errors

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -862,7 +862,14 @@ class Elasticsearch {
 
 			$response_body   = wp_remote_retrieve_body( $request );
 			$parsed_response = json_decode( $response_body, true );
-			return new \WP_Error( $parsed_response['status'], $parsed_response['error'] );
+			if ( is_array( $parsed_response ) ) {
+				$status = $parsed_response['status'] ?? 'status-not-set';
+				$error  = $parsed_response['error'] ?? 'error-not-set';
+			} else {
+				$status = $response_code;
+				$error  = $response_body;
+			}
+			return new \WP_Error( $status, $error );
 		}
 
 		return true;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes the `PHP Warning:  Trying to access array offset on value of type null in /var/www/html/wp-content/plugins/ElasticPress/includes/classes/Elasticsearch.php on line 865`  error message that can be seen [here](https://github.com/10up/ElasticPress/actions/runs/5178584344/jobs/9330254852?pr=3473#step:8:7094), for example.

### Changelog Entry
> Fixed - Error message when the Elasticsearch server is not available during the put mapping operation


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
