### PR TITLE
Fix search terms clearing post type filter from forms.

### DIFF
--- a/assets/js/api-search/src/reducer.js
+++ b/assets/js/api-search/src/reducer.js
@@ -29,8 +29,15 @@ export default (state, action) => {
 			break;
 		}
 		case 'SEARCH': {
-			newState.args = { ...newState.args, ...action.args, offset: 0 };
+			const { updateDefaults, ...args } = action.args;
+
+			newState.args = { ...newState.args, ...args, offset: 0 };
 			newState.isOn = true;
+
+			if (updateDefaults && args.post_type.length) {
+				newState.argsSchema.post_type.default = args.post_type;
+			}
+
 			break;
 		}
 		case 'SEARCH_FOR': {

--- a/assets/js/instant-results/apps/modal.js
+++ b/assets/js/instant-results/apps/modal.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { useApiSearch } from '../../api-search';
+import { facets } from '../config';
 import { getPostTypesFromForm } from '../utilities';
 import Modal from '../components/common/modal';
 import Layout from '../components/layout';
@@ -60,8 +61,9 @@ export default () => {
 
 			const { value } = inputRef.current;
 			const post_type = getPostTypesFromForm(inputRef.current.form);
+			const updateDefaults = !facets.some((f) => f.name === 'post_type');
 
-			search({ post_type, search: value });
+			search({ post_type, search: value, updateDefaults });
 		},
 		[inputRef, search],
 	);

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -400,7 +400,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 				cy.visit('/');
 				cy.intercept('*search=heavy*').as('apiRequest');
-				cy.get('.wp-block-search').last().as('productSearchBlock');
+				cy.get('.wc-block-product-search,.wp-block-search').last().as('productSearchBlock');
 				cy.get('@productSearchBlock').find('input[type="search"]').type('heavy{enter}');
 				cy.get('.ep-search-modal').should('be.visible');
 				cy.wait('@apiRequest');
@@ -425,7 +425,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 				cy.visit('/');
 				cy.intercept('*search=ergo*').as('apiRequest');
-				cy.get('.wp-block-search').last().as('productSearchBlock');
+				cy.get('.wc-block-product-search,.wp-block-search').last().as('productSearchBlock');
 				cy.get('@productSearchBlock').find('input[type="search"]').type('heavy{enter}');
 				cy.get('.ep-search-modal').should('be.visible');
 				cy.wait('@apiRequest');

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -17,6 +17,19 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 		cy.wait('@sidebarsRest');
 	}
 
+	/**
+	 * Create a Product Search widget.
+	 */
+	function createProductSearchWidget() {
+		cy.openWidgetsPage();
+		cy.openBlockInserter();
+		cy.getBlocksList().should('contain.text', 'Product Search'); // Checking if it exists give JS time to process the full list.
+		cy.insertBlock('Product Search');
+		cy.intercept('/wp-json/wp/v2/sidebars/*').as('sidebarsRest');
+		cy.get('.edit-widgets-header__actions button').contains('Update').click();
+		cy.wait('@sidebarsRest');
+	}
+
 	before(() => {
 		cy.deactivatePlugin('classic-widgets woocommerce', 'wpCli');
 		createSearchWidget();
@@ -365,6 +378,62 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.get('.ep-search-modal').should('be.visible');
 				cy.wait('@apiRequest');
 				cy.get('.ep-search-suggestion a').should('have.text', 'wordpress');
+			});
+
+			it('Is possible to set the default post type from a search form', () => {
+				cy.maybeEnableFeature('instant-results');
+
+				createProductSearchWidget();
+
+				/**
+				 * If the Post Type filter is in use, entering a new search
+				 * term should reset post type the filter.
+				 */
+				cy.visitAdminPage('admin.php?page=elasticpress');
+				cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
+				cy.contains('button', 'Instant Results').click();
+				cy.get('.components-form-token-field__input').type(
+					'{backspace}{backspace}{backspace}post type{downArrow}{enter}{esc}',
+				);
+				cy.contains('button', 'Save changes').click();
+				cy.wait('@apiRequest');
+
+				cy.visit('/');
+				cy.intercept('*search=heavy*').as('apiRequest');
+				cy.get('.wp-block-search').last().as('productSearchBlock');
+				cy.get('@productSearchBlock').find('input[type="search"]').type('heavy{enter}');
+				cy.get('.ep-search-modal').should('be.visible');
+				cy.wait('@apiRequest');
+				cy.url().should('include', 'post_type=product');
+				cy.get('.ep-search-input').type(' duty');
+				cy.wait(300); // eslint-disable-line
+				cy.wait('@apiRequest');
+				cy.url().should('not.include', 'post_type=product');
+
+				/**
+				 * If the Post Type filter is not in use, entering a new search
+				 * term should not reset the post type filter.
+				 */
+				cy.visitAdminPage('admin.php?page=elasticpress');
+				cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
+				cy.contains('button', 'Instant Results').click();
+				cy.contains('.components-form-token-field__token', 'Post type')
+					.find('button')
+					.click();
+				cy.contains('button', 'Save changes').click();
+				cy.wait('@apiRequest');
+
+				cy.visit('/');
+				cy.intercept('*search=ergo*').as('apiRequest');
+				cy.get('.wp-block-search').last().as('productSearchBlock');
+				cy.get('@productSearchBlock').find('input[type="search"]').type('heavy{enter}');
+				cy.get('.ep-search-modal').should('be.visible');
+				cy.wait('@apiRequest');
+				cy.url().should('include', 'post_type=product');
+				cy.get('.ep-search-input').type(' duty');
+				cy.wait(300); // eslint-disable-line
+				cy.wait('@apiRequest');
+				cy.url().should('include', 'post_type=product');
 			});
 		});
 

--- a/tests/cypress/support/commands/block-editor.js
+++ b/tests/cypress/support/commands/block-editor.js
@@ -4,7 +4,9 @@ Cypress.Commands.add('openBlockSettingsSidebar', () => {
 	cy.get('body').then(($el) => {
 		if ($el.hasClass('widgets-php')) {
 			cy.get('.edit-widgets-header__actions button[aria-label="Settings"]').click();
-			cy.get('.edit-widgets-sidebar__panel-tab').contains('Block').click();
+			cy.get('.edit-widgets-sidebar__panel-tab,.edit-widgets-sidebar__panel-tabs button')
+				.contains('Block')
+				.click();
 		} else {
 			cy.get('.edit-post-header__settings button[aria-label="Settings"]').click();
 			cy.get('.edit-post-sidebar__panel-tab').contains('Block').click();
@@ -21,7 +23,9 @@ Cypress.Commands.add('openBlockInserter', () => {
 		if ($body.hasClass('widgets-php')) {
 			cy.get('.edit-widgets-header-toolbar__inserter-toggle').click();
 		} else {
-			cy.get('.edit-post-header-toolbar__inserter-toggle').click();
+			cy.get(
+				'.edit-post-header-toolbar__inserter-toggle,.editor-document-tools__inserter-toggle',
+			).click();
 		}
 	});
 });

--- a/tests/cypress/support/commands/block-editor.js
+++ b/tests/cypress/support/commands/block-editor.js
@@ -9,7 +9,9 @@ Cypress.Commands.add('openBlockSettingsSidebar', () => {
 				.click();
 		} else {
 			cy.get('.edit-post-header__settings button[aria-label="Settings"]').click();
-			cy.get('.edit-post-sidebar__panel-tab').contains('Block').click();
+			cy.get('.edit-post-sidebar__panel-tab,.edit-post-sidebar__panel-tabs button')
+				.contains('Block')
+				.click();
 		}
 	});
 });


### PR DESCRIPTION
### Description of the Change
Fixes an issue where the default post type that is set from an `<input name="post_type">` field in the search form would be cleared if a new search term was entered.

Note that this is only true when the Post Type facet/filter is not in use. If the post type facet is enabled, it will be cleared as before. This is the expected behaviour for filters.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3868

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
Fixed - An issue in Instant Results where a default post type filter that is set by a field in the search form would be cleared if a new search term was entered.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
