### PR TITLE
Escape special chars on Instant Results and Autosuggest

### DIFF
--- a/assets/js/instant-results/components/results/result.js
+++ b/assets/js/instant-results/components/results/result.js
@@ -8,6 +8,7 @@ import { WPElement } from '@wordpress/element';
  */
 import { postTypeLabels } from '../../config';
 import { formatDate } from '../../utilities';
+import { escapeRegExp } from '../../../utils/helpers';
 import Result from '../common/result';
 
 /**
@@ -36,7 +37,7 @@ export default ({ hit, searchTerm, highlightTag }) => {
 	/**
 	 * Note: highlighting is redone here because the unified highlight type is not supported in ES5
 	 */
-	const regex = new RegExp(`\\b(${searchTerm})`, 'gi');
+	const regex = new RegExp(`\\b(${escapeRegExp(searchTerm)})`, 'gi');
 	let title;
 
 	if (highlightTag === '' || highlightTag === undefined) {

--- a/assets/js/utils/helpers.js
+++ b/assets/js/utils/helpers.js
@@ -47,7 +47,10 @@ export const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\
  * @returns {string} replaced string
  */
 export const replaceGlobally = (string, term, replacement) => {
-	return string.replace(new RegExp(escapeRegExp(term), 'g'), replacement);
+	return string.replace(
+		new RegExp(escapeRegExp(term), 'g'),
+		JSON.stringify(replacement).slice(1, -1), // Escapes especial chars and remove quotes added by JSON.stringify
+	);
 };
 
 /**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3968

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Special characters like `\` in search terms for both Autosuggest and Instant Results

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
