### PR TITLE
Add isFirstSearch prop to Instant Results

### DIFF
--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -105,7 +105,6 @@ export const ApiSearchProvider = ({
 		isOn: defaultIsOn,
 		isPoppingState: false,
 		searchResults: [],
-		searchedTerm: '',
 		totalResults: 0,
 	});
 

--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -105,8 +105,8 @@ export const ApiSearchProvider = ({
 		isOn: defaultIsOn,
 		isPoppingState: false,
 		searchResults: [],
-		searchedTerm: '',
 		totalResults: 0,
+		isFirstSearch: true,
 	});
 
 	/**
@@ -325,8 +325,16 @@ export const ApiSearchProvider = ({
 	/**
 	 * Provide state to context.
 	 */
-	const { aggregations, args, isLoading, isOn, searchResults, searchTerm, totalResults } =
-		stateRef.current;
+	const {
+		aggregations,
+		args,
+		isLoading,
+		isOn,
+		searchResults,
+		searchTerm,
+		totalResults,
+		isFirstSearch,
+	} = stateRef.current;
 
 	// eslint-disable-next-line react/jsx-no-constructed-context-values
 	const contextValue = {
@@ -347,6 +355,7 @@ export const ApiSearchProvider = ({
 		previousPage,
 		totalResults,
 		turnOff,
+		isFirstSearch,
 	};
 
 	return <Context.Provider value={contextValue}>{children}</Context.Provider>;

--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -104,10 +104,8 @@ export const ApiSearchProvider = ({
 		isLoading: false,
 		isOn: defaultIsOn,
 		isPoppingState: false,
-		searchTerm: '',
 		searchResults: [],
 		totalResults: 0,
-		isFirstSearch: true,
 	});
 
 	/**
@@ -326,16 +324,8 @@ export const ApiSearchProvider = ({
 	/**
 	 * Provide state to context.
 	 */
-	const {
-		aggregations,
-		args,
-		isLoading,
-		isOn,
-		searchResults,
-		searchTerm,
-		totalResults,
-		isFirstSearch,
-	} = stateRef.current;
+	const { aggregations, args, isLoading, isOn, searchResults, searchTerm, totalResults } =
+		stateRef.current;
 
 	// eslint-disable-next-line react/jsx-no-constructed-context-values
 	const contextValue = {
@@ -356,7 +346,6 @@ export const ApiSearchProvider = ({
 		previousPage,
 		totalResults,
 		turnOff,
-		isFirstSearch,
 	};
 
 	return <Context.Provider value={contextValue}>{children}</Context.Provider>;

--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -104,8 +104,10 @@ export const ApiSearchProvider = ({
 		isLoading: false,
 		isOn: defaultIsOn,
 		isPoppingState: false,
+		searchTerm: '',
 		searchResults: [],
 		totalResults: 0,
+		isFirstSearch: true,
 	});
 
 	/**
@@ -324,8 +326,16 @@ export const ApiSearchProvider = ({
 	/**
 	 * Provide state to context.
 	 */
-	const { aggregations, args, isLoading, isOn, searchResults, searchTerm, totalResults } =
-		stateRef.current;
+	const {
+		aggregations,
+		args,
+		isLoading,
+		isOn,
+		searchResults,
+		searchTerm,
+		totalResults,
+		isFirstSearch,
+	} = stateRef.current;
 
 	// eslint-disable-next-line react/jsx-no-constructed-context-values
 	const contextValue = {
@@ -346,6 +356,7 @@ export const ApiSearchProvider = ({
 		previousPage,
 		totalResults,
 		turnOff,
+		isFirstSearch,
 	};
 
 	return <Context.Provider value={contextValue}>{children}</Context.Provider>;

--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -105,6 +105,7 @@ export const ApiSearchProvider = ({
 		isOn: defaultIsOn,
 		isPoppingState: false,
 		searchResults: [],
+		searchedTerm: '',
 		totalResults: 0,
 	});
 

--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -107,6 +107,7 @@ export const ApiSearchProvider = ({
 		searchResults: [],
 		totalResults: 0,
 		isFirstSearch: true,
+		searchTerm: '',
 	});
 
 	/**

--- a/assets/js/api-search/src/reducer.js
+++ b/assets/js/api-search/src/reducer.js
@@ -60,8 +60,6 @@ export default (state, action) => {
 				aggregations,
 			} = action.response;
 
-			newState.isFirstSearch = false;
-
 			/**
 			 * Total number of items.
 			 */

--- a/assets/js/api-search/src/reducer.js
+++ b/assets/js/api-search/src/reducer.js
@@ -31,6 +31,8 @@ export default (state, action) => {
 		case 'SEARCH': {
 			newState.args = { ...newState.args, ...action.args, offset: 0 };
 			newState.isOn = true;
+			newState.searchTerm = action.args.search;
+			newState.args.search = action.args.search;
 			break;
 		}
 		case 'SEARCH_FOR': {

--- a/assets/js/api-search/src/reducer.js
+++ b/assets/js/api-search/src/reducer.js
@@ -60,6 +60,8 @@ export default (state, action) => {
 				aggregations,
 			} = action.response;
 
+			newState.isFirstSearch = false;
+
 			/**
 			 * Total number of items.
 			 */

--- a/assets/js/api-search/src/reducer.js
+++ b/assets/js/api-search/src/reducer.js
@@ -31,8 +31,6 @@ export default (state, action) => {
 		case 'SEARCH': {
 			newState.args = { ...newState.args, ...action.args, offset: 0 };
 			newState.isOn = true;
-			newState.searchTerm = action.args.search;
-			newState.args.search = action.args.search;
 			break;
 		}
 		case 'SEARCH_FOR': {

--- a/assets/js/api-search/src/reducer.js
+++ b/assets/js/api-search/src/reducer.js
@@ -58,6 +58,8 @@ export default (state, action) => {
 				aggregations,
 			} = action.response;
 
+			newState.isFirstSearch = false;
+
 			/**
 			 * Total number of items.
 			 */

--- a/assets/js/instant-results/components/layout/results.js
+++ b/assets/js/instant-results/components/layout/results.js
@@ -2,7 +2,7 @@
  * Internal depenencies.
  */
 import { useEffect, useRef, WPElement } from '@wordpress/element';
-import { _n, sprintf, __ } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -25,7 +25,6 @@ export default () => {
 		searchResults,
 		searchTerm,
 		totalResults,
-		isFirstSearch,
 	} = useApiSearch();
 
 	const headingRef = useRef();
@@ -51,39 +50,27 @@ export default () => {
 		headingRef.current.scrollIntoView({ behavior: 'smooth' });
 	}, [offset]);
 
-	/**
-	 * Display results text.
-	 *
-	 * @returns {string} Results text.
-	 */
-	const displayResults = () => {
-		if (searchTerm) {
-			return sprintf(
-				/* translators: %1$d: results count. %2$s: Search term. */
-				_n(
-					'%1$d result for “%2$s“',
-					'%1$d results for “%2$s“',
-					totalResults,
-					'elasticpress',
-				),
-				totalResults,
-				searchTerm,
-			);
-		}
-		return sprintf(
-			/* translators: %d: results count. */
-			_n('%d result', '%d results', totalResults, 'elasticpress'),
-			totalResults,
-		);
-	};
-
 	return (
 		<div className="ep-search-results">
 			<header className="ep-search-results__header">
 				<h1 className="ep-search-results__title" ref={headingRef} role="status">
-					{!isFirstSearch
-						? displayResults()
-						: sprintf(__('Loading results', 'elasticpress'))}
+					{searchTerm
+						? sprintf(
+								/* translators: %1$d: results count. %2$s: Search term. */
+								_n(
+									'%1$d result for “%2$s“',
+									'%1$d results for “%2$s“',
+									totalResults,
+									'elasticpress',
+								),
+								totalResults,
+								searchTerm,
+						  )
+						: sprintf(
+								/* translators: %d: results count. */
+								_n('%d result', '%d results', totalResults, 'elasticpress'),
+								totalResults,
+						  )}
 				</h1>
 
 				<Sort />

--- a/assets/js/instant-results/components/layout/results.js
+++ b/assets/js/instant-results/components/layout/results.js
@@ -2,7 +2,7 @@
  * Internal depenencies.
  */
 import { useEffect, useRef, WPElement } from '@wordpress/element';
-import { _n, sprintf } from '@wordpress/i18n';
+import { _n, sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -25,6 +25,7 @@ export default () => {
 		searchResults,
 		searchTerm,
 		totalResults,
+		isFirstSearch,
 	} = useApiSearch();
 
 	const headingRef = useRef();
@@ -50,27 +51,39 @@ export default () => {
 		headingRef.current.scrollIntoView({ behavior: 'smooth' });
 	}, [offset]);
 
+	/**
+	 * Display results text.
+	 *
+	 * @returns {string} Results text.
+	 */
+	const displayResults = () => {
+		if (searchTerm) {
+			return sprintf(
+				/* translators: %1$d: results count. %2$s: Search term. */
+				_n(
+					'%1$d result for “%2$s“',
+					'%1$d results for “%2$s“',
+					totalResults,
+					'elasticpress',
+				),
+				totalResults,
+				searchTerm,
+			);
+		}
+		return sprintf(
+			/* translators: %d: results count. */
+			_n('%d result', '%d results', totalResults, 'elasticpress'),
+			totalResults,
+		);
+	};
+
 	return (
 		<div className="ep-search-results">
 			<header className="ep-search-results__header">
 				<h1 className="ep-search-results__title" ref={headingRef} role="status">
-					{searchTerm
-						? sprintf(
-								/* translators: %1$d: results count. %2$s: Search term. */
-								_n(
-									'%1$d result for “%2$s“',
-									'%1$d results for “%2$s“',
-									totalResults,
-									'elasticpress',
-								),
-								totalResults,
-								searchTerm,
-						  )
-						: sprintf(
-								/* translators: %d: results count. */
-								_n('%d result', '%d results', totalResults, 'elasticpress'),
-								totalResults,
-						  )}
+					{!isFirstSearch
+						? displayResults()
+						: sprintf(__('Loading results', 'elasticpress'))}
 				</h1>
 
 				<Sort />

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -148,6 +148,9 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('@searchBlock').find('.wp-block-search__input').type('blog');
 				cy.get('@searchBlock').find('.wp-block-search__button').click();
 				cy.get('.ep-search-modal').as('searchModal').should('be.visible'); // Should be visible immediatly
+				cy.get('@searchModal')
+					.find('.ep-search-results__title')
+					.contains('Loading results');
 				cy.url().should('include', 'search=blog');
 
 				cy.wait('@apiRequest');

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -148,9 +148,6 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('@searchBlock').find('.wp-block-search__input').type('blog');
 				cy.get('@searchBlock').find('.wp-block-search__button').click();
 				cy.get('.ep-search-modal').as('searchModal').should('be.visible'); // Should be visible immediatly
-				cy.get('@searchModal')
-					.find('.ep-search-results__title')
-					.contains('Loading results');
 				cy.url().should('include', 'search=blog');
 
 				cy.wait('@apiRequest');

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -148,6 +148,10 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('@searchBlock').find('.wp-block-search__input').type('blog');
 				cy.get('@searchBlock').find('.wp-block-search__button').click();
 				cy.get('.ep-search-modal').as('searchModal').should('be.visible'); // Should be visible immediatly
+				cy.get('@searchModal')
+					.find('.ep-search-results__title')
+					.contains('Loading results');
+				cy.url().should('include', 'search=blog');
 				cy.url().should('include', 'search=blog');
 
 				cy.wait('@apiRequest');
@@ -172,6 +176,10 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 				// Show the modal in the same state after a reload
 				cy.reload();
+				cy.get('@searchModal')
+					.find('.ep-search-results__title')
+					.contains('Loading results');
+				cy.url().should('include', 'search=blog');
 				cy.wait('@apiRequest');
 				cy.get('@searchModal').should('be.visible').should('contain.text', 'blog');
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->



<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
This PR adds a new `isFirstSearch` to keep track of whether we are on the first time searching in instant results. If it is set to true instant results will show a "Loading results" text until we have set the results from Elastic.

Closes https://github.com/10up/ElasticPress/issues/3508

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1.- With instant results activated, search for a term
2.- You should see the text "Loading results" instead of "0 results" for a brief moment

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Display "Loading results" instead of "0 results" on first search.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez, @JakePT, @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
