### PR TITLE
Add support to number fields in the Features settings

### DIFF
--- a/includes/classes/REST/Features.php
+++ b/includes/classes/REST/Features.php
@@ -71,6 +71,9 @@ class Features {
 					case 'toggle':
 						$property['type'] = 'boolean';
 						break;
+					case 'number':
+						$property['type'] = 'number';
+						break;
 					case 'url':
 						$property['type']   = 'string';
 						$property['format'] = 'uri';

--- a/tests/php/REST/TestFeatures.php
+++ b/tests/php/REST/TestFeatures.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Test the Features REST controller
+ *
+ * @since 5.3.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest\REST;
+
+use ElasticPress\REST\Features;
+
+/**
+ * TestFeatures test class
+ */
+class TestFeatures extends \ElasticPressTest\BaseTestCase {
+	/**
+	 * Test get_args.
+	 *
+	 * @group rest
+	 * @group rest-features
+	 */
+	public function test_get_args() {
+		$features_rest     = new Features();
+		$features_instance = \ElasticPress\Features::factory();
+
+		$features_instance->registered_features = [];
+		$features_instance->register_feature(
+			new \ElasticPressTest\SettingsSchemaFeature()
+		);
+
+		$args = $features_rest->get_args();
+
+		$test_settings_schema = [
+			'description' => 'Test Settings Schema',
+			'type'        => 'object',
+			'properties'  => [
+				'active'            => [
+					'description' => 'Enable',
+					'type'        => 'boolean',
+				],
+				'test-select'       => [
+					'description' => 'Test Select',
+					'type'        => 'string',
+					'enum'        => [
+						'option_1',
+						'option_2',
+					],
+				],
+				'test-radio'        => [
+					'description' => 'Test Radio',
+					'type'        => 'string',
+					'enum'        => [
+						'radio_1',
+						'radio_2',
+					],
+				],
+				'test-toggle'       => [
+					'description' => 'Test Toggle',
+					'type'        => 'boolean',
+				],
+				'test-number'       => [
+					'description' => 'Test Number',
+					'type'        => 'number',
+				],
+				'test-url'          => [
+					'description' => 'Test URL',
+					'type'        => 'string',
+					'format'      => 'uri',
+				],
+				'test-text'         => [
+					'description' => 'Test Text',
+					'type'        => 'string',
+				],
+				'test-non-existent' => [
+					'description' => 'Test Non Existent',
+					'type'        => 'string',
+				],
+				'test-string'       => [
+					'description' => 'Test String',
+					'type'        => 'string',
+				],
+			],
+		];
+
+		$this->assertEquals( $test_settings_schema, $args['test_settings_schema'] );
+	}
+}

--- a/tests/php/REST/TestFeatures.php
+++ b/tests/php/REST/TestFeatures.php
@@ -24,7 +24,6 @@ class TestFeatures extends \ElasticPressTest\BaseTestCase {
 		$features_rest     = new Features();
 		$features_instance = \ElasticPress\Features::factory();
 
-		$features_instance->registered_features = [];
 		$features_instance->register_feature(
 			new \ElasticPressTest\SettingsSchemaFeature()
 		);
@@ -84,5 +83,7 @@ class TestFeatures extends \ElasticPressTest\BaseTestCase {
 		];
 
 		$this->assertEquals( $test_settings_schema, $args['test_settings_schema'] );
+
+		unset( $features_instance->registered_features['test_settings_schema'] );
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -182,6 +182,7 @@ require_once __DIR__ . '/includes/classes/factory/ProductFactory.php';
 require_once __DIR__ . '/includes/classes/BaseTestCase.php';
 require_once __DIR__ . '/includes/classes/FeatureTest.php';
 require_once __DIR__ . '/includes/classes/mock/Global/Feature.php';
+require_once __DIR__ . '/includes/classes/mock/SettingsSchemaFeature.php';
 require_once __DIR__ . '/includes/classes/mock/class-wp-cli-command.php';
 require_once __DIR__ . '/includes/classes/mock/class-wp-cli.php';
 require_once __DIR__ . '/includes/wp-cli-utils.php';

--- a/tests/php/includes/classes/mock/SettingsSchemaFeature.php
+++ b/tests/php/includes/classes/mock/SettingsSchemaFeature.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * SettingsSchemaFeature feature
+ *
+ * @since 5.3.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress\Indexables;
+
+/**
+ * SettingsSchemaFeature class
+ */
+class SettingsSchemaFeature extends \ElasticPress\Feature {
+	/**
+	 * Initialize feature setting it's config
+	 */
+	public function __construct() {
+		$this->slug  = 'test_settings_schema';
+		$this->title = 'Test Settings Schema';
+
+		parent::__construct();
+	}
+
+	/**
+	 * Required implementation
+	 */
+	public function setup() {}
+
+	/**
+	 * Output feature box long text
+	 */
+	public function output_feature_box_long() {}
+
+	/**
+	 * Set the `settings_schema` attribute
+	 */
+	protected function set_settings_schema() {
+		$this->settings_schema = array_merge(
+			$this->settings_schema,
+			[
+				'test-select'       => [
+					'key'     => 'test-select',
+					'label'   => 'Test Select',
+					'type'    => 'select',
+					'options' => [
+						[
+							'label' => 'Option 1',
+							'value' => 'option_1',
+						],
+						[
+							'label' => 'Option 2',
+							'value' => 'option_2',
+						],
+					],
+				],
+				'test-radio'        => [
+					'key'     => 'test-radio',
+					'label'   => 'Test Radio',
+					'type'    => 'radio',
+					'options' => [
+						[
+							'label' => 'Radio 1',
+							'value' => 'radio_1',
+						],
+						[
+							'label' => 'Radio 2',
+							'value' => 'radio_2',
+						],
+					],
+				],
+				'test-toggle'       => [
+					'key'   => 'test-toggle',
+					'label' => 'Test Toggle',
+					'type'  => 'toggle',
+				],
+				'test-number'       => [
+					'key'   => 'test-number',
+					'label' => 'Test Number',
+					'type'  => 'number',
+				],
+				'test-url'          => [
+					'key'   => 'test-url',
+					'label' => 'Test URL',
+					'type'  => 'url',
+				],
+				'test-text'         => [
+					'key'   => 'test-text',
+					'label' => 'Test Text',
+					'type'  => 'text',
+				],
+				'test-non-existent' => [
+					'key'   => 'test-non-existent',
+					'label' => 'Test Non Existent',
+					'type'  => 'non-existent',
+				],
+				'test-string'       => [
+					'key'   => 'test-string',
+					'label' => 'Test String',
+					'type'  => 'string',
+				],
+			]
+		);
+	}
+}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Note: This PR needs tests.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Support to "number" fields in the Features Settings API.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
