### PR TITLE
Fix Synonyms case sensitive issue

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -388,10 +388,12 @@ class Synonyms {
 		$mapping['settings']['analysis']['filter'][ $filter_name ] = $this->get_synonym_filter();
 
 		// Tell the analyzer to use our newly created filter.
-		$mapping['settings']['analysis']['analyzer']['default_search']['filter'] = array_values(
-			array_merge(
-				$mapping['settings']['analysis']['analyzer']['default_search']['filter'],
-				[ $filter_name ]
+		$mapping['settings']['analysis']['analyzer']['default_search']['filter'] = $this->maybe_change_filter_position(
+			array_values(
+				array_merge(
+					[ $filter_name ],
+					$mapping['settings']['analysis']['analyzer']['default_search']['filter'],
+				)
 			)
 		);
 
@@ -483,11 +485,13 @@ class Synonyms {
 				$setting['index']['analysis']['filter']['ep_synonyms_filter'] = $filter;
 
 				// Add the analyzer.
-				$setting['index']['analysis']['analyzer']['default_search']['filter'] = array_values(
-					array_unique(
-						array_merge(
-							$filters,
-							[ $this->get_synonym_filter_name() ]
+				$setting['index']['analysis']['analyzer']['default_search']['filter'] = $this->maybe_change_filter_position(
+					array_values(
+						array_unique(
+							array_merge(
+								[ $this->get_synonym_filter_name() ],
+								$filters
+							)
 						)
 					)
 				);
@@ -823,4 +827,23 @@ class Synonyms {
 			true
 		);
 	}
+
+	/**
+	 * Change the position of the lowercase filter to the beginning of the array.
+	 *
+	 * @param array $filters Array of filters.
+	 *
+	 * @return array
+	 */
+	private function maybe_change_filter_position( $filters ) {
+		$lowercase_index = array_search( 'lowercase', $filters, true );
+
+		if ( false !== $lowercase_index ) {
+			unset( $filters[ $lowercase_index ] );
+			array_unshift( $filters, 'lowercase' );
+		}
+
+		return $filters;
+	}
+
 }

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -831,11 +831,11 @@ class Synonyms {
 	/**
 	 * Change the position of the lowercase filter to the beginning of the array.
 	 *
+	 * @since 5.1.0
 	 * @param array $filters Array of filters.
-	 *
 	 * @return array
 	 */
-	private function maybe_change_filter_position( $filters ) {
+	protected function maybe_change_filter_position( array $filters ) : array {
 		$lowercase_filter = array_search( 'lowercase', $filters, true );
 
 		if ( false !== $lowercase_filter ) {

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -390,8 +390,8 @@ class Synonyms {
 		// Tell the analyzer to use our newly created filter.
 		$mapping['settings']['analysis']['analyzer']['default_search']['filter'] = array_values(
 			array_merge(
-				[ $filter_name ],
-				$mapping['settings']['analysis']['analyzer']['default_search']['filter']
+				$mapping['settings']['analysis']['analyzer']['default_search']['filter'],
+				[ $filter_name ]
 			)
 		);
 
@@ -486,8 +486,8 @@ class Synonyms {
 				$setting['index']['analysis']['analyzer']['default_search']['filter'] = array_values(
 					array_unique(
 						array_merge(
-							[ $this->get_synonym_filter_name() ],
-							$filters
+							$filters,
+							[ $this->get_synonym_filter_name() ]
 						)
 					)
 				);

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -836,10 +836,10 @@ class Synonyms {
 	 * @return array
 	 */
 	private function maybe_change_filter_position( $filters ) {
-		$lowercase_index = array_search( 'lowercase', $filters, true );
+		$lowercase_filter = array_search( 'lowercase', $filters, true );
 
-		if ( false !== $lowercase_index ) {
-			unset( $filters[ $lowercase_index ] );
+		if ( false !== $lowercase_filter ) {
+			unset( $filters[ $lowercase_filter ] );
 			array_unshift( $filters, 'lowercase' );
 		}
 

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -195,7 +195,7 @@ class TestSynonyms extends BaseTestCase {
 
 		$query = new \WP_Query(
 			[
-				's'      => 'hoodie',
+				's'      => 'HOODIE',
 				'fields' => 'ids',
 			]
 		);

--- a/tests/php/features/TestSynonyms.php
+++ b/tests/php/features/TestSynonyms.php
@@ -167,7 +167,7 @@ class TestSynonyms extends BaseTestCase {
 	 * @since 5.1.0
 	 * @group synonyms
 	 */
-	public function testSynonymsCaseInsensitive() {
+	public function test_synonyms_case_insensitive() {
 		$instance = $this->getFeature();
 
 		$this->ep_factory->post->create(


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where search synonyms are case sensitive

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3855 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Fix Synonyms case sensitive issue

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
