### PR TITLE
Remove remaining reference to Facets.

### DIFF
--- a/assets/js/blocks/facets/post-type/edit.js
+++ b/assets/js/blocks/facets/post-type/edit.js
@@ -56,7 +56,7 @@ const FacetBlockEdit = (props) => {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={__('Facet Settings', 'elasticpress')}>
+				<PanelBody title={__('Settings', 'elasticpress')}>
 					<FacetSearchPlaceholderControl
 						onChange={onChangeSearchPlaceholder}
 						value={searchPlaceholder}

--- a/includes/classes/Feature/Facets/Types/Taxonomy/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Widget.php
@@ -34,7 +34,7 @@ class Widget extends WP_Widget {
 			'show_instance_in_rest' => true,
 		);
 
-		parent::__construct( 'ep-facet', esc_html__( 'ElasticPress - Facet', 'elasticpress' ), $options );
+		parent::__construct( 'ep-facet', esc_html__( 'ElasticPress - Filter by Taxonomy', 'elasticpress' ), $options );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
Removes a remaining reference to Facets, instead of Filters.

### Changelog Entry
N/A

### Credits
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
