### PR TITLE
Fix: Media search returns no result in admin dashboard

### DIFF
--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -166,6 +166,11 @@ class Documents extends Feature {
 
 		$query->set( 'post_status', array_unique( $post_status ) );
 
+		// Bail, if query is for media library.
+		if ( isset( $_REQUEST['action'] ) && 'query-attachments' === $_REQUEST['action'] ) {
+			return;
+		}
+
 		if ( ! empty( $mime_types ) && is_string( $mime_types ) ) {
 			$mime_types = explode( ' ', $mime_types );
 		}

--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -129,6 +129,11 @@ class Documents extends Feature {
 			return;
 		}
 
+		// Bail, if query is for media library.
+		if ( isset( $_REQUEST['action'] ) && 'query-attachments' === $_REQUEST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
 		$post_status = $query->get( 'post_status', [] );
 		$post_type   = $query->get( 'post_type', [] );
 		$mime_types  = $query->get( 'post_mime_type', [] );
@@ -165,11 +170,6 @@ class Documents extends Feature {
 		}
 
 		$query->set( 'post_status', array_unique( $post_status ) );
-
-		// Bail, if query is for media library.
-		if ( isset( $_REQUEST['action'] ) && 'query-attachments' === $_REQUEST['action'] ) {
-			return;
-		}
 
 		if ( ! empty( $mime_types ) && is_string( $mime_types ) ) {
 			$mime_types = explode( ' ', $mime_types );

--- a/tests/php/features/TestDocuments.php
+++ b/tests/php/features/TestDocuments.php
@@ -107,8 +107,6 @@ class TestDocuments extends BaseTestCase {
 		// Need to call this since it's hooked to init
 		ElasticPress\Features::factory()->get_registered_feature( 'search' )->search_setup();
 
-		$post_ids = array();
-
 		$this->ep_factory->post->create();
 		$this->ep_factory->post->create(
 			array(
@@ -151,8 +149,6 @@ class TestDocuments extends BaseTestCase {
 
 		// Need to call this since it's hooked to init
 		ElasticPress\Features::factory()->get_registered_feature( 'search' )->search_setup();
-
-		$post_ids = array();
 
 		$this->ep_factory->post->create(
 			array(
@@ -225,5 +221,39 @@ class TestDocuments extends BaseTestCase {
 
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 2, $query->post_count );
+	}
+
+	/**
+	 * Test that search in media library is working correctly.
+	 *
+	 * @since 5.1.0
+	 * @group documents
+	 */
+	public function testQueryForAttachments() {
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+		ElasticPress\Features::factory()->activate_feature( 'documents' );
+		ElasticPress\Features::factory()->setup_features();
+
+		$this->ep_factory->post->create(
+			array(
+				'post_content'   => 'search me',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image',
+			)
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$_REQUEST['action'] = 'query-attachments';
+		$args               = array(
+			's'           => 'search me',
+			'post_type'   => 'attachment',
+			'post_status' => 'inherit',
+		);
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->post_count );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the search returns not result in the admin dashboard

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3821

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Add the add_filter( 'ep_ajax_wp_query_integration', '__return_true' ); in your codebase.
2. Make sure Protected Content and Documents are enabled
3. Search for the media name

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Media search returns no result in admin dashboard

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
