### PR TITLE
Stop caching autosuggest requests

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -85,14 +85,7 @@ class Autosuggest extends Feature {
 		add_filter( 'ep_weighted_query_for_post_type', [ $this, 'adjust_fuzzy_fields' ], 10, 3 );
 		add_filter( 'ep_saved_weighting_configuration', [ $this, 'epio_send_autosuggest_public_request' ] );
 		add_filter( 'wp', [ $this, 'epio_send_autosuggest_allowed' ] );
-		add_filter( 'ep_pre_dashboard_index', [ $this, 'epio_send_autosuggest_public_request' ] );
-		add_filter( 'ep_wp_cli_pre_index', [ $this, 'epio_send_autosuggest_public_request' ] );
-
-		add_action( 'ep_cli_after_set_search_algorithm_version', [ $this, 'delete_cached_query' ] );
-		add_action( 'ep_wp_cli_after_index', [ $this, 'delete_cached_query' ] );
-		add_action( 'ep_after_dashboard_index', [ $this, 'delete_cached_query' ] );
-		add_action( 'ep_after_update_feature', [ $this, 'delete_cached_query' ] );
-		add_action( 'ep_cli_after_clear_index', [ $this, 'delete_cached_query' ] );
+		add_filter( 'ep_pre_sync_index', [ $this, 'epio_send_autosuggest_public_request' ] );
 	}
 
 	/**
@@ -389,14 +382,6 @@ class Autosuggest extends Feature {
 		/** Search Feature @var Feature\Search\Search $search */
 		$search = $features->get_registered_feature( 'search' );
 
-		$post_types  = $search->get_searchable_post_types();
-		$post_status = get_post_stati(
-			[
-				'public'              => true,
-				'exclude_from_search' => false,
-			]
-		);
-
 		$query = $this->generate_search_query();
 
 		$epas_options = [
@@ -517,10 +502,10 @@ class Autosuggest extends Feature {
 		 */
 		$post_status = apply_filters( 'ep_term_suggest_post_status', array_values( $post_status ) );
 
-		add_filter( 'ep_intercept_remote_request', '__return_true' );
-		add_filter( 'ep_weighting_configuration', [ $features->get_registered_feature( $this->slug ), 'apply_autosuggest_weighting' ], 10, 1 );
+		add_filter( 'ep_intercept_remote_request', [ $this->intercept_remote_request() ] );
+		add_filter( 'ep_weighting_configuration', [ $features->get_registered_feature( $this->slug ), 'apply_autosuggest_weighting' ] );
 
-		add_filter( 'ep_do_intercept_request', [ $features->get_registered_feature( $this->slug ), 'intercept_search_request' ], 10, 4 );
+		add_filter( 'ep_do_intercept_request', [ $features->get_registered_feature( $this->slug ), 'intercept_search_request' ], 10, 2 );
 
 		add_filter( 'posts_pre_query', [ $features->get_registered_feature( $this->slug ), 'return_empty_posts' ], 100, 1 ); // after ES Query to ensure we are not falling back to DB in any case
 
@@ -562,7 +547,7 @@ class Autosuggest extends Feature {
 
 		remove_filter( 'ep_weighting_configuration', [ $features->get_registered_feature( $this->slug ), 'apply_autosuggest_weighting' ] );
 
-		remove_filter( 'ep_intercept_remote_request', '__return_true' );
+		remove_filter( 'ep_intercept_remote_request', [ $this->intercept_remote_request() ] );
 
 		return [
 			'body'        => $this->autosuggest_query,
@@ -599,63 +584,23 @@ class Autosuggest extends Feature {
 	}
 
 	/**
-	 * Store intercepted request value and return (cached) request result
+	 * Store intercepted request value and return a fake successful request result
 	 *
-	 * @param object $response Response
-	 * @param array  $query Query
-	 * @param array  $args WP_Query Argument array
-	 * @param int    $failures Count of failures in request loop
-	 * @return object $response Response
+	 * @param array $response Response
+	 * @param array $query    ES Query
+	 * @return array $response Response
 	 */
-	public function intercept_search_request( $response, $query = [], $args = [], $failures = 0 ) {
+	public function intercept_search_request( $response, $query = [] ) {
 		$this->autosuggest_query = $query['args']['body'];
 
-		// Let's make sure we also fire off the dummy request if settings have changed.
-		// But only fire this if we have object caching as otherwise this comes with a performance penalty.
-		// If we do not have object caching we cache only one value for 5 minutes in a transient.
-		if ( wp_using_ext_object_cache() ) {
-			$cache_key = md5( wp_json_encode( $query['url'] ) . wp_json_encode( $args['body'] ) );
-			$request   = wp_cache_get( $cache_key, 'ep_autosuggest' );
-			if ( false === $request ) {
-				$request = wp_remote_request( $query['url'], $args );
-				if ( isset( $request->http_response ) && isset( $request->http_response->body ) ) {
-					$request->http_response->body = '';
-				}
-				wp_cache_set( $cache_key, $request, 'ep_autosuggest' );
-			}
-		} else {
-			$cache_key = 'ep_autosuggest_query_request_cache';
-			$request   = get_transient( $cache_key );
-			if ( false === $request ) {
-				$request = wp_remote_request( $query['url'], $args );
-				if ( isset( $request->http_response ) && isset( $request->http_response->body ) ) {
-					$request->http_response->body = '';
-				}
-				set_transient( $cache_key, $request, 5 * MINUTE_IN_SECONDS );
-			}
-		}
-
-		return $request;
-	}
-
-	/**
-	 * Delete the cached query for autosuggest.
-	 *
-	 * @since 3.5.5
-	 */
-	public function delete_cached_query() {
-		global $wp_object_cache;
-		if ( wp_using_ext_object_cache() ) {
-			if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_group' ) ) {
-				wp_cache_flush_group( 'ep_autosuggest' );
-			} else {
-				// Try to delete the entire group.
-				// This may fail because the `$cache` property is not standardized.
-				unset( $wp_object_cache->cache['ep_autosuggest'] );
-			}
-		} else {
-			delete_transient( 'ep_autosuggest_query_request_cache' );
-		}
+		return [
+			'response' => [ 'code' => 200 ],
+			'body'     => wp_json_encode(
+				[
+					esc_html__( 'This is a fake request to build the ElasticPress Autosuggest query. It is not really sent.', 'elasticpress' ),
+				]
+			),
+		];
 	}
 
 	/**
@@ -729,6 +674,7 @@ class Autosuggest extends Feature {
 		if ( empty( $_REQUEST['ep_epio_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['ep_epio_nonce'] ), 'ep-epio-set-autosuggest' ) ) {
 			return;
 		}
+
 		if ( empty( $_GET['ep_epio_set_autosuggest'] ) ) {
 			return;
 		}
@@ -887,5 +833,32 @@ class Autosuggest extends Feature {
 
 		/* translators: 1. elasticpress.io logo;  */
 		return sprintf( esc_html__( 'Autosuggest By %s', 'elasticpress' ), $this->get_epio_logo() );
+	}
+
+	/**
+	 * Return true, so EP knows we want to intercept the remote request
+	 *
+	 * As we add and remove this function from `ep_intercept_remote_request`,
+	 * using `__return_true` could remove a *real* `__return_true` added by someone else.
+	 *
+	 * @since 4.7.0
+	 * @see https://github.com/10up/ElasticPress/issues/2887
+	 * @return true
+	 */
+	public function intercept_remote_request() {
+		return true;
+	}
+
+	/**
+	 * DEPRECATED. Delete the cached query for autosuggest.
+	 *
+	 * @since 3.5.5
+	 */
+	public function delete_cached_query() {
+		_doing_it_wrong(
+			__METHOD__,
+			esc_html__( 'This method should not be called anymore, as autosuggest requests are not sent regularly anymore.' ),
+			'ElasticPress 4.7.0'
+		);
 	}
 }

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -502,7 +502,7 @@ class Autosuggest extends Feature {
 		 */
 		$post_status = apply_filters( 'ep_term_suggest_post_status', array_values( $post_status ) );
 
-		add_filter( 'ep_intercept_remote_request', [ $this->intercept_remote_request() ] );
+		add_filter( 'ep_intercept_remote_request', [ $this, 'intercept_remote_request' ] );
 		add_filter( 'ep_weighting_configuration', [ $features->get_registered_feature( $this->slug ), 'apply_autosuggest_weighting' ] );
 
 		add_filter( 'ep_do_intercept_request', [ $features->get_registered_feature( $this->slug ), 'intercept_search_request' ], 10, 2 );
@@ -547,7 +547,7 @@ class Autosuggest extends Feature {
 
 		remove_filter( 'ep_weighting_configuration', [ $features->get_registered_feature( $this->slug ), 'apply_autosuggest_weighting' ] );
 
-		remove_filter( 'ep_intercept_remote_request', [ $this->intercept_remote_request() ] );
+		remove_filter( 'ep_intercept_remote_request', [ $this, 'intercept_remote_request' ] );
 
 		return [
 			'body'        => $this->autosuggest_query,

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -210,6 +210,7 @@ class Upgrades {
 	 * Upgrade routine of v4.7.0.
 	 *
 	 * Remove old total_fields_limit transients
+	 * Remove cached autosuggest requests
 	 *
 	 * @see https://github.com/10up/ElasticPress/pull/3552
 	 */
@@ -227,6 +228,11 @@ class Upgrades {
 			delete_site_transient( $transient_name );
 			delete_transient( $transient_name );
 		}
+
+		if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_group' ) ) {
+			wp_cache_flush_group( 'ep_autosuggest' );
+		}
+		delete_transient( 'ep_autosuggest_query_request_cache' );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

This PR changes the way authenticated requests for autosuggest are fired. These requests are used so the Elasticsearch hosting provider (EP.io, for example) knows which parameters are allowed in a query sent via JS, preventing anonymous users to send a query asking for shop orders, for example.

In #1890 (EP 3.5.2, in 2020) we introduced an authenticated request sent before the sync is started and when the weighting dashboard is saved. This request has a header `EP-Set-Autosuggest=true`. Before that, any request sending `ep-search-term=search test` or `ep-search-term=ep_autosuggest_placeholder` would set those values. To avoid sending a request per page load, EP cached the request sent.

The way we were caching it depended on the presence or absence of an external object cache: if present, we would cache a request per different query, if absent, we would just cache one query. Although that was made to allow for different autosuggest queries, it really doesn't fix the problem, as we can only have one set of allowed parameters.

This PR removes those cached requests, only sending a request to set allowed parameters before a sync or when the weighting dashboard is saved. If people want to run different autosuggest queries with different sets of allowed parameters, they can pass the superset of parameters (including everything) using the `ep_autosuggest_query_args` filter and checking if `$_GET['ep_epio_set_autosuggest']` is set and is not empty.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2887

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Autosuggest authenticated requests are not cached anymore and are only sent during the sync process or when the weighting dashboard is saved.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @kovshenin

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
