### PR TITLE
New ep_post_test_meta_value filter

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -2825,7 +2825,10 @@ class Post extends Indexable {
 		$empty_post = new \WP_Post( (object) [] );
 		$meta_keys  = $this->get_distinct_meta_field_keys_db( $force_refresh );
 
-		$fake_meta_values = array_combine( $meta_keys, array_fill( 0, count( $meta_keys ), 'test-value' ) );
+		$fake_meta_values = array_combine(
+			$meta_keys,
+			array_fill( 0, count( $meta_keys ), $this->get_test_meta_value() )
+		);
 		$filtered_meta    = apply_filters( 'ep_prepare_meta_data', $fake_meta_values, $empty_post );
 
 		$all_keys = array_filter(
@@ -2838,6 +2841,24 @@ class Post extends Indexable {
 		sort( $all_keys );
 
 		return $all_keys;
+	}
+
+	/**
+	 * Return the value used to fill meta fields while predicting indexable content.
+	 *
+	 * @since 5.1.0
+	 * @return string
+	 */
+	public function get_test_meta_value() : string {
+		/**
+		 * Filter the value used to fill meta fields while predicting indexable content.
+		 *
+		 * @hook ep_post_test_meta_value
+		 * @since 5.1.0
+		 * @param {string} $test_meta_value The test meta value. Default: test-value
+		 * @return {string} New test meta value
+		 */
+		return (string) apply_filters( 'ep_post_test_meta_value', 'test-value' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

[To be used by #99](https://github.com/10up/ElasticPressLabs/pull/99)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New ep_post_test_meta_value filter

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
