### PR TITLE
improve readability of sync output

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1339,9 +1339,11 @@ class Command extends WP_CLI_Command {
 				$time_elapsed      = Utility::timer_stop( 2 );
 				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Time elapsed: ', 'elasticpress' ) . '%N' . Utility::timer_format( $time_elapsed ) . $time_elapsed_diff ) );
 
-				$current_memory = round( memory_get_usage() / 1024 / 1024, 2 ) . 'mb';
-				$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
-				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
+				$current_memory = memory_get_usage() / 1024 / 1024;
+				$current_memory = ( $current_memory > 1000 ) ? round( $current_memory / 1024, 2 ) . 'gb' : round( $current_memory, 2 ) . 'mb';
+				$peak_memory    = memory_get_peak_usage() / 1024 / 1024;
+				$peak_memory    = ( $peak_memory > 1000 ) ? round( $peak_memory / 1024, 2 ) . 'gb' : round( $peak_memory, 2 ) . 'mb';
+				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . ' (Peak: ' . $peak_memory . ')' ) );
 			}
 		}
 	}

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -726,11 +726,11 @@ class IndexHelper {
 
 		$summary = sprintf(
 			/* translators: 1. Indexable type 2. Offset start, 3. Offset end, 4. Found items 5. Last object ID */
-			esc_html__( 'Processed %1$s %2$d - %3$d of %4$d. Last Object ID: %5$d', 'elasticpress' ),
+			esc_html__( 'Processed %1$s %2$s - %3$s of %4$s. Last Object ID: %5$d', 'elasticpress' ),
 			esc_html( strtolower( $indexable->labels['plural'] ) ),
-			$this->index_meta['from'],
-			$this->index_meta['offset'],
-			$this->index_meta['found_items'],
+			number_format( $this->index_meta['from'] ),
+			number_format( $this->index_meta['offset'] ),
+			number_format( $this->index_meta['found_items'] ),
 			$this->index_meta['current_sync_item']['last_processed_object_id']
 		);
 

--- a/includes/classes/REST/Sync.php
+++ b/includes/classes/REST/Sync.php
@@ -190,10 +190,10 @@ class Sync {
 				[
 					'message'    => sprintf(
 						/* translators: 1. Number of objects indexed, 2. Total number of objects, 3. Last object ID. */
-						esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ),
-						$index_meta['offset'],
-						$index_meta['found_items'],
-						$index_meta['current_sync_item']['last_processed_object_id']
+						esc_html__( 'Processed %1$s/%2$s. Last Object ID: %3$s', 'elasticpress' ),
+						number_format( $index_meta['offset'] ),
+						number_format( $index_meta['found_items'] ),
+						number_format( $index_meta['current_sync_item']['last_processed_object_id'] )
 					),
 					'index_meta' => $index_meta,
 				]

--- a/includes/partials/stats-page.php
+++ b/includes/partials/stats-page.php
@@ -84,7 +84,7 @@ $failed_queries = Stats::factory()->get_failed_queries();
 				<div class="ep-flex-container">
 					<div class="ep-totals-column inside">
 						<p class="ep-totals-title"><?php esc_html_e( 'Total Documents', 'elasticpress' ); ?></p>
-						<p class="ep-totals-data"><?php echo esc_html( $totals['docs'] ); ?></p>
+						<p class="ep-totals-data"><?php echo esc_html(number_format( $totals['docs'] )); ?></p>
 					</div>
 					<div class="ep-totals-column inside">
 						<p class="ep-totals-title"><?php esc_html_e( 'Total Size', 'elasticpress' ); ?></p>

--- a/includes/partials/stats-page.php
+++ b/includes/partials/stats-page.php
@@ -84,7 +84,7 @@ $failed_queries = Stats::factory()->get_failed_queries();
 				<div class="ep-flex-container">
 					<div class="ep-totals-column inside">
 						<p class="ep-totals-title"><?php esc_html_e( 'Total Documents', 'elasticpress' ); ?></p>
-						<p class="ep-totals-data"><?php echo esc_html(number_format( $totals['docs'] )); ?></p>
+						<p class="ep-totals-data"><?php echo esc_html( number_format( $totals['docs'] ) ); ?></p>
 					</div>
 					<div class="ep-totals-column inside">
 						<p class="ep-totals-title"><?php esc_html_e( 'Total Size', 'elasticpress' ); ?></p>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3987

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Do a sync via WP-CLI, notice change in output.

#### Output example (before):
```
...
Processed posts 40050 - 40200 of 571364. Last Object ID: 2444285
Processed posts 40200 - 40350 of 571364. Last Object ID: 2443651
Processed posts 40350 - 40500 of 571364. Last Object ID: 2443046
Time elapsed: 00:11:14.980000 (+26.058)
Memory Usage: 4978.59mb (Peak: 4982.8mb)
Processed posts 40500 - 40650 of 571364. Last Object ID: 2442462
Processed posts 40650 - 40800 of 571364. Last Object ID: 2441899
Processed posts 40800 - 40950 of 571364. Last Object ID: 2441234
...
```

#### Output example (after):
```
...
Processed posts 34,050 - 34,200 of 571,364. Last Object ID: 2467260
Processed posts 34,200 - 34,350 of 571,364. Last Object ID: 2466652
Processed posts 34,350 - 34,500 of 571,364. Last Object ID: 2466098
Time elapsed: 00:09:26.950000 (+24.593)
Memory Usage: 4.15gb (Peak: 4.15gb)
Processed posts 34,500 - 34,650 of 571,364. Last Object ID: 2465535
Processed posts 34,650 - 34,800 of 571,364. Last Object ID: 2464943
Processed posts 34,800 - 34,950 of 571,364. Last Object ID: 2464404
...
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Existing functionality

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @columbian-chris

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
