### PR TITLE
Add a new setting to Protect Content to use WP default order in admin

### DIFF
--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -64,6 +64,7 @@ class ProtectedContent extends Feature {
 			add_filter( 'ep_admin_wp_query_integration', '__return_true' );
 			add_action( 'pre_get_posts', [ $this, 'integrate' ] );
 			add_filter( 'ep_post_query_db_args', [ $this, 'query_password_protected_posts' ] );
+			add_filter( 'ep_set_sort', [ $this, 'maybe_change_sort' ] );
 		}
 
 		if ( Features::factory()->get_registered_feature( 'comments' )->is_active() ) {
@@ -426,5 +427,53 @@ class ProtectedContent extends Feature {
 	 */
 	public function sync_password_protected( $new_skip, bool $skip ) : bool {
 		return $skip;
+	}
+
+	/**
+	 * Maybe change the sort order for the WP Dashboard.
+	 *
+	 * If the admin user has enabled the setting to use the default WordPress sort order,
+	 * we will change the sort order to (somewhat) match the default WP behavior.
+	 *
+	 * @since 5.1.4
+	 *
+	 * @param array $default_sort The previous value of the `ep_set_sort` filter
+	 * @return array
+	 */
+	public function maybe_change_sort( $default_sort ) {
+		if ( ! function_exists( '\get_current_screen' ) ) {
+			return $default_sort;
+		}
+
+		$screen = get_current_screen();
+		if ( 'edit' !== $screen->base ) {
+			return $default_sort;
+		}
+
+		if ( ! $this->get_setting( 'use_default_wp_sort' ) ) {
+			return $default_sort;
+		}
+
+		return [
+			[ 'post_date' => [ 'order' => 'desc' ] ],
+			[ 'post_title.sortable' => [ 'order' => 'asc' ] ],
+		];
+	}
+
+	/**
+	 * Set the `settings_schema` attribute
+	 *
+	 * @since 5.1.4
+	 */
+	protected function set_settings_schema() {
+		$this->settings_schema = [
+			[
+				'default' => '0',
+				'key'     => 'use_default_wp_sort',
+				'help'    => __( 'Enable to use WordPress default sort for searches inside the WP Dashboard.', 'elasticpress' ),
+				'label'   => __( 'Use default WordPress sort on the WP Dashboard', 'elasticpress' ),
+				'type'    => 'checkbox',
+			],
+		];
 	}
 }

--- a/tests/php/features/TestProtectedContent.php
+++ b/tests/php/features/TestProtectedContent.php
@@ -453,7 +453,7 @@ class TestProtectedContent extends BaseTestCase {
 		ElasticPress\Features::factory()->activate_feature( 'protected_content' );
 		ElasticPress\Features::factory()->setup_features();
 
-		$exact_match_id = $this->ep_factory->post->create(
+		$exact_match_id       = $this->ep_factory->post->create(
 			[
 				'post_title' => 'exact match - beautiful',
 				'post_date'  => '2021-12-31 23:59:59',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3815

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New setting to Protect Content to use WP default order in admin

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @realrellek

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
