### PR TITLE
Fix status report page

### DIFF
--- a/includes/classes/StatusReport/IndexableContent.php
+++ b/includes/classes/StatusReport/IndexableContent.php
@@ -135,6 +135,7 @@ class IndexableContent extends Report {
 		$fields           = [];
 		$all_keys         = [];
 		$post_count_limit = 88000;
+		$limited          = false;
 
 		foreach ( $post_types as $post_type ) {
 			$post_type_obj = get_post_type_object( $post_type );

--- a/includes/classes/StatusReport/IndexableContent.php
+++ b/includes/classes/StatusReport/IndexableContent.php
@@ -93,6 +93,7 @@ class IndexableContent extends Report {
 		$post_types     = $post_indexable->get_indexable_post_types();
 
 		$post_stati = $post_indexable->get_indexable_post_status();
+		$fields     = [];
 
 		foreach ( $post_types as $post_type ) {
 			$post_type_obj   = get_post_type_object( $post_type );


### PR DESCRIPTION
### Description of the Change

Fixes the bug with status report page throwing an error when indexable post types returns an empty array.
Closes #3909

### How to test the Change

Add `ep_indexable_post_types` filter that returns an empty array.

### Changelog Entry
> Fixed - Status report page when indexable post types is an empty array.


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.