### PR TITLE
Refactor how transients are deleted by option name

### DIFF
--- a/tests/php/TestUninstall.php
+++ b/tests/php/TestUninstall.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Test the uninstall class/process
+ *
+ * @since 4.7.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+/**
+ * TestUninstall test class
+ */
+class TestUninstall extends BaseTestCase {
+	/**
+	 * Holds the EP_Uninstaller class instance.
+	 *
+	 * @var EP_Uninstaller
+	 */
+	protected $uninstaller;
+
+	/**
+	 * Setup each test.
+	 */
+	public function set_up() {
+		require_once __DIR__ . '/../../uninstall.php';
+
+		$this->uninstaller = new \EP_Uninstaller();
+
+		parent::set_up();
+	}
+
+	/**
+	 * Test the `delete_transients_by_option_name` method
+	 *
+	 * @group uninstall
+	 */
+	public function test_delete_transients_by_option_name() {
+		set_transient( 'ep_total_fields_limit_test', 'test' );
+		set_transient( 'ep_total_fields_limit_test_2', 'test' );
+		set_transient( 'ep_related_posts_test', 'test' );
+		set_transient( 'ep_related_posts_test_2', 'test' );
+
+		$method = $this->get_protected_method( 'delete_transients_by_option_name' );
+		$method->invoke( $this->uninstaller );
+
+		$this->assertFalse( get_transient( 'ep_total_fields_limit_test' ) );
+		$this->assertFalse( get_transient( 'ep_total_fields_limit_test_2' ) );
+		$this->assertFalse( get_transient( 'ep_related_posts_test' ) );
+		$this->assertFalse( get_transient( 'ep_related_posts_test_2' ) );
+	}
+
+	/**
+	 * Return a protected method made public.
+	 *
+	 * This should NOT be copied to any other class.
+	 *
+	 * @param string $method_name The method name
+	 * @return \ReflectionMethod
+	 */
+	protected function get_protected_method( string $method_name ) : \ReflectionMethod {
+		$reflection = new \ReflectionClass( '\EP_Uninstaller' );
+		$method     = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method;
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -81,10 +81,14 @@ class EP_Uninstaller {
 	 * @since 1.7
 	 */
 	public function __construct() {
-
 		// Exit if accessed directly.
 		if ( ! defined( 'ABSPATH' ) ) {
 			$this->exit_uninstaller();
+		}
+
+		// If testing, do not do anything automatically
+		if ( defined( 'EP_UNIT_TESTS' ) && EP_UNIT_TESTS ) {
+			return;
 		}
 
 		// EP_MANUAL_SETTINGS_RESET is used by the `settings-reset` WP-CLI command.
@@ -124,37 +128,41 @@ class EP_Uninstaller {
 	}
 
 	/**
-	 * Delete all transients of the Related Posts feature.
+	 * Delete remaining transients by their option names.
+	 *
+	 * @since 4.7.0
 	 */
-	protected function delete_related_posts_transients() {
+	protected function delete_transients_by_option_name() {
 		global $wpdb;
 
-		$related_posts_transients = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			"SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_related_posts_%'"
+		$transients = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			"SELECT option_name
+			FROM {$wpdb->prefix}options
+			WHERE
+				option_name LIKE '_transient_ep_total_fields_limit_%'
+				OR option_name LIKE '_transient_ep_related_posts_%'
+			"
 		);
 
-		foreach ( $related_posts_transients as $related_posts_transient ) {
-			$related_posts_transient = str_replace( '_transient_', '', $related_posts_transient );
-			delete_site_transient( $related_posts_transient );
-			delete_transient( $related_posts_transient );
+		foreach ( $transients as $transient ) {
+			$transient_name = str_replace( '_transient_', '', $transient );
+			delete_site_transient( $transient_name );
+			delete_transient( $transient_name );
 		}
 	}
 
 	/**
-	 * Delete all transients of the total fields limit.
+	 * DEPRECATED. Delete all transients of the Related Posts feature.
+	 */
+	protected function delete_related_posts_transients() {
+		_deprecated_function( __METHOD__, '4.7.0', '\EP_Uninstaller::delete_transients_by_name()' );
+	}
+
+	/**
+	 * DEPRECATED. Delete all transients of the total fields limit.
 	 */
 	protected function delete_total_fields_limit_transients() {
-		global $wpdb;
-
-		$related_posts_transients = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			"SELECT option_name FROM {$wpdb->prefix}options WHERE option_name LIKE '_transient_ep_total_fields_limit_%'"
-		);
-
-		foreach ( $related_posts_transients as $related_posts_transient ) {
-			$related_posts_transient = str_replace( '_transient_', '', $related_posts_transient );
-			delete_site_transient( $related_posts_transient );
-			delete_transient( $related_posts_transient );
-		}
+		_deprecated_function( __METHOD__, '4.7.0', '\EP_Uninstaller::delete_transients_by_name()' );
 	}
 
 	/**
@@ -180,16 +188,14 @@ class EP_Uninstaller {
 
 				$this->delete_options();
 				$this->delete_transients();
-				$this->delete_related_posts_transients();
-				$this->delete_total_fields_limit_transients();
+				$this->delete_transients_by_option_name();
 
 				restore_current_blog();
 			}
 		} else {
 			$this->delete_options();
 			$this->delete_transients();
-			$this->delete_related_posts_transients();
-			$this->delete_total_fields_limit_transients();
+			$this->delete_transients_by_option_name();
 		}
 	}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR unifies two methods that delete transients by their option name, making it easier to add more cases like that. It also adds a new class to test the uninstall process


### Changelog Entry

> Changed - Transients deletion during uninstall

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
