### PR TITLE
Use createRoot instead of render

### DIFF
--- a/assets/js/instant-results/admin/index.js
+++ b/assets/js/instant-results/admin/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { createRoot } from '@wordpress/element';
+import { createRoot, render } from '@wordpress/element';
 
 /**
  * Internal dependences.
@@ -10,8 +10,6 @@ import FacetSelector from './components/facet-selector';
 
 document.addEventListener('DOMContentLoaded', () => {
 	const input = document.getElementById('feature_instant_results_facets');
-	const root = createRoot(input.parentElement);
-
 	const {
 		className,
 		dataset: { fieldName },
@@ -20,13 +18,28 @@ document.addEventListener('DOMContentLoaded', () => {
 		value,
 	} = input;
 
-	root.render(
-		<FacetSelector
-			className={className}
-			data-field-name={fieldName}
-			defaultValue={value}
-			id={id}
-			name={name}
-		/>,
-	);
+	if (typeof createRoot === 'function') {
+		const root = createRoot(input.parentElement);
+
+		root.render(
+			<FacetSelector
+				className={className}
+				data-field-name={fieldName}
+				defaultValue={value}
+				id={id}
+				name={name}
+			/>,
+		);
+	} else {
+		render(
+			<FacetSelector
+				className={className}
+				data-field-name={fieldName}
+				defaultValue={value}
+				id={id}
+				name={name}
+			/>,
+			input.parentElement,
+		);
+	}
 });

--- a/assets/js/instant-results/admin/index.js
+++ b/assets/js/instant-results/admin/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependences.
@@ -10,6 +10,7 @@ import FacetSelector from './components/facet-selector';
 
 document.addEventListener('DOMContentLoaded', () => {
 	const input = document.getElementById('feature_instant_results_facets');
+	const root = createRoot(input.parentElement);
 
 	const {
 		className,
@@ -19,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		value,
 	} = input;
 
-	render(
+	root.render(
 		<FacetSelector
 			className={className}
 			data-field-name={fieldName}
@@ -27,6 +28,5 @@ document.addEventListener('DOMContentLoaded', () => {
 			id={id}
 			name={name}
 		/>,
-		input.parentElement,
 	);
 });

--- a/assets/js/instant-results/index.js
+++ b/assets/js/instant-results/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { createRoot } from '@wordpress/element';
+import { createRoot, render } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -15,19 +15,35 @@ import Modal from './apps/modal';
  */
 const init = () => {
 	const el = document.getElementById('ep-instant-results');
-	const root = createRoot(el);
-	root.render(
-		<ApiSearchProvider
-			apiEndpoint={apiEndpoint}
-			apiHost={apiHost}
-			argsSchema={argsSchema}
-			paramPrefix={paramPrefix}
-			requestIdBase={requestIdBase}
-		>
-			<Modal />
-		</ApiSearchProvider>,
-		el,
-	);
+
+	if (typeof createRoot === 'function') {
+		const root = createRoot(el);
+		root.render(
+			<ApiSearchProvider
+				apiEndpoint={apiEndpoint}
+				apiHost={apiHost}
+				argsSchema={argsSchema}
+				paramPrefix={paramPrefix}
+				requestIdBase={requestIdBase}
+			>
+				<Modal />
+			</ApiSearchProvider>,
+			el,
+		);
+	} else {
+		render(
+			<ApiSearchProvider
+				apiEndpoint={apiEndpoint}
+				apiHost={apiHost}
+				argsSchema={argsSchema}
+				paramPrefix={paramPrefix}
+				requestIdBase={requestIdBase}
+			>
+				<Modal />
+			</ApiSearchProvider>,
+			el,
+		);
+	}
 };
 
 window.addEventListener('DOMContentLoaded', init);

--- a/assets/js/instant-results/index.js
+++ b/assets/js/instant-results/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -15,8 +15,8 @@ import Modal from './apps/modal';
  */
 const init = () => {
 	const el = document.getElementById('ep-instant-results');
-
-	render(
+	const root = createRoot(el);
+	root.render(
 		<ApiSearchProvider
 			apiEndpoint={apiEndpoint}
 			apiHost={apiHost}

--- a/assets/js/ordering/index.js
+++ b/assets/js/ordering/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { createRoot } from '@wordpress/element';
+import { createRoot, render } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -9,5 +9,10 @@ import { createRoot } from '@wordpress/element';
 import { Pointers } from './pointers';
 
 const el = document.getElementById('ordering-app');
-const root = createRoot(el);
-root.render(<Pointers />);
+
+if (typeof createRoot === 'function') {
+	const root = createRoot(el);
+	root.render(<Pointers />);
+} else {
+	render(<Pointers />, el);
+}

--- a/assets/js/ordering/index.js
+++ b/assets/js/ordering/index.js
@@ -1,11 +1,13 @@
 /**
  * WordPress dependencies.
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
 import { Pointers } from './pointers';
 
-render(<Pointers />, document.getElementById('ordering-app'));
+const el = document.getElementById('ordering-app');
+const root = createRoot(el);
+root.render(<Pointers />);

--- a/assets/js/status-report/index.js
+++ b/assets/js/status-report/index.js
@@ -4,7 +4,7 @@
  * WordPress dependencies.
  */
 import domReady from '@wordpress/dom-ready';
-import { createRoot } from '@wordpress/element';
+import { createRoot, render } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -18,9 +18,7 @@ import Reports from './components/reports';
  * @returns {void}
  */
 const init = () => {
-	const report = document.getElementById('ep-status-reports');
 	const clipboard = new ClipboardJS('#ep-copy-report');
-	const root = createRoot(report);
 
 	/**
 	 * Handle successful copy.
@@ -46,7 +44,14 @@ const init = () => {
 	/**
 	 * Render reports.
 	 */
-	root.render(<Reports reports={reports} />);
+	const report = document.getElementById('ep-status-reports');
+
+	if (typeof createRoot === 'function') {
+		const root = createRoot(report);
+		root.render(<Reports reports={reports} />);
+	} else {
+		render(<Reports reports={reports} />, report);
+	}
 };
 
 domReady(init);

--- a/assets/js/status-report/index.js
+++ b/assets/js/status-report/index.js
@@ -4,7 +4,7 @@
  * WordPress dependencies.
  */
 import domReady from '@wordpress/dom-ready';
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -20,6 +20,7 @@ import Reports from './components/reports';
 const init = () => {
 	const report = document.getElementById('ep-status-reports');
 	const clipboard = new ClipboardJS('#ep-copy-report');
+	const root = createRoot(report);
 
 	/**
 	 * Handle successful copy.
@@ -45,7 +46,7 @@ const init = () => {
 	/**
 	 * Render reports.
 	 */
-	render(<Reports reports={reports} />, report);
+	root.render(<Reports reports={reports} />);
 };
 
 domReady(init);

--- a/assets/js/synonyms/index.js
+++ b/assets/js/synonyms/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { createRoot } from '@wordpress/element';
+import { createRoot, render } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -18,9 +18,18 @@ const SELECTOR = '#synonym-root';
  */
 const getRoot = () => document.querySelector(SELECTOR) || false;
 
-const root = createRoot(getRoot());
-root.render(
-	<AppContext>
-		<SynonymsEditor />
-	</AppContext>,
-);
+if (typeof createRoot === 'function') {
+	const root = createRoot(getRoot());
+	root.render(
+		<AppContext>
+			<SynonymsEditor />
+		</AppContext>,
+	);
+} else {
+	render(
+		<AppContext>
+			<SynonymsEditor />
+		</AppContext>,
+		getRoot(),
+	);
+}

--- a/assets/js/synonyms/index.js
+++ b/assets/js/synonyms/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -18,9 +18,9 @@ const SELECTOR = '#synonym-root';
  */
 const getRoot = () => document.querySelector(SELECTOR) || false;
 
-render(
+const root = createRoot(getRoot());
+root.render(
 	<AppContext>
 		<SynonymsEditor />
 	</AppContext>,
-	getRoot(),
 );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
This PR changes the method used to render the React element to use create.Root as per https://github.com/10up/ElasticPress/issues/3544

Closes https://github.com/10up/ElasticPress/issues/3544

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Use createRoot instead of render to render elements


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez , @burhandodhy, @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
