### PR TITLE
Add $context to get_capability()

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -171,7 +171,7 @@ class Synonyms {
 			'elasticpress',
 			esc_html__( 'ElasticPress Synonyms', 'elasticpress' ),
 			esc_html__( 'Synonyms', 'elasticpress' ),
-			Utils\get_capability(),
+			Utils\get_capability( 'synonyms' ),
 			'elasticpress-synonyms',
 			[ $this, 'admin_page' ]
 		);
@@ -248,7 +248,7 @@ class Synonyms {
 			'show_ui'            => false,
 			'show_in_menu'       => false,
 			'query_var'          => true,
-			'capabilities'       => Utils\get_post_map_capabilities(),
+			'capabilities'       => Utils\get_post_map_capabilities( 'synonyms' ),
 			'has_archive'        => false,
 			'hierarchical'       => false,
 			'menu_position'      => 100,

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -215,7 +215,7 @@ class SearchOrdering extends Feature {
 			'elasticpress',
 			esc_html__( 'Custom Results', 'elasticpress' ),
 			esc_html__( 'Custom Results', 'elasticpress' ),
-			Utils\get_capability(),
+			Utils\get_capability( 'search-ordering' ),
 			'edit.php?post_type=' . self::POST_TYPE_NAME
 		);
 	}
@@ -294,7 +294,7 @@ class SearchOrdering extends Feature {
 			'show_in_menu'         => false,
 			'query_var'            => true,
 			'rewrite'              => array( 'slug' => 'ep-pointer' ),
-			'capabilities'         => Utils\get_post_map_capabilities(),
+			'capabilities'         => Utils\get_post_map_capabilities( 'search-ordering' ),
 			'has_archive'          => false,
 			'hierarchical'         => false,
 			'menu_position'        => 100,

--- a/includes/classes/REST/SearchOrdering.php
+++ b/includes/classes/REST/SearchOrdering.php
@@ -71,7 +71,7 @@ class SearchOrdering {
 	 * @return boolean
 	 */
 	public function check_permission() {
-		$capability = Utils\get_capability();
+		$capability = Utils\get_capability( 'search-ordering' );
 
 		return current_user_can( $capability );
 	}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -54,47 +54,66 @@ function get_epio_credentials() {
 /**
  * Get WP capability needed for a user to interact with ElasticPress in the admin
  *
- * @since 4.5.0
+ * @since 4.5.0, 5.1.0 added $context
+ * @param string $context Context for the capability. Defaults to empty string.
  * @return string
  */
-function get_capability() : string {
+function get_capability( string $context = '' ) : string {
 	/**
 	 * Filter the WP capability needed to interact with ElasticPress in the admin
 	 *
-	 * @since 4.5.0
+	 * Example:
+	 * ```
+	 * add_filter(
+	 *     'ep_capability',
+	 *     function ( $cacapability, $context ) {
+	 *         return ( 'synonyms' === $context ) ?
+	 *            'manage_elasticpress_synonyms' :
+	 *            $cacapability;
+	 *     },
+	 *     10,
+	 *     2
+	 * );
+	 * ```
+	 *
+	 * @since 4.5.0, 5.1.0 added $context
 	 * @hook ep_capability
 	 * @param  {string} $capability Capability name. Defaults to `'manage_elasticpress'`
+	 * @param  {string} $context    Additional context
 	 * @return {string} New capability value
 	 */
-	return apply_filters( 'ep_capability', 'manage_elasticpress' );
+	return apply_filters( 'ep_capability', 'manage_elasticpress', $context );
 }
 
 /**
  * Get WP capability needed for a user to interact with ElasticPress in the network admin
  *
- * @since 4.5.0
+ * @since 4.5.0, 5.1.0 added $context
+ * @param string $context Context for the capability. Defaults to empty string.
  * @return string
  */
-function get_network_capability() : string {
+function get_network_capability( string $context = '' ) : string {
 	/**
 	 * Filter the WP capability needed to interact with ElasticPress in the network admin
 	 *
-	 * @since 4.5.0
+	 * @since 4.5.0, 5.1.0 added $context
 	 * @hook ep_network_capability
 	 * @param  {string} $capability Capability name. Defaults to `'manage_network_elasticpress'`
+	 * @param  {string} $context    Additional context
 	 * @return {string} New capability value
 	 */
-	return apply_filters( 'ep_network_capability', 'manage_network_elasticpress' );
+	return apply_filters( 'ep_network_capability', 'manage_network_elasticpress', $context );
 }
 
 /**
  * Get mapped capabilities for post types
  *
- * @since 4.5.0
+ * @since 4.5.0, 5.1.0 added $context
+ * @param string $context Context for the capability. Defaults to empty string.
  * @return array
  */
-function get_post_map_capabilities() : array {
-	$capability = get_capability();
+function get_post_map_capabilities( string $context = '' ) : array {
+	$capability = get_capability( $context );
 
 	return [
 		'edit_post'          => $capability,

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -276,13 +276,14 @@ class TestUtils extends BaseTestCase {
 		/**
 		 * Test the `ep_capability` filter.
 		 */
-		$change_cap_name = function( $cap ) {
+		$change_cap_name = function( $cap, $context ) {
 			$this->assertSame( 'manage_elasticpress', $cap );
+			$this->assertSame( 'context', $context );
 			return 'custom_manage_ep';
 		};
-		add_filter( 'ep_capability', $change_cap_name );
+		add_filter( 'ep_capability', $change_cap_name, 10, 2 );
 
-		$this->assertSame( 'custom_manage_ep', Utils\get_capability() );
+		$this->assertSame( 'custom_manage_ep', Utils\get_capability( 'context' ) );
 	}
 
 	/**
@@ -296,13 +297,14 @@ class TestUtils extends BaseTestCase {
 		/**
 		 * Test the `ep_network_capability` filter.
 		 */
-		$change_cap_name = function( $cap ) {
+		$change_cap_name = function( $cap, $context ) {
 			$this->assertSame( 'manage_network_elasticpress', $cap );
+			$this->assertSame( 'context', $context );
 			return 'custom_manage_network_ep';
 		};
-		add_filter( 'ep_network_capability', $change_cap_name );
+		add_filter( 'ep_network_capability', $change_cap_name, 10, 2 );
 
-		$this->assertSame( 'custom_manage_network_ep', Utils\get_network_capability() );
+		$this->assertSame( 'custom_manage_network_ep', Utils\get_network_capability( 'context' ) );
 	}
 
 	/**
@@ -322,6 +324,32 @@ class TestUtils extends BaseTestCase {
 		];
 
 		$this->assertSame( $expected, Utils\get_post_map_capabilities() );
+	}
+
+	/**
+	 * Test the `get_post_map_capabilities` function passing context
+	 *
+	 * @since 5.1.0
+	 */
+	public function test_get_post_map_capabilities_with_context() {
+		$change_cap_name = function( $cap, $context ) {
+			$this->assertSame( 'manage_elasticpress', $cap );
+			$this->assertSame( 'context', $context );
+			return 'custom_manage_ep';
+		};
+		add_filter( 'ep_capability', $change_cap_name, 10, 2 );
+
+		$expected = [
+			'edit_post'          => 'custom_manage_ep',
+			'edit_posts'         => 'custom_manage_ep',
+			'edit_others_posts'  => 'custom_manage_ep',
+			'publish_posts'      => 'custom_manage_ep',
+			'read_post'          => 'custom_manage_ep',
+			'read_private_posts' => 'custom_manage_ep',
+			'delete_post'        => 'custom_manage_ep',
+		];
+
+		$this->assertSame( $expected, Utils\get_post_map_capabilities( 'context' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Users wanting to manage synonyms-related capabilities, for example, can use the following snippet and add the `manage_elasticpress_synonyms` capability to their chosen role:
```php
add_filter(
	'ep_capability',
	function ( $cacapability, $context ) {
		return ( 'synonyms' === $context ) ?
			'manage_elasticpress_synonyms' :
			$cacapability;
	},
	10,
	2
);
```

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3787

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Context parameter to the get_capability() function

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @selim13

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
