### PR TITLE
Manually enqueue facet meta range if in < WP 6.1

### DIFF
--- a/includes/classes/Feature/Facets/Types/MetaRange/Block.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Block.php
@@ -131,6 +131,16 @@ class Block extends \ElasticPress\Feature\Facets\Block {
 		$renderer_class = apply_filters( 'ep_facet_renderer_class', __NAMESPACE__ . '\Renderer', 'meta-range', 'block', $attributes );
 		$renderer       = new $renderer_class();
 
+		/**
+		 * Before WP 6.1, setting `viewScript` while having a `render_callback` function
+		 * did not enqueue the script.
+		 *
+		 * @see https://core.trac.wordpress.org/changeset/54367
+		 */
+		if ( version_compare( get_bloginfo( 'version' ), '6.1', '<' ) ) {
+			wp_enqueue_script( 'ep-facets-meta-range-block-view-script' );
+		}
+
 		ob_start();
 
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-elasticpress-facet' ] );

--- a/includes/classes/Feature/Facets/Types/MetaRange/Block.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Block.php
@@ -132,8 +132,8 @@ class Block extends \ElasticPress\Feature\Facets\Block {
 		$renderer       = new $renderer_class();
 
 		/**
-		 * Before WP 6.1, setting `viewScript` while having a `render_callback` function
-		 * did not enqueue the script.
+		 * Prior to WP 6.1, if you set `viewScript` while using a `render_callback` function,
+		 * the script was not enqueued.
 		 *
 		 * @see https://core.trac.wordpress.org/changeset/54367
 		 */


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3603

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Display the meta range facet block in versions prior to WP 6.1

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
