### PR TITLE
Add HPOS compatibility notice for WooCommerce Orders

### DIFF
--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -45,6 +45,7 @@ class Orders {
 		add_action( 'parse_query', [ $this, 'maybe_hook_woocommerce_search_fields' ], 1 );
 		add_action( 'parse_query', [ $this, 'search_order' ], 11 );
 		add_action( 'pre_get_posts', [ $this, 'translate_args' ], 11, 1 );
+		add_filter( 'ep_admin_notices', [ $this, 'hpos_compatibility_notice' ] );
 	}
 
 	/**
@@ -333,6 +334,48 @@ class Orders {
 		);
 
 		return $supported_post_types;
+	}
+
+	/**
+	 * Display a notice if WooCommerce Orders are not compatible with ElasticPress
+	 *
+	 * If the user has WooCommerce, Protected Content, and HPOS enabled, orders will not go through ElasticPress.
+	 *
+	 * @param array $notices Current EP notices
+	 * @return array
+	 */
+	public function hpos_compatibility_notice( array $notices ) : array {
+		$current_screen = \get_current_screen();
+		if ( empty( $current_screen->id ) || 'woocommerce_page_wc-orders' !== $current_screen->id ) {
+			return $notices;
+		}
+
+		if ( \ElasticPress\Utils\get_option( 'ep_hide_wc_orders_incompatible_notice' ) ) {
+			return $notices;
+		}
+
+		$protected_content = \ElasticPress\Features::factory()->get_registered_feature( 'protected_content' );
+		if ( ! $protected_content->is_active() ) {
+			return $notices;
+		}
+
+		if (
+			! class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' )
+			|| ! method_exists( '\Automattic\WooCommerce\Utilities\OrderUtil', 'custom_orders_table_usage_is_enabled' ) ) {
+			return $notices;
+		}
+
+		if ( ! \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			return $notices;
+		}
+
+		$notices['wc_orders_incompatible'] = [
+			'html'    => esc_html__( "Although the WooCommerce and Protected Content features are enabled, ElasticPress will not integrate with the WooCommerce Orders list if WooCommerce's High-performance order storage is enabled.", 'elasticpress' ),
+			'type'    => 'warning',
+			'dismiss' => true,
+		];
+
+		return $notices;
 	}
 
 	/**

--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -520,7 +520,7 @@ class Orders {
 				"\ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' )->orders_autosuggest->{$method_name}()" // phpcs:ignore
 			);
 
-			if ( $this->woocommerce->is_orders_autosuggest_enabled() && method_exists( $this->woocommerce->orders_autosuggest, $method_name ) ) {
+			if ( $this->woocommerce->orders_autosuggest->is_enabled() && method_exists( $this->woocommerce->orders_autosuggest, $method_name ) ) {
 				call_user_func_array( [ $this->woocommerce->orders_autosuggest, $method_name ], $arguments );
 			}
 		}

--- a/tests/php/features/WooCommerce/TestWooCommerce.php
+++ b/tests/php/features/WooCommerce/TestWooCommerce.php
@@ -153,6 +153,7 @@ class TestWooCommerce extends WooCommerceBaseTestCase {
 	 *
 	 * @since 4.5.0
 	 * @group woocommerce
+	 * @expectedDeprecated ElasticPress\Feature\WooCommerce\WooCommerce::is_orders_autosuggest_available
 	 */
 	public function testIsOrdersAutosuggestAvailable() {
 		$woocommerce_feature = ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );
@@ -170,10 +171,11 @@ class TestWooCommerce extends WooCommerceBaseTestCase {
 	}
 
 	/**
-	 * Test the `is_orders_autosuggest_available` method
+	 * Test the `is_orders_autosuggest_enabled` method
 	 *
 	 * @since 4.5.0
 	 * @group woocommerce
+	 * @expectedDeprecated ElasticPress\Feature\WooCommerce\WooCommerce::is_orders_autosuggest_enabled
 	 */
 	public function testIsOrdersAutosuggestEnabled() {
 		$woocommerce_feature = ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );

--- a/tests/php/features/WooCommerce/TestWooCommerceOrders.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceOrders.php
@@ -348,7 +348,7 @@ class TestWooCommerceOrders extends WooCommerceBaseTestCase {
 		ElasticPress\Features::factory()->activate_feature( 'protected_content' );
 		$this->assertCount( 1, $this->orders->hpos_compatibility_notice( $notices ) );
 
-		$option_name = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
+		$option_name  = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
 		$change_value = function() {
 			return 'yes';
 		};

--- a/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
@@ -294,4 +294,60 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 
 		$this->assertSame( $expected_fields, $changed_search_fields );
 	}
+
+	/**
+	 * Test the `is_available` method
+	 *
+	 * @since 5.1.0
+	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
+	 */
+	public function test_is_available() {
+		$this->assertSame( $this->orders_autosuggest->is_available(), \ElasticPress\Utils\is_epio() );
+
+		/**
+		 * Test the `ep_woocommerce_orders_autosuggest_available` filter
+		 */
+		add_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_true' );
+		$this->assertTrue( $this->orders_autosuggest->is_available() );
+
+		add_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_false' );
+		$this->assertFalse( $this->orders_autosuggest->is_available() );
+	}
+
+	/**
+	 * Test the `is_enabled` method
+	 *
+	 * @since 5.1.0
+	 * @group woocommerce
+	 */
+	public function test_is_enabled() {
+		$this->assertFalse( $this->orders_autosuggest->is_enabled() );
+
+		/**
+		 * Make it available but it won't be enabled
+		 */
+		add_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_true' );
+		$this->assertFalse( $this->orders_autosuggest->is_enabled() );
+
+		/**
+		 * Enable it
+		 */
+		$filter = function() {
+			return [
+				'woocommerce' => [
+					'orders' => '1',
+				],
+			];
+		};
+		add_filter( 'pre_site_option_ep_feature_settings', $filter );
+		add_filter( 'pre_option_ep_feature_settings', $filter );
+		$this->assertTrue( $this->orders_autosuggest->is_enabled() );
+
+		/**
+		 * Make it unavailable. Even activated, it should not be considered enabled if not available anymore.
+		 */
+		remove_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_true' );
+		$this->assertFalse( $this->orders_autosuggest->is_enabled() );
+	}
 }

--- a/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
@@ -363,14 +363,14 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 		$this->assertTrue( $this->orders_autosuggest->is_hpos_compatible() );
 
 		// Turn HPOS on
-		$custom_orders_table  = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
+		$custom_orders_table        = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
 		$change_custom_orders_table = function() {
 			return 'yes';
 		};
 		add_filter( 'pre_option_' . $custom_orders_table, $change_custom_orders_table );
 
 		// Disable legacy mode
-		$legacy_mode  = \Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION;
+		$legacy_mode        = \Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION;
 		$change_legacy_mode = function() {
 			return 'no';
 		};
@@ -417,7 +417,7 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 	 */
 	public function test_get_setting_help_message_feature_hpos_incompatible() {
 		// Turn HPOS on
-		$custom_orders_table  = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
+		$custom_orders_table        = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
 		$change_custom_orders_table = function() {
 			return 'yes';
 		};

--- a/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
@@ -320,6 +320,7 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 	 *
 	 * @since 5.1.0
 	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
 	 */
 	public function test_is_enabled() {
 		$this->assertFalse( $this->orders_autosuggest->is_enabled() );
@@ -349,5 +350,92 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 		 */
 		remove_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_true' );
 		$this->assertFalse( $this->orders_autosuggest->is_enabled() );
+	}
+
+	/**
+	 * Test the `is_hpos_compatible` method
+	 *
+	 * @since 5.1.0
+	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
+	 */
+	public function test_is_hpos_compatible() {
+		$this->assertTrue( $this->orders_autosuggest->is_hpos_compatible() );
+
+		// Turn HPOS on
+		$custom_orders_table  = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
+		$change_custom_orders_table = function() {
+			return 'yes';
+		};
+		add_filter( 'pre_option_' . $custom_orders_table, $change_custom_orders_table );
+
+		// Disable legacy mode
+		$legacy_mode  = \Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION;
+		$change_legacy_mode = function() {
+			return 'no';
+		};
+		add_filter( 'pre_option_' . $legacy_mode, $change_legacy_mode );
+
+		$this->assertFalse( $this->orders_autosuggest->is_hpos_compatible() );
+	}
+
+	/**
+	 * Test the `add_settings_schema` method
+	 *
+	 * @since 5.1.0
+	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
+	 */
+	public function test_add_settings_schema() {
+		$new_settings_schema = $this->orders_autosuggest->add_settings_schema( [] );
+		$this->assertSame( 'orders', $new_settings_schema[0]['key'] );
+	}
+
+	/**
+	 * Test the `get_setting_help_message` method when the feature is available
+	 *
+	 * @since 5.1.0
+	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
+	 */
+	public function test_get_setting_help_message_feature_available() {
+		/**
+		 * Make it available but it won't be enabled
+		 */
+		add_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_true' );
+
+		$new_settings_schema = $this->orders_autosuggest->add_settings_schema( [] );
+		$this->assertStringContainsString( 'You are directly connected to', $new_settings_schema[0]['help'] );
+	}
+
+	/**
+	 * Test the `get_setting_help_message` method when incompatible with HPOS
+	 *
+	 * @since 5.1.0
+	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
+	 */
+	public function test_get_setting_help_message_feature_hpos_incompatible() {
+		// Turn HPOS on
+		$custom_orders_table  = \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
+		$change_custom_orders_table = function() {
+			return 'yes';
+		};
+		add_filter( 'pre_option_' . $custom_orders_table, $change_custom_orders_table );
+
+		$new_settings_schema = $this->orders_autosuggest->add_settings_schema( [] );
+		$this->assertStringContainsString( 'Currently, autosuggest for orders is only available', $new_settings_schema[0]['help'] );
+	}
+
+	/**
+	 * Test the `get_setting_help_message` method when the feature is not available
+	 *
+	 * @since 5.1.0
+	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
+	 */
+	public function test_get_setting_help_message_feature_not_available() {
+		$new_settings_schema = $this->orders_autosuggest->add_settings_schema( [] );
+		$this->assertStringContainsString( 'Due to the sensitive nature of orders', $new_settings_schema[0]['help'] );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3849

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - HPOS compatibility notice for WooCommerce Orders


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
