### PR TITLE
Add new filter to disable query logging: ep_disable_query_logging

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1736,7 +1736,7 @@ class Elasticsearch {
 	 */
 	protected function add_query_log( $query ) {
 		$wp_debug      = defined( 'WP_DEBUG' ) && WP_DEBUG;
-		$wp_ep_debug = defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG );
+		$wp_ep_debug   = defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG;
 		
 		/**
 		 * Filter query logging. Don't log anything to the queries property when true.
@@ -1746,7 +1746,7 @@ class Elasticsearch {
 		 * @return {bool} New value
 		 * @since  5.2.0
 		 */
-		$disable_query_logging = apply_filters( 'ep_disable_query_logging', false )
+		$disable_query_logging = apply_filters( 'ep_disable_query_logging', false );
 
 		if ( ! $disable_query_logging && ( $wp_debug || $wp_ep_debug ) ) {
 			$this->queries[] = $query;

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1730,14 +1730,14 @@ class Elasticsearch {
 	 * Query logging. Don't log anything to the queries property when
 	 * WP_DEBUG is not enabled. Calls action 'ep_add_query_log' if you
 	 * want to access the query outside of the ElasticPress plugin. This
-	 * runs regardless of debufg settings.
+	 * runs regardless of debug settings.
 	 *
 	 * @param array $query Query to log.
 	 */
 	protected function add_query_log( $query ) {
-		$wp_debug      = defined( 'WP_DEBUG' ) && WP_DEBUG;
-		$wp_ep_debug   = defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG;
-		
+		$wp_debug    = defined( 'WP_DEBUG' ) && WP_DEBUG;
+		$wp_ep_debug = defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG;
+
 		/**
 		 * Filter query logging. Don't log anything to the queries property when true.
 		 *

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1735,6 +1735,9 @@ class Elasticsearch {
 	 * @param array $query Query to log.
 	 */
 	protected function add_query_log( $query ) {
+		$wp_debug      = defined( 'WP_DEBUG' ) && WP_DEBUG;
+		$wp_ep_debug = defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG );
+		
 		/**
 		 * Filter query logging. Don't log anything to the queries property when true.
 		 *
@@ -1743,8 +1746,9 @@ class Elasticsearch {
 		 * @return {bool} New value
 		 * @since  5.2.0
 		 */
-		if ( apply_filters( 'ep_disable_query_logging', false ) && ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ||
-		( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) ) {
+		$disable_query_logging = apply_filters( 'ep_disable_query_logging', false )
+
+		if ( ! $disable_query_logging && ( $wp_debug || $wp_ep_debug ) ) {
 			$this->queries[] = $query;
 		}
 

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1735,7 +1735,15 @@ class Elasticsearch {
 	 * @param array $query Query to log.
 	 */
 	protected function add_query_log( $query ) {
-		if ( apply_filters( 'ep_disable_query_logging', false ) && ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || 
+		/**
+		 * Filter query logging. Don't log anything to the queries property when true.
+		 *
+		 * @hook ep_disable_query_logging
+		 * @param  {bool} Whether to log to the queries property. Defaults to false.
+		 * @return {bool} New value
+		 * @since  5.2.0
+		 */
+		if ( apply_filters( 'ep_disable_query_logging', false ) && ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ||
 		( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) ) {
 			$this->queries[] = $query;
 		}

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1735,7 +1735,8 @@ class Elasticsearch {
 	 * @param array $query Query to log.
 	 */
 	protected function add_query_log( $query ) {
-		if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
+		if ( apply_filters( 'ep_disable_query_logging', false ) && ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || 
+		( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) ) {
 			$this->queries[] = $query;
 		}
 

--- a/tests/php/TestElasticsearch.php
+++ b/tests/php/TestElasticsearch.php
@@ -378,4 +378,35 @@ class TestElasticsearch extends BaseTestCase {
 		];
 		$this->assertEqualsCanonicalizing( $expected, \ElasticPress\Elasticsearch::factory()->get_indices_comparison() );
 	}
+
+	/**
+	 * Test the ep_disable_query_logging filter
+	 *
+	 * @since 5.2.0
+	 * @group elasticsearch
+	 */
+	public function testEpDisableQueryLoggingFilter() {
+		$elasticsearch = new \ElasticPress\Elasticsearch();
+
+		$reflection = new \ReflectionClass( $elasticsearch );
+		$property   = $reflection->getProperty( 'queries' );
+		$property->setAccessible( true );
+		$method = $reflection->getMethod( 'add_query_log' );
+		$method->setAccessible( true );
+
+		$example_query = [ 'example_query' ];
+
+		add_filter( 'ep_disable_query_logging', '__return_true' );
+
+		$method->invokeArgs( $elasticsearch, [ $example_query ] );
+		$this->assertEmpty( $property->getValue( $elasticsearch ) );
+
+		remove_filter( 'ep_disable_query_logging', '__return_true' );
+
+		$method->invokeArgs( $elasticsearch, [ $example_query ] );
+
+		$queries = $property->getValue( $elasticsearch );
+		$this->assertCount( 1, $queries );
+		$this->assertSame( $example_query, $queries[0] );
+	}
 }


### PR DESCRIPTION
### Description of the Change
Adds a new filter called `ep_disable_query_logging` to disable query logging due to potential memory leaks.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4006

### How to test the Change
`add_filter( 'ep_disable_query_logging', '__return_true' );`

### Changelog Entry
> Added - New filter ep_disable_query_logging to disable query logging

### Credits
Props @davidsword

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
