### PR TITLE
Bump Elasticsearch version for E2E tests

### DIFF
--- a/bin/es-docker/Dockerfile
+++ b/bin/es-docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG ES_VERSION=7.5.2
+ARG ES_VERSION=7.10.2
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
 
 RUN if [ -d plugins/ingest-attachment ]; then true ; else ./bin/elasticsearch-plugin install ingest-attachment -b; fi

--- a/bin/es-docker/docker-compose.yml
+++ b/bin/es-docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
       context: .
       args:
-        ES_VERSION: ${ES_VERSION-7.5.2}
+        ES_VERSION: ${ES_VERSION-7.10.2}
     ports:
       - 8890:9200
     mem_limit: 1024M


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR bumps the Elasticsearch version to 7.10.2 that is used in the E2E tests.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump Elasticsearch version to 7.10.2 for E2E tests


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
