### PR TITLE
Check for document before removing it.

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -356,7 +356,8 @@ class SyncManager extends \ElasticPress\SyncManager {
 
 		// Our post was published, but is no longer, so let's remove it from the Elasticsearch index.
 		if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
-			$this->action_delete_post( $post_id );
+			// Check that the document exists - it may not in the case of auto-saving a new post. If it exists, remove it.
+			$indexable->get( $post_id ) && $this->action_delete_post( $post_id );
 		} else {
 			$indexable_post_types = $indexable->get_indexable_post_types();
 


### PR DESCRIPTION
### Description of the Change

This change adds a check to make sure a document exists before deleting it - in the `action_sync_on_update` function only.

Because `wp_insert_post` triggers `action_sync_on_update`, a delete is called on a non-existing document.

On some systems, this will log a 404 error from the ES database - and contribute to noise in the logs.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Existing behaviour:

Create a new post, `action_delete_post` will be called.

With this PR:

Create a new post, `action_delete_post` will not be called.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - `action_sync_on_update` checks for document before deleting, to avoid calling delete on post creation & auto-save.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @EarthlingDavey

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
