### PR TITLE
Tear down WooCommerce functionalities when the plugin is not active

### DIFF
--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -48,6 +48,21 @@ class Orders {
 	}
 
 	/**
+	 * Unsetup order related hooks
+	 *
+	 * @since 5.0.0
+	 */
+	public function tear_down() {
+		remove_filter( 'ep_sync_insert_permissions_bypass', [ $this, 'bypass_order_permissions_check' ] );
+		remove_filter( 'ep_prepare_meta_allowed_protected_keys', [ $this, 'allow_meta_keys' ] );
+		remove_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'add_order_items_search' ], 20 );
+		remove_filter( 'ep_pc_skip_post_content_cleanup', [ $this, 'keep_order_fields' ], 20 );
+		remove_action( 'parse_query', [ $this, 'maybe_hook_woocommerce_search_fields' ], 1 );
+		remove_action( 'parse_query', [ $this, 'search_order' ], 11 );
+		remove_action( 'pre_get_posts', [ $this, 'translate_args' ], 11 );
+	}
+
+	/**
 	 * Allow order creations on the front end to get synced
 	 *
 	 * @param  bool $override Original order perms check value

--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -65,6 +65,26 @@ class OrdersAutosuggest {
 	}
 
 	/**
+	 * Un-setup feature functionality.
+	 *
+	 * @since 5.0.0
+	 */
+	public function tear_down() {
+		remove_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		remove_filter( 'ep_after_update_feature', [ $this, 'after_update_feature' ] );
+		remove_filter( 'ep_after_sync_index', [ $this, 'epio_save_search_template' ] );
+		remove_filter( 'ep_saved_weighting_configuration', [ $this, 'epio_save_search_template' ] );
+		remove_filter( 'ep_indexable_post_status', [ $this, 'post_statuses' ] );
+		remove_filter( 'ep_indexable_post_types', [ $this, 'post_types' ] );
+		remove_action( 'rest_api_init', [ $this, 'rest_api_init' ] );
+		remove_filter( 'ep_post_sync_args', [ $this, 'filter_term_suggest' ] );
+		remove_filter( 'ep_post_mapping', [ $this, 'mapping' ] );
+		remove_action( 'ep_woocommerce_shop_order_search_fields', [ $this, 'set_search_fields' ] );
+		remove_filter( 'ep_index_posts_args', [ $this, 'maybe_query_password_protected_posts' ] );
+		remove_filter( 'posts_where', [ $this, 'maybe_set_posts_where' ] );
+	}
+
+	/**
 	 * Get the endpoint for WooCommerce Orders search.
 	 *
 	 * @return string WooCommerce orders search endpoint.

--- a/includes/classes/Feature/WooCommerce/Products.php
+++ b/includes/classes/Feature/WooCommerce/Products.php
@@ -63,6 +63,34 @@ class Products {
 	}
 
 	/**
+	 * Un-setup product related hooks
+	 *
+	 * @since 5.0.0
+	 */
+	public function tear_down() {
+		remove_action( 'ep_formatted_args', [ $this, 'price_filter' ] );
+		remove_filter( 'ep_prepare_meta_allowed_protected_keys', [ $this, 'allow_meta_keys' ] );
+		remove_filter( 'ep_sync_taxonomies', [ $this, 'sync_taxonomies' ] );
+		remove_filter( 'ep_term_suggest_post_type', [ $this, 'suggest_wc_add_post_type' ] );
+		remove_filter( 'ep_facet_include_taxonomies', [ $this, 'add_product_attributes' ] );
+		remove_filter( 'ep_weighting_fields_for_post_type', [ $this, 'add_product_attributes_to_weighting' ] );
+		remove_filter( 'ep_weighting_default_post_type_weights', [ $this, 'add_product_default_post_type_weights' ] );
+		remove_filter( 'ep_prepare_meta_data', [ $this, 'add_variations_skus_meta' ] );
+		remove_filter( 'request', [ $this, 'admin_product_list_request_query' ], 9 );
+		remove_action( 'pre_get_posts', [ $this, 'translate_args' ], 11 );
+		remove_filter( 'ep_facet_tax_special_slug_taxonomies', [ $this, 'add_taxonomy_attributes' ] );
+
+		// Custom product ordering
+		remove_action( 'ep_admin_notices', [ $this, 'maybe_display_notice_about_product_ordering' ] );
+		remove_action( 'woocommerce_after_product_ordering', [ $this, 'action_sync_on_woocommerce_sort_single' ] );
+
+		// Settings for Weight results by date
+		remove_action( 'ep_weight_settings_after_search', [ $this, 'add_weight_settings_search' ] );
+		remove_filter( 'ep_feature_settings_schema', [ $this, 'add_weight_settings_search_schema' ] );
+		remove_filter( 'ep_is_decaying_enabled', [ $this, 'maybe_disable_decaying' ] );
+	}
+
+	/**
 	 * Modifies main query to allow filtering by price with WooCommerce "Filter by price" widget.
 	 *
 	 * @param array    $args ES args

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -105,10 +105,14 @@ class WooCommerce extends Feature {
 	/**
 	 * Setup or tear down the functionality depending on the plugin being active for the current site.
 	 *
+	 * If the site wasn't initialized yet (it does not have its database tables created) we skip it.
+	 *
 	 * @since 5.0.0
+	 * @param int $blog_id Blog ID
+	 * @return void
 	 */
-	public function setup_or_tear_down() {
-		if ( \is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+	public function setup_or_tear_down( $blog_id ) {
+		if ( wp_is_site_initialized( $blog_id ) && \is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 			$this->setup();
 		} else {
 			$this->tear_down();

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -88,21 +88,36 @@ tests_add_filter( 'muplugins_loaded', __NAMESPACE__ . '\load_plugin' );
  * @since  3.0
  */
 function setup_wc() {
-	if ( class_exists( '\WC_Install' ) ) {
-		define( 'WP_UNINSTALL_PLUGIN', true );
-
-		update_option( 'woocommerce_status_options', array( 'uninstall_data' => 1 ) );
-		include_once __DIR__ . '/../../vendor/woocommerce/uninstall.php';
-
-		\WC_Install::install();
-
-		$GLOBALS['wp_roles'] = new \WP_Roles();
-
-		echo 'Installing WooCommerce version ' . WC()->version . ' ...' . PHP_EOL; // phpcs:ignore
+	if ( ! class_exists( '\WC_Install' ) ) {
+		return;
 	}
-}
 
+	define( 'WP_UNINSTALL_PLUGIN', true );
+
+	update_option( 'woocommerce_status_options', array( 'uninstall_data' => 1 ) );
+	include_once __DIR__ . '/../../vendor/woocommerce/uninstall.php';
+
+	\WC_Install::install();
+
+	$GLOBALS['wp_roles'] = new \WP_Roles();
+
+	echo 'Installing WooCommerce version ' . WC()->version . ' ...' . PHP_EOL; // phpcs:ignore
+}
 tests_add_filter( 'setup_theme', __NAMESPACE__ . '\setup_wc' );
+
+/**
+ * Set WooCommerce as an active plugin
+ *
+ * @since 5.0.0
+ * @param array $active_plugins Active plugins
+ * @return array
+ */
+function add_woocommerce_to_active_plugins( $active_plugins ) {
+	$active_plugins   = (array) $active_plugins;
+	$active_plugins[] = 'woocommerce/woocommerce.php';
+	return $active_plugins;
+}
+tests_add_filter( 'option_active_plugins', __NAMESPACE__ . '\add_woocommerce_to_active_plugins' );
 
 /**
  * Completely skip looking up translations


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #2865

### How to test the Change
1. Activate ElasticPress for the entire network
2. Activate WooCommerce just on the first site
3. Activate the WooCommerce EP feature
4. Run `wp cache flush` and `wp transient delete wc_attribute_taxonomies --url=<url_of_second_site>`
5. Run `wp elasticpress sync --setup --yes --network-wide`
6. See the warning in the error log
7. Apply the PR
8. Do the same steps and see the warning is gone

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - WooCommerce-related hooks are now removed when switching to a site that does not have WC active


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @MARQAS 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
