### PR TITLE
Major refactor of the Term::format_args() method and conditionally set search fields for term queries in REST API requests.

### DIFF
--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -53,6 +53,8 @@ class QueryIntegration {
 
 		// Filter term query
 		add_filter( 'terms_pre_query', [ $this, 'maybe_filter_query' ], 10, 2 );
+
+		add_filter( 'rest_post_tag_query', [ $this, 'maybe_set_search_fields' ], 10, 2 );
 	}
 
 	/**
@@ -239,6 +241,27 @@ class QueryIntegration {
 		}
 
 		return $new_terms;
+	}
+
+	/**
+	 * Conditionally set search fields for term queries in REST API requests.
+	 *
+	 * If in an REST API request that came from WordPress edit screen, do not search for term description.
+	 *
+	 * @param array           $prepared_args Array of arguments for get_terms().
+	 * @param WP_REST_Request $request       The REST API request.
+	 * @return array
+	 */
+	public function maybe_set_search_fields( $prepared_args, $request ) {
+		$referer = $request->get_header( 'referer' );
+
+		if ( empty( $referer ) || ! preg_match( '/post\.php\?post=([0-9]*)&action=edit/', $referer ) ) {
+			return $prepared_args;
+		}
+
+		$prepared_args['search_fields'] = [ 'name', 'slug' ];
+
+		return $prepared_args;
 	}
 
 	/**

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -62,456 +62,22 @@ class Term extends Indexable {
 	 * @return array
 	 */
 	public function format_args( $query_vars ) {
-		/**
-		 * Support `number` query var
-		 */
-		if ( ! empty( $query_vars['number'] ) ) {
-			$number = (int) $query_vars['number'];
-		} else {
-			/**
-			 * Set the maximum results window size.
-			 *
-			 * The request will return a HTTP 500 Internal Error if the size of the
-			 * request is larger than the [index.max_result_window] parameter in ES.
-			 * See the scroll api for a more efficient way to request large data sets.
-			 *
-			 * @return int The max results window size.
-			 *
-			 * @since 2.3.0
-			 */
-			$number = apply_filters( 'ep_max_results_window', 10000 );
-		}
+		$query_vars = $this->sanitize_query_vars( $query_vars );
 
 		$formatted_args = [
-			'from' => 0,
-			'size' => $number,
+			'from' => $this->parse_from( $query_vars ),
+			'size' => $this->parse_size( $query_vars ),
 		];
 
-		/**
-		 * Support `offset` query var
-		 */
-		if ( isset( $query_vars['offset'] ) ) {
-			$formatted_args['from'] = (int) $query_vars['offset'];
+		$formatted_args = $this->maybe_orderby( $formatted_args, $query_vars );
+
+		$filters = $this->parse_filters( $query_vars );
+		if ( ! empty( $filters ) ) {
+			$formatted_args['post_filter'] = $filters;
 		}
 
-		/**
-		 * Support `order` and `orderby` query vars
-		 */
-
-		// Set sort order, default is 'ASC'.
-		if ( ! empty( $query_vars['order'] ) ) {
-			$order = $this->parse_order( $query_vars['order'] );
-		} else {
-			$order = 'desc';
-		}
-
-		// Set orderby, default is 'name'.
-		if ( empty( $query_vars['orderby'] ) ) {
-			$query_vars['orderby'] = 'name';
-		}
-
-		// Set sort type.
-		$formatted_args['sort'] = $this->parse_orderby( $query_vars['orderby'], $order, $query_vars );
-
-		$filter = [
-			'bool' => [
-				'must' => [],
-			],
-		];
-
-		$use_filters = false;
-
-		/**
-		 * Support `taxonomy` query var
-		 */
-		$taxonomy = [];
-		if ( ! empty( $query_vars['taxonomy'] ) ) {
-			$taxonomy       = (array) $query_vars['taxonomy'];
-			$terms_map_name = 'terms';
-
-			if ( count( $taxonomy ) < 2 ) {
-				$terms_map_name = 'term';
-				$taxonomy       = $taxonomy[0];
-			}
-
-			$filter['bool']['must'][] = [
-				$terms_map_name => [
-					'taxonomy.raw' => $taxonomy,
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `object_ids` query var
-		 */
-		if ( ! empty( $query_vars['object_ids'] ) ) {
-			$filter['bool']['must'][]['bool']['must'][] = [
-				'terms' => [
-					'object_ids.value' => (array) $query_vars['object_ids'],
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `get` query var
-		 */
-		if ( ! empty( $query_vars['get'] ) && 'all' === $query_vars['get'] ) {
-			$query_vars['childless']    = false;
-			$query_vars['child_of']     = 0;
-			$query_vars['hide_empty']   = false;
-			$query_vars['hierarchical'] = false;
-			$query_vars['pad_counts']   = false;
-		}
-
-		/**
-		 * Support `include` query var
-		 */
-		if ( ! empty( $query_vars['include'] ) ) {
-			$filter['bool']['must'][]['bool']['must'] = [
-				'terms' => [
-					'term_id' => array_values( (array) $query_vars['include'] ),
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `exclude` query var
-		 */
-		if ( empty( $query_vars['include'] ) && ! empty( $query_vars['exclude'] ) ) {
-			$filter['bool']['must'][]['bool']['must_not'] = [
-				'terms' => [
-					'term_id' => array_values( (array) $query_vars['exclude'] ),
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `exclude_tree` query var
-		 */
-		if ( empty( $query_vars['include'] ) && ! empty( $query_vars['exclude_tree'] ) ) {
-			$filter['bool']['must'][]['bool']['must_not'] = [
-				'terms' => [
-					'term_id' => array_values( (array) $query_vars['exclude_tree'] ),
-				],
-			];
-
-			$filter['bool']['must'][]['bool']['must_not'] = [
-				'terms' => [
-					'parent' => array_values( (array) $query_vars['exclude_tree'] ),
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `name` query var
-		 */
-		if ( ! empty( $query_vars['name'] ) ) {
-			$filter['bool']['must'][] = [
-				'terms' => [
-					'name.raw' => (array) $query_vars['name'],
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `slug` query var
-		 */
-		if ( ! empty( $query_vars['slug'] ) ) {
-			if ( ! is_array( $query_vars['slug'] ) ) {
-				$query_vars['slug'] = array( $query_vars['slug'] );
-			}
-
-			$query_vars['slug'] = array_map( 'sanitize_title', $query_vars['slug'] );
-
-			$filter['bool']['must'][] = [
-				'terms' => [
-					'slug.raw' => (array) $query_vars['slug'],
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `term_taxonomy_id` query var
-		 */
-		if ( ! empty( $query_vars['term_taxonomy_id'] ) ) {
-			$filter['bool']['must'][]['bool']['must'] = [
-				'terms' => [
-					'term_taxonomy_id' => array_values( (array) $query_vars['term_taxonomy_id'] ),
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `hierarchical` and `hide_empty` query var
-		 *
-		 * `hierarchical` needs to work in conjunction with `hide_empty`, as per WP docs:
-		 * > `hierarchical`: Whether to include terms that have non-empty descendants (even if $hide_empty is set to true).
-		 *
-		 * In summary:
-		 * - hide_empty AND hierarchical: count > 1 OR hierarchy.children > 1
-		 * - hide_empty AND NOT hierarchical: count > 1 (ignore hierarchy.children)
-		 * - NOT hide_empty (AND hierarchical): there is no need to limit the query
-		 *
-		 * @see https://developer.wordpress.org/reference/classes/WP_Term_Query/__construct/
-		 */
-		$hide_empty = isset( $query_vars['hide_empty'] ) ? $query_vars['hide_empty'] : '';
-		if ( $hide_empty ) {
-			$hierarchical = isset( $query_vars['hierarchical'] ) ? $query_vars['hierarchical'] : '';
-
-			if ( $hierarchical ) {
-				$filter_clause = [ 'bool' => [ 'should' => [] ] ];
-
-				$filter_clause['bool']['should'][] = [
-					'range' => [
-						'count' => [
-							'gte' => 1,
-						],
-					],
-				];
-
-				$filter_clause['bool']['should'][] = [
-					'range' => [
-						'hierarchy.children.count' => [
-							'gte' => 1,
-						],
-					],
-				];
-
-				$filter['bool']['must'][] = $filter_clause;
-
-				$use_filters = true;
-			} else {
-				$filter['bool']['must'][] = [
-					'range' => [
-						'count' => [
-							'gte' => 1,
-						],
-					],
-				];
-			}
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `search`, `name__like` and `description__like` query_vars
-		 */
-		if ( ! empty( $query_vars['search'] ) || ! empty( $query_vars['name__like'] ) || ! empty( $query_vars['description__like'] ) ) {
-
-			$search        = ! empty( $query_vars['search'] ) ? $query_vars['search'] : '';
-			$search_fields = [];
-
-			if ( ! empty( $query_vars['name__like'] ) ) {
-				$search          = $query_vars['name__like'];
-				$search_fields[] = 'name';
-			}
-
-			if ( ! empty( $query_vars['description__like'] ) ) {
-				$search          = $query_vars['description__like'];
-				$search_fields[] = 'description';
-			}
-
-			/**
-			 * Allow for search field specification
-			 */
-			if ( ! empty( $query_vars['search_fields'] ) ) {
-				$search_fields = $query_vars['search_fields'];
-			}
-
-			if ( ! empty( $search_fields ) ) {
-				$prepared_search_fields = [];
-
-				if ( ! empty( $search_fields['meta'] ) ) {
-					$metas = (array) $search_fields['meta'];
-
-					foreach ( $metas as $meta ) {
-						$prepared_search_fields[] = 'meta.' . $meta . '.value';
-					}
-
-					unset( $search_fields['meta'] );
-				}
-
-				$prepared_search_fields = array_merge( $search_fields, $prepared_search_fields );
-			} else {
-				$prepared_search_fields = [
-					'name',
-					'slug',
-					'taxonomy',
-					'description',
-				];
-			}
-
-			/**
-			 * Filter fields to search on Term query
-			 *
-			 * @hook ep_term_search_fields
-			 * @param  {array} $search_fields Search fields
-			 * @param  {array} $query_vars Query variables
-			 * @since  3.4
-			 * @return {array} New search fields
-			 */
-			$prepared_search_fields = apply_filters( 'ep_term_search_fields', $prepared_search_fields, $query_vars );
-
-			$search_algorithm        = $this->get_search_algorithm( $search, $prepared_search_fields, $query_vars );
-			$formatted_args['query'] = $search_algorithm->get_query( 'term', $search, $prepared_search_fields, $query_vars );
-		} else {
-			$formatted_args['query']['match_all'] = [
-				'boost' => 1,
-			];
-		}
-
-		/**
-		 * Support `child_of` query var.
-		 */
-		if ( ! empty( $query_vars['child_of'] ) && ( is_string( $taxonomy ) || count( $taxonomy ) < 2 ) ) {
-			$filter['bool']['must'][]['bool']['must'][] = [
-				'match_phrase' => [
-					'hierarchy.ancestors.terms' => (int) $query_vars['child_of'],
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `parent` query var.
-		 */
-		if ( isset( $query_vars['parent'] ) && '' !== $query_vars['parent'] ) {
-			$filter['bool']['must'][]['bool']['must'] = [
-				'term' => [
-					'parent' => (int) $query_vars['parent'],
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		/**
-		 * Support `childless` query var.
-		 */
-		if ( ! empty( $query_vars['childless'] ) ) {
-			$filter['bool']['must'][]['bool']['must'] = [
-				'term' => [
-					'hierarchy.children.terms' => 0,
-				],
-			];
-
-			$use_filters = true;
-		}
-
-		$meta_queries = [];
-
-		/**
-		 * Support `meta_key`, `meta_value`, and `meta_compare` query args
-		 */
-		if ( ! empty( $query_vars['meta_key'] ) ) {
-			$meta_query_array = [
-				'key' => $query_vars['meta_key'],
-			];
-
-			if ( isset( $query_vars['meta_value'] ) && '' !== $query_vars['meta_value'] ) {
-				$meta_query_array['value'] = $query_vars['meta_value'];
-			}
-
-			if ( isset( $query_vars['meta_compare'] ) ) {
-				$meta_query_array['compare'] = $query_vars['meta_compare'];
-			}
-
-			$meta_queries[] = $meta_query_array;
-		}
-
-		/**
-		 * Support 'meta_query' query var.
-		 */
-		if ( ! empty( $query_vars['meta_query'] ) ) {
-			$meta_queries = array_merge( $meta_queries, $query_vars['meta_query'] );
-		}
-
-		if ( ! empty( $meta_queries ) ) {
-			$built_meta_queries = $this->build_meta_query( $meta_queries );
-
-			if ( $built_meta_queries ) {
-				$filter['bool']['must'][] = $built_meta_queries;
-				$use_filters              = true;
-			}
-		}
-
-		/**
-		 * Support `fields` query var.
-		 */
-		if ( isset( $query_vars['fields'] ) ) {
-			switch ( $query_vars['fields'] ) {
-				case 'ids':
-					$formatted_args['_source'] = [
-						'includes' => [
-							'term_id',
-						],
-					];
-					break;
-
-				case 'id=>name':
-					$formatted_args['_source'] = [
-						'includes' => [
-							'term_id',
-							'name',
-						],
-					];
-					break;
-
-				case 'id=>parent':
-					$formatted_args['_source'] = [
-						'includes' => [
-							'term_id',
-							'parent',
-						],
-					];
-					break;
-
-				case 'id=>slug':
-					$formatted_args['_source'] = [
-						'includes' => [
-							'term_id',
-							'slug',
-						],
-					];
-					break;
-
-				case 'names':
-					$formatted_args['_source'] = [
-						'includes' => [
-							'name',
-						],
-					];
-					break;
-				case 'tt_ids':
-					$formatted_args['_source'] = [
-						'includes' => [
-							'term_taxonomy_id',
-						],
-					];
-					break;
-			}
-		}
-
-		if ( $use_filters ) {
-			$formatted_args['post_filter'] = $filter;
-		}
+		$formatted_args = $this->maybe_set_search_fields( $formatted_args, $query_vars );
+		$formatted_args = $this->maybe_set_fields( $formatted_args, $query_vars );
 
 		/**
 		 * Filter full Elasticsearch query for Terms indexable
@@ -944,4 +510,634 @@ class Term extends Indexable {
 		return $sort;
 	}
 
+	/**
+	 * Sanitize WP_Term_Query arguments to be used to create the ES query.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function sanitize_query_vars( $query_vars ) {
+		if ( ! empty( $query_vars['get'] ) && 'all' === $query_vars['get'] ) {
+			$query_vars['childless']    = false;
+			$query_vars['child_of']     = 0;
+			$query_vars['hide_empty']   = false;
+			$query_vars['hierarchical'] = false;
+			$query_vars['pad_counts']   = false;
+		}
+
+		$query_vars['taxonomy'] = ( ! empty( $query_vars['taxonomy'] ) ) ?
+			(array) $query_vars['taxonomy'] :
+			[];
+
+		return $query_vars;
+	}
+
+	/**
+	 * Parse the `from` clause of the ES Query.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return int
+	 */
+	protected function parse_from( $query_vars ) {
+		return ( isset( $query_vars['offset'] ) ) ? (int) $query_vars['offset'] : 0;
+	}
+
+	/**
+	 * Parse the `size` clause of the ES Query.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return int
+	 */
+	protected function parse_size( $query_vars ) {
+		if ( ! empty( $query_vars['number'] ) ) {
+			$number = (int) $query_vars['number'];
+		} else {
+			/**
+			 * Set the maximum results window size.
+			 *
+			 * The request will return a HTTP 500 Internal Error if the size of the
+			 * request is larger than the [index.max_result_window] parameter in ES.
+			 * See the scroll api for a more efficient way to request large data sets.
+			 *
+			 * @return int The max results window size.
+			 *
+			 * @since 2.3.0
+			 */
+			$number = apply_filters( 'ep_max_results_window', 10000 );
+		}
+
+		return $number;
+	}
+
+	/**
+	 * Parse the order of results in the ES query.
+	 *
+	 * @since 5.1.0
+	 * @param array $formatted_args Formatted Elasticsearch query
+	 * @param array $query_vars     WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function maybe_orderby( $formatted_args, $query_vars ) {
+		// Set sort order, default is 'ASC'.
+		if ( ! empty( $query_vars['order'] ) ) {
+			$order = $this->parse_order( $query_vars['order'] );
+		} else {
+			$order = 'desc';
+		}
+
+		// Set orderby, default is 'name'.
+		if ( empty( $query_vars['orderby'] ) ) {
+			$query_vars['orderby'] = 'name';
+		}
+
+		// Set sort type.
+		$formatted_args['sort'] = $this->parse_orderby( $query_vars['orderby'], $order, $query_vars );
+
+		return $formatted_args;
+	}
+
+	/**
+	 * Based on WP_Term_Query arguments, parses the various filters that could be applied into the ES query.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_filters( $query_vars ) {
+		$filters = [
+			'taxonomy'                => $this->parse_taxonomy( $query_vars ),
+			'object_ids'              => $this->parse_object_ids( $query_vars ),
+			'include'                 => $this->parse_include( $query_vars ),
+			'exclude'                 => $this->parse_exclude( $query_vars ),
+			'exclude_tree'            => $this->parse_exclude_tree( $query_vars ),
+			'name'                    => $this->parse_name( $query_vars ),
+			'slug'                    => $this->parse_slug( $query_vars ),
+			'term_taxonomy_id'        => $this->parse_term_taxonomy_id( $query_vars ),
+			'hierarchical_hide_empty' => $this->parse_hierarchical_hide_empty( $query_vars ),
+			'child_of'                => $this->parse_child_of( $query_vars ),
+			'parent'                  => $this->parse_parent( $query_vars ),
+			'childless'               => $this->parse_childless( $query_vars ),
+			'meta_query'              => $this->parse_meta_queries( $query_vars ),
+		];
+
+		$filters = array_values( array_filter( $filters ) );
+
+		if ( ! empty( $filters ) ) {
+			$filters = [
+				'bool' => [
+					'must' => $filters,
+				],
+			];
+		}
+
+		return $filters;
+	}
+
+	/**
+	 * Parse the `taxonomy` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_taxonomy( $query_vars ) {
+		if ( empty( $query_vars['taxonomy'] ) ) {
+			return [];
+		}
+
+		if ( count( $query_vars['taxonomy'] ) < 2 ) {
+			return [
+				'term' => [
+					'taxonomy.raw' => $query_vars['taxonomy'][0],
+				],
+			];
+		}
+
+		return [
+			'terms' => [
+				'taxonomy.raw' => $query_vars['taxonomy'],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `object_ids` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_object_ids( $query_vars ) {
+		if ( empty( $query_vars['object_ids'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must' => [
+					'terms' => [
+						'object_ids.value' => (array) $query_vars['object_ids'],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `include` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_include( $query_vars ) {
+		if ( empty( $query_vars['include'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must' => [
+					'terms' => [
+						'term_id' => array_values( (array) $query_vars['include'] ),
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `exclude` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_exclude( $query_vars ) {
+		if ( ! empty( $query_vars['include'] ) || empty( $query_vars['exclude'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must_not' => [
+					'terms' => [
+						'term_id' => array_values( (array) $query_vars['exclude'] ),
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `exclude_tree` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_exclude_tree( $query_vars ) {
+		if ( ! empty( $query_vars['include'] ) || empty( $query_vars['exclude_tree'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must_not' => [
+					[
+						'terms' => [
+							'term_id' => array_values( (array) $query_vars['exclude_tree'] ),
+						],
+					],
+					[
+						'terms' => [
+							'parent' => array_values( (array) $query_vars['exclude_tree'] ),
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `name` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_name( $query_vars ) {
+		if ( empty( $query_vars['name'] ) ) {
+			return [];
+		}
+
+		return [
+			'terms' => [
+				'name.raw' => (array) $query_vars['name'],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `slug` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_slug( $query_vars ) {
+		if ( empty( $query_vars['slug'] ) ) {
+			return [];
+		}
+
+		$query_vars['slug'] = (array) $query_vars['slug'];
+		$query_vars['slug'] = array_map( 'sanitize_title', $query_vars['slug'] );
+
+		return [
+			'terms' => [
+				'slug.raw' => (array) $query_vars['slug'],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `term_taxonomy_id` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_term_taxonomy_id( $query_vars ) {
+		if ( empty( $query_vars['term_taxonomy_id'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must' => [
+					'terms' => [
+						'term_taxonomy_id' => array_values( (array) $query_vars['term_taxonomy_id'] ),
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `hide_empty` and `hierarchical` WP Term Query args and transform them into ES query clauses.
+	 *
+	 * `hierarchical` needs to work in conjunction with `hide_empty`, as per WP docs:
+	 * > `hierarchical`: Whether to include terms that have non-empty descendants (even if $hide_empty is set to true).
+	 *
+	 * In summary:
+	 * - hide_empty AND hierarchical: count > 1 OR hierarchy.children > 1
+	 * - hide_empty AND NOT hierarchical: count > 1 (ignore hierarchy.children)
+	 * - NOT hide_empty (AND hierarchical): there is no need to limit the query
+	 *
+	 * @see https://developer.wordpress.org/reference/classes/WP_Term_Query/__construct/
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_hierarchical_hide_empty( $query_vars ) {
+		$hide_empty = isset( $query_vars['hide_empty'] ) ? $query_vars['hide_empty'] : '';
+		if ( ! $hide_empty ) {
+			return [];
+		}
+
+		$hierarchical = isset( $query_vars['hierarchical'] ) ? $query_vars['hierarchical'] : '';
+		if ( ! $hierarchical ) {
+			return [
+				'range' => [
+					'count' => [
+						'gte' => 1,
+					],
+				],
+			];
+		}
+
+		return [
+			'bool' => [
+				'should' => [
+					[
+						'range' => [
+							'count' => [
+								'gte' => 1,
+							],
+						],
+					],
+					[
+						'range' => [
+							'hierarchy.children.count' => [
+								'gte' => 1,
+							],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `child_of` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_child_of( $query_vars ) {
+		if ( empty( $query_vars['child_of'] ) || count( $query_vars['taxonomy'] ) > 1 ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must' => [
+					'match_phrase' => [
+						'hierarchy.ancestors.terms' => (int) $query_vars['child_of'],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `parent` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_parent( $query_vars ) {
+		if ( ! isset( $query_vars['parent'] ) || '' === $query_vars['parent'] ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must' => [
+					'term' => [
+						'parent' => (int) $query_vars['parent'],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse the `childless` WP Term Query arg and transform it into an ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_childless( $query_vars ) {
+		if ( empty( $query_vars['childless'] ) ) {
+			return [];
+		}
+
+		return [
+			'bool' => [
+				'must' => [
+					'term' => [
+						'hierarchy.children.terms' => 0,
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Parse WP Term Query meta queries and transform them into ES query clauses.
+	 *
+	 * @since 5.1.0
+	 * @param array $query_vars WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function parse_meta_queries( $query_vars ) {
+		$meta_queries = [];
+		/**
+		 * Support `meta_key`, `meta_value`, and `meta_compare` query args
+		 */
+		if ( ! empty( $query_vars['meta_key'] ) ) {
+			$meta_query_array = [
+				'key' => $query_vars['meta_key'],
+			];
+
+			if ( isset( $query_vars['meta_value'] ) && '' !== $query_vars['meta_value'] ) {
+				$meta_query_array['value'] = $query_vars['meta_value'];
+			}
+
+			if ( isset( $query_vars['meta_compare'] ) ) {
+				$meta_query_array['compare'] = $query_vars['meta_compare'];
+			}
+
+			$meta_queries[] = $meta_query_array;
+		}
+
+		/**
+		 * Support 'meta_query' query var.
+		 */
+		if ( ! empty( $query_vars['meta_query'] ) ) {
+			$meta_queries = array_merge( $meta_queries, $query_vars['meta_query'] );
+		}
+
+		if ( ! empty( $meta_queries ) ) {
+			$built_meta_queries = $this->build_meta_query( $meta_queries );
+
+			if ( $built_meta_queries ) {
+				return $built_meta_queries;
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * If in a search context, using `name__like`, or `description__like` set search fields, otherwise query everything.
+	 *
+	 * @since 5.1.0
+	 * @param array $formatted_args Formatted Elasticsearch query
+	 * @param array $query_vars     WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function maybe_set_search_fields( $formatted_args, $query_vars ) {
+		if ( empty( $query_vars['search'] ) && empty( $query_vars['name__like'] ) && empty( $query_vars['description__like'] ) ) {
+			$formatted_args['query']['match_all'] = [
+				'boost' => 1,
+			];
+
+			return $formatted_args;
+		}
+
+		$search        = ! empty( $query_vars['search'] ) ? $query_vars['search'] : '';
+		$search_fields = [];
+
+		if ( ! empty( $query_vars['name__like'] ) ) {
+			$search          = $query_vars['name__like'];
+			$search_fields[] = 'name';
+		}
+
+		if ( ! empty( $query_vars['description__like'] ) ) {
+			$search          = $query_vars['description__like'];
+			$search_fields[] = 'description';
+		}
+
+		/**
+		 * Allow for search field specification
+		 */
+		if ( ! empty( $query_vars['search_fields'] ) ) {
+			$search_fields = $query_vars['search_fields'];
+		}
+
+		if ( ! empty( $search_fields ) ) {
+			$prepared_search_fields = [];
+
+			if ( ! empty( $search_fields['meta'] ) ) {
+				$metas = (array) $search_fields['meta'];
+
+				foreach ( $metas as $meta ) {
+					$prepared_search_fields[] = 'meta.' . $meta . '.value';
+				}
+
+				unset( $search_fields['meta'] );
+			}
+
+			$prepared_search_fields = array_merge( $search_fields, $prepared_search_fields );
+		} else {
+			$prepared_search_fields = [
+				'name',
+				'slug',
+				'taxonomy',
+				'description',
+			];
+		}
+
+		/**
+		 * Filter fields to search on Term query
+		 *
+		 * @hook ep_term_search_fields
+		 * @param  {array} $search_fields Search fields
+		 * @param  {array} $query_vars Query variables
+		 * @since  3.4
+		 * @return {array} New search fields
+		 */
+		$prepared_search_fields = apply_filters( 'ep_term_search_fields', $prepared_search_fields, $query_vars );
+
+		$search_algorithm        = $this->get_search_algorithm( $search, $prepared_search_fields, $query_vars );
+		$formatted_args['query'] = $search_algorithm->get_query( 'term', $search, $prepared_search_fields, $query_vars );
+
+		return $formatted_args;
+	}
+
+	/**
+	 * If needed set the `fields` ES query clause.
+	 *
+	 * @since 5.1.0
+	 * @param array $formatted_args Formatted Elasticsearch query
+	 * @param array $query_vars     WP_Term_Query arguments
+	 * @return array
+	 */
+	protected function maybe_set_fields( $formatted_args, $query_vars ) {
+		if ( ! isset( $query_vars['fields'] ) ) {
+			return $formatted_args;
+		}
+
+		switch ( $query_vars['fields'] ) {
+			case 'ids':
+				$formatted_args['_source'] = [
+					'includes' => [
+						'term_id',
+					],
+				];
+				break;
+
+			case 'id=>name':
+				$formatted_args['_source'] = [
+					'includes' => [
+						'term_id',
+						'name',
+					],
+				];
+				break;
+
+			case 'id=>parent':
+				$formatted_args['_source'] = [
+					'includes' => [
+						'term_id',
+						'parent',
+					],
+				];
+				break;
+
+			case 'id=>slug':
+				$formatted_args['_source'] = [
+					'includes' => [
+						'term_id',
+						'slug',
+					],
+				];
+				break;
+
+			case 'names':
+				$formatted_args['_source'] = [
+					'includes' => [
+						'name',
+					],
+				];
+				break;
+			case 'tt_ids':
+				$formatted_args['_source'] = [
+					'includes' => [
+						'term_taxonomy_id',
+					],
+				];
+				break;
+		}
+
+		return $formatted_args;
+	}
 }

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -844,8 +844,8 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 123, $args['post_filter']['bool']['must'][0]['bool']['must_not']['terms']['term_id'][0] );
-		$this->assertSame( 123, $args['post_filter']['bool']['must'][1]['bool']['must_not']['terms']['parent'][0] );
+		$this->assertSame( 123, $args['post_filter']['bool']['must'][0]['bool']['must_not'][0]['terms']['term_id'][0] );
+		$this->assertSame( 123, $args['post_filter']['bool']['must'][0]['bool']['must_not'][1]['terms']['parent'][0] );
 	}
 
 	/**
@@ -1173,7 +1173,7 @@ class TestTerm extends BaseTestCase {
 		);
 
 		$this->assertSame( 'category', $args['post_filter']['bool']['must'][0]['term']['taxonomy.raw'] );
-		$this->assertSame( 123, $args['post_filter']['bool']['must'][1]['bool']['must'][0]['match_phrase']['hierarchy.ancestors.terms'] );
+		$this->assertSame( 123, $args['post_filter']['bool']['must'][1]['bool']['must']['match_phrase']['hierarchy.ancestors.terms'] );
 
 		$args = $term->format_args(
 			[


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3699

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Major refactor of the Term::format_args() method and conditionally set search fields for term queries in REST API requests.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @mgurtzweiler


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
