### PR TITLE
Add tooltips for meta keys to the weighting screen.

### DIFF
--- a/assets/js/weighting/components/field.js
+++ b/assets/js/weighting/components/field.js
@@ -1,7 +1,7 @@
 /**
  * WordPress Dependencies.
  */
-import { Button, CheckboxControl, RangeControl } from '@wordpress/components';
+import { Button, CheckboxControl, RangeControl, Tooltip } from '@wordpress/components';
 import { WPElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
@@ -14,9 +14,10 @@ import { trash } from '@wordpress/icons';
  * @param {Function} props.onChange Change handler.
  * @param {Function} props.onDelete Delete handler.
  * @param {object} props.value Values.
+ * @param {boolean} props.showTooltip Whether to show field name tooltip.
  * @returns {WPElement} Component element.
  */
-export default ({ label, onChange, onDelete, value }) => {
+export default ({ label, onChange, onDelete, value, showTooltip }) => {
 	const { enabled = false, weight = 0 } = value;
 
 	/**
@@ -45,7 +46,15 @@ export default ({ label, onChange, onDelete, value }) => {
 	return (
 		<div className="ep-weighting-field">
 			<fieldset>
-				<legend className="ep-weighting-field__name">{label}</legend>
+				<legend className="ep-weighting-field__name">
+					{showTooltip ? (
+						<Tooltip text={label}>
+							<span>{label}</span>
+						</Tooltip>
+					) : (
+						label
+					)}
+				</legend>
 				<div className="ep-weighting-field__searchable">
 					<CheckboxControl
 						checked={enabled}

--- a/assets/js/weighting/components/group.js
+++ b/assets/js/weighting/components/group.js
@@ -168,6 +168,7 @@ export default ({ group, postType }) => {
 						onDelete={() => {
 							onDelete(key);
 						}}
+						showTooltip
 					/>
 				</PanelRow>
 			))}


### PR DESCRIPTION

### Description of the Change
Adds a tooltip for field names for meta keys on the weighting screen to allow seeing the full name if it has been truncated.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3851

### How to test the Change
1. On the weighting screen, add a field with a name longer than 30 characters, it should be truncated with an ellipsis (...).
2. Hover over the field name, the full meta key should be visible in a tooltop.

### Changelog Entry
Added - A tooltip for meta keys to the weighting screen to allow seeing the full key if it has been truncated.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
