### PR TITLE
Message queue for the sync

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -703,7 +703,7 @@ class IndexHelper {
 					$wp_error_messages
 				);
 
-				$this->queue_message( implode( "\n", $wp_error_messages ), 'warning' );
+				$this->queue_message( $wp_error_messages, 'warning' );
 			} elseif ( count( $failed_objects ) ) {
 				$errors_output = $this->output_index_errors( $failed_objects );
 
@@ -717,7 +717,7 @@ class IndexHelper {
 
 				$this->index_meta['current_sync_item']['failed'] += count( $failed_objects );
 
-				$this->queue_message( implode( "\n", $errors_output ), 'warning' );
+				$this->queue_message( $errors_output, 'warning' );
 			} else {
 				$this->index_meta['current_sync_item']['synced'] += count( $queued_items );
 			}

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -2,8 +2,11 @@
 /**
  * Index Helper
  *
+ * NOTE: As explained in the doc linked below, the dashboard sync exits after each output()
+ * call, to respond to the AJAX request. That means this script will be called several times
+ * while syncing via dashboard, relying on the index_meta to pick it up where it stopped.
+ *
  * @since 4.0.0
- * @see docs/indexing-process.md
  * @see https://elasticpress.zendesk.com/hc/en-us/articles/16672117103501-Sync-Process
  * @package elasticpress
  */
@@ -85,6 +88,9 @@ class IndexHelper {
 			$this->build_index_meta();
 		}
 
+		// For the dashboard, this will be called and exit the script until the queue is empty again.
+		$this->flush_messages_queue();
+
 		while ( $this->has_items_to_be_processed() ) {
 			$this->process_sync_item();
 		}
@@ -137,6 +143,7 @@ class IndexHelper {
 			'start_time'        => microtime( true ),
 			'start_date_time'   => $start_date_time ? $start_date_time->format( DATE_ATOM ) : false,
 			'starting_indices'  => $starting_indices,
+			'messages_queue'    => [],
 			'totals'            => [
 				'total'      => 0,
 				'synced'     => 0,
@@ -696,7 +703,7 @@ class IndexHelper {
 					$wp_error_messages
 				);
 
-				$this->output( implode( "\n", $wp_error_messages ), 'warning' );
+				$this->queue_message( implode( "\n", $wp_error_messages ), 'warning' );
 			} elseif ( count( $failed_objects ) ) {
 				$errors_output = $this->output_index_errors( $failed_objects );
 
@@ -710,7 +717,7 @@ class IndexHelper {
 
 				$this->index_meta['current_sync_item']['failed'] += count( $failed_objects );
 
-				$this->output( $errors_output, 'warning' );
+				$this->queue_message( implode( "\n", $errors_output ), 'warning' );
 			} else {
 				$this->index_meta['current_sync_item']['synced'] += count( $queued_items );
 			}
@@ -718,19 +725,18 @@ class IndexHelper {
 
 		$this->index_meta['current_sync_item']['last_processed_object_id'] = end( $this->current_query['objects'] )->ID;
 
-		$this->output(
-			sprintf(
-				/* translators: 1. Indexable type 2. Offset start, 3. Offset end, 4. Found items 5. Last object ID */
-				esc_html__( 'Processed %1$s %2$d - %3$d of %4$d. Last Object ID: %5$d', 'elasticpress' ),
-				esc_html( strtolower( $indexable->labels['plural'] ) ),
-				$this->index_meta['from'],
-				$this->index_meta['offset'],
-				$this->index_meta['found_items'],
-				$this->index_meta['current_sync_item']['last_processed_object_id']
-			),
-			'info',
-			'index_next_batch'
+		$summary = sprintf(
+			/* translators: 1. Indexable type 2. Offset start, 3. Offset end, 4. Found items 5. Last object ID */
+			esc_html__( 'Processed %1$s %2$d - %3$d of %4$d. Last Object ID: %5$d', 'elasticpress' ),
+			esc_html( strtolower( $indexable->labels['plural'] ) ),
+			$this->index_meta['from'],
+			$this->index_meta['offset'],
+			$this->index_meta['found_items'],
+			$this->index_meta['current_sync_item']['last_processed_object_id']
 		);
+
+		$this->queue_message( $summary, 'info', 'index_next_batch' );
+		$this->flush_messages_queue();
 	}
 
 	/**
@@ -1370,6 +1376,47 @@ class IndexHelper {
 		 * @return  {int} New number of entries
 		 */
 		return (int) apply_filters( 'ep_index_default_per_page', Utils\get_option( 'ep_bulk_setting', 350 ) );
+	}
+
+	/**
+	 * Add a message to the queue
+	 *
+	 * @since 4.7.0
+	 * @param string|array $message_text Message to be outputted
+	 * @param string       $type         Type of message
+	 * @param string       $context      Context of the output
+	 */
+	protected function queue_message( $message_text, string $type, string $context = '' ) {
+		$this->index_meta['messages_queue'][] = [
+			'text'    => $message_text,
+			'type'    => $type,
+			'context' => $context,
+		];
+	}
+
+	/**
+	 * Display messages in the queue.
+	 *
+	 * NOTE: As the dashboard sync exits after every output call (to respond the AJAX request),
+	 * this will just output one message. As the method is called every time the script is called,
+	 * all messages will be displayed but one at a time.
+	 *
+	 * @since 4.7.0
+	 */
+	protected function flush_messages_queue() {
+		if ( ! is_array( $this->index_meta['messages_queue'] ) ) {
+			return;
+		}
+
+		$messages_count = count( $this->index_meta['messages_queue'] );
+		if ( 0 === $messages_count ) {
+			return;
+		}
+
+		for ( $i = 0; $i < $messages_count; $i++ ) {
+			$next_message = array_shift( $this->index_meta['messages_queue'] );
+			$this->output( $next_message['text'], $next_message['type'], $next_message['context'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR fixes the problem outlined in #3510 by adding a small message queue to the sync script.

A few things to note:
1. The sync script accepts a `total_attempts` parameter. The script will try that number of times to sync a batch;
2. For the dashboard sync, total_attemps it 3;
3. As the dashboard sync relies on several AJAX calls, the process is interrupted and started every time it calls the output method (so the AJAX request is replied to with a message.)
4. When we output during one of those tries, the script exits earlier than we need, not setting the last processed item ID properly

With the message queue in place, we avoid calling the output method in the middle of the process.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3510

### Changelog Entry
> Fixed - Same error message being displayed more than once on the Dashboard sync


### Credits
Props @felipeelia, @MARQAS, @tott, and @wildberrylillet.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
