### PR TITLE
New `get` WP-CLI command

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1595,7 +1595,7 @@ class Command extends WP_CLI_Command {
 
 		$object = $indexable->get( $args[1] );
 		if ( ! $object ) {
-			WP_CLI::error( $object );
+			WP_CLI::error( esc_html__( 'Not found', 'elasticpress' ) );
 		}
 
 		$pretty = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pretty' );

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1590,4 +1590,46 @@ class Command extends WP_CLI_Command {
 
 		$this->pretty_json_encode( $response, $pretty );
 	}
+
+	/**
+	 * Get a specific content in Elasticsearch
+	 *
+	 * ## OPTIONS
+	 *
+	 * <indexable>
+	 * : Indexable slug. Example: `post`
+	 *
+	 * <ID>
+	 * : Content ID
+	 *
+	 * [--pretty]
+	 * : Use this flag to render a pretty-printed version of the JSON response.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 */
+	public function get( $args, $assoc_args ) {
+		$indexables = Indexables::factory();
+
+		$indexable = $indexables->get( $args[0] );
+		if ( ! $indexable || ! $indexables->is_active( $args[0] ) ) {
+			$message = wp_sprintf(
+				/* translators: list of active indexables slugs */
+				esc_html__( 'Indexable not found or inactive. Active indexables are: %l', 'elasticpress' ),
+				$indexables->get_all( null, true )
+			);
+			WP_CLI::error( $message );
+		}
+
+		$object = $indexable->get( $args[1] );
+		if ( ! $object ) {
+			WP_CLI::error( esc_html__( 'Not found', 'elasticpress' ) );
+		}
+
+		$pretty = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pretty' );
+
+		$this->pretty_json_encode( $object, $pretty );
+	}
 }

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1052,9 +1052,54 @@ class TestCommands extends BaseTestCase {
 
 		$output = $this->getActualOutputForAssertion();
 		$this->assertStringStartsWith( "{\n", $output );
+	}
+
+	/**
+	 * Test the `get` method
+	 *
+	 * @since 4.7.0
+	 * @group commands
+	 */
+	public function test_get() {
+		$post_id = $this->ep_factory->post->create();
+
+		$this->command->get( [ 'post', $post_id ], [] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringStartsWith( '{', $output );
+		$this->assertStringContainsString( '"post_id":' . $post_id, $output );
 
 		// clean output buffer
 		ob_clean();
+
+		// test with --pretty flag
+		$this->command->get( [ 'post', $post_id ], [ 'pretty' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringStartsWith( "{\n", $output );
+		$this->assertStringContainsString( '"post_id": ' . $post_id, $output );
+	}
+
+	/**
+	 * Test the `get` method when an indexable does not exist
+	 *
+	 * @since 4.7.0
+	 * @group commands
+	 */
+	public function test_get_wrong_indexable() {
+		$this->expectException( '\Exception' );
+		$this->command->get( [ 'absent', '1' ], [] );
+	}
+
+	/**
+	 * Test the `get` method when a post is not found
+	 *
+	 * @since 4.7.0
+	 * @group commands
+	 */
+	public function test_get_not_found() {
+		$this->expectExceptionMessage( 'Not found' );
+		$this->command->get( [ 'post', '99999' ], [] );
 	}
 
 	/**

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1104,7 +1104,7 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
-	 * Test the `get` method
+	 * Test the `get` command
 	 *
 	 * @since 4.7.0
 	 * @group commands
@@ -1130,7 +1130,7 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
-	 * Test the `get` method when an indexable does not exist
+	 * Test the `get` command when an indexable does not exist
 	 *
 	 * @since 4.7.0
 	 * @group commands
@@ -1141,7 +1141,7 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
-	 * Test the `get` method when a post is not found
+	 * Test the `get` command when a post is not found
 	 *
 	 * @since 4.7.0
 	 * @group commands
@@ -1149,6 +1149,26 @@ class TestCommands extends BaseTestCase {
 	public function test_get_not_found() {
 		$this->expectExceptionMessage( 'Not found' );
 		$this->command->get( [ 'post', '99999' ], [] );
+	}
+
+	/**
+	 * Test the `get` command when `--debug-http-request` is passed
+	 *
+	 * @since 4.7.0
+	 * @group commands
+	 */
+	public function test_get_debug_http_request() {
+		$this->expectExceptionMessage( 'Not found' );
+
+		// test with --debug-http-request flag
+		$this->command->get( [ 'post', '99999' ], [ 'debug-http-request' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'URL:', $output );
+		$this->assertStringContainsString( 'Request Args:', $output );
+		$this->assertStringContainsString( 'Transport:', $output );
+		$this->assertStringContainsString( 'Context:', $output );
+		$this->assertStringContainsString( 'Response:', $output );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR introduces a new `get` WP-CLI command. Example: `wp elasticpress get post 123 --pretty` returns a pretty-formatted version of the post with ID 123.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3565

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New `get` WP-CLI command


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
