### PR TITLE
Feature/display langs in status report

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1585,7 +1585,7 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_index_settings( $args, $assoc_args ) {
-		$response = Elasticsearch::factory()->get_index_settings( $args[0] );
+		$response = Elasticsearch::factory()->get_index_settings( $args[0], true );
 		$pretty   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pretty' );
 
 		$this->pretty_json_encode( $response, $pretty );

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -945,17 +945,29 @@ class Elasticsearch {
 	}
 
 	/**
-	 * Get index settings.
+	 * Get index settings
 	 *
-	 * @param string $index Index name.
-	 * @since  4.4.0
+	 * @param string $index         Index name
+	 * @param bool   $force_refresh Whether to use or not a cached value. Default false, use cached.
+	 * @since  4.4.0, 4.7.0 added the $force_refresh parameter
 	 * @return array|WP_Error Raw ES response from the $index/_settings?flat_settings=true endpoint
 	 */
-	public function get_index_settings( string $index ) {
+	public function get_index_settings( string $index, bool $force_refresh = false ) {
+		$transient_key = "ep_index_settings_{$index}";
+
+		if ( ! $force_refresh ) {
+			$cache = get_transient( $transient_key );
+			if ( false !== $cache ) {
+				return $cache;
+			}
+		}
+
 		$endpoint = trailingslashit( $index ) . '_settings?flat_settings=true';
 		$request  = $this->remote_request( $endpoint, [], [], 'get_index_settings' );
 
-		if ( is_wp_error( $request ) ) {
+		$response_code = wp_remote_retrieve_response_code( $request );
+		if ( is_wp_error( $request ) || 200 !== $response_code ) {
+			set_transient( $transient_key, $request, MINUTE_IN_SECONDS );
 			return $request;
 		}
 
@@ -963,7 +975,38 @@ class Elasticsearch {
 
 		$settings = json_decode( $response_body, true );
 
+		set_transient( $transient_key, $settings, DAY_IN_SECONDS );
+
 		return $settings;
+	}
+
+	/**
+	 * Get a particular index setting
+	 *
+	 * @param string $index         Index name
+	 * @param string $setting       Setting name
+	 * @param bool   $force_refresh Whether to use or not a cached value. Default false, use cached.
+	 * @return mixed
+	 */
+	public function get_index_setting( string $index, string $setting, bool $force_refresh = false ) {
+		$settings = $this->get_index_settings( $index, $force_refresh );
+
+		if ( is_wp_error( $settings ) || empty( $settings[ $index ]['settings'][ $setting ] ) ) {
+			return null;
+		}
+
+		return $settings[ $index ]['settings'][ $setting ];
+	}
+
+	/**
+	 * Given an index return its total fields limit
+	 *
+	 * @since 4.4.0, 4.7.0 wrapper of get_index_setting()
+	 * @param string $index_name The index name
+	 * @return int|null
+	 */
+	public function get_index_total_fields_limit( $index_name ) {
+		return $this->get_index_setting( $index_name, 'index.mapping.total_fields.limit' );
 	}
 
 	/**
@@ -1733,41 +1776,4 @@ class Elasticsearch {
 			'present_indices' => array_intersect( $all_index_names, $cluster_index_names ),
 		];
 	}
-
-	/**
-	 * Given an index return its total fields limit
-	 *
-	 * @since 4.4.0
-	 * @param string $index_name The index name
-	 * @return int|null
-	 */
-	public function get_index_total_fields_limit( $index_name ) {
-		$cache_key = 'ep_total_fields_limit_' . $index_name;
-
-		$is_network = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK;
-		if ( $is_network ) {
-			$cached = get_site_transient( $cache_key );
-		} else {
-			$cached = get_transient( $cache_key );
-		}
-		if ( ! empty( $cached ) ) {
-			return $cached;
-		}
-
-		$index_settings = $this->get_index_settings( $index_name );
-		if ( is_wp_error( $index_settings ) || empty( $index_settings[ $index_name ]['settings']['index.mapping.total_fields.limit'] ) ) {
-			return null;
-		}
-
-		$es_field_limit = $index_settings[ $index_name ]['settings']['index.mapping.total_fields.limit'];
-
-		if ( $is_network ) {
-			set_site_transient( $cache_key, $es_field_limit, DAY_IN_SECONDS );
-		} else {
-			set_transient( $cache_key, $es_field_limit, DAY_IN_SECONDS );
-		}
-
-		return (int) $es_field_limit;
-	}
-
 }

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -851,6 +851,16 @@ class Elasticsearch {
 
 		$response_code = wp_remote_retrieve_response_code( $request );
 
+		/**
+		 * Fires after sending a put mapping request
+		 *
+		 * @hook ep_after_put_mapping
+		 * @since 4.7.0
+		 * @param {string}         $index   Index name
+		 * @param {WP_Error|array} $request The response or WP_Error on failure.
+		 */
+		do_action( 'ep_after_put_mapping', $index, $request );
+
 		// If WP_Error or not 200, return false or error message depends on attribute.
 		if ( is_wp_error( $request ) || 200 !== $response_code ) {
 			if ( 'bool' === $return_type ) {
@@ -956,7 +966,7 @@ class Elasticsearch {
 		$transient_key = "ep_index_settings_{$index}";
 
 		if ( ! $force_refresh ) {
-			$cache = get_transient( $transient_key );
+			$cache = Utils\get_transient( $transient_key );
 			if ( false !== $cache ) {
 				return $cache;
 			}
@@ -967,7 +977,7 @@ class Elasticsearch {
 
 		$response_code = wp_remote_retrieve_response_code( $request );
 		if ( is_wp_error( $request ) || 200 !== $response_code ) {
-			set_transient( $transient_key, $request, MINUTE_IN_SECONDS );
+			Utils\set_transient( $transient_key, $request, MINUTE_IN_SECONDS );
 			return $request;
 		}
 

--- a/includes/classes/Indexable/Comment/SyncManager.php
+++ b/includes/classes/Indexable/Comment/SyncManager.php
@@ -20,6 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Sync manager class
  */
 class SyncManager extends SyncManagerAbstract {
+	/**
+	 * Indexable slug
+	 *
+	 * @since 4.7.0
+	 * @var   string
+	 */
+	public $indexable_slug = 'comment';
 
 	/**
 	 * Setup actions and filters
@@ -45,6 +52,11 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'added_comment_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'deleted_comment_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'updated_comment_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
+
+		// Clear index settings cache
+		add_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_after_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 	}
 
 	/**
@@ -61,6 +73,11 @@ class SyncManager extends SyncManagerAbstract {
 		remove_action( 'added_comment_meta', [ $this, 'action_queue_meta_sync' ] );
 		remove_action( 'deleted_comment_meta', [ $this, 'action_queue_meta_sync' ] );
 		remove_action( 'updated_comment_meta', [ $this, 'action_queue_meta_sync' ] );
+
+		// Clear index settings cache
+		remove_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
+		remove_action( 'ep_after_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		remove_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 	}
 
 	/**

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -75,9 +75,9 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'edited_term', array( $this, 'action_edited_term' ), 10, 3 );
 		add_action( 'deleted_term_relationships', array( $this, 'action_deleted_term_relationships' ), 10, 3 );
 
-		// Clear field limit cache
+		// Clear index settings cache
 		add_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
-		add_action( 'ep_sync_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_after_put_mapping', [ $this, 'clear_index_settings_cache' ] );
 		add_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 
 		// Clear distinct meta field per post type cache
@@ -110,6 +110,11 @@ class SyncManager extends SyncManagerAbstract {
 		remove_filter( 'ep_sync_insert_permissions_bypass', array( $this, 'filter_bypass_permission_checks_for_machines' ) );
 		remove_filter( 'ep_sync_delete_permissions_bypass', array( $this, 'filter_bypass_permission_checks_for_machines' ) );
 		remove_filter( 'ep_post_sync_kill', [ $this, 'kill_sync_for_password_protected' ] );
+
+		// Clear index settings cache
+		remove_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
+		remove_action( 'ep_after_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		remove_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 	}
 
 	/**
@@ -744,18 +749,6 @@ class SyncManager extends SyncManagerAbstract {
 	 */
 	public function clear_total_fields_limit_cache() {
 		_deprecated_function( __METHOD__, '4.7.0', '\ElasticPress\Indexable\Post\SyncManager::clear_index_settings_cache()' );
-	}
-
-	/**
-	 * Clear the cache of the total fields limit
-	 *
-	 * @since 4.7.0
-	 */
-	public function clear_index_settings_cache() {
-		$indexable = Indexables::factory()->get( $this->indexable_slug );
-		$cache_key = 'ep_index_settings_' . $indexable->get_index_name();
-
-		Utils\delete_transient( $cache_key );
 	}
 
 	/**

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -76,9 +76,9 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'deleted_term_relationships', array( $this, 'action_deleted_term_relationships' ), 10, 3 );
 
 		// Clear field limit cache
-		add_action( 'ep_update_index_settings', [ $this, 'clear_total_fields_limit_cache' ] );
-		add_action( 'ep_sync_put_mapping', [ $this, 'clear_total_fields_limit_cache' ] );
-		add_action( 'ep_saved_weighting_configuration', [ $this, 'clear_total_fields_limit_cache' ] );
+		add_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_sync_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 
 		// Clear distinct meta field per post type cache
 		add_action( 'wp_insert_post', [ $this, 'clear_meta_keys_db_per_post_type_cache_by_post_id' ] );
@@ -738,19 +738,24 @@ class SyncManager extends SyncManagerAbstract {
 	}
 
 	/**
-	 * Clear the cache of the total fields limit
+	 * DEPRECATED. Clear the cache of the total fields limit
 	 *
 	 * @since 4.4.0
 	 */
 	public function clear_total_fields_limit_cache() {
-		$indexable = Indexables::factory()->get( $this->indexable_slug );
-		$cache_key = 'ep_total_fields_limit_' . $indexable->get_index_name();
+		_deprecated_function( __METHOD__, '4.7.0', '\ElasticPress\Indexable\Post\SyncManager::clear_index_settings_cache()' );
+	}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			delete_site_transient( $cache_key );
-		} else {
-			delete_transient( $cache_key );
-		}
+	/**
+	 * Clear the cache of the total fields limit
+	 *
+	 * @since 4.7.0
+	 */
+	public function clear_index_settings_cache() {
+		$indexable = Indexables::factory()->get( $this->indexable_slug );
+		$cache_key = 'ep_index_settings_' . $indexable->get_index_name();
+
+		Utils\delete_transient( $cache_key );
 	}
 
 	/**

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -20,6 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Sync manager class
  */
 class SyncManager extends SyncManagerAbstract {
+	/**
+	 * Indexable slug
+	 *
+	 * @since 4.7.0
+	 * @var   string
+	 */
+	public $indexable_slug = 'term';
 
 	/**
 	 * Setup actions and filters
@@ -43,6 +50,11 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'pre_delete_term', [ $this, 'action_queue_children_sync' ] );
 		add_action( 'pre_delete_term', [ $this, 'action_sync_on_delete' ] );
 		add_action( 'set_object_terms', [ $this, 'action_sync_on_object_update' ], 10, 2 );
+
+		// Clear index settings cache
+		add_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_after_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 	}
 
 	/**
@@ -59,6 +71,11 @@ class SyncManager extends SyncManagerAbstract {
 		remove_action( 'pre_delete_term', [ $this, 'action_queue_children_sync' ] );
 		remove_action( 'pre_delete_term', [ $this, 'action_sync_on_delete' ] );
 		remove_action( 'set_object_terms', [ $this, 'action_sync_on_object_update' ] );
+
+		// Clear index settings cache
+		remove_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
+		remove_action( 'ep_after_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		remove_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 	}
 
 	/**

--- a/includes/classes/Indexable/User/SyncManager.php
+++ b/includes/classes/Indexable/User/SyncManager.php
@@ -20,6 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Sync manager class
  */
 class SyncManager extends SyncManagerAbstract {
+	/**
+	 * Indexable slug
+	 *
+	 * @since 4.7.0
+	 * @var   string
+	 */
+	public $indexable_slug = 'user';
 
 	/**
 	 * Setup actions and filters
@@ -38,6 +45,11 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'updated_user_meta', [ $this, 'action_queue_meta_sync' ], 10, 4 );
 		add_action( 'added_user_meta', [ $this, 'action_queue_meta_sync' ], 10, 4 );
 		add_action( 'deleted_user_meta', [ $this, 'action_queue_meta_sync' ], 10, 4 );
+
+		// Clear index settings cache
+		add_action( 'ep_update_index_settings', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_after_put_mapping', [ $this, 'clear_index_settings_cache' ] );
+		add_action( 'ep_saved_weighting_configuration', [ $this, 'clear_index_settings_cache' ] );
 
 		// @todo Handle deleted meta
 	}

--- a/includes/classes/StatusReport/Indices.php
+++ b/includes/classes/StatusReport/Indices.php
@@ -79,6 +79,21 @@ class Indices extends Report {
 				'value' => $elasticsearch->get_index_total_fields_limit( $index['index'] ),
 			];
 
+			$fields['analyzer_language'] = [
+				'label' => 'analyzer_language',
+				'value' => $elasticsearch->get_index_setting( $index['index'], 'index.analysis.analyzer.default.language' ),
+			];
+
+			$fields['stop_language'] = [
+				'label' => 'stop_language',
+				'value' => $elasticsearch->get_index_setting( $index['index'], 'index.analysis.filter.ep_stop.stopwords' ),
+			];
+
+			$fields['snowball_language'] = [
+				'label' => 'snowball_language',
+				'value' => $elasticsearch->get_index_setting( $index['index'], 'index.analysis.filter.ewp_snowball.language' ),
+			];
+
 			$groups[] = [
 				'title'  => $index['index'],
 				'fields' => $fields,

--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -268,6 +268,18 @@ abstract class SyncManager {
 	}
 
 	/**
+	 * Clear the cache of the total fields limit
+	 *
+	 * @since 4.7.0
+	 */
+	public function clear_index_settings_cache() {
+		$indexable = Indexables::factory()->get( $this->indexable_slug );
+		$cache_key = 'ep_index_settings_' . $indexable->get_index_name();
+
+		Utils\delete_transient( $cache_key );
+	}
+
+	/**
 	 * Implementation should setup hooks/filters
 	 *
 	 * @since 3.0

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -48,6 +48,7 @@ class Upgrades {
 			'4.2.2' => [ 'upgrade_4_2_2', 'init' ],
 			'4.4.0' => [ 'upgrade_4_4_0', 'init' ],
 			'4.5.0' => [ 'upgrade_4_5_0', 'init' ],
+			'4.7.0' => [ 'upgrade_4_7_0', 'init' ],
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ] );
@@ -203,6 +204,29 @@ class Upgrades {
 	 */
 	public function upgrade_4_5_0() {
 		setup_roles();
+	}
+
+	/**
+	 * Upgrade routine of v4.7.0.
+	 *
+	 * Remove old total_fields_limit transients
+	 *
+	 * @see https://github.com/10up/ElasticPress/pull/3552
+	 */
+	public function upgrade_4_7_0() {
+		global $wpdb;
+
+		$transients = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			"SELECT option_name
+			FROM {$wpdb->prefix}options
+			WHERE option_name LIKE '_transient_ep_total_fields_limit_%'"
+		);
+
+		foreach ( $transients as $transient ) {
+			$transient_name = str_replace( '_transient_', '', $transient );
+			delete_site_transient( $transient_name );
+			delete_transient( $transient_name );
+		}
 	}
 
 	/**

--- a/tests/php/TestUninstall.php
+++ b/tests/php/TestUninstall.php
@@ -36,16 +36,16 @@ class TestUninstall extends BaseTestCase {
 	 * @group uninstall
 	 */
 	public function test_delete_transients_by_option_name() {
-		set_transient( 'ep_total_fields_limit_test', 'test' );
-		set_transient( 'ep_total_fields_limit_test_2', 'test' );
+		set_transient( 'ep_index_settings_test', 'test' );
+		set_transient( 'ep_index_settings_test_2', 'test' );
 		set_transient( 'ep_related_posts_test', 'test' );
 		set_transient( 'ep_related_posts_test_2', 'test' );
 
 		$method = $this->get_protected_method( 'delete_transients_by_option_name' );
 		$method->invoke( $this->uninstaller );
 
-		$this->assertFalse( get_transient( 'ep_total_fields_limit_test' ) );
-		$this->assertFalse( get_transient( 'ep_total_fields_limit_test_2' ) );
+		$this->assertFalse( get_transient( 'ep_index_settings_test' ) );
+		$this->assertFalse( get_transient( 'ep_index_settings_test_2' ) );
 		$this->assertFalse( get_transient( 'ep_related_posts_test' ) );
 		$this->assertFalse( get_transient( 'ep_related_posts_test_2' ) );
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -139,7 +139,7 @@ class EP_Uninstaller {
 			"SELECT option_name
 			FROM {$wpdb->prefix}options
 			WHERE
-				option_name LIKE '_transient_ep_total_fields_limit_%'
+				option_name LIKE '_transient_ep_index_settings_%'
 				OR option_name LIKE '_transient_ep_related_posts_%'
 			"
 		);


### PR DESCRIPTION
This should be reviewed only after #3551 is merged.

### Description of the Change

As it could be interesting to show more index settings in the status report, this PR changes EP so instead of caching a single index setting value (`index.mapping.total_fields.limit`) it caches the whole array (~4kb max.)

Note: As the transient is set using an expiration time, it won't be added an autoload option.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Indices' language settings in status reports


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
