### PR TITLE
Refactor of triggerAutosuggestEvent with adjustments for the dataLayer.push() call

### DIFF
--- a/assets/js/autosuggest/index.js
+++ b/assets/js/autosuggest/index.js
@@ -83,26 +83,40 @@ function triggerAutosuggestEvent(detail) {
 	const event = new CustomEvent('ep-autosuggest-click', { detail });
 	window.dispatchEvent(event);
 
-	/**
-	 * Check if window.gtag was already defined, otherwise
-	 * try to use window.dataLayer.push, available by default
-	 * for Tag Manager users.
-	 */
-	let epGtag = null;
-	if (typeof window?.gtag === 'function') {
-		epGtag = window.gtag;
-	} else if (typeof window?.dataLayer?.push === 'function') {
-		epGtag = window.dataLayer.push;
+	if (parseInt(epas.triggerAnalytics, 10) !== 1) {
+		return;
 	}
 
-	if (detail.searchTerm && parseInt(epas.triggerAnalytics, 10) === 1 && epGtag) {
-		const action = `click - ${detail.searchTerm}`;
-		// eslint-disable-next-line no-undef
-		epGtag('event', action, {
-			event_category: 'EP :: Autosuggest',
-			event_label: detail.url,
-			transport_type: 'beacon',
-		});
+	if (!detail.searchTerm) {
+		return;
+	}
+
+	const action = `click - ${detail.searchTerm}`;
+	try {
+		/**
+		 * Check if window.gtag was already defined, otherwise
+		 * try to use window.dataLayer.push, available by default
+		 * for Tag Manager users.
+		 */
+		if (typeof window?.gtag === 'function') {
+			window.gtag('event', action, {
+				event_category: 'EP :: Autosuggest',
+				event_label: detail.url,
+				transport_type: 'beacon',
+			});
+			return;
+		}
+		if (typeof window?.dataLayer?.push === 'function') {
+			window.dataLayer.push({
+				event: 'ep_autosuggest_click',
+				ep_autosuggest_search_term: detail.searchTerm,
+				ep_autosuggest_clicked_url: detail.url,
+				event_category: 'EP :: Autosuggest',
+				event_label: detail.url,
+			});
+		}
+	} catch (error) {
+		// When Ad blocks are enabled, the call above will fail
 	}
 }
 

--- a/assets/js/autosuggest/index.js
+++ b/assets/js/autosuggest/index.js
@@ -100,6 +100,8 @@ function triggerAutosuggestEvent(detail) {
 		 */
 		if (typeof window?.gtag === 'function') {
 			window.gtag('event', action, {
+				ep_autosuggest_search_term: detail.searchTerm,
+				ep_autosuggest_clicked_url: detail.url,
 				event_category: 'EP :: Autosuggest',
 				event_label: detail.url,
 				transport_type: 'beacon',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3925

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Autosuggest GA tracking to work when ad blocks are enabled. The dataLayer.push() call now pushes a custom event called `ep_autosuggest_click` with `ep_autosuggest_search_term` and `ep_autosuggest_clicked_url` as custom parameters.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @anjulahettige 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
