### PR TITLE
Better handle failed queries on the Stats page

### DIFF
--- a/includes/classes/Stats.php
+++ b/includes/classes/Stats.php
@@ -109,7 +109,7 @@ class Stats {
 		if ( ! empty( $return['errors'] ) ) {
 			$this->failed_queries[] = [
 				'path'  => $path,
-				'error' => json_encode( $return['errors'] ),
+				'error' => wp_json_encode( $return['errors'] ),
 			];
 		}
 

--- a/includes/partials/stats-page.php
+++ b/includes/partials/stats-page.php
@@ -25,15 +25,33 @@ if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 
 Stats::factory()->build_stats();
 
-$index_health = Stats::factory()->get_health();
-$totals       = Stats::factory()->get_totals();
+$index_health   = Stats::factory()->get_health();
+$totals         = Stats::factory()->get_totals();
+$failed_queries = Stats::factory()->get_failed_queries();
 ?>
 
 <div class="error-overlay <?php if ( ! empty( $index_meta ) ) : ?>syncing<?php endif; ?>"></div>
 <div class="wrap metabox-holder">
 	<h1><?php esc_html_e( 'Index Health', 'elasticpress' ); ?></h1>
 
-	<?php if ( ! empty( $index_health ) ) : ?>
+	<?php if ( ! empty( $failed_queries ) ) : ?>
+		<p>
+			<?php esc_html_e( 'It seems some requests to Elasticsearch failed and it was not possible to build your stats properly:', 'elasticpress' ); ?>
+		</p>
+		<ul>
+			<?php foreach ( $failed_queries as $failed_query ) : ?>
+				<li>
+					<?php
+					printf(
+						'<code>%1$s</code>: <code>%2$s</code>',
+						esc_html( $failed_query['path'] ),
+						esc_html( $failed_query['error'] )
+					);
+					?>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+	<?php elseif ( ! empty( $index_health ) ) : ?>
 		<div class="ep-flex-container">
 			<div class="stats-list postbox">
 				<h2 class="hndle stats-list-th"><span><?php esc_html_e( 'Index list', 'elasticpress' ); ?></span><span><?php esc_html_e( 'Health', 'elasticpress' ); ?></span></h2>

--- a/tests/php/TestStats.php
+++ b/tests/php/TestStats.php
@@ -8,6 +8,9 @@
 namespace ElasticPressTest;
 
 use ElasticPress;
+use ElasticPress\Elasticsearch;
+use ElasticPress\Indexables;
+use ElasticPress\Stats;
 
 /**
  * Stats test class
@@ -29,10 +32,10 @@ class TestStats extends BaseTestCase {
 
 		wp_set_current_user( $admin_id );
 
-		ElasticPress\Elasticsearch::factory()->delete_all_indices();
-		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+		Elasticsearch::factory()->delete_all_indices();
+		Indexables::factory()->get( 'post' )->put_mapping();
 
-		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->reset_sync_queue();
+		Indexables::factory()->get( 'post' )->sync_manager->reset_sync_queue();
 
 		$this->setup_test_post_type();
 
@@ -41,6 +44,8 @@ class TestStats extends BaseTestCase {
 		global $hook_suffix;
 		$hook_suffix = 'sites.php';
 		set_current_screen();
+
+		Stats::factory()->clear_failed_queries();
 	}
 
 	/**
@@ -65,15 +70,17 @@ class TestStats extends BaseTestCase {
 	 */
 	public function testTotals() {
 		$this->ep_factory->post->create();
-		ElasticPress\Elasticsearch::factory()->refresh_indices();
+		Elasticsearch::factory()->refresh_indices();
 
-		ElasticPress\Stats::factory()->build_stats();
+		Stats::factory()->build_stats();
 
-		$totals = ElasticPress\Stats::factory()->get_totals();
+		$totals = Stats::factory()->get_totals();
 
 		$this->assertEquals( 1, $totals['docs'] );
 		$this->assertTrue( ! empty( $totals['size'] ) );
 		$this->assertTrue( ! empty( $totals['memory'] ) );
+
+		$this->assertEmpty( Stats::factory()->get_failed_queries() );
 	}
 
 	/**
@@ -84,13 +91,69 @@ class TestStats extends BaseTestCase {
 	 */
 	public function testHealth() {
 		$this->ep_factory->post->create();
-		ElasticPress\Elasticsearch::factory()->refresh_indices();
+		Elasticsearch::factory()->refresh_indices();
 
-		ElasticPress\Stats::factory()->build_stats();
+		Stats::factory()->build_stats();
 
-		$health = ElasticPress\Stats::factory()->get_health();
+		$health = Stats::factory()->get_health();
 
 		$this->assertEquals( 1, count( $health ) );
 		$this->assertEquals( 'exampleorg-post-1', array_keys( $health )[0] );
+	}
+
+	/**
+	 * Test if a failed query is registered if a request returns a WP_Error
+	 *
+	 * @since 5.0.1
+	 * @group stats
+	 */
+	public function test_failed_queries_wp_error() {
+		add_filter( 'ep_intercept_remote_request', '__return_true' );
+
+		$return_wp_error = function () {
+			return new \WP_Error( 'code', 'Message' );
+		};
+		add_filter( 'ep_do_intercept_request', $return_wp_error );
+
+		Stats::factory()->build_stats( true );
+		$failed_queries = Stats::factory()->get_failed_queries();
+		$this->assertSame(
+			[
+				[
+					'path'  => '_stats?format=json',
+					'error' => 'Message',
+				],
+			],
+			$failed_queries
+		);
+	}
+
+	/**
+	 * Test if a failed query is registered if a request returns an Elasticsearch error
+	 *
+	 * @since 5.0.1
+	 * @group stats
+	 */
+	public function test_failed_queries_es_error() {
+		add_filter( 'ep_intercept_remote_request', '__return_true' );
+
+		$return_es_error = function () {
+			return [
+				'body' => wp_json_encode( [ 'errors' => [ 'some error data' ] ] ),
+			];
+		};
+		add_filter( 'ep_do_intercept_request', $return_es_error );
+
+		Stats::factory()->build_stats( true );
+		$failed_queries = Stats::factory()->get_failed_queries();
+		$this->assertSame(
+			[
+				[
+					'path'  => '_stats?format=json',
+					'error' => '["some error data"]',
+				],
+			],
+			$failed_queries
+		);
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3729

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Failed queries in the Index Health page will now be outputted with their error messages


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @pvnanini

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
