### PR TITLE
Add aggregations back to the query

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -404,6 +404,12 @@ class Elasticsearch {
 				 * @param  {array} $query_args Current WP Query arguments
 				 */
 				do_action( 'ep_retrieve_aggregations', $response['aggregations'], $query, '', $query_args );
+
+				if ( method_exists( $query_object, 'set' ) ) {
+					$query_object->set( 'ep_aggregations', $response['aggregations'] );
+				} else {
+					$query_object->query_vars['ep_aggregations'] = $response['aggregations'];
+				}
 			}
 
 			/**
@@ -456,11 +462,15 @@ class Elasticsearch {
 			 *
 			 * @hook ep_es_query_results
 			 * @param {array} $results Results from Elasticsearch
-			 * @param  {response} $response Raw response from Elasticsearch
-			 * @param  {array} $query Raw Elasticsearch query
-			 * @param  {array} $query_args Query arguments
-			 * @param  {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
-			 * @return  {array} New results
+			 *      @param {int}   $results.found_documents Total number of documents.
+			 *      @param {array} $results.documents       Array of documents.
+			 *      @param {array} $results.aggregations    Array of aggregations.
+			 *      @param {array} $results.suggest         Array of suggestions.
+			 * @param {response} $response Raw response from Elasticsearch
+			 * @param {array} $query Raw Elasticsearch query
+			 * @param {array} $query_args Query arguments
+			 * @param {mixed} $query_object Could be WP_Query, WP_User_Query, etc.
+			 * @return {array} New results
 			 */
 			return apply_filters(
 				'ep_es_query_results',

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -405,10 +405,12 @@ class Elasticsearch {
 				 */
 				do_action( 'ep_retrieve_aggregations', $response['aggregations'], $query, '', $query_args );
 
-				if ( method_exists( $query_object, 'set' ) ) {
-					$query_object->set( 'ep_aggregations', $response['aggregations'] );
-				} else {
-					$query_object->query_vars['ep_aggregations'] = $response['aggregations'];
+				if ( is_object( $query_object ) ) {
+					if ( method_exists( $query_object, 'set' ) ) {
+						$query_object->set( 'ep_aggregations', $response['aggregations'] );
+					} else {
+						$query_object->query_vars['ep_aggregations'] = $response['aggregations'];
+					}
 				}
 			}
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -9146,4 +9146,33 @@ class TestPost extends BaseTestCase {
 		$index_settings = $settings[ $index_name ]['settings'];
 		$this->assertSame( '_arabic_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
 	}
+
+	/**
+	 * Test if aggregations are set
+	 *
+	 * @since 5.1.0
+	 * @group post
+	 */
+	public function test_aggregations_return() {
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+				'fields'       => 'ids',
+				'aggs'         => [
+					'name' => 'my_aggs',
+					'aggs' => [
+						'terms' => [
+							'size'  => 10000,
+							'field' => 'terms.category.slug',
+						],
+					],
+				],
+				'ep_custom_id' => 'my_query',
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertArrayHasKey( 'ep_aggregations', $query->query_vars );
+		$this->assertArrayHasKey( 'my_aggs', $query->query_vars['ep_aggregations'] );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3822

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Aggregations created with the `'aggs'` WP_Query parameter, are now retrievable using `$query->query_vars['ep_aggregations']`.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
