### PR TITLE
Bug fix - Correct `@param` type for `$attributes` parameter in `ep_facet_renderer_class` filter

### DIFF
--- a/includes/classes/Feature/Facets/Types/Taxonomy/Block.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Block.php
@@ -165,7 +165,7 @@ class Block extends \ElasticPress\Feature\Facets\Block {
 		 * @param {string} $classname  The name of the class to be instantiated and used as a renderer.
 		 * @param {string} $facet_type The type of the facet.
 		 * @param {string} $context    Context where the renderer will be used: `block` or `widget`, for example.
-		 * @param {string} $attributes Element attributes.
+		 * @param {array} $attributes Element attributes.
 		 * @return {string} The name of the class
 		 */
 		$renderer_class = apply_filters( 'ep_facet_renderer_class', __NAMESPACE__ . '\Renderer', 'taxonomy', 'block', $attributes );


### PR DESCRIPTION
Update filter documentation.

### Description of the Change
Corrects the `@param` type of `$attributes` parameter in the  `ep_facet_renderer_class` filter.

### How to test the Change
`Line 148` of `includes/classes/Feature/Facets/Types/Taxonomy/Block.php` should display as:

```php
@param {array} $attributes Element attributes.
```

### Changelog Entry
> Fixed - Bug fix

### Credits
@misfist

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
