### PR TITLE
Avoid empty meta fields

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -810,9 +810,12 @@ class Search extends Feature {
 			return;
 		}
 
-		$exclude_from_search = isset( $_POST['ep_exclude_from_search'] ) ? true : false;
+		if ( isset( $_POST['ep_exclude_from_search'] ) ) {
+			update_post_meta( $post_id, 'ep_exclude_from_search', true );
+		} else {
+			delete_post_meta( $post_id, 'ep_exclude_from_search' );
+		}
 
-		update_post_meta( $post_id, 'ep_exclude_from_search', $exclude_from_search );
 	}
 
 	/**

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -533,12 +533,8 @@ class SearchOrdering extends Feature {
 			}
 		}
 
+		update_post_meta( $post_id, 'pointers', $final_order_data );
 		update_post_meta( $post_id, 'search_term', $post->post_title );
-		if ( ! empty( $final_order_data ) ) {
-			update_post_meta( $post_id, 'pointers', $final_order_data );
-		} else {
-			delete_post_meta( $post_id, 'pointers' );
-		}
 	}
 
 	/**

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -533,8 +533,12 @@ class SearchOrdering extends Feature {
 			}
 		}
 
-		update_post_meta( $post_id, 'pointers', $final_order_data );
 		update_post_meta( $post_id, 'search_term', $post->post_title );
+		if ( ! empty( $final_order_data ) ) {
+			update_post_meta( $post_id, 'pointers', $final_order_data );
+		} else {
+			delete_post_meta( $post_id, 'pointers' );
+		}
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -8024,6 +8024,28 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that post meta value should be empty when it is not set.
+	 */
+	public function testMetaValueNotSet() {
+		$post_ids    = array();
+		$post_ids[0] = $this->ep_factory->post->create(
+			array(
+				'post_content' => 'find me in search',
+			)
+		);
+		$post_ids[1] = $this->ep_factory->post->create(
+			array(
+				'post_content' => 'exlcude from search',
+				'meta_input'   => array( 'ep_exclude_from_search' => true ),
+			)
+		);
+
+		$this->assertEmpty( get_post_meta( $post_ids[0], 'ep_exclude_from_search', true ) );
+		$this->assertEquals( 1, get_post_meta( $post_ids[1], 'ep_exclude_from_search', true ) );
+
+	}
+
+	/**
 	 * Tests search term is wrapped in html tag with custom class
 	 */
 	public function testHighlightTagsWithCustomClass() {

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -8042,7 +8042,6 @@ class TestPost extends BaseTestCase {
 
 		$this->assertEmpty( get_post_meta( $post_ids[0], 'ep_exclude_from_search', true ) );
 		$this->assertEquals( 1, get_post_meta( $post_ids[1], 'ep_exclude_from_search', true ) );
-
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR will delete the meta fields when it is not set instead of updating the meta with false or empty value
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3490 

### How to test the Change
- Create a post without setting the Exclude from search option in the post
- Check the post meta and notice that it should be empty if it is not set
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Update post metas only if they are set or have some value


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
