### PR TITLE
Autosuggest - Google Analytics and EP.io

### DIFF
--- a/assets/js/autosuggest/index.js
+++ b/assets/js/autosuggest/index.js
@@ -83,14 +83,22 @@ function triggerAutosuggestEvent(detail) {
 	const event = new CustomEvent('ep-autosuggest-click', { detail });
 	window.dispatchEvent(event);
 
-	if (
-		detail.searchTerm &&
-		parseInt(epas.triggerAnalytics, 10) === 1 &&
-		typeof gtag === 'function'
-	) {
+	/**
+	 * Check if window.gtag was already defined, otherwise
+	 * try to use window.dataLayer.push, available by default
+	 * for Tag Manager users.
+	 */
+	let epGtag = null;
+	if (typeof window?.gtag === 'function') {
+		epGtag = window.gtag;
+	} else if (typeof window?.dataLayer?.push === 'function') {
+		epGtag = window.dataLayer.push;
+	}
+
+	if (detail.searchTerm && parseInt(epas.triggerAnalytics, 10) === 1 && epGtag) {
 		const action = `click - ${detail.searchTerm}`;
 		// eslint-disable-next-line no-undef
-		gtag('event', action, {
+		epGtag('event', action, {
 			event_category: 'EP :: Autosuggest',
 			event_label: detail.url,
 			transport_type: 'beacon',

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -901,15 +901,17 @@ class Autosuggest extends Feature {
 
 		$this->maybe_add_epio_settings_schema();
 
-		$set_in_wp_config = defined( 'EP_AUTOSUGGEST_ENDPOINT' ) && EP_AUTOSUGGEST_ENDPOINT;
+		if ( ! Utils\is_epio() ) {
+			$set_in_wp_config = defined( 'EP_AUTOSUGGEST_ENDPOINT' ) && EP_AUTOSUGGEST_ENDPOINT;
 
-		$this->settings_schema[] = [
-			'disabled' => $set_in_wp_config,
-			'help'     => $set_in_wp_config ? __( 'This address will be exposed to the public.', 'elasticpress' ) : '',
-			'key'      => 'endpoint_url',
-			'label'    => __( 'Endpoint URL', 'elasticpress' ),
-			'type'     => 'url',
-		];
+			$this->settings_schema[] = [
+				'disabled' => $set_in_wp_config,
+				'help'     => $set_in_wp_config ? __( 'This address will be exposed to the public.', 'elasticpress' ) : '',
+				'key'      => 'endpoint_url',
+				'label'    => __( 'Endpoint URL', 'elasticpress' ),
+				'type'     => 'url',
+			];
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR fixes 2 different problems:

1. ElasticPress.io customers should not see the Autosuggest Endpoint URL field
2. If the website is adding a Google Tag via Tag Manager, the gtag function will not be available. This PR creates the method, using the same idea shared in [this article](https://developers.google.com/analytics/devguides/migration/ecommerce/gtm-ga4-to-ua#4_enable_the_gtagjs_api).

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3833

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Autosuggest - Hide the Autosuggest Endpoint URL field for EP.io users
> Fixed - Autosuggest - Google Analytics integration gtag call

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia, @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
