### PR TITLE
Fix ep_woocommerce_default_supported_post_types calls

### DIFF
--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -134,6 +134,11 @@ class Orders {
 	 * @return array
 	 */
 	public function add_order_items_search( $post_args, $post_id ) {
+		$order = wc_get_order( $post_id );
+		if ( ! $order ) {
+			return $post_args;
+		}
+
 		$searchable_post_types = $this->get_admin_searchable_post_types();
 
 		// Make sure it is only WooCommerce orders we touch.
@@ -144,7 +149,6 @@ class Orders {
 		$post_indexable = Indexables::factory()->get( 'post' );
 
 		// Get order items.
-		$order     = wc_get_order( $post_id );
 		$item_meta = [];
 		foreach ( $order->get_items() as $delta => $product_item ) {
 			// WooCommerce 3.x uses WC_Order_Item_Product instance while 2.x an array

--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -298,10 +298,10 @@ class Orders {
 		 *
 		 * @hook ep_woocommerce_orders_supported_post_types
 		 * @since 4.7.0
-		 * @param {array} $post_types Post types
+		 * @param {array} $supported_post_types Post types
 		 * @return {array} New post types
 		 */
-		$supported_post_types = apply_filters( 'ep_woocommerce_orders_supported_post_types', $post_types );
+		$supported_post_types = apply_filters( 'ep_woocommerce_orders_supported_post_types', $supported_post_types );
 
 		$supported_post_types = array_intersect(
 			$supported_post_types,

--- a/includes/classes/Feature/WooCommerce/Products.php
+++ b/includes/classes/Feature/WooCommerce/Products.php
@@ -740,11 +740,11 @@ class Products {
 		 *
 		 * @hook ep_woocommerce_products_supported_post_types
 		 * @since 4.7.0
-		 * @param {array}    $post_types Post types
-		 * @param {WP_Query} $query      The WP_Query object
+		 * @param {array}    $supported_post_types Post types
+		 * @param {WP_Query} $query                The WP_Query object
 		 * @return {array} New post types
 		 */
-		$supported_post_types = apply_filters( 'ep_woocommerce_products_supported_post_types', $post_types, $query );
+		$supported_post_types = apply_filters( 'ep_woocommerce_products_supported_post_types', $supported_post_types, $query );
 
 		$supported_post_types = array_intersect(
 			$supported_post_types,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3678

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Calls to `ep_woocommerce_default_supported_post_types` were ignored

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @MARQAS 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
