### PR TITLE
Fix Orders Autosuggest compatibility with WooCommerce 8.2

### DIFF
--- a/assets/css/woocommerce/admin/orders.css
+++ b/assets/css/woocommerce/admin/orders.css
@@ -1,8 +1,12 @@
 @import "components/combobox.css";
 @import "components/suggestion.css";
 
-#posts-filter .search-box {
-	position: relative;
+#posts-filter,
+#wc-orders-filter {
+
+	& .search-box {
+		position: relative;
+	}
 }
 
 #ep-woocommerce-order-search {

--- a/assets/js/woocommerce/admin/orders/index.js
+++ b/assets/js/woocommerce/admin/orders/index.js
@@ -103,7 +103,7 @@ const AuthenticatedApiSearchProvider = ({ children }) => {
  * @returns {void}
  */
 const init = async () => {
-	const form = document.getElementById('posts-filter');
+	const form = document.querySelector('#posts-filter, #wc-orders-filter');
 	const input = form.s;
 
 	if (!input) {

--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -135,12 +135,14 @@ class OrdersAutosuggest {
 	 * @param string $hook_suffix The current admin page.
 	 */
 	public function enqueue_admin_assets( $hook_suffix ) {
-		if ( 'edit.php' !== $hook_suffix ) {
+		if ( ! in_array( $hook_suffix, [ 'edit.php', 'woocommerce_page_wc-orders' ], true ) ) {
 			return;
 		}
 
-		if ( ! isset( $_GET['post_type'] ) || 'shop_order' !== $_GET['post_type'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return;
+		if ( 'edit.php' === $hook_suffix ) {
+			if ( ! isset( $_GET['post_type'] ) || 'shop_order' !== $_GET['post_type'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				return;
+			}
 		}
 
 		wp_enqueue_style(


### PR DESCRIPTION
### Description of the Change
WooCommerce has recently introduced High-performance Order Storage, which means that the admin Orders page is no longer a posts table. This resulted in markup changes that stopped Orders Autosuggest from working. This PR fixes those issues.

### How to test the Change
Orders Autosuggest should function as expected.

### Changelog Entry
Fixed - Orders Autosuggest compatibility with WooCommerce 8.2. **Note:** Orders Autosuggest requires WooCommerce to be configured to use high-performance order storage in compatibility mode, or legacy posts storage.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
