### PR TITLE
New ep stop filter

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -733,12 +733,12 @@ function use_language_in_setting( $language = 'english', $context = '' ) {
 	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 	$translations = wp_get_available_translations();
 
-	// Bail early if not in the array of available translations.
-	if ( empty( $translations[ $ep_language ]['english_name'] ) ) {
-		return $language;
+	// Default to en_US if not in the array of available translations.
+	if ( ! empty( $translations[ $ep_language ]['english_name'] ) ) {
+		$wp_language = $translations[ $ep_language ]['language'];
+	} else {
+		$wp_language = 'en_US';
 	}
-
-	$wp_language = $translations[ $ep_language ]['language'];
 
 	/**
 	 * Languages supported in Elasticsearch mappings.
@@ -758,7 +758,7 @@ function use_language_in_setting( $language = 'english', $context = '' ) {
 		'czech'      => [ 'cs' ],
 		'danish'     => [ 'da' ],
 		'dutch'      => [ 'nl_NL_formal', 'nl_NL', 'nl_BE' ],
-		'english'    => [ 'en', 'en_AU', 'en_GB', 'en_NZ', 'en_CA', 'en_ZA' ],
+		'english'    => [ 'en', 'en_AU', 'en_GB', 'en_NZ', 'en_CA', 'en_US', 'en_ZA' ],
 		'estonian'   => [ 'et' ],
 		'finnish'    => [ 'fi' ],
 		'french'     => [ 'fr', 'fr_CA', 'fr_FR', 'fr_BE' ],
@@ -828,6 +828,10 @@ function use_language_in_setting( $language = 'english', $context = '' ) {
 		}
 
 		return 'English';
+	}
+
+	if ( 'filter_ep_stop' === $context ) {
+		return "_{$language}_";
 	}
 
 	return $language;

--- a/includes/mappings/comment/7-0.php
+++ b/includes/mappings/comment/7-0.php
@@ -64,15 +64,8 @@ return [
 			'analyzer'   => [
 				'default'          => [
 					'tokenizer' => 'standard',
-					'filter'    => [ 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					'filter'    => [ 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ],
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'shingle_analyzer' => [
@@ -98,14 +91,7 @@ return [
 				],
 				'ewp_snowball'       => [
 					'type'     => 'snowball',
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
 				'edge_ngram'         => [
@@ -113,6 +99,12 @@ return [
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
+				],
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
 				],
 			],
 			'normalizer' => [

--- a/includes/mappings/comment/initial.php
+++ b/includes/mappings/comment/initial.php
@@ -48,15 +48,8 @@ return [
 			'analyzer'   => [
 				'default'          => [
 					'tokenizer' => 'standard',
-					'filter'    => [ 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					'filter'    => [ 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ],
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'shingle_analyzer' => [
@@ -82,14 +75,7 @@ return [
 				],
 				'ewp_snowball'       => [
 					'type'     => 'snowball',
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
 				'edge_ngram'         => [
@@ -97,6 +83,12 @@ return [
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edgeNGram',
+				],
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
 				],
 			],
 			'normalizer' => [

--- a/includes/mappings/post/5-2.php
+++ b/includes/mappings/post/5-2.php
@@ -56,7 +56,7 @@ return array(
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters
 					 */
-					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
 					/**
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *
@@ -66,14 +66,7 @@ return array(
 					 * @return {array<string>} New filters
 					 */
 					'char_filter' => apply_filters( 'ep_default_analyzer_char_filters', array( 'html_strip' ) ),
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'    => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				),
 				'shingle_analyzer' => array(
@@ -99,14 +92,7 @@ return array(
 				),
 				'ewp_snowball'       => array(
 					'type'     => 'snowball',
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
 				'edge_ngram'         => array(
@@ -115,6 +101,12 @@ return array(
 					'min_gram' => 3,
 					'type'     => 'edgeNGram',
 				),
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
 			),
 			'normalizer' => array(
 				'lowerasciinormalizer' => array(

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -72,7 +72,7 @@ return array(
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters
 					 */
-					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
 					/**
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *
@@ -115,14 +115,7 @@ return array(
 				),
 				'ewp_snowball'       => array(
 					'type'     => 'snowball',
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
 				'edge_ngram'         => array(
@@ -131,6 +124,12 @@ return array(
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
 				),
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
 			),
 			'normalizer' => array(
 				'lowerasciinormalizer' => array(

--- a/includes/mappings/term/7-0.php
+++ b/includes/mappings/term/7-0.php
@@ -28,7 +28,8 @@ return [
 			'analyzer'   => [
 				'default'          => [
 					'tokenizer' => 'standard',
-					'filter'    => [ 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
+					'filter'    => [ 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ],
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'shingle_analyzer' => [
@@ -54,6 +55,7 @@ return [
 				],
 				'ewp_snowball'       => [
 					'type'     => 'snowball',
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
 				'edge_ngram'         => [
@@ -61,6 +63,12 @@ return [
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
+				],
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
 				],
 			],
 			'normalizer' => [

--- a/includes/mappings/term/initial.php
+++ b/includes/mappings/term/initial.php
@@ -18,7 +18,7 @@ return [
 			'analyzer'   => [
 				'default'          => [
 					'tokenizer' => 'standard',
-					'filter'    => [ 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ],
+					'filter'    => [ 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ],
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'shingle_analyzer' => [
@@ -44,6 +44,7 @@ return [
 				],
 				'ewp_snowball'       => [
 					'type'     => 'snowball',
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
 				'edge_ngram'         => [
@@ -51,6 +52,12 @@ return [
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edgeNGram',
+				],
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
 				],
 			],
 			'normalizer' => [

--- a/includes/mappings/user/7-0.php
+++ b/includes/mappings/user/7-0.php
@@ -64,15 +64,8 @@ return array(
 			'analyzer'   => array(
 				'default'          => array(
 					'tokenizer' => 'standard',
-					'filter'    => array( 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					'filter'    => array( 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ),
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				),
 				'shingle_analyzer' => array(
@@ -98,14 +91,7 @@ return array(
 				),
 				'ewp_snowball'       => array(
 					'type'     => 'snowball',
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
 				'edge_ngram'         => array(
@@ -114,6 +100,12 @@ return array(
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
 				),
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
 			),
 			'normalizer' => array(
 				'lowerasciinormalizer' => array(

--- a/includes/mappings/user/initial.php
+++ b/includes/mappings/user/initial.php
@@ -48,15 +48,8 @@ return array(
 			'analyzer'   => array(
 				'default'          => array(
 					'tokenizer' => 'standard',
-					'filter'    => array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					'filter'    => array( 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ),
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				),
 				'shingle_analyzer' => array(
@@ -82,14 +75,7 @@ return array(
 				),
 				'ewp_snowball'       => array(
 					'type'     => 'snowball',
-					/**
-					 * Filter Elasticsearch default language in mapping
-					 *
-					 * @hook ep_analyzer_language
-					 * @param  {string} $lang Default language
-					 * @param {string} $lang_context Language context
-					 * @return {string} New language
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
 				'edge_ngram'         => array(
@@ -98,6 +84,12 @@ return array(
 					'min_gram' => 3,
 					'type'     => 'edgeNGram',
 				),
+				'ep_stop'            => [
+					'type'        => 'stop',
+					'ignore_case' => true,
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
 			),
 			'normalizer' => array(
 				'lowerasciinormalizer' => array(

--- a/tests/php/TestDashboard.php
+++ b/tests/php/TestDashboard.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Test dashboard functions
+ *
+ * @since 4.7.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress\Dashboard;
+
+/**
+ * Dashboard test class
+ */
+class TestDashboard extends BaseTestCase {
+	/**
+	 * Setup each test
+	 */
+	public function set_up() {
+		remove_filter( 'translations_api', __NAMESPACE__ . '\skip_translations_api' );
+	}
+
+	/**
+	 * Clean up after each test
+	 */
+	public function tear_down() {
+		tests_add_filter( 'translations_api', __NAMESPACE__ . '\skip_translations_api' );
+	}
+
+	/**
+	 * Test the default behavior of the `use_language_in_setting` function
+	 *
+	 * @group dashboard
+	 */
+	public function test_use_language_in_setting() {
+		$this->assertSame( 'english', Dashboard\use_language_in_setting() );
+
+		$existing_lang = function () {
+			return 'ar';
+		};
+		add_filter( 'ep_default_language', $existing_lang );
+		$this->assertSame( 'arabic', Dashboard\use_language_in_setting() );
+
+		$existing_lang = function () {
+			return 'non-existent';
+		};
+		add_filter( 'ep_default_language', $existing_lang );
+		$this->assertSame( 'english', Dashboard\use_language_in_setting() );
+	}
+
+	/**
+	 * Test the default behavior of the `use_language_in_setting` function for the `filter_ewp_snowball` context
+	 *
+	 * @group dashboard
+	 */
+	public function test_use_language_in_setting_for_snowball() {
+		$this->assertSame( 'English', Dashboard\use_language_in_setting( '', 'filter_ewp_snowball' ) );
+
+		$existing_lang = function () {
+			return 'hy';
+		};
+		add_filter( 'ep_default_language', $existing_lang );
+		$this->assertSame( 'Armenian', Dashboard\use_language_in_setting( '', 'filter_ewp_snowball' ) );
+
+		$existing_lang = function () {
+			return 'non-existent';
+		};
+		add_filter( 'ep_default_language', $existing_lang );
+		$this->assertSame( 'English', Dashboard\use_language_in_setting( '', 'filter_ewp_snowball' ) );
+	}
+
+	/**
+	 * Test the default behavior of the `use_language_in_setting` function for the `filter_ewp_snowball` context
+	 *
+	 * @group dashboard
+	 */
+	public function test_use_language_in_setting_for_stop() {
+		$this->assertSame( '_english_', Dashboard\use_language_in_setting( '', 'filter_ep_stop' ) );
+
+		$existing_lang = function () {
+			return 'ar';
+		};
+		add_filter( 'ep_default_language', $existing_lang );
+		$this->assertSame( '_arabic_', Dashboard\use_language_in_setting( '', 'filter_ep_stop' ) );
+
+		$existing_lang = function () {
+			return 'non-existent';
+		};
+		add_filter( 'ep_default_language', $existing_lang );
+		$this->assertSame( '_english_', Dashboard\use_language_in_setting( '', 'filter_ep_stop' ) );
+	}
+}

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1722,4 +1722,32 @@ class TestTerm extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'elasticsearch_success', $properties );
 		$this->assertEquals( 4, count( $term_query->terms ) );
 	}
+
+	/**
+	 * Test if the mapping applies the ep_stop filter correctly
+	 *
+	 * @since 4.7.0
+	 * @group term
+	 */
+	public function test_mapping_ep_stop_filter() {
+		$indexable      = ElasticPress\Indexables::factory()->get( 'term' );
+		$index_name     = $indexable->get_index_name();
+		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
+		$index_settings = $settings[ $index_name ]['settings'];
+
+		$this->assertContains( 'ep_stop', $index_settings['index.analysis.analyzer.default.filter'] );
+		$this->assertSame( '_english_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
+
+		$change_lang = function( $lang, $context ) {
+			return 'filter_ep_stop' === $context ? '_arabic_' : $lang;
+		};
+		add_filter( 'ep_analyzer_language', $change_lang, 11, 2 );
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		$indexable->put_mapping();
+
+		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
+		$index_settings = $settings[ $index_name ]['settings'];
+		$this->assertSame( '_arabic_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
+	}
 }

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -1599,4 +1599,31 @@ class TestUser extends BaseTestCase {
 		$this->assertEquals( $user_1, $results['objects'][0]->ID );
 	}
 
+	/**
+	 * Test if the mapping applies the ep_stop filter correctly
+	 *
+	 * @since 4.7.0
+	 * @group user
+	 */
+	public function test_mapping_ep_stop_filter() {
+		$indexable      = ElasticPress\Indexables::factory()->get( 'user' );
+		$index_name     = $indexable->get_index_name();
+		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
+		$index_settings = $settings[ $index_name ]['settings'];
+
+		$this->assertContains( 'ep_stop', $index_settings['index.analysis.analyzer.default.filter'] );
+		$this->assertSame( '_english_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
+
+		$change_lang = function( $lang, $context ) {
+			return 'filter_ep_stop' === $context ? '_arabic_' : $lang;
+		};
+		add_filter( 'ep_analyzer_language', $change_lang, 11, 2 );
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		$indexable->put_mapping();
+
+		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
+		$index_settings = $settings[ $index_name ]['settings'];
+		$this->assertSame( '_arabic_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR introduces a new ep_stop filter, that changes the stop words used according to the language set.

### Changelog Entry
> Added - New ep_stop filter, that changes the stop words used according to the language set.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
