### PR TITLE
Apply ngram_fields on search query when ajax and weighting enable

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -195,7 +195,7 @@ class Autosuggest extends Feature {
 	 * @return array $query adjusted ES Query arguments
 	 */
 	public function adjust_fuzzy_fields( $query, $post_type, $args ) {
-		if ( ! Utils\is_integrated_request( $this->slug, [ 'public' ] ) || empty( $args['s'] ) ) {
+		if ( ! Utils\is_integrated_request( $this->slug, [ 'public', 'ajax' ] ) || empty( $args['s'] ) ) {
 			return $query;
 		}
 

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -180,7 +180,7 @@ class Autosuggest extends Feature {
 	 * @return array
 	 */
 	public function set_fuzziness( $fuzziness, $search_fields, $args ) {
-		if ( Utils\is_integrated_request( $this->slug, [ 'public' ] ) && ! empty( $args['s'] ) ) {
+		if ( Utils\is_integrated_request( $this->slug, $this->get_contexts() ) && ! empty( $args['s'] ) ) {
 			return 'auto';
 		}
 		return $fuzziness;
@@ -195,7 +195,7 @@ class Autosuggest extends Feature {
 	 * @return array $query adjusted ES Query arguments
 	 */
 	public function adjust_fuzzy_fields( $query, $post_type, $args ) {
-		if ( ! Utils\is_integrated_request( $this->slug, [ 'public', 'ajax' ] ) || empty( $args['s'] ) ) {
+		if ( ! Utils\is_integrated_request( $this->slug, $this->get_contexts() ) || empty( $args['s'] ) ) {
 			return $query;
 		}
 
@@ -925,5 +925,23 @@ class Autosuggest extends Feature {
 			esc_html__( 'This method should not be called anymore, as autosuggest requests are not sent regularly anymore.' ),
 			'ElasticPress 4.7.0'
 		);
+	}
+
+	/**
+	 * Get the contexts where autosuggest is used.
+	 *
+	 * @since 5.1.0
+	 * @return array
+	 */
+	protected function get_contexts() : array {
+		/**
+		 * Filter contexts where autosuggest is used.
+		 *
+		 * @hook ep_autosuggest_contexts
+		 * @since 5.1.0
+		 * @param {array} $contexts Contexts where autosuggest is used
+		 * @return {array} New contexts
+		 */
+		return apply_filters( 'ep_autosuggest_contexts', [ 'public', 'ajax' ] );
 	}
 }

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -928,18 +928,18 @@ class Autosuggest extends Feature {
 	}
 
 	/**
-	 * Get the contexts where autosuggest is used.
+	 * Get the contexts for autosuggest.
 	 *
 	 * @since 5.1.0
 	 * @return array
 	 */
 	protected function get_contexts() : array {
 		/**
-		 * Filter contexts where autosuggest is used.
+		 * Filter contexts for autosuggest.
 		 *
 		 * @hook ep_autosuggest_contexts
 		 * @since 5.1.0
-		 * @param {array} $contexts Contexts where autosuggest is used
+		 * @param {array} $contexts Contexts for autosuggest
 		 * @return {array} New contexts
 		 */
 		return apply_filters( 'ep_autosuggest_contexts', [ 'public', 'ajax' ] );

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -675,7 +675,7 @@ function is_integrated_request( $context, $types = [] ) {
 	}
 
 	$is_admin_request             = is_admin();
-	$is_ajax_request              = defined( 'DOING_AJAX' ) && DOING_AJAX;
+	$is_ajax_request              = wp_doing_ajax();
 	$is_rest_request              = defined( 'REST_REQUEST' ) && REST_REQUEST;
 	$is_integrated_admin_request  = false;
 	$is_integrated_ajax_request   = false;

--- a/tests/php/features/TestAutosuggest.php
+++ b/tests/php/features/TestAutosuggest.php
@@ -325,11 +325,11 @@ class TestAutosuggest extends BaseTestCase {
 	/**
 	 * Test whether autosuggest ngram fields apply to the search query when AJAX integration and weighting is enabled.
 	 *
-	 * @since 5.1.o
+	 * @since 5.1.0
 	 * @group autosuggest
 	 */
 	public function test_autosuggest_ngram_fields_for_ajax_call() {
-		define( 'DOING_AJAX', true );
+		add_filter( 'wp_doing_ajax', '__return_true' );
 
 		$this->get_feature()->setup();
 

--- a/tests/php/features/TestAutosuggest.php
+++ b/tests/php/features/TestAutosuggest.php
@@ -366,5 +366,6 @@ class TestAutosuggest extends BaseTestCase {
 		);
 
 		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->found_posts );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the ngram fields to query when ajax integration and weighting is enabled. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3832 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Inconsistent search results when calling the same function via PHP and Ajax

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
