### PR TITLE
WIP: Display the error log when a sync completes with errors.

### DIFF
--- a/assets/js/sync-ui/components/log.js
+++ b/assets/js/sync-ui/components/log.js
@@ -82,7 +82,11 @@ export default () => {
 
 	return (
 		<>
-			<TabPanel className="ep-sync-log" tabs={tabs}>
+			<TabPanel
+				className="ep-sync-log"
+				initialTabName={errorCount > 0 ? 'error' : 'full'}
+				tabs={tabs}
+			>
 				{({ name }) => {
 					switch (name) {
 						case 'full':

--- a/tests/cypress/integration/dashboard-sync.cy.js
+++ b/tests/cypress/integration/dashboard-sync.cy.js
@@ -199,7 +199,15 @@ describe('Dashboard Sync', () => {
 		cy.contains('button', 'Log').click();
 		cy.contains('button', 'Errors').click();
 		cy.contains('.ep-sync-errors', 'No errors found in the log.').should('exist');
+
+		/**
+		 * Reload the page, so we can check if the Error Log tab is opened by default when an error occurs.
+		 */
+		cy.visitAdminPage('admin.php?page=elasticpress-sync');
 		cy.contains('button', 'Start sync').click();
+		cy.get('.ep-sync-errors__table', {
+			timeout: Cypress.config('elasticPressIndexTimeout'),
+		}).should('be.visible');
 		cy.get('.ep-sync-errors tr', { timeout: Cypress.config('elasticPressIndexTimeout') })
 			.contains('Limit of total fields [???] in index [???] has been exceeded')
 			.should('exist');

--- a/tests/cypress/wordpress-files/test-plugins/sync-error.php
+++ b/tests/cypress/wordpress-files/test-plugins/sync-error.php
@@ -9,18 +9,36 @@
  * @package ElasticPress_Tests_E2e
  */
 
-add_filter( 'ep_total_field_limit', fn() => 100 );
+namespace ElasticPress\Tests\E2E\SyncError;
+
+const META_COUNT = 100;
+
+add_filter( 'ep_total_field_limit', fn() => META_COUNT );
 
 add_filter(
 	'ep_prepare_meta_data',
 	function ( $post_meta, $post ) {
 		if ( 0 === $post->ID % 2 ) {
-			for ( $i = 0; $i < 100; $i++ ) {
+			for ( $i = 0; $i < META_COUNT; $i++ ) {
 				$post_meta[ "test_meta_{$i}_title_{$post->ID}" ] = 'Lorem';
 				$post_meta[ "test_meta_{$i}_body_{$post->ID}" ]  = 'Ipsum';
 			}
 		}
 		return $post_meta;
+	},
+	10,
+	2
+);
+
+add_filter(
+	'ep_prepare_meta_allowed_protected_keys',
+	function ( $allowed_meta, $post ) {
+		for ( $i = 0; $i < META_COUNT; $i++ ) {
+			$allowed_meta[] = "test_meta_{$i}_title_{$post->ID}";
+			$allowed_meta[] = "test_meta_{$i}_body_{$post->ID}";
+		}
+
+		return $allowed_meta;
 	},
 	10,
 	2


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Automatically opens the _Log_ panel with the Errors tab open when a sync completes with errors. Additionally, if errors are in the log, the log tabs will default to the Error log when opened. If the log is already open to either tab when a sync completes nothing will happen.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3893

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
Added - Automatically open the error log when a sync completes with errors.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @JakePT, @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
