### PR TITLE
Sync command stop-on-error flag

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1311,7 +1311,7 @@ class Command extends WP_CLI_Command {
 		static $time_elapsed = 0, $counter = 0;
 
 		// Special treatment if stop-on-error flag is set.
-		if ( ! empty( $args['stop_on_error'] ) && in_array( $message['status'], [ 'error', 'warning' ] ) ) {
+		if ( ! empty( $args['stop_on_error'] ) && in_array( $message['status'], [ 'error', 'warning' ], true ) ) {
 			$this->clear_sync();
 			WP_CLI::error( $message['message'] );
 		}

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -803,14 +803,15 @@ class Command extends WP_CLI_Command {
 			'static_bulk'    => $static_bulk,
 		];
 
-		$show_errors = isset( $assoc_args['show-errors'] ) || ( isset( $assoc_args['show-bulk-errors'] ) && ! $no_bulk ) || ( isset( $assoc_args['show-nobulk-errors'] ) && $no_bulk );
+		$index_args['stop_on_error'] = WP_CLI\Utils\get_flag_value( $assoc_args, 'stop-on-error', false );
+
+		$show_errors = $index_args['stop_on_error'] ||
+			WP_CLI\Utils\get_flag_value( $assoc_args, 'show-errors', false ) ||
+			( WP_CLI\Utils\get_flag_value( $assoc_args, 'show-bulk-errors', false ) && ! $no_bulk ) ||
+			( WP_CLI\Utils\get_flag_value( $assoc_args, 'show-nobulk-errors', false ) && $no_bulk );
 
 		if ( $show_errors ) {
 			$index_args['show_errors'] = true;
-		}
-
-		if ( isset( $assoc_args['stop-on-error'] ) && $show_errors ) {
-			$index_args['stop_on_error'] = true;
 		}
 
 		if ( ! empty( $assoc_args['post-ids'] ) ) {

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1310,12 +1310,6 @@ class Command extends WP_CLI_Command {
 	public function index_output( $message, $args, $index_meta, $context ) {
 		static $time_elapsed = 0, $counter = 0;
 
-		// Special treatment if stop-on-error flag is set.
-		if ( ! empty( $args['stop_on_error'] ) && in_array( $message['status'], [ 'error', 'warning' ], true ) ) {
-			$this->clear_sync();
-			WP_CLI::error( $message['message'] );
-		}
-
 		switch ( $message['status'] ) {
 			case 'success':
 				WP_CLI::success( $message['message'] );

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -716,7 +716,7 @@ class IndexHelper {
 				);
 
 				$this->index_meta['current_sync_item']['failed'] += count( $failed_objects );
-				$error_type = ! empty( $this->args['stop_on_error'] ) ? 'error' : 'warning';
+				$error_type                                       = ! empty( $this->args['stop_on_error'] ) ? 'error' : 'warning';
 
 				$this->queue_message( $errors_output, $error_type );
 			} else {

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -710,7 +710,11 @@ class IndexHelper {
 
 				$this->index_meta['current_sync_item']['failed'] += count( $failed_objects );
 
-				$this->output( $errors_output, 'warning' );
+				if ( ! empty( $this->args['stop_on_error'] ) ) {
+					$this->output( $errors_output, 'error' );
+				} else {
+					$this->output( $errors_output, 'warning' );
+				}
 			} else {
 				$this->index_meta['current_sync_item']['synced'] += count( $queued_items );
 			}

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -959,7 +959,7 @@ class TestCommands extends BaseTestCase {
 		];
 
 		$elasticsearch_mock->expects( $this->exactly( 1 ) )
-			->method( 'remote_request' )
+			->method( 'bulk_index_dynamically' )
 			->willReturn( $fake_request );
 
 		$index_args = [

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -934,31 +934,34 @@ class TestCommands extends BaseTestCase {
 	 * Expect an error message that stops the sync instead of a warning.
 	 */
 	public function testSyncStopOnError() {
-		add_filter( 'http_response', function( $request ) {
-			$fake_request = json_decode( wp_remote_retrieve_body( $request ) );
+		add_filter(
+			'http_response',
+			function( $request ) {
+				$fake_request = json_decode( wp_remote_retrieve_body( $request ) );
 
-			if (  ! empty( $fake_request->items ) ) {
-				$fake_request->errors = true;
+				if ( ! empty( $fake_request->items ) ) {
+					$fake_request->errors = true;
 
-				$fake_item = new \stdClass();
-				$fake_item->index = new \stdClass();
-				$fake_item->index->error = new \stdClass();
-				$fake_item->index->status = 400;
-				$fake_item->index->_id = 10;
-				$fake_item->index->type = '_doc';
-				$fake_item->index->_index = 'dummy-index';
-				$fake_item->index->error->reason = 'my dummy error reason';
-				$fake_item->index->error->type = 'my dummy error type';
+					$fake_item                       = new \stdClass();
+					$fake_item->index                = new \stdClass();
+					$fake_item->index->error         = new \stdClass();
+					$fake_item->index->status        = 400;
+					$fake_item->index->_id           = 10;
+					$fake_item->index->type          = '_doc';
+					$fake_item->index->_index        = 'dummy-index';
+					$fake_item->index->error->reason = 'my dummy error reason';
+					$fake_item->index->error->type   = 'my dummy error type';
 
-				$fake_request->items[0] = $fake_item;
+					$fake_request->items[0] = $fake_item;
 
-				$request['body'] = wp_json_encode( $fake_request );
+					$request['body'] = wp_json_encode( $fake_request );
+
+					return $request;
+				}
 
 				return $request;
 			}
-
-			return $request;
-		} );
+		);
 
 		Indexables::factory()->get( 'post' )->delete_index();
 
@@ -966,12 +969,15 @@ class TestCommands extends BaseTestCase {
 
 		$this->expectExceptionMessage( '10 (Post): [my dummy error type] my dummy error reason' );
 
-		$this->command->sync( [], [
-			'setup' => true,
-			'show-errors' => true,
-			'stop-on-error' => true,
-			'yes' => true,
-		] );
+		$this->command->sync(
+			[],
+			[
+				'setup'         => true,
+				'show-errors'   => true,
+				'stop-on-error' => true,
+				'yes'           => true,
+			]
+		);
 	}
 
 	/**

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -930,6 +930,51 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
+	 * Test sync command with stop-on-error flag.
+	 * Expect an error message that stops the sync instead of a warning.
+	 */
+	public function testSyncStopOnError() {
+		add_filter( 'http_response', function( $request ) {
+			$fake_request = json_decode( wp_remote_retrieve_body( $request ) );
+
+			if (  ! empty( $fake_request->items ) ) {
+				$fake_request->errors = true;
+
+				$fake_item = new \stdClass();
+				$fake_item->index = new \stdClass();
+				$fake_item->index->error = new \stdClass();
+				$fake_item->index->status = 400;
+				$fake_item->index->_id = 10;
+				$fake_item->index->type = '_doc';
+				$fake_item->index->_index = 'dummy-index';
+				$fake_item->index->error->reason = 'my dummy error reason';
+				$fake_item->index->error->type = 'my dummy error type';
+
+				$fake_request->items[0] = $fake_item;
+
+				$request['body'] = wp_json_encode( $fake_request );
+
+				return $request;
+			}
+
+			return $request;
+		} );
+
+		Indexables::factory()->get( 'post' )->delete_index();
+
+		$this->ep_factory->post->create_many( 10 );
+
+		$this->expectExceptionMessage( '10 (Post): [my dummy error type] my dummy error reason' );
+
+		$this->command->sync( [], [
+			'setup' => true,
+			'show-errors' => true,
+			'stop-on-error' => true,
+			'yes' => true,
+		] );
+	}
+
+	/**
 	 * Test request command throws an error if request fails.
 	 */
 	public function testRequestThrowsError() {

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -966,7 +966,7 @@ class TestCommands extends BaseTestCase {
 		);
 		Indexables::factory()->get( 'post' )->delete_index();
 
-		$this->ep_factory->post->create_many( 1 );
+		$this->ep_factory->post->create();
 
 		$this->expectExceptionMessage( '10 (Post): [my dummy error type] my dummy error reason' );
 

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -932,6 +932,8 @@ class TestCommands extends BaseTestCase {
 	/**
 	 * Test sync command with stop-on-error flag.
 	 * Expect an error message that stops the sync instead of a warning.
+	 *
+	 * @since 4.7.0
 	 */
 	public function testSyncStopOnError() {
 		add_filter(

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -936,49 +936,42 @@ class TestCommands extends BaseTestCase {
 	 * @since 4.7.0
 	 */
 	public function test_sync_stop_on_error() {
-		add_filter(
-			'http_response',
-			function( $request ) {
-				$fake_request = json_decode( wp_remote_retrieve_body( $request ) );
+		$elasticsearch_mock = $this->getMockBuilder( \ElasticPress\IndexHelper::class )
+			->setMethods( [ 'bulk_index_dynamically' ] )
+			->getMock();
 
-				if ( ! empty( $fake_request->items ) ) {
-					$fake_request->errors = true;
+		$fake_request = [
+			'errors' => true,
+		];
 
-					$fake_item                       = new \stdClass();
-					$fake_item->index                = new \stdClass();
-					$fake_item->index->error         = new \stdClass();
-					$fake_item->index->status        = 400;
-					$fake_item->index->_id           = 10;
-					$fake_item->index->type          = '_doc';
-					$fake_item->index->_index        = 'dummy-index';
-					$fake_item->index->error->reason = 'my dummy error reason';
-					$fake_item->index->error->type   = 'my dummy error type';
+		$fake_item                       = new \stdClass();
+		$fake_item->items                = new \stdClass();
+		$fake_item->index                = new \stdClass();
+		$fake_item->index->error         = new \stdClass();
+		$fake_item->index->status        = 400;
+		$fake_item->index->_id           = 10;
+		$fake_item->index->type          = '_doc';
+		$fake_item->index->_index        = 'dummy-index';
+		$fake_item->index->error->reason = 'my dummy error reason';
+		$fake_item->index->error->type   = 'my dummy error type';
 
-					$fake_request->items[0] = $fake_item;
+		$fake_request->items[0] = $fake_item;
 
-					$request['body'] = wp_json_encode( $fake_request );
+		$elasticsearch_mock->expects( $this->exactly( 1 ) )
+			->method( 'remote_request' )
+			->willReturn( $fake_request );
 
-					return $request;
-				}
-
-				return $request;
-			}
-		);
-
-		Indexables::factory()->get( 'post' )->delete_index();
-
-		$this->ep_factory->post->create_many( 10 );
+		$index_args = [
+			'method'         => 'cli',
+			'output_method'  => [ $this->command, 'index_output' ],
+			'stop_on_error' => true,
+			'show-errors'   => false
+		];
 
 		$this->expectExceptionMessage( '10 (Post): [my dummy error type] my dummy error reason' );
 
-		$this->command->sync(
-			[],
-			[
-				'setup'         => true,
-				'show-errors'   => true,
-				'stop-on-error' => true,
-				'yes'           => true,
-			]
+		ElasticPress\IndexHelper::factory()->full_index(
+			$index_args
 		);
 	}
 

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -942,28 +942,29 @@ class TestCommands extends BaseTestCase {
 
 		$fake_request = [
 			'errors' => true,
+			'items'  => [
+				[
+					'index' => [
+						'error' => [
+							'reason' => 'my dummy error reason',
+							'type'   => 'my dummy error type'
+						],
+						'status' => 400,
+						'_id'    => '10',
+						'type'   => '_doc',
+						'_index' => 'dummy-index'
+					]
+				]
+			]
 		];
-
-		$fake_item                       = new \stdClass();
-		$fake_item->items                = new \stdClass();
-		$fake_item->index                = new \stdClass();
-		$fake_item->index->error         = new \stdClass();
-		$fake_item->index->status        = 400;
-		$fake_item->index->_id           = 10;
-		$fake_item->index->type          = '_doc';
-		$fake_item->index->_index        = 'dummy-index';
-		$fake_item->index->error->reason = 'my dummy error reason';
-		$fake_item->index->error->type   = 'my dummy error type';
-
-		$fake_request->items[0] = $fake_item;
 
 		$elasticsearch_mock->expects( $this->exactly( 1 ) )
 			->method( 'remote_request' )
 			->willReturn( $fake_request );
 
 		$index_args = [
-			'method'         => 'cli',
-			'output_method'  => [ $this->command, 'index_output' ],
+			'method'        => 'cli',
+			'output_method' => [ $this->command, 'index_output' ],
 			'stop_on_error' => true,
 			'show-errors'   => false
 		];

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -935,7 +935,7 @@ class TestCommands extends BaseTestCase {
 	 *
 	 * @since 4.7.0
 	 */
-	public function testSyncStopOnError() {
+	public function test_sync_stop_on_error() {
 		add_filter(
 			'http_response',
 			function( $request ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR introduces a new flag `stop-on-error` to stop sync the moment we find an error. We accomplish this by returning an error logged by `output()` that later kills the sync.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2000

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Flag --stop-on-error


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
