### PR TITLE
Add feature settings REST API

### DIFF
--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -431,20 +431,19 @@ class DidYouMean extends Feature {
 				'label'   => __( 'Search behavior when no result is found', 'elasticpress' ),
 				'options' => [
 					[
-						[
-							'label' => __( 'Display the top suggestion', 'elasticpress' ),
-							'value' => 0,
-						],
-						[
-							'label' => __( 'Display all the suggestions', 'elasticpress' ),
-							'value' => 'list',
-						],
-						[
-							'label' => __( 'Automatically redirect the user to the top suggestion', 'elasticpress' ),
-							'value' => 'redirect',
-						],
+						'label' => __( 'Display the top suggestion', 'elasticpress' ),
+						'value' => '0',
+					],
+					[
+						'label' => __( 'Display all the suggestions', 'elasticpress' ),
+						'value' => 'list',
+					],
+					[
+						'label' => __( 'Automatically redirect the user to the top suggestion', 'elasticpress' ),
+						'value' => 'redirect',
 					],
 				],
+				'type'    => 'radio',
 			],
 		];
 	}

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -666,6 +666,7 @@ class Facets extends Feature {
 					'value' => 'any',
 				],
 			],
+			'type'    => 'radio',
 		];
 	}
 

--- a/includes/classes/REST/Features.php
+++ b/includes/classes/REST/Features.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Features REST API Controller
+ *
+ * @since 5.0.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress\REST;
+
+use ElasticPress\IndexHelper;
+use ElasticPress\Utils;
+
+/**
+ * Features API controller class.
+ *
+ * @since 5.0.0
+ * @package elasticpress
+ */
+class Features {
+
+	/**
+	 * Register routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'elasticpress/v1',
+			'features',
+			[
+				'args'                => $this->get_args(),
+				'callback'            => [ $this, 'update_settings' ],
+				'methods'             => 'PUT',
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+	}
+
+	/**
+	 * Get args schema.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		$args = [];
+
+		$features = \ElasticPress\Features::factory()->registered_features;
+
+		foreach ( $features as $feature ) {
+			$properties = [];
+
+			$schema = $feature->get_settings_schema();
+
+			foreach ( $schema as $schema ) {
+				$property = [ 'description' => $schema['label'] ];
+
+				switch ( $schema['type'] ) {
+					case 'select':
+					case 'radio':
+						$property['enum'] = array_map( fn( $o ) => $o['value'], $schema['options'] );
+						break;
+					case 'multiple':
+						$property['type'] = 'string';
+						break;
+					case 'checkbox':
+						$property['type'] = 'boolean';
+						break;
+					default:
+						$property['type'] = 'string';
+						break;
+				}
+
+				$properties[ $schema['key'] ] = $property;
+			}
+
+			$args[ $feature->slug ] = [
+				'description' => $feature->get_title(),
+				'properties'  => $properties,
+				'type'        => 'object',
+			];
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Check that the request has permission to sync.
+	 *
+	 * @return boolean
+	 */
+	public function check_permission() {
+		$capability = Utils\get_capability();
+
+		return current_user_can( $capability );
+	}
+
+	/**
+	 * Start or continue a sync.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return void
+	 */
+	public function update_settings( \WP_REST_Request $request ) {
+		$settings = $request->get_params();
+
+		Utils\update_option( 'ep_feature_settings', $settings );
+
+		wp_send_json_success();
+	}
+}

--- a/includes/classes/REST/Features.php
+++ b/includes/classes/REST/Features.php
@@ -53,6 +53,10 @@ class Features {
 			$schema = $feature->get_settings_schema();
 
 			foreach ( $schema as $schema ) {
+				if ( ! isset( $schema['label'] ) ) {
+					continue;
+				}
+
 				$property = [ 'description' => $schema['label'] ];
 
 				switch ( $schema['type'] ) {

--- a/includes/classes/Screen.php
+++ b/includes/classes/Screen.php
@@ -62,10 +62,12 @@ class Screen {
 		$this->sync_screen        = new Screen\Sync();
 		$this->health_info_screen = new Screen\HealthInfo();
 		$this->status_report      = new Screen\StatusReport();
+		$this->dashboard          = new Screen\Dashboard();
 
 		$this->sync_screen->setup();
 		$this->health_info_screen->setup();
 		$this->status_report->setup();
+		$this->dashboard->setup();
 	}
 
 	/**

--- a/includes/classes/Screen/Dashboard.php
+++ b/includes/classes/Screen/Dashboard.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Dashboard screen class.
+ *
+ * @since  3.6.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress\Screen;
+
+use ElasticPress\REST;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Dashboard screen.
+ *
+ * @since 5.0.0
+ * @package ElasticPress
+ */
+class Dashboard {
+	/**
+	 * Initialize class
+	 */
+	public function setup() {
+		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * @since 5.0.0
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		$controller = new REST\Features();
+		$controller->register_routes();
+	}
+}

--- a/includes/classes/Screen/Dashboard.php
+++ b/includes/classes/Screen/Dashboard.php
@@ -2,7 +2,7 @@
 /**
  * Dashboard screen class.
  *
- * @since  3.6.0
+ * @since 5.0.0
  * @package elasticpress
  */
 
@@ -31,7 +31,6 @@ class Dashboard {
 	/**
 	 * Register REST API routes.
 	 *
-	 * @since 5.0.0
 	 * @return void
 	 */
 	public function register_rest_routes() {


### PR DESCRIPTION
### Description of the Change
Adds a REST API endpoint at `/wp-json/elasticpress/v1/features` for updating feature settings. The endpoint uses the settings schema added to features by #3655 to provide validation for updating the `ep_feature_settings` via a `PUT` request.

This PR also creates a `Dashboard` screen class to register the endpoint (for consistency with Sync). The name dashboard was for consistency with the `dashboard-page.php` file used to render it.

### How to test the Change
1. Make an `OPTIONS` request to `/wp-json/elasticpress/v1/features`. The feature settings and their types and possible values should be shown as supported `args`.
2. Copy the saved `ep_feature_settings` option from the database and unserialize it as JSON. Make modifications and send it as the body in a `PUT` request to `/wp-json/elasticpress/v1/features`. Valid changes according to the definitions in the `OPTIONS` response should update the feature settings, and be reflected in the admin, while changes that are invalid should result in a 400 error.

### Changelog Entry
Added - Added a REST API endpoint at `elasticpress/v1/features` for updating feature settings.


### Credits
Props @JakePT 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
