### PR TITLE
Features backwards compatibility

### DIFF
--- a/assets/js/features/components/control.js
+++ b/assets/js/features/components/control.js
@@ -8,6 +8,7 @@ import {
 	RadioControl,
 	SelectControl,
 	TextControl,
+	TextareaControl,
 	ToggleControl,
 } from '@wordpress/components';
 import { safeHTML } from '@wordpress/dom';
@@ -216,6 +217,17 @@ export default ({
 									label={label}
 									onChange={onChange}
 									disabled={isDisabled}
+								/>
+							);
+						}
+						case 'textarea': {
+							return (
+								<TextareaControl
+									help={helpHtml}
+									label={label}
+									onChange={onChange}
+									disabled={isDisabled}
+									value={value}
 								/>
 							);
 						}

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -593,7 +593,7 @@ abstract class Feature {
 	}
 
 	/**
-	 * Default implementation of `set_settings_schema` basedd on the `default_settings` attribute
+	 * Default implementation of `set_settings_schema` based on the `default_settings` attribute
 	 *
 	 * @since 5.0.0
 	 */

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -165,7 +165,7 @@ abstract class Feature {
 	 *
 	 * @since  3.0
 	 */
-	abstract public function output_feature_box_long();
+	public function output_feature_box_long() {}
 
 	/**
 	 * Create feature
@@ -563,11 +563,7 @@ abstract class Feature {
 	 * @return array
 	 */
 	public function get_settings_schema() {
-		if ( [] === $this->settings_schema && method_exists( $this, 'set_settings_schema' ) ) {
-			$this->set_settings_schema();
-		}
-
-		$req_status = $this->requirements_status();
+		$this->set_settings_schema();
 
 		$active = [
 			'default'          => false,
@@ -594,5 +590,33 @@ abstract class Feature {
 		 * @return {array} New $settings_schema value
 		 */
 		return apply_filters( 'ep_feature_settings_schema', $settings_schema, $this->slug, $this );
+	}
+
+	/**
+	 * Default implementation of `set_settings_schema` basedd on the `default_settings` attribute
+	 *
+	 * @since 5.0.0
+	 */
+	protected function set_settings_schema() {
+		if ( [] === $this->default_settings ) {
+			return;
+		}
+
+		foreach ( $this->default_settings as $key => $default_value ) {
+			$type = 'text';
+			if ( in_array( $default_value, [ '0', '1' ], true ) ) {
+				$type = 'checkbox';
+			}
+			if ( is_bool( $default_value ) ) {
+				$type = 'toggle';
+			}
+
+			$this->settings_schema[] = [
+				'default' => $default_value,
+				'key'     => $key,
+				'label'   => $key,
+				'type'    => $type,
+			];
+		}
 	}
 }

--- a/tests/php/TestFeature.php
+++ b/tests/php/TestFeature.php
@@ -129,4 +129,65 @@ class TestFeature extends BaseTestCase {
 			$settings_schema
 		);
 	}
+
+	/**
+	 * Test set_settings_schema.
+	 *
+	 * @group feature
+	 */
+	public function test_set_settings_schema() {
+		$stub                   = $this->getMockForAbstractClass( '\ElasticPress\Feature' );
+		$stub->slug             = 'slug';
+		$stub->default_settings = [
+			'field_1' => '0',
+			'field_2' => '1',
+			'field_3' => 'text',
+			'field_4' => true,
+			'field_5' => false,
+		];
+
+		$this->assertSame(
+			[
+				[
+					'default'          => false,
+					'key'              => 'active',
+					'label'            => 'Enable',
+					'requires_feature' => false,
+					'requires_sync'    => false,
+					'type'             => 'toggle',
+				],
+				[
+					'default' => '0',
+					'key'     => 'field_1',
+					'label'   => 'field_1',
+					'type'    => 'checkbox',
+				],
+				[
+					'default' => '1',
+					'key'     => 'field_2',
+					'label'   => 'field_2',
+					'type'    => 'checkbox',
+				],
+				[
+					'default' => 'text',
+					'key'     => 'field_3',
+					'label'   => 'field_3',
+					'type'    => 'text',
+				],
+				[
+					'default' => true,
+					'key'     => 'field_4',
+					'label'   => 'field_4',
+					'type'    => 'toggle',
+				],
+				[
+					'default' => false,
+					'key'     => 'field_5',
+					'label'   => 'field_5',
+					'type'    => 'toggle',
+				],
+			],
+			$stub->get_settings_schema()
+		);
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Old features will have their settings displayed based on their default setting values.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
