### PR TITLE
Fixed Implicitly marking parameter $woocommerce as nullable is deprecated warning with PHP 8.4

### DIFF
--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -49,7 +49,7 @@ class OrdersAutosuggest {
 	 *
 	 * @param WooCommerce|null $woocommerce WooCommerce feature object instance
 	 */
-	public function __construct( $woocommerce = null ) {
+	public function __construct( ?WooCommerce $woocommerce = null ) {
 		$this->index       = Indexables::factory()->get( 'post' )->get_index_name();
 		$this->woocommerce = $woocommerce ?
 			$woocommerce :

--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -49,7 +49,7 @@ class OrdersAutosuggest {
 	 *
 	 * @param WooCommerce|null $woocommerce WooCommerce feature object instance
 	 */
-	public function __construct( WooCommerce|null $woocommerce = null ) {
+	public function __construct( $woocommerce = null ) {
 		$this->index       = Indexables::factory()->get( 'post' )->get_index_name();
 		$this->woocommerce = $woocommerce ?
 			$woocommerce :

--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -49,7 +49,7 @@ class OrdersAutosuggest {
 	 *
 	 * @param WooCommerce|null $woocommerce WooCommerce feature object instance
 	 */
-	public function __construct( WooCommerce $woocommerce = null ) {
+	public function __construct( WooCommerce|null $woocommerce = null ) {
 		$this->index       = Indexables::factory()->get( 'post' )->get_index_name();
 		$this->woocommerce = $woocommerce ?
 			$woocommerce :


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Updates `OrdersAutosuggest.php` to allow `$woocommece` to be nullable explicitly. 

I manually tested this fix with PHP 8.1 > 8.4

Closes #4086 

### How to test the Change
Update to PHP 8.4 to receive the error, then apply the change and it should go away. 

It would be good to test this change with WooCommerce installed

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - PHP 8.4: Implicitly marking parameter $woocommerce as nullable is deprecated  (#4086)

### Credits
Props @BrookeDot

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
