### PR TITLE
Allow to use the site default language

### DIFF
--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -165,13 +165,21 @@ $bulk_setting = Utils\get_option( 'ep_bulk_setting', 350 );
 						<?php
 						$ep_language = Utils\get_language();
 
-						wp_dropdown_languages(
+						$dropdown = wp_dropdown_languages(
 							[
 								'id'       => 'ep_language',
 								'name'     => 'ep_language',
 								'selected' => $ep_language,
+								'echo'     => false,
 							]
 						);
+
+						$default_site_option = sprintf(
+							"<option value='ep_site_default'>%s</option>",
+							__( 'Default to Site Language', 'elasticpress' )
+						);
+
+						echo preg_replace( '/<select(.*?)>/', "<select$1>{$default_site_option}", $dropdown ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						?>
 						<p class="description"><?php esc_html_e( 'Default language for your Elasticsearch mapping.', 'elasticpress' ); ?></p>
 					</td>

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -495,13 +495,8 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
  * @return string Default EP language.
  */
 function get_language() {
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		$ep_language = get_site_option( 'ep_language' );
-	} else {
-		$ep_language = get_option( 'ep_language' );
-	}
-
-	$ep_language = ! empty( $ep_language ) ? $ep_language : get_locale();
+	$ep_language = get_option( 'ep_language' );
+	$ep_language = ! empty( $ep_language ) ? $ep_language : 'ep_site_default';
 
 	/**
 	 * Filter the default language to use at index time

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -10,6 +10,8 @@ namespace ElasticPressTest;
 use ElasticPress;
 use ElasticPress\Utils;
 
+use function ElasticPress\Utils\get_language;
+
 /**
  * Dashboard test class
  */
@@ -388,5 +390,37 @@ class TestUtils extends BaseTestCase {
 			'results' => [ 1, 2, 3 ],
 		];
 		$this->assertSame( '', Utils\get_elasticsearch_error_reason( $not_an_error ) );
+	}
+
+	/**
+	 * Test the `get_language()` method
+	 *
+	 * @since 4.7.0
+	 * @group utils
+	 */
+	public function test_get_language() {
+		$this->assertSame( 'ep_site_default', get_language() );
+
+		$set_lang_via_option = function() {
+			return 'custom_via_option';
+		};
+		if ( is_multisite() ) {
+			add_filter( 'pre_site_option_ep_language', $set_lang_via_option );
+		} else {
+			add_filter( 'pre_option_ep_language', $set_lang_via_option );
+		}
+
+		$this->assertSame( 'custom_via_option', get_language() );
+
+		/**
+		 * Test the `ep_default_language` filter
+		 */
+		$set_lang_via_filter = function( $ep_language ) {
+			$this->assertSame( 'custom_via_option', $ep_language );
+			return 'custom_via_filter';
+		};
+		add_filter( 'ep_default_language', $set_lang_via_filter );
+
+		$this->assertSame( 'custom_via_filter', get_language() );
 	}
 }

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -10,8 +10,6 @@ namespace ElasticPressTest;
 use ElasticPress;
 use ElasticPress\Utils;
 
-use function ElasticPress\Utils\get_language;
-
 /**
  * Dashboard test class
  */
@@ -453,7 +451,7 @@ class TestUtils extends BaseTestCase {
 	 * @group utils
 	 */
 	public function test_get_language() {
-		$this->assertSame( 'ep_site_default', get_language() );
+		$this->assertSame( 'ep_site_default', Utils\get_language() );
 
 		$set_lang_via_option = function() {
 			return 'custom_via_option';
@@ -464,7 +462,7 @@ class TestUtils extends BaseTestCase {
 			add_filter( 'pre_option_ep_language', $set_lang_via_option );
 		}
 
-		$this->assertSame( 'custom_via_option', get_language() );
+		$this->assertSame( 'custom_via_option', Utils\get_language() );
 
 		/**
 		 * Test the `ep_default_language` filter
@@ -475,6 +473,6 @@ class TestUtils extends BaseTestCase {
 		};
 		add_filter( 'ep_default_language', $set_lang_via_filter );
 
-		$this->assertSame( 'custom_via_filter', get_language() );
+		$this->assertSame( 'custom_via_filter', Utils\get_language() );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds a new `Default to Site Language` option to the language selection in ElasticPress' settings page

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New `Default to Site Language` option in the language dropdown in ElasticPress' settings page


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
