### PR TITLE
Display sync history

### DIFF
--- a/includes/classes/Feature/Facets/Types/MetaRange/Block.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Block.php
@@ -131,6 +131,16 @@ class Block extends \ElasticPress\Feature\Facets\Block {
 		$renderer_class = apply_filters( 'ep_facet_renderer_class', __NAMESPACE__ . '\Renderer', 'meta-range', 'block', $attributes );
 		$renderer       = new $renderer_class();
 
+		/**
+		 * Before WP 6.1, setting `viewScript` while having a `render_callback` function
+		 * did not enqueue the script.
+		 *
+		 * @see https://core.trac.wordpress.org/changeset/54367
+		 */
+		if ( version_compare( get_bloginfo( 'version' ), '6.1', '<' ) ) {
+			wp_enqueue_script( 'ep-facets-meta-range-block-view-script' );
+		}
+
 		ob_start();
 
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-elasticpress-facet' ] );

--- a/includes/classes/Feature/Facets/Types/MetaRange/Block.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Block.php
@@ -132,8 +132,8 @@ class Block extends \ElasticPress\Feature\Facets\Block {
 		$renderer       = new $renderer_class();
 
 		/**
-		 * Before WP 6.1, setting `viewScript` while having a `render_callback` function
-		 * did not enqueue the script.
+		 * Prior to WP 6.1, if you set `viewScript` while using a `render_callback` function,
+		 * the script was not enqueued.
 		 *
 		 * @see https://core.trac.wordpress.org/changeset/54367
 		 */

--- a/tests/php/features/WooCommerce/TestWooCommerce.php
+++ b/tests/php/features/WooCommerce/TestWooCommerce.php
@@ -9,46 +9,12 @@ namespace ElasticPressTest;
 
 use ElasticPress;
 
+require_once __DIR__ . '/WooCommerceBaseTestCase.php';
+
 /**
  * WC test class
  */
-class TestWooCommerce extends BaseTestCase {
-
-	/**
-	 * Setup each test.
-	 *
-	 * @since 2.1
-	 * @group woocommerce
-	 */
-	public function set_up() {
-		global $wpdb;
-		parent::set_up();
-		$wpdb->suppress_errors();
-
-		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
-
-		wp_set_current_user( $admin_id );
-
-		ElasticPress\Elasticsearch::factory()->delete_all_indices();
-		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
-
-		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->sync_queue = [];
-
-		$this->setup_test_post_type();
-	}
-
-	/**
-	 * Clean up after each test. Reset our mocks
-	 *
-	 * @since 2.1
-	 * @group woocommerce
-	 */
-	public function tear_down() {
-		parent::tear_down();
-
-		$this->fired_actions = array();
-	}
-
+class TestWooCommerce extends WooCommerceBaseTestCase {
 	/**
 	 * Test search integration is on in general for product searches
 	 *

--- a/tests/php/features/WooCommerce/TestWooCommerceOrders.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceOrders.php
@@ -10,10 +10,12 @@ namespace ElasticPressTest;
 
 use ElasticPress;
 
+require_once __DIR__ . '/WooCommerceBaseTestCase.php';
+
 /**
  * WC orders test class
  */
-class TestWooCommerceOrders extends TestWooCommerce {
+class TestWooCommerceOrders extends WooCommerceBaseTestCase {
 	/**
 	 * Orders instance
 	 *

--- a/tests/php/features/WooCommerce/TestWooCommerceProduct.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceProduct.php
@@ -10,10 +10,12 @@ namespace ElasticPressTest;
 
 use ElasticPress;
 
+require_once __DIR__ . '/WooCommerceBaseTestCase.php';
+
 /**
  * WC products test class
  */
-class TestWooCommerceProduct extends TestWooCommerce {
+class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 	/**
 	 * Products instance
 	 *

--- a/tests/php/features/WooCommerce/WooCommerceBaseTestCase.php
+++ b/tests/php/features/WooCommerce/WooCommerceBaseTestCase.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * WooCommerce Base Test Case
+ *
+ * @since 5.0.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+/**
+ * WooCommerceBaseTestCase class
+ */
+class WooCommerceBaseTestCase extends BaseTestCase {
+	/**
+	 * Setup each test.
+	 *
+	 * @group woocommerce
+	 */
+	public function set_up() {
+		global $wpdb;
+		parent::set_up();
+		$wpdb->suppress_errors();
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $admin_id );
+
+		\ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		\ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+
+		\ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->sync_queue = [];
+
+		$this->setup_test_post_type();
+	}
+
+	/**
+	 * Clean up after each test. Reset our mocks
+	 *
+	 * @group woocommerce
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->fired_actions = array();
+	}
+}


### PR DESCRIPTION
### Description of the Change
Displays the sync history on the sync page. Currently limited to Completed syncs (with errors or not).

![elasticpress test_wp-admin_admin php_page=elasticpress-sync](https://github.com/10up/ElasticPress/assets/4100733/6dddd18d-eb30-4308-9d99-b423041b7a6e)

### How to test the Change
- Visit _ElasticPress > Sync_. A _Sync history_ panel should be visible with at least one previous sync (if coming from < 5.0.0).
- When a new sync is completed it should be added to the list automatically without a refresh.
- If a a sync is triggered via WP CLI that should be reflected in the the sync title.
- The history should not appear for the initial sync on a site, or after deleting an index.
- The _Delete and sync..._ and _Advanced options_ panels should only be visible if there is a sync history.

### Changelog Entry
Added - Added a sync history to the Sync page.


### Credits
Props @JakePT @felipeelia @brandwaffle @anjulahettige Apurv Ray


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
