### PR TITLE
Fix E2E tests

### DIFF
--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -154,10 +154,8 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 				.components-button.is-primary.woocommerce-save-button`,
 			).click();
 
-			// set the store to live.
-			cy.visitAdminPage('admin.php?page=wc-settings&tab=site-visibility');
-			cy.contains('label', 'Live').siblings('input[type="radio"]').check();
-			cy.get('.components-button.is-primary.woocommerce-save-button').click();
+			// disable coming soon option.
+			cy.wpCli('option update woocommerce_coming_soon off');
 
 			cy.logout();
 

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -146,11 +146,18 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 
 			// enable payment gateway.
 			cy.visitAdminPage('admin.php?page=wc-settings&tab=checkout&section=cod');
+			// if the checkbox is already checked, uncheck it first to enable the save button.
+			cy.get('#woocommerce_cod_enabled').uncheck();
 			cy.get('#woocommerce_cod_enabled').check();
 			cy.get(
 				`.button-primary.woocommerce-save-button,
 				.components-button.is-primary.woocommerce-save-button`,
 			).click();
+
+			// set the store to live.
+			cy.visitAdminPage('admin.php?page=wc-settings&tab=site-visibility');
+			cy.contains('label', 'Live').siblings('input[type="radio"]').check();
+			cy.get('.components-button.is-primary.woocommerce-save-button').click();
 
 			cy.logout();
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the E2E tests

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4068 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Fixed E2E tests

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
