### PR TITLE
Acknowledge all default modules as ES plugins

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1483,17 +1483,21 @@ class Elasticsearch {
 			// Save version of last node. We assume all nodes are same version.
 			$this->elasticsearch_version = $node['version'];
 
+			// Elasticsearch calls "modules" all default plugins that can't be uninstalled
+			if ( isset( $node['modules'] ) && is_array( $node['modules'] ) ) {
+				foreach ( $node['modules'] as $plugin ) {
+					$this->elasticsearch_plugins[ $plugin['name'] ] = $plugin['version'];
+				}
+
+				if ( ! empty( $node['modules'] ) && ! empty( $node['modules'][0]['opensearch_version'] ) ) {
+					$this->server_type = 'opensearch';
+				}
+			}
+
 			if ( isset( $node['plugins'] ) && is_array( $node['plugins'] ) ) {
 				foreach ( $node['plugins'] as $plugin ) {
 					$this->elasticsearch_plugins[ $plugin['name'] ] = $plugin['version'];
 				}
-			}
-			if ( isset( $node['modules'] )
-				&& is_array( $node['modules'] )
-				&& ! empty( $node['modules'] )
-				&& ! empty( $node['modules'][0]['opensearch_version'] )
-			) {
-				$this->server_type = 'opensearch';
 			}
 		}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

As mentioned in #3816, Elasticsearch 8 comes with the "ingest-attachment" installed by default, but ElasticPress does not acknowledge that. Actually, we should acknowledge all ES modules -- independent of the ES version.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3816

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Acknowledge all Elasticsearch modules, making the Documents feature available in ES 8 installations by default.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @Serverfox @jerasokcm

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
