### PR TITLE
In Terms Indexable`query_db`, for term count, use `wp_count_terms()` instead of `WP_Term_Query`

### DIFF
--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -621,13 +621,15 @@ class Term extends Indexable {
 	 */
 	public function query_db( $args ) {
 		$defaults = [
-			'number'       => $this->get_bulk_items_per_page(),
-			'offset'       => 0,
-			'orderby'      => 'id',
-			'order'        => 'desc',
-			'taxonomy'     => $this->get_indexable_taxonomies(),
-			'hide_empty'   => false,
-			'hierarchical' => false,
+			'number'                 => $this->get_bulk_items_per_page(),
+			'offset'                 => 0,
+			'orderby'                => 'id',
+			'order'                  => 'desc',
+			'taxonomy'               => $this->get_indexable_taxonomies(),
+			'hide_empty'             => false,
+			'hierarchical'           => false,
+			'update_term_meta_cache' => false,
+			'cache_results'          => false,
 		];
 
 		if ( isset( $args['per_page'] ) ) {

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -620,14 +620,14 @@ class Term extends Indexable {
 	 * @return array
 	 */
 	public function query_db( $args ) {
-
 		$defaults = [
-			'number'     => $this->get_bulk_items_per_page(),
-			'offset'     => 0,
-			'orderby'    => 'id',
-			'order'      => 'desc',
-			'taxonomy'   => $this->get_indexable_taxonomies(),
-			'hide_empty' => false,
+			'number'       => $this->get_bulk_items_per_page(),
+			'offset'       => 0,
+			'orderby'      => 'id',
+			'order'        => 'desc',
+			'taxonomy'     => $this->get_indexable_taxonomies(),
+			'hide_empty'   => false,
+			'hierarchical' => false,
 		];
 
 		if ( isset( $args['per_page'] ) ) {
@@ -651,22 +651,15 @@ class Term extends Indexable {
 		unset( $all_query_args['fields'] );
 
 		/**
-		 * This just seems so inefficient.
-		 *
-		 * @todo Better way to do this?
-		 */
-
-		/**
 		 * Filter database arguments for term count query
 		 *
 		 * @hook ep_term_all_query_db_args
-		 * @param  {array} $args Query arguments based to WP_Term_Query
+		 * @param  {array} $args Query arguments based to `wp_count_terms()`
 		 * @since  3.4
 		 * @return {array} New arguments
 		 */
-		$all_query = new WP_Term_Query( apply_filters( 'ep_term_all_query_db_args', $all_query_args, $args ) );
-
-		$total_objects = count( $all_query->terms );
+		$total_objects = wp_count_terms( apply_filters( 'ep_term_all_query_db_args', $all_query_args, $args ) );
+		$total_objects = ! is_wp_error( $total_objects ) ? (int) $total_objects : 0;
 
 		if ( ! empty( $args['offset'] ) ) {
 			if ( (int) $args['offset'] >= $total_objects ) {


### PR DESCRIPTION
### Description of the Change
We're seeing on sites with a very large amount of terms, terms indexing isn't starting because of a query that is being killed:
```
SELECT t.*, tt.* FROM wp_terms AS t INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE t.term_id IN (.....,......,......,......,......,......,......,......,......,......,......,......,......,......,......,......,......,......,......)
```

This is because in `query_db()` for the terms Indexable, we are calling a new instance of `WP_Term_Query`, which ultimately calls `_prime_term_caches` and triggers an expensive, unnecessary query: https://github.com/WordPress/WordPress/blob/e99a11600602fbb5282b59227004d61c543d812d/wp-includes/taxonomy.php#L4071

It isn't required for the ultimate term count in `$total_objects`, so we should be good to replace it with a simple `wp_count_terms()` call (which doesn't ultimately call `_prime_term_caches()` due to an early return).

Aside: I've also set `hierarchical` to `false` because I'm seeing that it performs a no limit query which, on a site with a lot of terms, is being killed: https://github.com/WordPress/WordPress/blob/e99a11600602fbb5282b59227004d61c543d812d/wp-includes/class-wp-term-query.php#L635-L644. I don't think it's the hierarchical structure is necessary for indexing (correct me if I'm wrong).

### How to test the Change
1) Attempt to index a terms indexable and validate that the terms count is the same in `wp vip-search index --indexables=term`

### Changelog Entry
Changed - counts are now calculated with `wp_count_terms()` in Indexable Terms `query_db`


### Credits
Props @rebeccahum


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
