### PR TITLE
Replace Sync AJAX callback with REST API endpoint.

### DIFF
--- a/assets/js/sync-ui/config.js
+++ b/assets/js/sync-ui/config.js
@@ -3,7 +3,7 @@
  */
 const {
 	auto_start_index: autoIndex,
-	ajax_url: ajaxUrl,
+	api_url: apiUrl,
 	index_meta: indexMeta = null,
 	is_epio: isEpio,
 	ep_last_sync_date: lastSyncDateTime = null,
@@ -11,4 +11,4 @@ const {
 	nonce,
 } = window.epDash;
 
-export { autoIndex, ajaxUrl, indexMeta, isEpio, lastSyncDateTime, lastSyncFailed, nonce };
+export { autoIndex, apiUrl, indexMeta, isEpio, lastSyncDateTime, lastSyncFailed, nonce };

--- a/assets/js/sync-ui/index.js
+++ b/assets/js/sync-ui/index.js
@@ -8,7 +8,7 @@ import { SyncProvider } from '../sync';
  * Internal dependencies.
  */
 import {
-	ajaxUrl,
+	apiUrl,
 	autoIndex,
 	lastSyncDateTime,
 	lastSyncFailed,
@@ -25,7 +25,7 @@ import SettingsPage from './apps/settings-page';
  */
 const App = () => (
 	<SyncProvider
-		ajaxUrl={ajaxUrl}
+		apiUrl={apiUrl}
 		autoIndex={autoIndex}
 		defaultLastSyncDateTime={lastSyncDateTime}
 		defaultLastSyncFailed={lastSyncFailed}

--- a/assets/js/sync/index.js
+++ b/assets/js/sync/index.js
@@ -36,7 +36,7 @@ const Context = createContext();
  * App component.
  *
  * @param {object} props Component props.
- * @param {string} props.ajaxUrl AJAX URL endpoint.
+ * @param {string} props.apiUrl API endpoint URL.
  * @param {boolean} props.autoIndex Whether to start an index automatically.
  * @param {Function} props.children Component children
  * @param {string} props.defaultLastSyncDateTime Last sync date and time.
@@ -47,7 +47,7 @@ const Context = createContext();
  * @returns {WPElement} App component.
  */
 export const SyncProvider = ({
-	ajaxUrl,
+	apiUrl,
 	autoIndex,
 	children,
 	defaultLastSyncDateTime,
@@ -59,7 +59,7 @@ export const SyncProvider = ({
 	/**
 	 * Indexing methods.
 	 */
-	const { cancelIndex, index, indexStatus } = useIndex(ajaxUrl, nonce);
+	const { cancelIndex, index, indexStatus } = useIndex(apiUrl, nonce);
 
 	/**
 	 * Message log state.
@@ -261,7 +261,7 @@ export const SyncProvider = ({
 		 * messages. Returns a Promise that resolves if syncing should
 		 * continue.
 		 *
-		 * @param {object} response AJAX response.
+		 * @param {object} response API response.
 		 * @returns {Promise} Promise that resolves if sync is to continue.
 		 */
 		(response) => {

--- a/includes/classes/REST/Sync.php
+++ b/includes/classes/REST/Sync.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Sync REST API Controller
+ *
+ * @since 5.0.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress\REST;
+
+use ElasticPress\IndexHelper;
+use ElasticPress\Utils;
+
+/**
+ * Sync API controller class.
+ *
+ * @since 5.0.0
+ * @package elasticpress
+ */
+class Sync {
+
+	/**
+	 * Register routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'elasticpress/v1',
+			'sync',
+			[
+				'args'                => $this->get_args_schema(),
+				'callback'            => [ $this, 'sync' ],
+				'methods'             => 'POST',
+				'permission_callback' => [ $this, 'sync_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			'elasticpress/v1',
+			'sync',
+			[
+				'callback'            => [ $this, 'get_sync_status' ],
+				'methods'             => 'GET',
+				'permission_callback' => [ $this, 'sync_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			'elasticpress/v1',
+			'sync',
+			[
+				'callback'            => [ $this, 'cancel_sync' ],
+				'methods'             => 'DELETE',
+				'permission_callback' => [ $this, 'sync_permissions_check' ],
+			]
+		);
+	}
+
+	/**
+	 * Get args schema.
+	 *
+	 * @return array
+	 */
+	public function get_args_schema() {
+		return [
+			'include'               => [
+				'items' => [
+					'type' => 'integer',
+				],
+				'type'  => 'array',
+			],
+			'indexables'            => [
+				'items'    => [
+					'type' => 'string',
+				],
+				'required' => false,
+				'type'     => 'array',
+			],
+			'lower_limit_object_id' => [
+				'type'     => 'integer',
+				'required' => false,
+			],
+			'offset'                => [
+				'required' => false,
+				'type'     => 'integer',
+			],
+			'post_type'             => [
+				'items' => [
+					'type' => 'string',
+				],
+				'type'  => 'array',
+			],
+			'put_mapping'           => [
+				'default'  => false,
+				'type'     => 'boolean',
+				'required' => false,
+			],
+			'upper_limit_object_id' => [
+				'type'     => 'integer',
+				'required' => false,
+			],
+		];
+	}
+
+	/**
+	 * Check that the request has permission to sync.
+	 *
+	 * @return boolean
+	 */
+	public function sync_permissions_check() {
+		$capability = Utils\get_capability();
+
+		return current_user_can( $capability );
+	}
+
+	/**
+	 * Start or continue a sync.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return void
+	 */
+	public function sync( \WP_REST_Request $request ) {
+		$index_meta = Utils\get_indexing_status();
+
+		if ( isset( $index_meta['method'] ) && 'cli' === $index_meta['method'] ) {
+			$this->get_sync_status( $request );
+			exit;
+		}
+
+		$args = array_merge(
+			[
+				'method'        => 'dashboard',
+				'network_wide'  => 0,
+				'output_method' => [ $this, 'output' ],
+				'show_errors'   => true,
+			],
+			$request->get_params()
+		);
+
+		IndexHelper::factory()->full_index( $args );
+	}
+
+	/**
+	 * Output the result of indexing.
+	 *
+	 * @param array $message Index details.
+	 * @return void
+	 */
+	public function output( array $message ) {
+		switch ( $message['status'] ) {
+			case 'success':
+				wp_send_json_success( $message );
+				break;
+			case 'error':
+				wp_send_json_error( $message );
+				break;
+			default:
+				wp_send_json( [ 'data' => $message ] );
+				break;
+		}
+	}
+
+	/**
+	 * Get the status of a sync in progress.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return void
+	 */
+	public function get_sync_status( \WP_REST_Request $request ) {
+		$index_meta = Utils\get_indexing_status();
+
+		if ( isset( $index_meta['method'] ) && 'cli' === $index_meta['method'] ) {
+			wp_send_json_success(
+				[
+					'message'    => sprintf(
+						/* translators: 1. Number of objects indexed, 2. Total number of objects, 3. Last object ID. */
+						esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ),
+						$index_meta['offset'],
+						$index_meta['found_items'],
+						$index_meta['current_sync_item']['last_processed_object_id']
+					),
+					'index_meta' => $index_meta,
+				]
+			);
+		}
+
+		wp_send_json_success(
+			[
+				'is_finished' => true,
+				'totals'      => Utils\get_option( 'ep_last_index' ),
+			]
+		);
+	}
+
+	/**
+	 * Cancel a sync in progress.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return void
+	 */
+	public function cancel_sync( \WP_REST_Request $request ) {
+		$index_meta = Utils\get_indexing_status();
+
+		if ( isset( $index_meta['method'] ) && 'cli' === $index_meta['method'] ) {
+			set_transient( 'ep_wpcli_sync_interrupted', true, MINUTE_IN_SECONDS );
+			wp_send_json_success();
+			exit;
+		}
+
+		Utils\delete_option( 'ep_index_meta' );
+
+		wp_send_json_success();
+	}
+}

--- a/includes/classes/Screen/Sync.php
+++ b/includes/classes/Screen/Sync.php
@@ -141,6 +141,7 @@ class Sync {
 	/**
 	 * Register REST API routes.
 	 *
+	 * @since 5.0.0
 	 * @return void
 	 */
 	public function register_rest_routes() {

--- a/includes/classes/Screen/Sync.php
+++ b/includes/classes/Screen/Sync.php
@@ -8,11 +8,12 @@
 
 namespace ElasticPress\Screen;
 
-use ElasticPress\IndexHelper;
-use ElasticPress\Screen;
-use ElasticPress\Utils;
-use ElasticPress\Stats;
 use ElasticPress\Elasticsearch;
+use ElasticPress\IndexHelper;
+use ElasticPress\REST;
+use ElasticPress\Screen;
+use ElasticPress\Stats;
+use ElasticPress\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -29,100 +30,8 @@ class Sync {
 	 * Initialize class
 	 */
 	public function setup() {
-		add_action( 'wp_ajax_ep_index', [ $this, 'action_wp_ajax_ep_index' ] );
-		add_action( 'wp_ajax_ep_index_status', [ $this, 'action_wp_ajax_ep_index_status' ] );
-		add_action( 'wp_ajax_ep_cancel_index', [ $this, 'action_wp_ajax_ep_cancel_index' ] );
-
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-	}
-
-	/**
-	 * Getting the status of ongoing index fired by WP CLI
-	 *
-	 * @since  3.6.0
-	 */
-	public function action_wp_ajax_ep_index_status() {
-		if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) || ! EP_DASHBOARD_SYNC ) {
-			wp_send_json_error( null, 403 );
-			exit;
-		}
-
-		$index_meta = Utils\get_indexing_status();
-
-		if ( isset( $index_meta['method'] ) && 'cli' === $index_meta['method'] ) {
-			wp_send_json_success(
-				[
-					'message'    => sprintf(
-						/* translators: 1. Number of objects indexed, 2. Total number of objects, 3. Last object ID */
-						esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ),
-						$index_meta['offset'],
-						$index_meta['found_items'],
-						$index_meta['current_sync_item']['last_processed_object_id']
-					),
-					'index_meta' => $index_meta,
-				]
-			);
-		}
-
-		wp_send_json_success(
-			[
-				'is_finished' => true,
-				'totals'      => Utils\get_option( 'ep_last_index' ),
-			]
-		);
-	}
-
-	/**
-	 * Perform index
-	 *
-	 * @since 3.6.0
-	 */
-	public function action_wp_ajax_ep_index() {
-		if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) || ! EP_DASHBOARD_SYNC ) {
-			wp_send_json_error( null, 403 );
-			exit;
-		}
-
-		$index_meta = Utils\get_indexing_status();
-
-		if ( isset( $index_meta['method'] ) && 'cli' === $index_meta['method'] ) {
-			$this->action_wp_ajax_ep_index_status();
-			exit;
-		}
-
-		IndexHelper::factory()->full_index(
-			[
-				'method'        => 'dashboard',
-				'put_mapping'   => ! empty( $_REQUEST['put_mapping'] ),
-				'output_method' => [ $this, 'index_output' ],
-				'show_errors'   => true,
-				'network_wide'  => 0,
-			]
-		);
-	}
-
-	/**
-	 * Cancel index
-	 *
-	 * @since 3.6.0
-	 */
-	public function action_wp_ajax_ep_cancel_index() {
-		if ( ! check_ajax_referer( 'ep_dashboard_nonce', 'nonce', false ) || ! EP_DASHBOARD_SYNC ) {
-			wp_send_json_error( null, 403 );
-			exit;
-		}
-
-		$index_meta = Utils\get_indexing_status();
-
-		if ( isset( $index_meta['method'] ) && 'cli' === $index_meta['method'] ) {
-			set_transient( 'ep_wpcli_sync_interrupted', true, MINUTE_IN_SECONDS );
-			wp_send_json_success();
-			exit;
-		}
-
-		Utils\delete_option( 'ep_index_meta' );
-
-		wp_send_json_success();
+		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 	}
 
 	/**
@@ -156,7 +65,7 @@ class Sync {
 			Utils\get_asset_info( 'sync-styles', 'version' )
 		);
 
-		$data       = array( 'nonce' => wp_create_nonce( 'ep_dashboard_nonce' ) );
+		$data       = array( 'nonce' => wp_create_nonce( 'wp_rest' ) );
 		$index_meta = Utils\get_indexing_status();
 		$last_sync  = Utils\get_option( 'ep_last_sync', false );
 
@@ -214,7 +123,7 @@ class Sync {
 			]
 		);
 
-		$data['ajax_url']             = admin_url( 'admin-ajax.php' );
+		$data['api_url']              = rest_url( 'elasticpress/v1/sync' );
 		$data['install_sync']         = empty( $last_sync );
 		$data['install_complete_url'] = esc_url( $install_complete_url );
 		$data['sync_complete']        = esc_html__( 'Sync complete', 'elasticpress' );
@@ -230,24 +139,12 @@ class Sync {
 	}
 
 	/**
-	 * Output information received from the index helper class.
+	 * Register REST API routes.
 	 *
-	 * @param array $message Message to be outputted with its status and additional info, if needed.
+	 * @return void
 	 */
-	public static function index_output( $message ) {
-		switch ( $message['status'] ) {
-			case 'success':
-				wp_send_json_success( $message );
-				break;
-
-			case 'error':
-				wp_send_json_error( $message );
-				break;
-
-			default:
-				wp_send_json( [ 'data' => $message ] );
-				break;
-		}
-		exit;
+	public function register_rest_routes() {
+		$controller = new REST\Sync();
+		$controller->register_routes();
 	}
 }

--- a/tests/cypress/integration/dashboard-sync.cy.js
+++ b/tests/cypress/integration/dashboard-sync.cy.js
@@ -145,9 +145,9 @@ describe('Dashboard Sync', () => {
 		cy.visitAdminPage('admin.php?page=elasticpress-sync');
 
 		// Start sync via dashboard and pause it
-		cy.intercept('POST', '/wp-admin/admin-ajax.php*').as('ajaxRequest');
+		cy.intercept('POST', '/wp-json/elasticpress/v1/sync*').as('apiRequest');
 		cy.get('.ep-sync-button--sync').click();
-		cy.wait('@ajaxRequest').its('response.statusCode').should('eq', 200);
+		cy.wait('@apiRequest').its('response.statusCode').should('eq', 200);
 		cy.get('.ep-sync-button--pause').should('be.visible');
 
 		// Can not activate a feature.


### PR DESCRIPTION
### Description of the Change
Replaces the admin-ajax.php callbacks used by the Sync page with a REST API. This also adds support for additional arguments that are passed to the index helper:

- `include`
- `indexables`
- `lower_limit_object_id`
- `offset`
- `post_type`
- `put_mapping`
- `upper_limit_object_id`

This PR updates the Sync page to use the REST API, but there is no UI for the additional parameters at this stage.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3627

### How to test the Change
- Sync should function as normal.
- `POST` requests to `wp-json/elasticpress/v1/sync` with the above parameters should perform the expected sync.
- `GET` requests to `wp-json/elasticpress/v1/sync` should return the status of an in progress sync.
- `DELETE` requests to `wp-json/elasticpress/v1/sync` should cancel an in progress sync.

### Changelog Entry
> Changed - Moved syncing from an admin-ajax.php callback to a custom REST API endpoint with support for additional arguments.

### Credits
Props @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
