### PR TITLE
Rely on WP site-default option + only display available langs

### DIFF
--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -168,12 +168,12 @@ $bulk_setting = Utils\get_option( 'ep_bulk_setting', 350 );
 
 						wp_dropdown_languages(
 							[
-								'id'                          => 'ep_language',
-								'name'                        => 'ep_language',
-								'selected'                    => $ep_language,
-								'languages'                   => Dashboard\get_available_languages( 'locales' ),
-								'show_option_site_default'    => true,
-								'explicit_option_en_us'       => true,
+								'id'                       => 'ep_language',
+								'name'                     => 'ep_language',
+								'selected'                 => $ep_language,
+								'languages'                => Dashboard\get_available_languages( 'locales' ),
+								'show_option_site_default' => true,
+								'explicit_option_en_us'    => true,
 								'show_available_translations' => false,
 							]
 						);

--- a/includes/partials/settings-page.php
+++ b/includes/partials/settings-page.php
@@ -6,8 +6,9 @@
  * @package elasticpress
  */
 
-use ElasticPress\Utils as Utils;
-use ElasticPress\Elasticsearch as Elasticsearch;
+use ElasticPress\Dashboard;
+use ElasticPress\Utils;
+use ElasticPress\Elasticsearch;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -165,21 +166,17 @@ $bulk_setting = Utils\get_option( 'ep_bulk_setting', 350 );
 						<?php
 						$ep_language = Utils\get_language();
 
-						$dropdown = wp_dropdown_languages(
+						wp_dropdown_languages(
 							[
-								'id'       => 'ep_language',
-								'name'     => 'ep_language',
-								'selected' => $ep_language,
-								'echo'     => false,
+								'id'                          => 'ep_language',
+								'name'                        => 'ep_language',
+								'selected'                    => $ep_language,
+								'languages'                   => Dashboard\get_available_languages( 'locales' ),
+								'show_option_site_default'    => true,
+								'explicit_option_en_us'       => true,
+								'show_available_translations' => false,
 							]
 						);
-
-						$default_site_option = sprintf(
-							"<option value='ep_site_default'>%s</option>",
-							__( 'Default to Site Language', 'elasticpress' )
-						);
-
-						echo preg_replace( '/<select(.*?)>/', "<select$1>{$default_site_option}", $dropdown ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						?>
 						<p class="description"><?php esc_html_e( 'Default language for your Elasticsearch mapping.', 'elasticpress' ); ?></p>
 					</td>

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -510,13 +510,13 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 }
 
 /**
- * Returns the defaiult language for ES mapping.
+ * Returns the default language for ES mapping.
  *
  * @return string Default EP language.
  */
 function get_language() {
 	$ep_language = get_option( 'ep_language' );
-	$ep_language = ! empty( $ep_language ) ? $ep_language : 'ep_site_default';
+	$ep_language = ! empty( $ep_language ) ? $ep_language : 'site-default';
 
 	/**
 	 * Filter the default language to use at index time

--- a/tests/php/TestDashboard.php
+++ b/tests/php/TestDashboard.php
@@ -105,7 +105,7 @@ class TestDashboard extends BaseTestCase {
 	}
 
 	/**
-	 * Test the `use_language_in_setting` function when on multisite using `ep_site_default`
+	 * Test the `use_language_in_setting` function when on multisite using `site-default`
 	 *
 	 * @group skip-on-single-site
 	 * @group dashboard
@@ -138,5 +138,37 @@ class TestDashboard extends BaseTestCase {
 		 */
 		switch_to_blog( $site_he_il );
 		$this->assertSame( 'english', Dashboard\use_language_in_setting() );
+	}
+
+	/**
+	 * Test the `get_available_languages` function
+	 *
+	 * @group dashboard
+	 */
+	public function test_get_available_languages() {
+		$languages = Dashboard\get_available_languages();
+		$this->assertSame( [ 'ar', 'ary' ], $languages['arabic'] );
+		$this->assertSame( [ 'th' ], $languages['thai'] );
+
+		$languages = Dashboard\get_available_languages( 'locales' );
+		$this->assertContains( 'ar', $languages );
+		$this->assertContains( 'ary', $languages );
+		$this->assertContains( 'th', $languages );
+	}
+
+	/**
+	 * Test the `ep_available_languages` filter
+	 *
+	 * @group dashboard
+	 */
+	public function test_get_available_languages_ep_available_languages_filter() {
+		$add_language = function ( $languages ) {
+			$languages['custom'] = [ 'cu_ST', 'om' ];
+			return $languages;
+		};
+		add_filter( 'ep_available_languages', $add_language );
+
+		$languages = Dashboard\get_available_languages();
+		$this->assertSame( [ 'cu_ST', 'om' ], $languages['custom'] );
 	}
 }

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -445,7 +445,7 @@ class TestUtils extends BaseTestCase {
 	 * @group utils
 	 */
 	public function test_get_language() {
-		$this->assertSame( 'ep_site_default', Utils\get_language() );
+		$this->assertSame( 'site-default', Utils\get_language() );
 
 		$set_lang_via_option = function() {
 			return 'custom_via_option';


### PR DESCRIPTION
### Description of the Change

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3586

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Changed - Only display available languages in the Settings screen


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT and @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
