### PR TITLE
Fix disappearing Orders search field when using Orders Autosuggest

### DIFF
--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -11,6 +11,7 @@ import {
 	useRef,
 	WPElement,
 } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -298,13 +299,23 @@ export const ApiSearchProvider = ({
 
 			setIsLoading(true);
 
-			const response = await fetchResults(urlParams);
+			try {
+				const response = await fetchResults(urlParams);
 
-			if (!response) {
-				return;
+				if (!response) {
+					return;
+				}
+
+				setResults(response);
+			} catch (e) {
+				const errorMessage = sprintf(
+					__('ElasticPress: Unable to fetch results. %s', 'elasticpress'),
+					e.message,
+				);
+
+				console.error(errorMessage); // eslint-disable-line no-console
 			}
 
-			setResults(response);
 			setIsLoading(false);
 		};
 


### PR DESCRIPTION
### Description of the Change
Prevents a crash occurring in Instant Results and Orders Autosuggest for requests to the search API that return a non-200 or non-JSON response by catching and logging errors to the console.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3675

### How to test the Change
1. Enable Orders Autosuggest and sync.
2. Filter `ep_woocommerce_order_search_endpoint` to return any string that is not a valid seach endpoint.
3. Go to _WooCommerce > Orders_ and enter a search query without submitting.
4. The search form should not disappear.
5. Check the browser console. An error starting with "ElasticPress: Unable to fetch results." should be shown with the original error message. In this example it is likely "HTTP 404".

### Changelog Entry
Fixed - Fixed an issue where there WooCommerce Orders search field would disappear when Orders Autosuggest is receiving an unexpected response from ElasticPress.io.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT @anjulahettige 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
