### PR TITLE
Fix: Attempt to read property base on null

### DIFF
--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -441,6 +441,10 @@ class ProtectedContent extends Feature {
 		}
 
 		$screen = get_current_screen();
+		if ( empty( $screen ) ) {
+			return $default_sort;
+		}
+
 		if ( 'edit' !== $screen->base ) {
 			return $default_sort;
 		}

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -441,11 +441,7 @@ class ProtectedContent extends Feature {
 		}
 
 		$screen = get_current_screen();
-		if ( empty( $screen ) ) {
-			return $default_sort;
-		}
-
-		if ( 'edit' !== $screen->base ) {
+		if ( empty( $screen ) || 'edit' !== $screen->base ) {
 			return $default_sort;
 		}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where a warning is thrown when protected content is enabled and WP_Query runs in the AJAX callback

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4059 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Enable the protected content feature.
2. Add `add_filter( 'ep_ajax_wp_query_integration', '__return_true' );` filter
3. Call the WP_Query with a search parameter and ensure the orderby parameter is empty in the ajax callback function

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. --> 
> Fixed -  Attempt to read property "base" on null


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @yarovikov

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
