### PR TITLE
Fix: Failed Query logs automatically cleared on page refresh

### DIFF
--- a/includes/classes/StatusReport/FailedQueries.php
+++ b/includes/classes/StatusReport/FailedQueries.php
@@ -137,6 +137,15 @@ class FailedQueries extends Report {
 		}
 
 		$this->query_logger->clear_logs();
+
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
+			$redirect_url = network_admin_url( 'admin.php?page=elasticpress-status-report' );
+		} else {
+			$redirect_url = admin_url( 'admin.php?page=elasticpress-status-report' );
+		}
+
+		wp_safe_redirect( $redirect_url );
+		exit();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the failed query logs are automatically cleared on page refresh. What happened is that the user clicked on the `Clear query log` button. EP reloads the report page with a nonce in the url. On the next page reload the valid nonce is available in the URL, EP automatically clear the logs. https://github.com/10up/ElasticPress/blob/develop/includes/classes/StatusReport/FailedQueries.php#L134


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Run  wp elasticpress delete-index command
2. Go to "Status Report" page.
3. Click on `Clear query log` button.
4. Search anything on the frontend
5. Refresh the Status Report page and make sure new logs are there. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Failed Query logs are automatically cleared on refreshing the "Status Report" page


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
