### PR TITLE
Don't open instant results modal if an autosuggest suggestion is selected.

### DIFF
--- a/assets/js/autosuggest/index.js
+++ b/assets/js/autosuggest/index.js
@@ -362,6 +362,8 @@ function updateAutosuggestBox(options, input) {
 		}
 	});
 
+	setInputActiveDescendant('', input);
+
 	return true;
 }
 
@@ -373,6 +375,7 @@ function updateAutosuggestBox(options, input) {
 function hideAutosuggestBox() {
 	const lists = document.querySelectorAll('.autosuggest-list');
 	const containers = document.querySelectorAll('.ep-autosuggest');
+	const inputs = document.querySelectorAll('.ep-autosuggest-container [aria-activedescendant]');
 
 	// empty all EP results lists
 	lists.forEach((list) => {
@@ -386,6 +389,9 @@ function hideAutosuggestBox() {
 		// eslint-disable-next-line
 		container.style = 'display: none;';
 	});
+
+	// Remove active descendant attribute from all inputs
+	inputs.forEach((input) => setInputActiveDescendant('', input));
 
 	return true;
 }

--- a/assets/js/instant-results/apps/modal.js
+++ b/assets/js/instant-results/apps/modal.js
@@ -49,6 +49,15 @@ export default () => {
 
 			inputRef.current = event.target.s;
 
+			/**
+			 * Don't open the modal if an autosuggest suggestion is selected.
+			 */
+			const activeDescendant = inputRef.current.getAttribute('aria-activedescendant');
+
+			if (activeDescendant) {
+				return;
+			}
+
 			const { value } = inputRef.current;
 			const post_type = getPostTypesFromForm(inputRef.current.form);
 

--- a/tests/cypress/integration/features/autosuggest.cy.js
+++ b/tests/cypress/integration/features/autosuggest.cy.js
@@ -4,6 +4,7 @@ describe('Autosuggest Feature', () => {
 	});
 
 	beforeEach(() => {
+		cy.maybeDisableFeature('instant-results');
 		cy.deactivatePlugin('custom-headers-for-autosuggest', 'wpCli');
 	});
 
@@ -101,5 +102,12 @@ describe('Autosuggest Feature', () => {
 
 		cy.get('.ep-autosuggest li a').first().click();
 		cy.url().should('include', 'cypress=foobar');
+	});
+
+	it('Can select an Autosuggest suggestion even if Instant Results is active', () => {
+		cy.maybeEnableFeature('instant-results');
+		cy.visit('/');
+		cy.get('.wp-block-search__input').type('blog{downArrow}{enter}');
+		cy.url().should('include', 'blog');
 	});
 });


### PR DESCRIPTION
…cted.

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Prevents the Instant Results modal from opening if an Autosuggest suggestion is highlighted, allowing the user to open the suggestion with the Enter key without a conflict.

Closes #3824

### How to test the Change
1. Activate Instant Results and Autosuggest.
2. Enter a search query so that suggestions appear.
3. Navigate to a suggestion with the arrow keys and press Enter.
4. You should be taken to the suggestion and Instant Results should not launch,

### Changelog Entry
Fixed - An issue where pressing Enter to select an Autosuggest suggestion would instead open Instant Results.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
