### PR TITLE
Rename Facets feature to Filters.

### DIFF
--- a/assets/js/instant-results/admin/components/facet-selector.js
+++ b/assets/js/instant-results/admin/components/facet-selector.js
@@ -70,7 +70,7 @@ export default ({ defaultValue, ...props }) => {
 			<FormTokenField
 				__experimentalExpandOnFocus
 				__experimentalShowHowTo={false}
-				label={__('Select facets', 'elasticpress')}
+				label={__('Select filters', 'elasticpress')}
 				onChange={onChange}
 				suggestions={suggestions}
 				value={value}

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -486,13 +486,27 @@ class Facets extends Feature {
 	 * @since 2.5
 	 */
 	public function output_feature_box_long() {
+		if ( current_theme_supports( 'widgets' ) ) {
+			$message = sprintf(
+				/* translators: Widgets Edit Screen URL */
+				__( "Adds <a href='%s'>filter widgets</a> that administrators can add to the website's sidebars (widgetized areas), so that visitors can filter applicable content and search results by one or more taxonomy terms.", 'elasticpress' ),
+				esc_url( admin_url( 'widgets.php' ) )
+			);
+		}
+
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+			$message = sprintf(
+				/* translators: Site Editor URL */
+				__( "Adds <a href='%s'>filter blocks</a> that administrators can add to the website's templates and template parts, so that visitors can filter applicable content and search results by one or more taxonomy terms.", 'elasticpress' ),
+				esc_url( admin_url( 'site-editor.php' ) )
+			);
+		}
+
+		if ( ! isset( $message ) ) {
+			return;
+		}
 		?>
-		<p>
-			<?php
-			// translators: URL
-			echo wp_kses_post( sprintf( __( "Adds <a href='%s'>Filter widgets</a> that administrators can add to the website's sidebars (widgetized areas), so that visitors can filter applicable content and search results by one or more taxonomy terms.", 'elasticpress' ), esc_url( admin_url( 'widgets.php' ) ) ) );
-			?>
-		</p>
+		<p><?php echo wp_kses_post( $message ); ?></p>
 		<?php
 	}
 

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -37,7 +37,7 @@ class Facets extends Feature {
 	public function __construct() {
 		$this->slug = 'facets';
 
-		$this->title = esc_html__( 'Facets', 'elasticpress' );
+		$this->title = esc_html__( 'Filters', 'elasticpress' );
 
 		$this->summary = __( 'Add controls to your website to filter content by one or more taxonomies.', 'elasticpress' );
 
@@ -128,7 +128,7 @@ class Facets extends Feature {
 			<div class="input-wrap">
 				<label><input name="settings[match_type]" type="radio" <?php checked( $settings['match_type'], 'all' ); ?> value="all"><?php echo wp_kses_post( __( 'Show any content tagged to <strong>all</strong> selected terms', 'elasticpress' ) ); ?></label><br>
 				<label><input name="settings[match_type]" type="radio" <?php checked( $settings['match_type'], 'any' ); ?> value="any"><?php echo wp_kses_post( __( 'Show all content tagged to <strong>any</strong> selected term', 'elasticpress' ) ); ?></label>
-				<p class="field-description"><?php esc_html_e( '"All" will only show content that matches all facets. "Any" will show content that matches any facet.', 'elasticpress' ); ?></p>
+				<p class="field-description"><?php esc_html_e( '"All" will only show content that matches all filters. "Any" will show content that matches any filter.', 'elasticpress' ); ?></p>
 			</div>
 		</div>
 		<?php
@@ -490,7 +490,7 @@ class Facets extends Feature {
 		<p>
 			<?php
 			// translators: URL
-			echo wp_kses_post( sprintf( __( "Adds a <a href='%s'>Facet widget</a> that administrators can add to the website's sidebars (widgetized areas), so that visitors can filter applicable content and search results by one or more taxonomy terms.", 'elasticpress' ), esc_url( admin_url( 'widgets.php' ) ) ) );
+			echo wp_kses_post( sprintf( __( "Adds <a href='%s'>Filter widgets</a> that administrators can add to the website's sidebars (widgetized areas), so that visitors can filter applicable content and search results by one or more taxonomy terms.", 'elasticpress' ), esc_url( admin_url( 'widgets.php' ) ) ) );
 			?>
 		</p>
 		<?php

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -154,7 +154,7 @@ class InstantResults extends Feature {
 			</div>
 		</div>
 		<div class="field">
-			<label for="feature_instant_results_facets" class="field-name status"><?php esc_html_e( 'Facets', 'elasticpress' ); ?></label>
+			<label for="feature_instant_results_facets" class="field-name status"><?php esc_html_e( 'Filters', 'elasticpress' ); ?></label>
 			<div class="input-wrap">
 				<input value="<?php echo esc_attr( $this->settings['facets'] ); ?>" type="text" name="settings[facets]" id="feature_instant_results_facets">
 			</div>
@@ -170,7 +170,7 @@ class InstantResults extends Feature {
 					<input name="settings[match_type]" type="radio" <?php checked( $this->settings['match_type'], 'any' ); ?> value="any">
 					<?php echo wp_kses_post( __( 'Show all content tagged to <strong>any</strong> selected term', 'elasticpress' ) ); ?>
 				</label>
-				<p class="field-description"><?php esc_html_e( '"All" will only show content that matches all facets. "Any" will show content that matches any facet.', 'elasticpress' ); ?></p>
+				<p class="field-description"><?php esc_html_e( '"All" will only show content that matches all filters. "Any" will show content that matches any filter.', 'elasticpress' ); ?></p>
 			</div>
 		</div>
 		<div class="field">

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -56,7 +56,7 @@ class WooCommerce extends Feature {
 
 		$this->title = esc_html__( 'WooCommerce', 'elasticpress' );
 
-		$this->summary = __( '“I want a cotton, woman’s t-shirt, for under $15 that’s in stock.” Faceted product browsing strains servers and increases load times. Your buyers can find the perfect product quickly, and buy it quickly.', 'elasticpress' );
+		$this->summary = __( '“I want a cotton, woman’s t-shirt, for under $15 that’s in stock.” Filtered product browsing strains servers and increases load times. Your buyers can find the perfect product quickly, and buy it quickly.', 'elasticpress' );
 
 		$this->docs_url = __( 'https://elasticpress.zendesk.com/hc/en-us/articles/360050447492-Configuring-ElasticPress-via-the-Plugin-Dashboard#woocommerce', 'elasticpress' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,7 @@ __Search__: Instantly find the content you’re looking for. The first time.
 
 __Instant Results__: A built for WordPress search experience that bypasses WordPress for optimal performance. Instant Results routes search queries through a dedicated API, separate from WordPress, returning results up to 10x faster than previous versions of ElasticPress.
 
-__WooCommerce__: “I want a cotton, woman’s t-shirt, for under $15 that’s in stock.” Faceted product browsing strains servers and increases load times. Your buyers can find the perfect product quickly, and buy it quickly.
+__WooCommerce__: “I want a cotton, woman’s t-shirt, for under $15 that’s in stock.” Filtered product browsing strains servers and increases load times. Your buyers can find the perfect product quickly, and buy it quickly.
 
 __Related Posts__: ElasticPress understands data in real time, so it can instantly deliver engaging and precise related content with no impact on site performance.
 
@@ -27,7 +27,7 @@ __Documents__: Indexes text inside of popular file types, and adds those files t
 
 __Autosuggest__: Suggest relevant content as text is entered into the search field.
 
-__Facets__: Add controls to your website to filter content by one or more taxonomies.
+__Filters__: Add controls to your website to filter content by one or more taxonomies.
 
 __Users__: Improve user search relevancy and query performance.
 


### PR DESCRIPTION
### Description of the Change
Renames the "Facets" feature to "Filters".

The change is made in user-facing copy only. In code the feature is still referred to as Facets, and links to external documentation remain pointed to documentation on Facets. References in the changelog have _not_ been retrospectively updated.

### How to test the Change
On the _ElasticPress > Features_ page, any references to facets should now reference filters.

### Changelog Entry
Changed - Renamed the Facets feature to Filters.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
