### PR TITLE
Create a default_search analyzer

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -379,8 +379,8 @@ class Synonyms {
 		}
 
 		// Ensure we have analyzers and that it is an array.
-		if ( ! isset( $mapping['settings']['analysis']['analyzer']['default']['filter'] )
-			|| ! is_array( $mapping['settings']['analysis']['analyzer']['default']['filter'] )
+		if ( ! isset( $mapping['settings']['analysis']['analyzer']['default_search']['filter'] )
+			|| ! is_array( $mapping['settings']['analysis']['analyzer']['default_search']['filter'] )
 		) {
 			return $mapping;
 		}
@@ -389,10 +389,10 @@ class Synonyms {
 		$mapping['settings']['analysis']['filter'][ $filter_name ] = $this->get_synonym_filter();
 
 		// Tell the analyzer to use our newly created filter.
-		$mapping['settings']['analysis']['analyzer']['default']['filter'] = array_values(
+		$mapping['settings']['analysis']['analyzer']['default_search']['filter'] = array_values(
 			array_merge(
 				[ $filter_name ],
-				$mapping['settings']['analysis']['analyzer']['default']['filter']
+				$mapping['settings']['analysis']['analyzer']['default_search']['filter']
 			)
 		);
 
@@ -464,7 +464,7 @@ class Synonyms {
 			function( $success, $index ) {
 				$filter  = $this->get_synonym_filter();
 				$mapping = Elasticsearch::factory()->get_mapping( $index );
-				$filters = $mapping[ $index ]['settings']['index']['analysis']['analyzer']['default']['filter'];
+				$filters = $mapping[ $index ]['settings']['index']['analysis']['analyzer']['default_search']['filter'];
 
 				/*
 				 * Due to limitations in Elasticsearch, we can't remove the filter and analyzer
@@ -479,7 +479,7 @@ class Synonyms {
 				$setting['index']['analysis']['filter']['ep_synonyms_filter'] = $filter;
 
 				// Add the analyzer.
-				$setting['index']['analysis']['analyzer']['default']['filter'] = array_values(
+				$setting['index']['analysis']['analyzer']['default_search']['filter'] = array_values(
 					array_unique(
 						array_merge(
 							[ $this->get_synonym_filter_name() ],

--- a/includes/mappings/post/5-2.php
+++ b/includes/mappings/post/5-2.php
@@ -48,24 +48,19 @@ return array(
 			'analyzer'   => array(
 				'default'          => array(
 					'tokenizer'   => 'standard',
-					/**
-					 * Filter Elasticsearch default analyzer's filters
-					 *
-					 * @since 3.6.2
-					 * @hook ep_default_analyzer_filters
-					 * @param  {array<string>} $filters Default filters
-					 * @return {array<string>} New filters
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
-					/**
-					 * Filter Elasticsearch default analyzer's char_filter
-					 *
-					 * @since 4.2.2
-					 * @hook ep_default_analyzer_char_filters
-					 * @param  {array<string>} $char_filters Default filter
-					 * @return {array<string>} New filters
-					 */
+					/* This filter is documented in includes/mappings/post/7-0.php */
 					'char_filter' => apply_filters( 'ep_default_analyzer_char_filters', array( 'html_strip' ) ),
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'language'    => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
+				),
+				'default_search'   => array(
+					'tokenizer'   => 'standard',
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'standard', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					/* This filter is documented in includes/mappings/post/7-0.php */
+					'char_filter' => apply_filters( 'ep_default_search_analyzer_char_filters', array( 'html_strip' ) ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'    => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				),

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -127,23 +127,23 @@ return array(
 				),
 			),
 			'filter'     => array(
-				'shingle_filter'     => array(
+				'shingle_filter' => array(
 					'type'             => 'shingle',
 					'min_shingle_size' => 2,
 					'max_shingle_size' => 5,
 				),
-				'ewp_snowball'       => array(
+				'ewp_snowball'   => array(
 					'type'     => 'snowball',
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
-				'edge_ngram'         => array(
+				'edge_ngram'     => array(
 					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
 				),
-				'ep_stop'            => [
+				'ep_stop'        => [
 					'type'        => 'stop',
 					'ignore_case' => true,
 					/* This filter is documented in includes/mappings/post/7-0.php */

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -72,7 +72,7 @@ return array(
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters
 					 */
-					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
 					/**
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *
@@ -131,10 +131,6 @@ return array(
 					'type'             => 'shingle',
 					'min_shingle_size' => 2,
 					'max_shingle_size' => 5,
-				),
-				'ewp_word_delimiter' => array(
-					'type'              => 'word_delimiter_graph',
-					'preserve_original' => true,
 				),
 				'ewp_snowball'       => array(
 					'type'     => 'snowball',

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -102,7 +102,7 @@ return array(
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters
 					 */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
 					/**
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -92,6 +92,29 @@ return array(
 					 */
 					'language'    => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				),
+				'default_search'   => array(
+					'tokenizer'   => 'standard',
+					/**
+					 * Filter Elasticsearch default analyzer's filters
+					 *
+					 * @since 5.0.0
+					 * @hook ep_default_search_analyzer_filters
+					 * @param  {array<string>} $filters Default filters
+					 * @return {array<string>} New filters
+					 */
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					/**
+					 * Filter Elasticsearch default analyzer's char_filter
+					 *
+					 * @since 5.0.0
+					 * @hook ep_default_search_analyzer_char_filters
+					 * @param  {array<string>} $char_filters Default filter
+					 * @return {array<string>} New filters
+					 */
+					'char_filter' => apply_filters( 'ep_default_search_analyzer_char_filters', array( 'html_strip' ) ),
+					/* This filter is documented above */
+					'language'    => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
+				),
 				'shingle_analyzer' => array(
 					'type'      => 'custom',
 					'tokenizer' => 'standard',

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -102,7 +102,7 @@ return array(
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters
 					 */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
 					/**
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -354,10 +354,10 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				/**
 				 * Perform a search.
 				 */
-				cy.intercept('*search=wordpre*').as('apiRequest');
+				cy.intercept('*search=wordpless*').as('apiRequest');
 				cy.visit('/');
 				cy.get('.wp-block-search').last().as('searchBlock');
-				cy.get('@searchBlock').find('input[type="search"]').type('wordpre');
+				cy.get('@searchBlock').find('input[type="search"]').type('wordpless');
 				cy.get('@searchBlock').find('button').click();
 				cy.get('.ep-search-modal').should('be.visible');
 				cy.wait('@apiRequest');

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -75,15 +75,13 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 		cy.activatePlugin('woocommerce', 'wpCli');
 		cy.maybeEnableFeature('woocommerce');
 
-		cy.updateFeatures({
-			search: {
-				active: 1,
-				highlight_enabled: true,
-				highlight_excerpt: true,
-				highlight_tag: 'mark',
-				highlight_color: '#157d84',
-				decaying_enabled: 'disabled_includes_products',
-			},
+		cy.updateFeatures('search', {
+			active: 1,
+			highlight_enabled: true,
+			highlight_excerpt: true,
+			highlight_tag: 'mark',
+			highlight_color: '#157d84',
+			decaying_enabled: 'disabled_includes_products',
 		}).then(() => {
 			cy.updateWeighting({
 				product: {

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -78,7 +78,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 		cy.updateWeighting({
 			product: {
 				'meta._variations_skus.value': {
-					weight: 1,
+					weight: 10,
 					enabled: true,
 				},
 			},
@@ -90,7 +90,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 				 */
 				// eslint-disable-next-line cypress/no-unnecessary-waiting
 				cy.wait(2000);
-				cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
+				cy.visit('/?s=awesome-aluminum-shoes-variation-sku&explain');
 				cy.contains(
 					'.site-content article:nth-of-type(1) h2',
 					'Awesome Aluminum Shoes',

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -75,10 +75,20 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 		cy.activatePlugin('woocommerce', 'wpCli');
 		cy.maybeEnableFeature('woocommerce');
 
+		cy.updateFeatures({
+			search: {
+				active: 1,
+				highlight_enabled: true,
+				highlight_excerpt: true,
+				highlight_tag: 'mark',
+				highlight_color: '#157d84',
+				decaying_enabled: 'disabled_includes_products',
+			},
+		});
 		cy.updateWeighting({
 			product: {
 				'meta._variations_skus.value': {
-					weight: 10,
+					weight: 1,
 					enabled: true,
 				},
 			},
@@ -90,7 +100,7 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 				 */
 				// eslint-disable-next-line cypress/no-unnecessary-waiting
 				cy.wait(2000);
-				cy.visit('/?s=awesome-aluminum-shoes-variation-sku&explain');
+				cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
 				cy.contains(
 					'.site-content article:nth-of-type(1) h2',
 					'Awesome Aluminum Shoes',

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -84,27 +84,28 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 				highlight_color: '#157d84',
 				decaying_enabled: 'disabled_includes_products',
 			},
-		});
-		cy.updateWeighting({
-			product: {
-				'meta._variations_skus.value': {
-					weight: 1,
-					enabled: true,
-				},
-			},
 		}).then(() => {
-			cy.wpCli('elasticpress sync --setup --yes').then(() => {
-				/**
-				 * Give Elasticsearch some time. Apparently, if the visit happens right after the index, it won't find anything.
-				 *
-				 */
-				// eslint-disable-next-line cypress/no-unnecessary-waiting
-				cy.wait(2000);
-				cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
-				cy.contains(
-					'.site-content article:nth-of-type(1) h2',
-					'Awesome Aluminum Shoes',
-				).should('exist');
+			cy.updateWeighting({
+				product: {
+					'meta._variations_skus.value': {
+						weight: 1,
+						enabled: true,
+					},
+				},
+			}).then(() => {
+				cy.wpCli('elasticpress sync --setup --yes').then(() => {
+					/**
+					 * Give Elasticsearch some time. Apparently, if the visit happens right after the index, it won't find anything.
+					 *
+					 */
+					// eslint-disable-next-line cypress/no-unnecessary-waiting
+					cy.wait(2000);
+					cy.visit('/?s=awesome-aluminum-shoes-variation-sku');
+					cy.contains(
+						'.site-content article:nth-of-type(1) h2',
+						'Awesome Aluminum Shoes',
+					).should('exist');
+				});
 			});
 		});
 	});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -169,13 +169,16 @@ Cypress.Commands.add('publishPost', (postData, viewPost) => {
 	cy.wait(2000);
 });
 
-Cypress.Commands.add('updateFeatures', (newFeaturesValues = {}) => {
-	const features = { ...cy.elasticPress.defaultFeatures, ...newFeaturesValues };
-
-	const escapedFeatures = JSON.stringify(features);
+Cypress.Commands.add('updateFeatures', (featureName, newValues) => {
+	const escapedNewValues = JSON.stringify(newValues);
 
 	cy.wpCliEval(
-		`$features = json_decode( '${escapedFeatures}', true ); update_option( 'ep_feature_settings', $features );`,
+		`
+		$feature_settings = get_option( 'ep_feature_settings', [] );
+
+		$feature_settings['${featureName}'] = json_decode( '${escapedNewValues}', true );
+		update_option( 'ep_feature_settings', $feature_settings );
+		`,
 	);
 });
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -170,7 +170,7 @@ Cypress.Commands.add('publishPost', (postData, viewPost) => {
 });
 
 Cypress.Commands.add('updateFeatures', (newFeaturesValues = {}) => {
-	const features = Object.assign({}, cy.elasticPress.defaultFeatures, ...newFeaturesValues);
+	const features = { ...cy.elasticPress.defaultFeatures, ...newFeaturesValues };
 
 	const escapedFeatures = JSON.stringify(features);
 

--- a/tests/cypress/wordpress-files/test-docs/content-example.xml
+++ b/tests/cypress/wordpress-files/test-docs/content-example.xml
@@ -4834,7 +4834,7 @@
 sneakers, tennis shoes, trainers, runners
 
 # Defined alternatives (explicit mappings).
-shoes => sneaker, sandal, boots, high heels]]></content:encoded>
+shoes => shoes, sneaker, sandal, boots, high heels]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
 		<wp:post_id>2002</wp:post_id>
 		<wp:post_date><![CDATA[2021-02-17 15:48:58]]></wp:post_date>

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -125,4 +125,39 @@ class TestSynonyms extends BaseTestCase {
 		$this->assertEquals( 'foo, bar', $instance->validate_synonym( ' foo, bar ' ) );
 		$this->assertEquals( 'foo => bar', $instance->validate_synonym( ' foo => bar ' ) );
 	}
+
+	/**
+	 * Test synonyms with spaces
+	 *
+	 * @since 5.0.0
+	 * @group synonyms
+	 * @group skip-on-single-site
+	 */
+	public function test_synonyms_with_spaces() {
+		$instance = $this->getFeature();
+
+		wp_insert_post(
+			[
+				'ID'           => $instance->get_synonym_post_id(),
+				'post_content' => 'internet of things, IoT',
+				'post_type'    => $instance::POST_TYPE_NAME,
+			],
+			true
+		);
+		$instance->update_synonyms();
+
+		$post_id = $this->ep_factory->post->create( [ 'post_content' => 'IoT' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				's'      => 'internet of things',
+				'fields' => 'ids',
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertSame( $post_id, $query->posts['0'] );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2877

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Added a `default_search` analyzer to differentiate what is applied during sync and search time.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
