### PR TITLE
Modernize ep_highlight_excerpt to deal with block content

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -285,14 +285,18 @@ class Search extends Feature {
 	 * @return string $text the new excerpt
 	 */
 	public function ep_highlight_excerpt( $text, $post ) {
-
 		$settings = $this->get_settings();
 
 		// reproduces wp_trim_excerpt filter, preserving the excerpt_more and excerpt_length filters
 		if ( '' === $text ) {
 			$text = get_the_content( '', false, $post );
+
+			$text = strip_shortcodes( $text );
+			$text = excerpt_remove_blocks( $text );
+
 			$text = apply_filters( 'the_content', $text );
 			$text = str_replace( '\]\]\>', ']]&gt;', $text );
+
 			$text = strip_tags( $text, '<' . esc_html( $settings['highlight_tag'] ) . '>' );
 
 			// use the defined length, if already applied...
@@ -300,9 +304,12 @@ class Search extends Feature {
 
 			// use defined excerpt_more filter if it is used
 			$excerpt_more = apply_filters( 'excerpt_more', $text );
-
 			$excerpt_more = $excerpt_more !== $text ? $excerpt_more : '[&hellip;]';
 
+			/**
+			 * WordPress would handle this using `wp_trim_words` but that removes all tags,
+			 * including the one used to highlight the search term.
+			 */
 			$words = explode( ' ', $text, $excerpt_length + 1 );
 			if ( count( $words ) > $excerpt_length ) {
 				array_pop( $words );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3695

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Infinite loop when using excerpt highlighting with posts that use blocks that print an excerpt


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @JakePT 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
