### PR TITLE
Use the correct version of PluginPostStatusInfo depending on the WP version

### DIFF
--- a/assets/js/search/editor/plugins/exclude-from-search.js
+++ b/assets/js/search/editor/plugins/exclude-from-search.js
@@ -3,7 +3,8 @@
  */
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { PluginPostStatusInfo } from '@wordpress/edit-post';
+import { PluginPostStatusInfo as PluginPostStatusInfoLegacy } from '@wordpress/edit-post';
+import { PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 export default () => {
@@ -17,8 +18,18 @@ export default () => {
 		editPost({ meta: { ...meta, ep_exclude_from_search } });
 	};
 
+	let WrapperElement = null;
+	let marginBottomProp = {};
+
+	if (typeof PluginPostStatusInfo !== 'undefined') {
+		WrapperElement = PluginPostStatusInfo;
+		marginBottomProp = { __nextHasNoMarginBottom: true };
+	} else {
+		WrapperElement = PluginPostStatusInfoLegacy;
+	}
+
 	return (
-		<PluginPostStatusInfo>
+		<WrapperElement>
 			<CheckboxControl
 				label={__('Exclude from search results', 'elasticpress')}
 				help={__(
@@ -27,7 +38,8 @@ export default () => {
 				)}
 				checked={ep_exclude_from_search}
 				onChange={onChange}
+				{...marginBottomProp}
 			/>
-		</PluginPostStatusInfo>
+		</WrapperElement>
 	);
 };


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3995

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Deprecation warning related to PluginPostStatusInfo

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
