### PR TITLE
Override ES highlighting in IR

### DIFF
--- a/assets/js/instant-results/components/layout/results.js
+++ b/assets/js/instant-results/components/layout/results.js
@@ -50,6 +50,15 @@ export default () => {
 		headingRef.current.scrollIntoView({ behavior: 'smooth' });
 	}, [offset]);
 
+	/**
+	 * Note: highlighting is redone here because the unified highlight type is not supported in ES5
+	 */
+	const regex = new RegExp(`\\b(${searchTerm})`, 'gi');
+	searchResults.forEach((hit, index) => {
+		const resultsText = hit._source.post_title.replace(regex, (word) => `<mark>${word}</mark>`);
+		searchResults[index].highlight.post_title = resultsText;
+	});
+
 	return (
 		<div className="ep-search-results">
 			<header className="ep-search-results__header">

--- a/assets/js/instant-results/components/layout/results.js
+++ b/assets/js/instant-results/components/layout/results.js
@@ -19,7 +19,7 @@ import Sort from '../tools/sort';
  */
 export default () => {
 	const {
-		args: { offset, per_page },
+		args: { offset, per_page, highlight },
 		nextPage,
 		previousPage,
 		searchResults,
@@ -50,15 +50,6 @@ export default () => {
 		headingRef.current.scrollIntoView({ behavior: 'smooth' });
 	}, [offset]);
 
-	/**
-	 * Note: highlighting is redone here because the unified highlight type is not supported in ES5
-	 */
-	const regex = new RegExp(`\\b(${searchTerm})`, 'gi');
-	searchResults.forEach((hit, index) => {
-		const resultsText = hit._source.post_title.replace(regex, (word) => `<mark>${word}</mark>`);
-		searchResults[index].highlight.post_title = resultsText;
-	});
-
 	return (
 		<div className="ep-search-results">
 			<header className="ep-search-results__header">
@@ -86,7 +77,7 @@ export default () => {
 			</header>
 
 			{searchResults.map((hit) => (
-				<Result key={hit._id} hit={hit} />
+				<Result key={hit._id} hit={hit} searchTerm={searchTerm} highlightTag={highlight} />
 			))}
 
 			<Pagination

--- a/assets/js/instant-results/components/results/result.js
+++ b/assets/js/instant-results/components/results/result.js
@@ -17,9 +17,9 @@ import Result from '../common/result';
  * @param {object} props.hit Elasticsearch hit.
  * @returns {WPElement} Component element.
  */
-export default ({ hit }) => {
+export default ({ hit, searchTerm, highlightTag }) => {
 	const {
-		highlight: { post_title: title, post_content_plain: postContent = [] },
+		highlight: { post_content_plain: postContent = [] },
 		_source: {
 			meta: { _wc_average_rating: [{ value: averageRating } = {}] = [] },
 			permalink: url,
@@ -30,6 +30,21 @@ export default ({ hit }) => {
 			thumbnail,
 		},
 	} = hit;
+
+	/**
+	 * Note: highlighting is redone here because the unified highlight type is not supported in ES5
+	 */
+	const regex = new RegExp(`\\b(${searchTerm})`, 'gi');
+	let title;
+
+	if (highlightTag === '' || highlightTag === undefined) {
+		title = hit._source.post_title;
+	} else {
+		title = hit._source.post_title.replace(
+			regex,
+			(word) => `<${highlightTag}>${word}</${highlightTag}>`,
+		);
+	}
 
 	const date = postType === 'post' ? formatDate(postDate) : null;
 	const excerpt = postContent.join('…');

--- a/assets/js/instant-results/components/results/result.js
+++ b/assets/js/instant-results/components/results/result.js
@@ -15,6 +15,8 @@ import Result from '../common/result';
  *
  * @param {object} props Component props.
  * @param {object} props.hit Elasticsearch hit.
+ * @param {object} props.searchTerm Search term from input search.
+ * @param {object} props.highlightTag Selected highlight tag.
  * @returns {WPElement} Component element.
  */
 export default ({ hit, searchTerm, highlightTag }) => {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
This PR overrides the result coming from ES highlight, as noted in https://github.com/10up/ElasticPress/issues/3497 there seems to be an issue with how the highlighter returns results in partial/no matches

We should probably remove when we drop support for ES5
 
Closes https://github.com/10up/ElasticPress/issues/3497

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix - Highlighting returning inaccurate post title when partial/no term match


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT , @tomi10up, @oscarssanchez, @felipeelia   ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
