### PR TITLE
Fix: Sync page URL after enabling the feature that requires sync

### DIFF
--- a/assets/js/sync/src/utilities.js
+++ b/assets/js/sync/src/utilities.js
@@ -4,11 +4,9 @@
  * @returns {void}
  */
 export const clearSyncParam = () => {
-	window.history.replaceState(
-		{},
-		document.title,
-		document.location.pathname + document.location.search.replace(/&do_sync/, ''),
-	);
+	const url = new URL(document.location.href);
+	url.searchParams.delete('do_sync');
+	window.history.replaceState({}, document.title, url);
 };
 
 /**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes a issue where feature that requires sync redirect to wrong url.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Enable the feature that requires a new sync. Save the settings. 
2. The user is redirected to the Sync page. 
3. Refresh the page and the user gets an error message “Sorry, you are not allowed to access this page.”

<img width="1236" alt="image" src="https://github.com/10up/ElasticPress/assets/7139602/d32d4a2d-d469-4734-9753-cdf959ef0494">


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Redirect to correct sync url after enabling feature that requires a new sync
 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
