### PR TITLE
Fix: Documentation for ep_facet_search_get_terms_args filter

### DIFF
--- a/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
@@ -95,10 +95,10 @@ class Renderer {
 			 *
 			 * @since  3.5.0
 			 * @hook ep_facet_search_get_terms_args
-			 * @param  {array} $query Weighting query
-			 * @param  {string} $post_type Post type
-			 * @param  {array} $args WP Query arguments
-			 * @return  {array} New query
+			 * @param  {array} $terms_args Array of arguments passed to get_terms()
+			 * @param  {array} $args Widget args
+			 * @param  {array} $instance Instance settings
+			 * @return  {array} New terms args
 			 */
 			apply_filters(
 				'ep_facet_search_get_terms_args',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the documentation for `ep_facet_search_get_terms_args` filter

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3518

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fix documentation for ep_facet_search_get_terms_args filter



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
