### PR TITLE
Fix PHP 8.2 deprecation notice in WooCommerce\Orders.

### DIFF
--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -25,7 +25,7 @@ class Orders {
 	 *
 	 * @var string
 	 */
-	private $index;
+	protected $index;
 	
 	/**
 	 * Initialize feature.

--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -21,6 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Orders {
 	/**
+	 * The name of the index;
+	 *
+	 * @var string
+	 */
+	private $index;
+	
+	/**
 	 * Initialize feature.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes a deprecation notice because the `$index` property is undeclared in `ElasticPress\Feature\WooCommerce\Orders` and created dynamically.

### Changelog Entry
Declared property `$index` in Orders.php in order to avoid the [deprecation notice](https://php.watch/versions/8.2/dynamic-properties-deprecated) in PHP 8.2.

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
