### PR TITLE
Add the get-index-settings WP-CLI command

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1565,4 +1565,29 @@ class Command extends WP_CLI_Command {
 		$instant_results->epio_delete_search_template();
 		WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );
 	}
+
+	/**
+	 * Get an index settings
+	 *
+	 * ## OPTIONS
+	 *
+	 * <index_name>
+	 * : Index name
+	 *
+	 * [--pretty]
+	 * : Use this flag to render a pretty-printed version of the JSON response.
+	 *
+	 * @subcommand get-index-settings
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get_index_settings( $args, $assoc_args ) {
+		$response = Elasticsearch::factory()->get_index_settings( $args[0] );
+		$pretty   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pretty' );
+
+		$this->pretty_json_encode( $response, $pretty );
+	}
 }

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1033,6 +1033,31 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
+	 * Test get-index-settings command returns an index settings.
+	 *
+	 * @since 4.7.0
+	 */
+	public function testGetIndexSettings() {
+		$this->command->get_index_settings( [ 'exampleorg-post-1' ], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringStartsWith( '{', $output );
+		$this->assertStringContainsString( 'index.mapping.total_fields.limit', $output );
+
+		// clean output buffer
+		ob_clean();
+
+		// test with --pretty flag
+		$this->command->get_index_settings( [ 'exampleorg-post-1' ], [ 'pretty' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringStartsWith( "{\n", $output );
+
+		// clean output buffer
+		ob_clean();
+	}
+
+	/**
 	 * Test commands throws an error if indexing is already happening.
 	 */
 	public function testThrowsErrorIfIndexingIsAlreadyHappening() {


### PR DESCRIPTION
### Description of the Change

This PR adds a new `get-index-settings` WP-CLI command

### Changelog Entry
> Added - New `get-index-settings` WP-CLI command


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
