### PR TITLE
Use site_meta instead of blog_option

### DIFF
--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -216,11 +216,13 @@ class Upgrades {
 	public function upgrade_4_7_0() {
 		global $wpdb;
 
-		$sites = \get_sites( [ 'number' => 0 ] );
-		foreach ( $sites as $site ) {
-			$blog_option = get_blog_option( $site->blog_id, 'ep_indexable' );
-			if ( $blog_option ) {
-				update_site_meta( $site->blog_id, 'ep_indexable', $blog_option );
+		if ( is_multisite() ) {
+			$sites = \get_sites( [ 'number' => 0 ] );
+			foreach ( $sites as $site ) {
+				$blog_option = get_blog_option( $site->blog_id, 'ep_indexable' );
+				if ( $blog_option ) {
+					update_site_meta( $site->blog_id, 'ep_indexable', $blog_option );
+				}
 			}
 		}
 

--- a/includes/classes/Upgrades.php
+++ b/includes/classes/Upgrades.php
@@ -216,6 +216,14 @@ class Upgrades {
 	public function upgrade_4_7_0() {
 		global $wpdb;
 
+		$sites = \get_sites( [ 'number' => 0 ] );
+		foreach ( $sites as $site ) {
+			$blog_option = get_blog_option( $site->blog_id, 'ep_indexable' );
+			if ( $blog_option ) {
+				update_site_meta( $site->blog_id, 'ep_indexable', $blog_option );
+			}
+		}
+
 		$transients = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			"SELECT option_name
 			FROM {$wpdb->prefix}options

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -47,7 +47,6 @@ function setup() {
 	add_action( 'ep_add_query_log', __NAMESPACE__ . '\log_version_query_error' );
 	add_filter( 'ep_analyzer_language', __NAMESPACE__ . '\use_language_in_setting', 10, 2 );
 	add_filter( 'wp_kses_allowed_html', __NAMESPACE__ . '\filter_allowed_html', 10, 2 );
-	add_action( 'manage_blogs_custom_column', __NAMESPACE__ . '\add_blogs_column', 10, 2 );
 	add_action( 'rest_api_init', __NAMESPACE__ . '\setup_endpoint' );
 
 	/**
@@ -58,7 +57,7 @@ function setup() {
 	 * @param  {bool}  $show True to show.
 	 * @return {bool}  New value
 	 */
-	$show_indexing_option_on_multisite = apply_filters( 'ep_show_indexing_option_on_multisite', true );
+	$show_indexing_option_on_multisite = apply_filters( 'ep_show_indexing_option_on_multisite', defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK );
 
 	if ( $show_indexing_option_on_multisite ) {
 		add_filter( 'wpmu_blogs_columns', __NAMESPACE__ . '\filter_blogs_columns', 10, 1 );
@@ -877,21 +876,23 @@ function filter_blogs_columns( $columns ) {
  * @return void | string
  */
 function add_blogs_column( $column_name, $blog_id ) {
+	if ( 'elasticpress' !== $column_name ) {
+		return;
+	}
+
 	$site = get_site( $blog_id );
 	if ( $site->deleted || $site->archived || $site->spam ) {
 		return;
 	}
-	if ( 'elasticpress' === $column_name ) {
-		$is_indexable = get_blog_option( $blog_id, 'ep_indexable', 'yes' );
 
-		printf(
-			'<input %1$s class="index-toggle" data-blog-id="%2$s" disabled type="checkbox">',
-			checked( $is_indexable, 'yes', false ),
-			esc_attr( $blog_id )
-		);
-	}
+	$is_indexable = get_site_meta( $blog_id, 'ep_indexable', true );
+	$is_indexable = '' !== $is_indexable ? $is_indexable : 'yes';
 
-	return $column_name;
+	printf(
+		'<input %1$s class="index-toggle" data-blog-id="%2$s" disabled type="checkbox">',
+		checked( $is_indexable, 'yes', false ),
+		esc_attr( $blog_id )
+	);
 }
 
 /**
@@ -904,8 +905,13 @@ function action_wp_ajax_ep_site_admin() {
 	if ( - 1 === $blog_id || ! check_ajax_referer( 'epsa', 'nonce', false ) ) {
 		return wp_send_json_error();
 	}
-	$old    = get_blog_option( $blog_id, 'ep_indexable' );
+
+	/**
+	 * NOTE: This will be removed in ElasticPress 5.0.0. Implementations should rely on site_meta since 4.7.0.
+	 */
 	$result = update_blog_option( $blog_id, 'ep_indexable', $checked );
+
+	$result = update_site_meta( $blog_id, 'ep_indexable', $checked );
 	$data   = [
 		'blog_id' => $blog_id,
 		'result'  => $result,

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -177,17 +177,15 @@ function is_epio() {
  * @return boolean
  */
 function is_site_indexable( $blog_id = null ) {
-	if ( is_multisite() ) {
-		$site = get_site( $blog_id );
-
-		$is_indexable = get_blog_option( (int) $blog_id, 'ep_indexable', 'yes' );
-
-		if ( 'no' === $is_indexable || $site['deleted'] || $site['archived'] || $site['spam'] ) {
-			return false;
-		}
+	if ( ! is_multisite() ) {
+		return true;
 	}
 
-	return true;
+	$site = get_site( $blog_id );
+
+	$is_indexable = get_site_meta( (int) $blog_id, 'ep_indexable', true );
+
+	return 'no' !== $is_indexable && ! $site['deleted'] && ! $site['archived'] && ! $site['spam'];
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -183,7 +183,7 @@ function is_site_indexable( $blog_id = null ) {
 
 	$site = get_site( $blog_id );
 
-	$is_indexable = get_site_meta( (int) $blog_id, 'ep_indexable', true );
+	$is_indexable = get_site_meta( $site['blog_id'], 'ep_indexable', true );
 
 	return 'no' !== $is_indexable && ! $site['deleted'] && ! $site['archived'] && ! $site['spam'];
 }

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -198,7 +198,7 @@ class TestCommands extends BaseTestCase {
 		ElasticPress\Features::factory()->setup_features();
 
 		$blog_id = $this->factory->blog->create();
-		update_blog_option( $blog_id, 'ep_indexable', 'no' );
+		update_site_meta( $blog_id, 'ep_indexable', 'no' );
 
 		$this->factory->blog->create();
 

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -63,6 +63,7 @@ class TestUtils extends BaseTestCase {
 	 *
 	 * @since 3.2
 	 * @group utils
+	 * @group skip-on-single-site
 	 */
 	public function testIsSiteIndexableByDefault() {
 		delete_site_meta( get_current_blog_id(), 'ep_indexable' );
@@ -75,19 +76,16 @@ class TestUtils extends BaseTestCase {
 	 *
 	 * @since 3.2
 	 * @group utils
+	 * @group skip-on-single-site
 	 */
 	public function testIsSiteIndexableByDefaultSpam() {
 		delete_site_meta( get_current_blog_id(), 'ep_indexable' );
 
-		if ( is_multisite() ) {
-			update_blog_status( get_current_blog_id(), 'spam', 1 );
+		update_blog_status( get_current_blog_id(), 'spam', 1 );
 
-			$this->assertFalse( ElasticPress\Utils\is_site_indexable() );
+		$this->assertFalse( ElasticPress\Utils\is_site_indexable() );
 
-			update_blog_status( get_current_blog_id(), 'spam', 0 );
-		} else {
-			$this->assertTrue( ElasticPress\Utils\is_site_indexable() );
-		}
+		update_blog_status( get_current_blog_id(), 'spam', 0 );
 	}
 
 	/**
@@ -95,15 +93,11 @@ class TestUtils extends BaseTestCase {
 	 *
 	 * @since 3.2
 	 * @group utils
+	 * @group skip-on-single-site
 	 */
 	public function testIsSiteIndexableDisabled() {
 		update_site_meta( get_current_blog_id(), 'ep_indexable', 'no' );
-
-		if ( is_multisite() ) {
-			$this->assertFalse( ElasticPress\Utils\is_site_indexable() );
-		} else {
-			$this->assertTrue( ElasticPress\Utils\is_site_indexable() );
-		}
+		$this->assertFalse( ElasticPress\Utils\is_site_indexable() );
 	}
 
 	/**

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -65,7 +65,7 @@ class TestUtils extends BaseTestCase {
 	 * @group utils
 	 */
 	public function testIsSiteIndexableByDefault() {
-		delete_option( 'ep_indexable' );
+		delete_site_meta( get_current_blog_id(), 'ep_indexable' );
 
 		$this->assertTrue( ElasticPress\Utils\is_site_indexable() );
 	}
@@ -77,7 +77,7 @@ class TestUtils extends BaseTestCase {
 	 * @group utils
 	 */
 	public function testIsSiteIndexableByDefaultSpam() {
-		delete_option( 'ep_indexable' );
+		delete_site_meta( get_current_blog_id(), 'ep_indexable' );
 
 		if ( is_multisite() ) {
 			update_blog_status( get_current_blog_id(), 'spam', 1 );
@@ -97,7 +97,7 @@ class TestUtils extends BaseTestCase {
 	 * @group utils
 	 */
 	public function testIsSiteIndexableDisabled() {
-		update_option( 'ep_indexable', 'no' );
+		update_site_meta( get_current_blog_id(), 'ep_indexable', 'no' );
 
 		if ( is_multisite() ) {
 			$this->assertFalse( ElasticPress\Utils\is_site_indexable() );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR changes all the *blog_option() calls to *site_meta() as this way we don't need to iterate over all sites to check if they are indexable or not.

For ElasticPress 4.7 we are still keeping the blog_option for backwards compatibility. In ElasticPress 5.0 we can remove that entirely.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3457

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Changed - In a multisite, if a site is indexable or not is now stored in site meta, instead of a blog option.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @Rahe

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
