### PR TITLE
Fix date block error when date is not selected

### DIFF
--- a/assets/js/blocks/facets/date/view.js
+++ b/assets/js/blocks/facets/date/view.js
@@ -16,7 +16,11 @@ const initFacet = () => {
 		form.addEventListener('submit', function (event) {
 			event.preventDefault();
 
-			const { value } = this.querySelector(`[name="${filterName}"]:checked`);
+			const { value } = this.querySelector(`[name="${filterName}"]:checked`) || '';
+			if (!value) {
+				return;
+			}
+
 			const { value: startDateValue } =
 				this.querySelector('.ep-date-range-picker')?.querySelector(
 					`[name="${filterName}_from"]`,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.



Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an error where the Date filter throws an error when the submit button is clicked without selecting a date

`view.js:19 Uncaught TypeError: Cannot destructure property 'value' of 'this.querySelector(...)' as it is null.`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - JS error when submit button is clicked without selecting a date


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
