### PR TITLE
Fix: Function _load_textdomain_just_in_time was called incorrectly

### DIFF
--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -622,4 +622,13 @@ abstract class Feature {
 			];
 		}
 	}
+
+	/**
+	 * Sets the i18n strings for the feature.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+	}
 }

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -40,14 +40,6 @@ class Autosuggest extends Feature {
 	public function __construct() {
 		$this->slug = 'autosuggest';
 
-		$this->title = esc_html__( 'Autosuggest', 'elasticpress' );
-
-		$this->short_title = esc_html__( 'Autosuggest', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'Input fields of type "search" or with the CSS class "search-field" or "ep-autosuggest" will be enhanced with autosuggest functionality. As text is entered into the search field, suggested content will appear below it, based on top search results for the text. Suggestions link directly to the content.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#autosuggest', 'elasticpress' );
-
 		$this->requires_install_reindex = true;
 
 		$this->default_settings = [
@@ -61,6 +53,22 @@ class Autosuggest extends Feature {
 		$this->is_powered_by_epio = Utils\is_epio();
 
 		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Autosuggest', 'elasticpress' );
+
+		$this->short_title = esc_html__( 'Autosuggest', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'Input fields of type "search" or with the CSS class "search-field" or "ep-autosuggest" will be enhanced with autosuggest functionality. As text is entered into the search field, suggested content will appear below it, based on top search results for the text. Suggestions link directly to the content.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#autosuggest', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/Feature/Comments/Comments.php
+++ b/includes/classes/Feature/Comments/Comments.php
@@ -36,18 +36,27 @@ class Comments extends Feature {
 	public function __construct() {
 		$this->slug = 'comments';
 
-		$this->title = esc_html__( 'Comments', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'This feature will empower your website to overcome traditional WordPress comment search and query limitations that can present themselves at scale. This feature is only needed if you are using <code>WP_Comment_Query</code> directly.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#comments', 'elasticpress' );
-
 		$this->requires_install_reindex = true;
 
 		Indexables::factory()->register( new Indexable\Comment\Comment(), false );
 
 		parent::__construct();
 	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Comments', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'This feature will empower your website to overcome traditional WordPress comment search and query limitations that can present themselves at scale. This feature is only needed if you are using <code>WP_Comment_Query</code> directly.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#comments', 'elasticpress' );
+	}
+
 
 	/**
 	 * Setup search functionality

--- a/includes/classes/Feature/Comments/Comments.php
+++ b/includes/classes/Feature/Comments/Comments.php
@@ -57,7 +57,6 @@ class Comments extends Feature {
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#comments', 'elasticpress' );
 	}
 
-
 	/**
 	 * Setup search functionality
 	 *

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -21,12 +21,6 @@ class DidYouMean extends Feature {
 	public function __construct() {
 		$this->slug = 'did-you-mean';
 
-		$this->title = esc_html__( 'Did You Mean', 'elasticpress' );
-
-		$this->summary = '<p>' . __( '"Did You Mean" search feature provides alternative suggestions for misspelled or ambiguous search queries, enhancing search accuracy and user experience. To display suggestions in your theme, please follow <a href="https://www.elasticpress.io/documentation/article/did-you-mean/">this tutorial</a>.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/did-you-mean/', 'elasticpress' );
-
 		$this->requires_install_reindex = true;
 
 		$this->available_during_installation = true;
@@ -38,6 +32,20 @@ class DidYouMean extends Feature {
 		$this->requires_feature = 'search';
 
 		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Did You Mean', 'elasticpress' );
+
+		$this->summary = '<p>' . __( '"Did You Mean" search feature provides alternative suggestions for misspelled or ambiguous search queries, enhancing search accuracy and user experience. To display suggestions in your theme, please follow <a href="https://www.elasticpress.io/documentation/article/did-you-mean/">this tutorial</a>.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/did-you-mean/', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -25,15 +25,23 @@ class Documents extends Feature {
 	public function __construct() {
 		$this->slug = 'documents';
 
+		$this->requires_install_reindex = false;
+
+		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Documents', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Website search results will include popular document file types, using file names as well as their content. Supported file types include: ppt, pptx, doc, docx, xls, xlsx, pdf, csv, txt.', 'elasticpress' ) . '</p>';
 
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#documents', 'elasticpress' );
-
-		$this->requires_install_reindex = false;
-
-		parent::__construct();
 	}
 
 	/**

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -38,24 +38,6 @@ class Facets extends Feature {
 	public function __construct() {
 		$this->slug = 'facets';
 
-		$this->title = esc_html__( 'Filters', 'elasticpress' );
-
-		$this->summary = '<p>' .
-			( wp_is_block_theme()
-				? sprintf(
-					/* translators: Site Editor URL */
-					__( 'Adds <a href="%s">filter blocks</a> that administrators can add to the website’s templates and template parts, so that visitors can filter applicable content and search results by one or more taxonomy terms, metafields, and date ranges.', 'elasticpress' ),
-					esc_url( admin_url( 'site-editor.php' ) )
-				)
-				: sprintf(
-					/* translators: Widgets Edit Screen URL */
-					__( 'Adds <a href="%s">filter widgets</a> that administrators can add to the website’s sidebars (widgetized areas), so that visitors can filter applicable content and search results by one or more taxonomy terms, metafields, and date ranges.', 'elasticpress' ),
-					esc_url( admin_url( 'widgets.php' ) )
-				)
-			) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#filters', 'elasticpress' );
-
 		$this->requires_install_reindex = false;
 
 		$this->default_settings = [
@@ -101,6 +83,32 @@ class Facets extends Feature {
 		}
 
 		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Filters', 'elasticpress' );
+
+		$this->summary = '<p>' .
+		( wp_is_block_theme()
+			? sprintf(
+				/* translators: Site Editor URL */
+				__( 'Adds <a href="%s">filter blocks</a> that administrators can add to the website’s templates and template parts, so that visitors can filter applicable content and search results by one or more taxonomy terms, metafields, and date ranges.', 'elasticpress' ),
+				esc_url( admin_url( 'site-editor.php' ) )
+			)
+			: sprintf(
+				/* translators: Widgets Edit Screen URL */
+				__( 'Adds <a href="%s">filter widgets</a> that administrators can add to the website’s sidebars (widgetized areas), so that visitors can filter applicable content and search results by one or more taxonomy terms, metafields, and date ranges.', 'elasticpress' ),
+				esc_url( admin_url( 'widgets.php' ) )
+			)
+		) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#filters', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -67,15 +67,6 @@ class InstantResults extends Feature {
 	public function __construct() {
 		$this->slug = 'instant-results';
 
-		$this->title = esc_html__( 'Instant Results', 'elasticpress' );
-
-		$this->short_title = esc_html__( 'Instant Results', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'WordPress search forms will display results instantly. When the search query is submitted, a modal will open that populates results by querying ElasticPress directly, bypassing WordPress. As the user refines their search, results are refreshed.', 'elasticpress' ) . '</p>' .
-			'<p>' . __( 'Requires an <a href="https://www.elasticpress.io/" target="_blank">ElasticPress.io plan</a> or a custom proxy to function.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#instant-results', 'elasticpress' );
-
 		$this->host = trailingslashit( Utils\get_host() );
 
 		$this->index = Indexables::factory()->get( 'post' )->get_index_name();
@@ -101,6 +92,24 @@ class InstantResults extends Feature {
 
 		parent::__construct();
 	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Instant Results', 'elasticpress' );
+
+		$this->short_title = esc_html__( 'Instant Results', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'WordPress search forms will display results instantly. When the search query is submitted, a modal will open that populates results by querying ElasticPress directly, bypassing WordPress. As the user refines their search, results are refreshed.', 'elasticpress' ) . '</p>' .
+		'<p>' . __( 'Requires an <a href="https://www.elasticpress.io/" target="_blank">ElasticPress.io plan</a> or a custom proxy to function.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#instant-results', 'elasticpress' );
+	}
+
 
 	/**
 	 * Output detailed feature description.

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -110,7 +110,6 @@ class InstantResults extends Feature {
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#instant-results', 'elasticpress' );
 	}
 
-
 	/**
 	 * Output detailed feature description.
 	 *

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -30,18 +30,26 @@ class ProtectedContent extends Feature {
 	public function __construct() {
 		$this->slug = 'protected_content';
 
-		$this->title = esc_html__( 'Protected Content', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'Syncs unpublished content — including private, draft, and scheduled posts — improving load times in places like the administrative dashboard where WordPress needs to include protected content in a query.', 'elasticpress' ) . '</p>' .
-			'<p><em>' . __( 'We recommend using a secured Elasticsearch setup, such as ElasticPress.io, to prevent potential exposure of content not intended for the public.', 'elasticpress' ) . '</em></p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#protected-content', 'elasticpress' );
-
 		$this->requires_install_reindex = true;
 
 		$this->available_during_installation = true;
 
 		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Protected Content', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'Syncs unpublished content — including private, draft, and scheduled posts — improving load times in places like the administrative dashboard where WordPress needs to include protected content in a query.', 'elasticpress' ) . '</p>' .
+		'<p><em>' . __( 'We recommend using a secured Elasticsearch setup, such as ElasticPress.io, to prevent potential exposure of content not intended for the public.', 'elasticpress' ) . '</em></p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#protected-content', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -165,7 +165,6 @@ class RelatedPosts extends Feature {
 		return $query->posts;
 	}
 
-
 	/**
 	 * Setup all feature filters
 	 *

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -171,12 +171,6 @@ class RelatedPosts extends Feature {
 	 * @since  2.1
 	 */
 	public function setup() {
-		$this->title = esc_html__( 'Related Posts', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'Instantly deliver engaging and precise related content with no impact on site performance. Output related content using our block or directly in your theme using our <a href="https://www.elasticpress.io/documentation/article/related-posts-api/">API functions</a>.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#related-posts', 'elasticpress' );
-
 		add_action( 'widgets_init', [ $this, 'register_widget' ] );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', [ $this, 'hide_legacy_widget' ] );
 		add_filter( 'ep_formatted_args', [ $this, 'formatted_args' ], 10, 2 );

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -26,15 +26,23 @@ class RelatedPosts extends Feature {
 	public function __construct() {
 		$this->slug = 'related_posts';
 
+		$this->requires_install_reindex = false;
+
+		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Related Posts', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Instantly deliver engaging and precise related content with no impact on site performance. Output related content using our block or directly in your theme using our <a href="https://www.elasticpress.io/documentation/article/related-posts-api/">API functions</a>.', 'elasticpress' ) . '</p>';
 
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#related-posts', 'elasticpress' );
-
-		$this->requires_install_reindex = false;
-
-		parent::__construct();
 	}
 
 	/**
@@ -157,12 +165,19 @@ class RelatedPosts extends Feature {
 		return $query->posts;
 	}
 
+
 	/**
 	 * Setup all feature filters
 	 *
 	 * @since  2.1
 	 */
 	public function setup() {
+		$this->title = esc_html__( 'Related Posts', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'Instantly deliver engaging and precise related content with no impact on site performance. Output related content using our block or directly in your theme using our <a href="https://www.elasticpress.io/documentation/article/related-posts-api/">API functions</a>.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#related-posts', 'elasticpress' );
+
 		add_action( 'widgets_init', [ $this, 'register_widget' ] );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', [ $this, 'hide_legacy_widget' ] );
 		add_filter( 'ep_formatted_args', [ $this, 'formatted_args' ], 10, 2 );

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -52,13 +52,6 @@ class Search extends Feature {
 	public function __construct() {
 		$this->slug = 'search';
 
-		$this->title = esc_html__( 'Post Search', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'Instantly find the content you’re looking for. The first time.', 'elasticpress' ) . '</p>' .
-			'<p>' . __( 'Overcome higher-end performance and functional limits posed by the traditional WordPress structured (SQL) database to deliver superior keyword search, instantly. ElasticPress indexes custom fields, tags, and other metadata to improve search results. Fuzzy matching accounts for misspellings and verb tenses.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#post-search', 'elasticpress' );
-
 		$this->requires_install_reindex = false;
 
 		$this->default_settings = [
@@ -75,12 +68,30 @@ class Search extends Feature {
 	}
 
 	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Post Search', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'Instantly find the content you’re looking for. The first time.', 'elasticpress' ) . '</p>' .
+		'<p>' . __( 'Overcome higher-end performance and functional limits posed by the traditional WordPress structured (SQL) database to deliver superior keyword search, instantly. ElasticPress indexes custom fields, tags, and other metadata to improve search results. Fuzzy matching accounts for misspellings and verb tenses.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#post-search', 'elasticpress' );
+	}
+
+	/**
 	 * We need to delay search setup up since it will fire after protected content and protected
 	 * content filters into the search setup
 	 *
 	 * @since 2.2
 	 */
 	public function setup() {
+
+		Indexables::factory()->activate( 'post' );
+
 		add_action( 'init', [ $this, 'search_setup' ] );
 		add_filter( 'ep_sanitize_feature_settings', [ $this, 'sanitize_highlighting_settings' ] );
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -89,7 +89,6 @@ class Search extends Feature {
 	 * @since 2.2
 	 */
 	public function setup() {
-
 		Indexables::factory()->activate( 'post' );
 
 		add_action( 'init', [ $this, 'search_setup' ] );

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -52,17 +52,25 @@ class SearchOrdering extends Feature {
 	public function __construct() {
 		$this->slug = 'searchordering';
 
-		$this->title = esc_html__( 'Custom Search Results', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'Selected posts will be inserted into search results in the specified position.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#custom-search-results', 'elasticpress' );
-
 		$this->requires_install_reindex = false;
 
 		$this->requires_feature = 'search';
 
 		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Custom Search Results', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'Selected posts will be inserted into search results in the specified position.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#custom-search-results', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/Feature/Terms/Terms.php
+++ b/includes/classes/Feature/Terms/Terms.php
@@ -33,17 +33,25 @@ class Terms extends Feature {
 	public function __construct() {
 		$this->slug = 'terms';
 
-		$this->title = esc_html__( 'Terms', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'This feature will empower your website to overcome traditional WordPress term search and query limitations that can present themselves at scale. This feature is only needed if you are using <code>WP_Term_Query</code> directly.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#terms', 'elasticpress' );
-
 		$this->requires_install_reindex = true;
 
 		Indexables::factory()->register( new Indexable\Term\Term(), false );
 
 		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'Terms', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'This feature will empower your website to overcome traditional WordPress term search and query limitations that can present themselves at scale. This feature is only needed if you are using <code>WP_Term_Query</code> directly.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#terms', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -54,12 +54,6 @@ class WooCommerce extends Feature {
 	public function __construct() {
 		$this->slug = 'woocommerce';
 
-		$this->title = esc_html__( 'WooCommerce', 'elasticpress' );
-
-		$this->summary = '<p>' . __( 'Most caching and performance tools can’t keep up with the nearly infinite ways your visitors might filter or navigate your products. No matter how many products, filters, or customers you have, ElasticPress will keep your online store performing quickly. If used in combination with the Protected Content feature, ElasticPress will also accelerate order searches and back end product management.', 'elasticpress' ) . '</p>';
-
-		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#woocommerce', 'elasticpress' );
-
 		$this->requires_install_reindex = true;
 
 		$this->setting_requires_install_reindex = 'orders';
@@ -75,6 +69,20 @@ class WooCommerce extends Feature {
 		$this->orders_autosuggest = new OrdersAutosuggest( $this );
 
 		parent::__construct();
+	}
+
+	/**
+	 * Sets i18n strings.
+	 *
+	 * @return void
+	 * @since 5.2.0
+	 */
+	public function set_i18n_strings(): void {
+		$this->title = esc_html__( 'WooCommerce', 'elasticpress' );
+
+		$this->summary = '<p>' . __( 'Most caching and performance tools can’t keep up with the nearly infinite ways your visitors might filter or navigate your products. No matter how many products, filters, or customers you have, ElasticPress will keep your online store performing quickly. If used in combination with the Protected Content feature, ElasticPress will also accelerate order searches and back end product management.', 'elasticpress' ) . '</p>';
+
+		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#woocommerce', 'elasticpress' );
 	}
 
 	/**

--- a/includes/classes/Features.php
+++ b/includes/classes/Features.php
@@ -330,6 +330,8 @@ class Features {
 		do_action( 'ep_setup_features' );
 
 		foreach ( $this->registered_features as $feature_slug => $feature ) {
+			$feature->set_i18n_strings();
+
 			if ( $feature->is_active() ) {
 				$feature->setup();
 			}

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -76,7 +76,10 @@ abstract class Indexable {
 	 * @since 4.5.0
 	 * @var array
 	 */
-	public $labels = [];
+	public $labels = [
+		'plural'   => '',
+		'singular' => '',
+	];
 
 	/**
 	 * Get number of bulk items to index per page

--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -33,24 +33,17 @@ class Comment extends Indexable {
 	public $slug = 'comment';
 
 	/**
-	 * Create indexable and initialize dependencies
-	 *
-	 * @since 3.6.0
-	 */
-	public function __construct() {
-		$this->labels = [
-			'plural'   => esc_html__( 'Comments', 'elasticpress' ),
-			'singular' => esc_html__( 'Comment', 'elasticpress' ),
-		];
-	}
-
-	/**
 	 * Instantiate the indexable SyncManager and QueryIntegration, the main responsibles for the WP integration.
 	 *
 	 * @since 4.5.0
 	 * @return void
 	 */
 	public function setup() {
+		$this->labels = [
+			'plural'   => esc_html__( 'Comments', 'elasticpress' ),
+			'singular' => esc_html__( 'Comment', 'elasticpress' ),
+		];
+
 		$this->sync_manager      = new SyncManager( $this->slug );
 		$this->query_integration = new QueryIntegration();
 	}

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -42,11 +42,12 @@ class Post extends Indexable {
 	public $support_indexing_advanced_pagination = true;
 
 	/**
-	 * Create indexable and initialize dependencies
+	 * Instantiate the indexable SyncManager and QueryIntegration
 	 *
-	 * @since  3.0
+	 * @since 5.2.0
+	 * @return void
 	 */
-	public function __construct() {
+	public function setup() {
 		$this->labels = [
 			'plural'   => esc_html__( 'Posts', 'elasticpress' ),
 			'singular' => esc_html__( 'Post', 'elasticpress' ),

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -32,24 +32,17 @@ class Term extends Indexable {
 	public $slug = 'term';
 
 	/**
-	 * Create indexable and initialize dependencies
-	 *
-	 * @since 3.1
-	 */
-	public function __construct() {
-		$this->labels = [
-			'plural'   => esc_html__( 'Terms', 'elasticpress' ),
-			'singular' => esc_html__( 'Term', 'elasticpress' ),
-		];
-	}
-
-	/**
 	 * Instantiate the indexable SyncManager and QueryIntegration, the main responsibles for the WP integration.
 	 *
 	 * @since 4.5.0
 	 * @return void
 	 */
 	public function setup() {
+		$this->labels = [
+			'plural'   => esc_html__( 'Terms', 'elasticpress' ),
+			'singular' => esc_html__( 'Term', 'elasticpress' ),
+		];
+
 		$this->sync_manager      = new SyncManager( $this->slug );
 		$this->query_integration = new QueryIntegration( $this->slug );
 	}

--- a/tests/php/features/TestAutosuggest.php
+++ b/tests/php/features/TestAutosuggest.php
@@ -68,6 +68,7 @@ class TestAutosuggest extends BaseTestCase {
 	 */
 	public function testConstruct() {
 		$instance = new ElasticPress\Feature\Autosuggest\Autosuggest();
+		$instance->set_i18n_strings();
 
 		$this->assertEquals( 'autosuggest', $instance->slug );
 		$this->assertEquals( 'Autosuggest', $instance->title );

--- a/tests/php/features/TestComments.php
+++ b/tests/php/features/TestComments.php
@@ -73,6 +73,7 @@ class TestComments extends BaseTestCase {
 	 */
 	public function testConstruct() {
 		$instance = new ElasticPress\Feature\Comments\Comments();
+		$instance->set_i18n_strings();
 
 		$this->assertEquals( 'comments', $instance->slug );
 		$this->assertEquals( 'Comments', $instance->title );

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -43,6 +43,7 @@ class TestDidYouMean extends BaseTestCase {
 	 */
 	public function testConstruct() {
 		$instance = new ElasticPress\Feature\DidYouMean\DidYouMean();
+		$instance->set_i18n_strings();
 
 		$this->assertEquals( 'did-you-mean', $instance->slug );
 		$this->assertEquals( 'Did You Mean', $instance->title );

--- a/tests/php/features/TestSearchOrdering.php
+++ b/tests/php/features/TestSearchOrdering.php
@@ -73,6 +73,8 @@ class TestSearchOrdering extends BaseTestCase {
 	 */
 	public function testConstruct() {
 		$instance = new \ElasticPress\Feature\SearchOrdering\SearchOrdering();
+		$instance->set_i18n_strings();
+
 		$this->assertSame( 'searchordering', $instance->slug );
 		$this->assertSame( 'Custom Search Results', $instance->title );
 	}

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -6167,6 +6167,7 @@ class TestPost extends BaseTestCase {
 	public function testPostConstructor() {
 
 		$post = new \ElasticPress\Indexable\Post\Post();
+		$post->setup();
 
 		$this->assertSame( 'Posts', $post->labels['plural'] );
 		$this->assertSame( 'Post', $post->labels['singular'] );

--- a/tests/php/screen/TestStatusReport.php
+++ b/tests/php/screen/TestStatusReport.php
@@ -64,7 +64,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'failed-queries', 'elasticpress', 'indices', 'last-sync', 'features' ],
+			[ 'failed-queries', 'wordpress', 'elasticpress', 'indices', 'last-sync', 'features' ],
 			array_keys( $reports )
 		);
 	}

--- a/tests/php/screen/TestStatusReport.php
+++ b/tests/php/screen/TestStatusReport.php
@@ -64,7 +64,7 @@ class TestStatusReport extends BaseTestCase {
 
 		$reports = $status_report->get_reports();
 		$this->assertSame(
-			[ 'failed-queries', 'wordpress', 'elasticpress', 'indices', 'last-sync', 'features' ],
+			[ 'failed-queries', 'elasticpress', 'indices', 'last-sync', 'features' ],
 			array_keys( $reports )
 		);
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the `Function _load_textdomain_just_in_time was called incorrectly` warning.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4049

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Using a different language in wp-admin and having WP_DEBUG on and no other plugin enabled, you should be able to see all the notices.


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - PHP Notice: Function _load_textdomain_just_in_time was called incorrectly 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
