### PR TITLE
Refactor code to use updated ->get_settings() method

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -102,13 +102,6 @@ class Autosuggest extends Feature {
 	 */
 	public function output_feature_box_settings() {
 		$settings = $this->get_settings();
-
-		if ( ! $settings ) {
-			$settings = [];
-		}
-
-		$settings = wp_parse_args( $settings, $this->default_settings );
-
 		?>
 		<div class="field">
 			<div class="field-name status"><label for="feature_autosuggest_selector"><?php esc_html_e( 'Autosuggest Selector', 'elasticpress' ); ?></label></div>
@@ -356,9 +349,8 @@ class Autosuggest extends Feature {
 			return;
 		}
 
-		$host         = Utils\get_host();
-		$endpoint_url = false;
-		$settings     = $this->get_settings();
+		$host     = Utils\get_host();
+		$settings = $this->get_settings();
 
 		if ( defined( 'EP_AUTOSUGGEST_ENDPOINT' ) && EP_AUTOSUGGEST_ENDPOINT ) {
 			$endpoint_url = EP_AUTOSUGGEST_ENDPOINT;
@@ -366,18 +358,12 @@ class Autosuggest extends Feature {
 			if ( Utils\is_epio() ) {
 				$endpoint_url = trailingslashit( $host ) . Indexables::factory()->get( 'post' )->get_index_name() . '/autosuggest';
 			} else {
-				if ( ! $settings ) {
-					$settings = [];
-				}
-
-				$settings = wp_parse_args( $settings, $this->default_settings );
-
-				if ( empty( $settings['endpoint_url'] ) ) {
-					return;
-				}
-
 				$endpoint_url = $settings['endpoint_url'];
 			}
+		}
+
+		if ( empty( $endpoint_url ) ) {
+			return;
 		}
 
 		wp_enqueue_script(

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -123,12 +123,6 @@ class Facets extends Feature {
 	 */
 	public function output_feature_box_settings() {
 		$settings = $this->get_settings();
-
-		if ( ! $settings ) {
-			$settings = [];
-		}
-
-		$settings = wp_parse_args( $settings, $this->default_settings );
 		?>
 		<div class="field">
 			<div class="field-name status"><?php esc_html_e( 'Match Type', 'elasticpress' ); ?></div>
@@ -615,12 +609,7 @@ class Facets extends Feature {
 	 * @return string
 	 */
 	public function get_match_type() {
-		$settings = wp_parse_args(
-			$this->get_settings(),
-			array(
-				'match_type' => 'all',
-			)
-		);
+		$settings = $this->get_settings();
 
 		/**
 		 * Filter the match type of all facets. Can be 'all' or 'any'.

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -89,7 +89,7 @@ class InstantResults extends Feature {
 			'per_page'      => get_option( 'posts_per_page', 6 ),
 		];
 
-		$settings = $this->get_settings();
+		$this->settings = $this->get_settings();
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -89,9 +89,7 @@ class InstantResults extends Feature {
 			'per_page'      => get_option( 'posts_per_page', 6 ),
 		];
 
-		$settings = $this->get_settings() ? $this->get_settings() : array();
-
-		$this->settings = wp_parse_args( $settings, $this->default_settings );
+		$settings = $this->get_settings();
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -124,12 +124,6 @@ class Search extends Feature {
 	public function enqueue_scripts() {
 		$settings = $this->get_settings();
 
-		if ( ! $settings ) {
-			$settings = [];
-		}
-
-		$settings = wp_parse_args( $settings, $this->default_settings );
-
 		if ( true !== $settings['highlight_enabled'] ) {
 			return;
 		}
@@ -164,12 +158,6 @@ class Search extends Feature {
 
 		// get current config
 		$settings = $this->get_settings();
-
-		if ( ! $settings ) {
-			$settings = [];
-		}
-
-		$settings = wp_parse_args( $settings, $this->default_settings );
 
 		if ( true !== $settings['highlight_enabled'] ) {
 			return $formatted_args;
@@ -269,12 +257,6 @@ class Search extends Feature {
 
 		$settings = $this->get_settings();
 
-		if ( ! $settings ) {
-			$settings = [];
-		}
-
-		$settings = wp_parse_args( $settings, $this->default_settings );
-
 		if ( ! empty( $settings['highlight_excerpt'] ) && true === $settings['highlight_excerpt'] ) {
 			remove_filter( 'get_the_excerpt', 'wp_trim_excerpt' );
 			add_filter( 'get_the_excerpt', [ $this, 'ep_highlight_excerpt' ], 10, 2 );
@@ -294,12 +276,6 @@ class Search extends Feature {
 	public function ep_highlight_excerpt( $text, $post ) {
 
 		$settings = $this->get_settings();
-
-		if ( ! $settings ) {
-			$settings = [];
-		}
-
-		$settings = wp_parse_args( $settings, $this->default_settings );
 
 		// reproduces wp_trim_excerpt filter, preserving the excerpt_more and excerpt_length filters
 		if ( '' === $text ) {
@@ -438,12 +414,6 @@ class Search extends Feature {
 	 */
 	public function is_decaying_enabled( $args = [] ) {
 		$settings = $this->get_settings();
-		$settings = wp_parse_args(
-			$settings,
-			[
-				'decaying_enabled' => true,
-			]
-		);
 
 		$is_decaying_enabled = (bool) $settings['decaying_enabled'];
 
@@ -637,13 +607,6 @@ class Search extends Feature {
 	 */
 	public function output_feature_box_settings() {
 		$settings = $this->get_settings();
-
-		if ( ! $settings ) {
-			$settings = [];
-		}
-
-		$settings = wp_parse_args( $settings, $this->default_settings );
-
 		?>
 		<div class="field">
 			<div class="field-name status"><?php esc_html_e( 'Weight results by date', 'elasticpress' ); ?></div>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

This PR refactors the ElasticPress features that make use of the `get_settings()` method

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1930

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Adding settings etc should remain the same.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Refactor get_settings() usage inside ElasticPress features.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez, @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
