### PR TITLE
Fix: Console error due to unavailability of key

### DIFF
--- a/assets/js/features/components/feature.js
+++ b/assets/js/features/components/feature.js
@@ -42,7 +42,11 @@ export default ({ feature }) => {
 			{/* eslint-disable-next-line react/no-danger */}
 			<p dangerouslySetInnerHTML={{ __html: safeHTML(summary) }} />
 			{reqStatusMessages.map((m) => (
-				<Notice isDismissible={false} status={reqStatusCode === 2 ? 'error' : 'warning'}>
+				<Notice
+					isDismissible={false}
+					status={reqStatusCode === 2 ? 'error' : 'warning'}
+					key={m}
+				>
 					{/* eslint-disable-next-line react/no-danger */}
 					<span dangerouslySetInnerHTML={{ __html: safeHTML(m) }} />
 				</Notice>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where clicking on the Instant Results throws an error in the console 

![image](https://github.com/10up/ElasticPress/assets/7139602/6860e417-2a8f-458e-9f50-14fea8c560cd)


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #
 
### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Console error when click on the Instant Results. 
 


### Credits
<!-- Please list any and all contributors on this @burhandodhy hat they can be added to this projects CREDITS.md file. -->
Props @burhan


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
