### PR TITLE
Fix: HTML escape issue on the install page

### DIFF
--- a/includes/partials/install-page.php
+++ b/includes/partials/install-page.php
@@ -122,7 +122,7 @@ $skip_index_url = remove_query_arg( 'ep-skip-features', $skip_install_url );
 													</span>
 												</a>
 												<span role="tooltip" class="a11y-tip__help a11y-tip__help--top">
-													<?php echo wp_kses_post( $feature->summary ); ?>
+													   <?php echo wp_kses( $feature->summary, 'ep-html' ); ?>
 													<?php esc_html_e( 'Click to learn more.', 'elasticpress' ); ?>
 												</span>
 											</span>

--- a/includes/partials/install-page.php
+++ b/includes/partials/install-page.php
@@ -122,7 +122,7 @@ $skip_index_url = remove_query_arg( 'ep-skip-features', $skip_install_url );
 													</span>
 												</a>
 												<span role="tooltip" class="a11y-tip__help a11y-tip__help--top">
-													<?php echo esc_html( $feature->summary ); ?>
+													<?php echo wp_kses_post( $feature->summary ); ?>
 													<?php esc_html_e( 'Click to learn more.', 'elasticpress' ); ?>
 												</span>
 											</span>

--- a/includes/partials/install-page.php
+++ b/includes/partials/install-page.php
@@ -122,7 +122,7 @@ $skip_index_url = remove_query_arg( 'ep-skip-features', $skip_install_url );
 													</span>
 												</a>
 												<span role="tooltip" class="a11y-tip__help a11y-tip__help--top">
-													   <?php echo wp_kses( $feature->summary, 'ep-html' ); ?>
+													<?php echo wp_kses( $feature->summary, 'ep-html' ); ?>
 													<?php esc_html_e( 'Click to learn more.', 'elasticpress' ); ?>
 												</span>
 											</span>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the content of the tooltip on the install page is not showing properly.

Before
<img width="618" alt="image" src="https://github.com/10up/ElasticPress/assets/7139602/02318510-5a29-47bd-ae92-ac3cf6db6e2f">


After fix
<img width="618" alt="image" src="https://github.com/10up/ElasticPress/assets/7139602/ccdbc4a5-7e98-4daa-a46b-8aeaf544e202">


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Content was not showing properly on the tooltop on install page
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
