### PR TITLE
Only update settings from schema.

### DIFF
--- a/includes/classes/REST/Features.php
+++ b/includes/classes/REST/Features.php
@@ -105,7 +105,29 @@ class Features {
 	 * @return void
 	 */
 	public function update_settings( \WP_REST_Request $request ) {
-		$settings = $request->get_params();
+		$settings = [];
+
+		$features = \ElasticPress\Features::factory()->registered_features;
+
+		foreach ( $features as $slug => $feature ) {
+			$param = $request->get_param( $slug );
+
+			if ( ! $param ) {
+				continue;
+			}
+
+			$settings[ $slug ] = [];
+
+			$schema = $feature->get_settings_schema();
+
+			foreach ( $schema as $schema ) {
+				$key = $schema['key'];
+
+				if ( isset( $param[ $key ] ) ) {
+					$settings[ $slug ][ $key ] = $param[ $key ];
+				}
+			}
+		}
 
 		Utils\update_option( 'ep_feature_settings', $settings );
 


### PR DESCRIPTION
### Description of the Change
The previous implementation of the Feature Settings API would also save all properties passed in the settings object that don't cause validation issues with the registered settings (it had been saving the _locale parameter of the request. This changes it so that only settings from the settings schema are saved.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
