### PR TITLE
Fix: Restrict applying a facet filter to the query if the filter value is empty.

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -401,6 +401,9 @@ class Facets extends Feature {
 
 			foreach ( $filter_names as $filter_name => $type_obj ) {
 				if ( 0 === strpos( $key, $filter_name ) ) {
+					if ( empty( $value ) ) {
+						continue;
+					}
 					$facet = str_replace( $filter_name, '', $key );
 
 					$filters = $type_obj->format_selected( $facet, $value, $filters );

--- a/tests/php/features/TestFacet.php
+++ b/tests/php/features/TestFacet.php
@@ -106,7 +106,7 @@ class TestFacet extends BaseTestCase {
 		$this->assertArrayHasKey( 'post_type', $selected );
 		$this->assertSame( 'posttype', $selected['post_type'] );
 
-		// test when filter is empty
+		// test when filter value is empty.
 		parse_str( 'ep_filter_category=&ep_filter_othertax=amet&s=', $_GET );
 		$selected = $facet_feature->get_selected();
 		$this->assertArrayNotHasKey( 'category', $selected['taxonomies'] );

--- a/tests/php/features/TestFacet.php
+++ b/tests/php/features/TestFacet.php
@@ -105,6 +105,12 @@ class TestFacet extends BaseTestCase {
 		$this->assertSelectedTax( array( $term->slug => true ), 'taxonomy', $selected );
 		$this->assertArrayHasKey( 'post_type', $selected );
 		$this->assertSame( 'posttype', $selected['post_type'] );
+
+		// test when filter is empty
+		parse_str( 'ep_filter_category=&ep_filter_othertax=amet&s=', $_GET );
+		$selected = $facet_feature->get_selected();
+		$this->assertArrayNotHasKey( 'category', $selected['taxonomies'] );
+		$this->assertArrayHasKey( 's', $selected );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the facet filter was applied on the query even when the filter value is empty

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3517

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Add the Facet block.
2. Apply the facet filter.
3. Remove the filter value from the query string.
4. Check the search result

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Restrict applying a facet filter to the query if the filter value is empty.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
