### PR TITLE
Fix: Post type setting wasn't respected during sync

### DIFF
--- a/assets/js/sync-ui/components/indexables.js
+++ b/assets/js/sync-ui/components/indexables.js
@@ -39,9 +39,9 @@ export default () => {
 			indexables.splice(indexables.indexOf(indexable), 1);
 		}
 
-		const post_types = !indexables.length || indexables.includes('post') ? args.post_types : [];
+		const post_type = !indexables.length || indexables.includes('post') ? args.post_type : [];
 
-		setArgs({ ...args, indexables, post_types });
+		setArgs({ ...args, indexables, post_type });
 	};
 
 	return indexables.length > 1 ? (

--- a/assets/js/sync-ui/components/post-types.js
+++ b/assets/js/sync-ui/components/post-types.js
@@ -28,15 +28,15 @@ export default () => {
 	 * @returns {void}
 	 */
 	const onChange = (postType, checked) => {
-		const post_types = [...args.post_types];
+		const post_type = [...args.post_type];
 
 		if (checked) {
-			post_types.push(postType);
+			post_type.push(postType);
 		} else {
-			post_types.splice(post_types.indexOf(postType), 1);
+			post_type.splice(post_type.indexOf(postType), 1);
 		}
 
-		setArgs({ ...args, post_types });
+		setArgs({ ...args, post_type });
 	};
 
 	return postTypes.length > 1 ? (
@@ -46,9 +46,9 @@ export default () => {
 			</legend>
 			{postTypes.map(([postType, label]) => (
 				<CheckboxControl
-					checked={args.post_types.includes(postType)}
+					checked={args.post_type.includes(postType)}
 					disabled={isSyncing}
-					indeterminate={!args.post_types.length}
+					indeterminate={!args.post_type.length}
 					key={postType}
 					label={label}
 					onChange={(checked) => onChange(postType, checked)}

--- a/assets/js/sync-ui/provider.js
+++ b/assets/js/sync-ui/provider.js
@@ -29,7 +29,7 @@ export const SyncSettingsProvider = ({ autoIndex, children, indexables, postType
 		lower_limit_object_id: null,
 		offset: 0,
 		put_mapping: false,
-		post_types: [],
+		post_type: [],
 		upper_limit_object_id: null,
 	});
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the Post Type wasn't respected during the sync from the dashboard. The problem was we were sending the `post_types` arg to the API where the IndexHelper accept `post_type`


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Go to Sync page.
2. Only select the Page post type
3. Make sure EP only sync the Pages


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Post type setting wasn't respected during sync
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
