### PR TITLE
Fix warning on the health page

### DIFF
--- a/includes/classes/Screen/HealthInfo.php
+++ b/includes/classes/Screen/HealthInfo.php
@@ -37,7 +37,7 @@ class HealthInfo {
 
 		$debug_info['ep-last-sync'] = [
 			'label'  => esc_html__( 'ElasticPress - Last Sync', 'elasticpress' ),
-			'fields' => $first_group['fields'],
+			'fields' => $first_group['fields'] ?? [],
 		];
 
 		return $debug_info;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the EP throws a warning `Trying to access array offset on value of type bool` on the Health page when there is no last sync information available. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Run `wp elasticpress settings-reset` command.
2. Go to health page `wp-admin/site-health.php?tab=debug` and make sure there is no waning

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Warning message on Health page when Last Sync information is not available. 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
