### PR TITLE
(fix) correct return type for Elasticsearch::index_document in phpdoc

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -78,7 +78,7 @@ class Elasticsearch {
 	 * @param  array   $document Formatted Elasticsearch document.
 	 * @param  boolean $blocking Blocking HTTP request or not.
 	 * @since  3.0
-	 * @return boolean|array
+	 * @return boolean|object
 	 */
 	public function index_document( $index, $type, $document, $blocking = true ) {
 		/**

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -260,7 +260,7 @@ abstract class Indexable {
 	 * @param  int     $object_id Object to index.
 	 * @param  boolean $blocking Blocking HTTP request or not.
 	 * @since  3.0
-	 * @return boolean
+	 * @return object|boolean
 	 */
 	public function index( $object_id, $blocking = false ) {
 		$document = $this->prepare_document( $object_id );
@@ -299,7 +299,7 @@ abstract class Indexable {
 		 *
 		 * @hook ep_after_index_{indexable_slug}
 		 * @param  {array} $document Document to index
-		 * @param  {array|boolean} $return ES response on success, false on failure
+		 * @param  {object|boolean} $return ES response on success, false on failure
 		 * @since  3.0
 		 */
 		do_action( 'ep_after_index_' . $this->slug, $document, $return );

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -65,7 +65,7 @@ function ep_find_related( $post_id, $return = 5 ) {
  * Index a post given an ID
  *
  * @param  int $post_id  Post ID
- * @return boolean|array
+ * @return boolean|object
  */
 function ep_index_post( $post_id ) {
 	_deprecated_function( __FUNCTION__, '3.0', "ElasticPress\Indexables::factory()->get( 'post' )->index" );


### PR DESCRIPTION
### Description of the Change
This PR corrects the phpdoc return type for Elasticsearch::index_document to prevent false IDE and static analyser warnings.
Closes #3880

### How to test the Change
N/A

### Changelog Entry
Fixed: Correct PHPdoc return type for correct Elasticsearch::index_document


### Credits
@ictbeheer


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
