### PR TITLE
Fix: Notice while updating a term is not displaying when plugin is ne…

### DIFF
--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -831,7 +831,19 @@ class AdminNotices {
 		 * @param  {array} $notices Admin notices
 		 * @return {array} New notices
 		 */
-		return apply_filters( 'ep_admin_notices', $this->notices );
+		$notices = apply_filters( 'ep_admin_notices', $this->notices );
+
+		// If the plugin is network-activated and not in the network admin, return the notices whose scope is site.
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK && ! is_network_admin() ) {
+			$notices = array_filter(
+				$notices,
+				function ( $notice ) {
+					return isset( $notice['scope'] ) && 'site' === $notice['scope'];
+				}
+			);
+		}
+
+		return $notices;
 	}
 
 	/**

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -421,6 +421,7 @@ class SyncManager extends \ElasticPress\SyncManager {
 						),
 						'type'    => 'warning',
 						'dismiss' => true,
+						'scope'   => 'site',
 					];
 					break;
 				}
@@ -436,6 +437,7 @@ class SyncManager extends \ElasticPress\SyncManager {
 			),
 			'type'    => 'warning',
 			'dismiss' => true,
+			'scope'   => 'site',
 		];
 
 		return $notices;
@@ -470,6 +472,7 @@ class SyncManager extends \ElasticPress\SyncManager {
 			),
 			'type'    => 'warning',
 			'dismiss' => true,
+			'scope'   => 'site',
 		];
 
 		return $notices;

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -298,13 +298,8 @@ function filter_plugin_action_links( $plugin_actions, $plugin_file ) {
  * @since  3.0
  */
 function maybe_notice( $force = false ) {
-	// Admins only.
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-		if ( ! is_super_admin() || ! is_network_admin() ) {
-			return false;
-		}
-	} elseif ( is_network_admin() || ! current_user_can( Utils\get_capability() ) ) {
-			return false;
+	if ( ! current_user_can( Utils\get_capability() ) ) {
+		return false;
 	}
 
 	/**

--- a/tests/php/TestAdminNotices.php
+++ b/tests/php/TestAdminNotices.php
@@ -648,7 +648,6 @@ class TestAdminNotices extends BaseTestCase {
 	 * Tests notice is show when number of posts linked with term is greater than number of items per cycle.
 	 */
 	public function testNumberOfPostsBiggerThanItemPerCycle() {
-
 		global $pagenow, $tax;
 
 		// set global variables.
@@ -671,6 +670,98 @@ class TestAdminNotices extends BaseTestCase {
 		$notices = ElasticPress\AdminNotices::factory()->get_notices();
 
 		$this->assertArrayHasKey( 'too_many_posts_on_term', $notices );
+	}
+
+	/**
+	 * Tests that the admin notice with the scope 'site' appears only on the sub site when the plugin is network-activated.
+	 *
+	 * @group admin-notices
+	 * @group skip-on-single-site
+	 */
+	public function test_notice_with_scope_site_shows_only_on_site() {
+		global $pagenow, $tax;
+
+		// set global variables.
+		$pagenow = 'edit-tags.php';
+
+		set_current_screen( 'edit-tags' );
+		$tax = get_taxonomy( 'category' );
+
+		$number_of_posts = ElasticPress\IndexHelper::factory()->get_index_default_per_page() + 10;
+		$term            = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		$this->posts     = $this->factory->post->create_many(
+			$number_of_posts,
+			[
+				'tax_input' => [
+					'category' => [
+						$term->term_id,
+					],
+				],
+			]
+		);
+
+		add_action(
+			'ep_admin_notices',
+			function ( $notices ) {
+				$notices['test_notice'] = [
+					'type'    => 'error',
+					'dismiss' => true,
+					'html'    => 'Test notice',
+				];
+
+				return $notices;
+			}
+		);
+
+		$notices = ElasticPress\AdminNotices::factory()->get_notices();
+		$this->assertCount( 1, $notices );
+		$this->assertArrayHasKey( 'too_many_posts_on_term', $notices );
+	}
+
+	/**
+	 * Tests that the admin notice with the scope 'site' has no effect when WordPress is not on multisite mode.
+	 *
+	 * @group admin-notices
+	 * @group skip-on-multi-site
+	 */
+	public function test_notice_with_scope_site_has_no_effect_on_non_multisite() {
+		global $pagenow, $tax;
+
+		// set global variables.
+		$pagenow = 'edit-tags.php';
+
+		set_current_screen( 'edit-tags' );
+		$tax = get_taxonomy( 'category' );
+
+		$number_of_posts = ElasticPress\IndexHelper::factory()->get_index_default_per_page() + 10;
+		$term            = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		$this->posts     = $this->factory->post->create_many(
+			$number_of_posts,
+			[
+				'tax_input' => [
+					'category' => [
+						$term->term_id,
+					],
+				],
+			]
+		);
+
+		add_action(
+			'ep_admin_notices',
+			function ( $notices ) {
+				$notices['test_notice'] = [
+					'type'    => 'error',
+					'dismiss' => true,
+					'html'    => 'Test notice',
+				];
+
+				return $notices;
+			}
+		);
+
+		$notices = ElasticPress\AdminNotices::factory()->get_notices();
+		$this->assertArrayHasKey( 'too_many_posts_on_term', $notices );
+		$this->assertArrayHasKey( 'test_notice', $notices );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the notice is not displayed while updating a term when the plugin is network-activated.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3604 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Notice not displayed while updating a term.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @MARQAS 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
