### PR TITLE
[WooCommerce] Order popularity DESC

### DIFF
--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -185,9 +185,9 @@ class Orders {
 	}
 
 	/**
-	 * Sets woocommerce meta search fields to an empty array if we are integrating the main query with ElasticSearch
+	 * Sets WooCommerce meta search fields to an empty array if we are integrating the main query with ElasticSearch
 	 *
-	 * Woocommerce calls this action as part of its own callback on parse_query. We add this filter only if the query
+	 * WooCommerce calls this action as part of its own callback on parse_query. We add this filter only if the query
 	 * is integrated with ElasticSearch.
 	 * If we were to always return array() on this filter, we'd break admin searches when WooCommerce module is activated
 	 * without the Protected Content Module

--- a/includes/classes/Feature/WooCommerce/Products.php
+++ b/includes/classes/Feature/WooCommerce/Products.php
@@ -917,11 +917,16 @@ class Products {
 		 */
 		$orderby = $query->get( 'orderby', null );
 		if ( $orderby && in_array( $orderby, [ 'price', 'popularity' ], true ) ) {
-			$order = $query->get( 'order', 'DESC' );
-			$query->set( 'order', $order );
-
-			$orderby_field = 'price' === $orderby ? '_price' : 'total_sales';
-			$query->set( 'orderby', $this->get_orderby_meta_mapping( $orderby_field ) );
+			switch ( $orderby ) {
+				case 'price':
+					$query->set( 'orderby', $this->get_orderby_meta_mapping( '_price' ) );
+					$query->set( 'order', $query->get( 'order' ) );
+					break;
+				case 'popularity':
+					$query->set( 'orderby', $this->get_orderby_meta_mapping( 'total_sales' ) );
+					$query->set( 'order', 'DESC' );
+					break;
+			}
 		}
 
 		/**

--- a/includes/classes/Feature/WooCommerce/Products.php
+++ b/includes/classes/Feature/WooCommerce/Products.php
@@ -893,7 +893,7 @@ class Products {
 		if ( empty( $search_term ) ) {
 			/**
 			 * For default sorting by popularity (total_sales) and rating
-			 * Woocommerce doesn't set the orderby correctly.
+			 * WooCommerce doesn't set the orderby correctly.
 			 * These lines will check the meta_key and correct the orderby based on that.
 			 * And this won't run in search result and only run in main query
 			 */

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -331,7 +331,7 @@ class WooCommerce extends Feature {
 	}
 
 	/**
-	 * DEPRECATED. Index Woocommerce meta
+	 * DEPRECATED. Index WooCommerce meta
 	 *
 	 * @param   array $meta Existing post meta.
 	 * @param   array $post Post arguments array.
@@ -362,7 +362,7 @@ class WooCommerce extends Feature {
 	}
 
 	/**
-	 * DEPRECATED. Index Woocommerce taxonomies
+	 * DEPRECATED. Index WooCommerce taxonomies
 	 *
 	 * @param   array $taxonomies Index taxonomies array.
 	 * @param   array $post Post properties array.
@@ -428,9 +428,9 @@ class WooCommerce extends Feature {
 	}
 
 	/**
-	 * DEPRECATED. Sets woocommerce meta search fields to an empty array if we are integrating the main query with ElasticSearch
+	 * DEPRECATED. Sets WooCommerce meta search fields to an empty array if we are integrating the main query with ElasticSearch
 	 *
-	 * Woocommerce calls this action as part of its own callback on parse_query. We add this filter only if the query
+	 * WooCommerce calls this action as part of its own callback on parse_query. We add this filter only if the query
 	 * is integrated with ElasticSearch.
 	 * If we were to always return array() on this filter, we'd break admin searches when WooCommerce module is activated
 	 * without the Protected Content Module


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3617

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed - WooCommerce products sorted by popularity are now always sorted in a descending order

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
