### PR TITLE
Execute the ep_remote_request action even on non-blocking requests

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1352,6 +1352,15 @@ class Elasticsearch {
 			$query['request']  = $request;
 			$this->add_query_log( $query );
 
+			/**
+			 * Fires after Elasticsearch remote request
+			 *
+			 * @hook ep_remote_request
+			 * @param {array}  $query Remote request arguments
+			 * @param {string} $type  Request type
+			 */
+			do_action( 'ep_remote_request', $query, $type );
+
 			return $request;
 		}
 
@@ -1359,13 +1368,7 @@ class Elasticsearch {
 		$query['request']     = $request;
 		$this->add_query_log( $query );
 
-		/**
-		 * Fires after Elasticsearch remote request
-		 *
-		 * @hook ep_remote_request
-		 * @param  {array} $query Remote request arguments
-		 * @param  {string} $type Request type
-		 */
+		// This action is documented above
 		do_action( 'ep_remote_request', $query, $type );
 
 		return $request;

--- a/tests/php/TestElasticsearch.php
+++ b/tests/php/TestElasticsearch.php
@@ -409,4 +409,37 @@ class TestElasticsearch extends BaseTestCase {
 		$this->assertCount( 1, $queries );
 		$this->assertSame( $example_query, $queries[0] );
 	}
+
+	/**
+	 * Test the `ep_remote_request` action
+	 *
+	 * @since 5.2.0
+	 * @group elasticsearch
+	 */
+	public function test_ep_remote_request_action() {
+		$elasticsearch = new \ElasticPress\Elasticsearch();
+
+		// Make sure we don't fire any real request
+		add_filter( 'ep_do_intercept_request', '__return_empty_array' );
+
+		$callback = function ( $query, $type ) {
+			$this->assertIsArray( $query );
+			$this->assertSame( 'example_type', $type );
+		};
+		add_action( 'ep_remote_request', $callback, 10, 2 );
+
+		// It starts with 1, likely because of some previous tests.
+		$initial_count = did_action( 'ep_remote_request' );
+
+		$elasticsearch->remote_request( '', [], [], 'example_type' );
+		$this->assertSame( $initial_count + 1, did_action( 'ep_remote_request' ) );
+
+		// Make sure we execute the action even on non-blocking requests
+		$callback = function ( $query ) {
+			$this->assertFalse( $query['args']['blocking'] );
+		};
+		add_action( 'ep_remote_request', $callback, 10, 2 );
+		$elasticsearch->remote_request( '', [ 'blocking' => false ], [], 'example_type' );
+		$this->assertSame( $initial_count + 2, did_action( 'ep_remote_request' ) );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/debug-bar-elasticpress/issues/109

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - The ep_remote_request action to also run on non-blocking requests

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
