### PR TITLE
Add nonce param to do_sync links

### DIFF
--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -175,11 +175,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$url = admin_url( 'network/admin.php?page=elasticpress-sync&do_sync=features' );
-		} else {
-			$url = admin_url( 'admin.php?page=elasticpress-sync&do_sync=features' );
-		}
+		$url = Utils\get_sync_url( 'features' );
 
 		$feature = Features::factory()->get_registered_feature( $auto_activate_sync );
 
@@ -250,11 +246,7 @@ class AdminNotices {
 			return false;
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$url = admin_url( 'network/admin.php?page=elasticpress-sync&do_sync=upgrade' );
-		} else {
-			$url = admin_url( 'admin.php?page=elasticpress-sync&do_sync=upgrade' );
-		}
+		$url = Utils\get_sync_url( 'upgrade' );
 
 		if ( defined( 'EP_DASHBOARD_SYNC' ) && ! EP_DASHBOARD_SYNC ) {
 			$html = esc_html__( 'Dashboard sync is disabled. The new version of ElasticPress requires that you delete all data and start a fresh sync using WP-CLI.', 'elasticpress' );

--- a/includes/partials/install-page.php
+++ b/includes/partials/install-page.php
@@ -12,13 +12,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
 	$setup_url     = admin_url( 'network/admin.php?page=elasticpress-settings' );
-	$sync_url      = admin_url( 'network/admin.php?page=elasticpress-sync&do_sync=install' );
 	$dashboard_url = admin_url( 'network/admin.php?page=elasticpress' );
 } else {
 	$setup_url     = admin_url( 'admin.php?page=elasticpress-settings' );
-	$sync_url      = admin_url( 'admin.php?page=elasticpress-sync&do_sync=install' );
 	$dashboard_url = admin_url( 'admin.php?page=elasticpress' );
 }
+
+$sync_url = \ElasticPress\Utils\get_sync_url( 'install' );
 
 $skip_install_url = add_query_arg(
 	[

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -767,13 +767,17 @@ function get_asset_info( $slug, $attribute = null ) {
  * Return the Sync Page URL.
  *
  * @since 4.4.0
- * @param boolean $do_sync Whether the link should or should not start a resync.
+ * @param boolean|string $do_sync Whether the link should or should not start a resync. Pass a string to store the reason of the resync.
  * @return string
  */
-function get_sync_url( bool $do_sync = false ) : string {
+function get_sync_url( $do_sync = false ) : string {
 	$page = 'admin.php?page=elasticpress-sync';
 	if ( $do_sync ) {
-		$page .= '&do_sync&ep_sync_nonce=' . wp_create_nonce( 'ep_sync_nonce' );
+		$page .= '&do_sync';
+		if ( is_string( $do_sync ) ) {
+			$page .= '=' . rawurlencode( $do_sync );
+		}
+		$page .= '&ep_sync_nonce=' . wp_create_nonce( 'ep_sync_nonce' );
 	}
 	return ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) ?
 		network_admin_url( $page ) :


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Missing nonces on some sync trigger URLs, making them require a manual interaction from the user.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
