### PR TITLE
Fix number_format call in timer_stop

### DIFF
--- a/includes/classes/Command/Utility.php
+++ b/includes/classes/Command/Utility.php
@@ -62,7 +62,7 @@ class Utility {
 	 */
 	public static function timer_stop( $precision = 3 ) {
 		$diff = microtime( true ) - self::$time_start;
-		return (float) number_format( (float) $diff, $precision );
+		return (float) number_format( (float) $diff, $precision, '.', '' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

By default, it will format thousands+ to 1,000.00, which will be only 1 after being cast to float.

As seen in #3987, the time counter would reset after ~16 minutes (~960 seconds). It turns out, the call to number_format in Utility::number_format would transform 1000 to 1,000.00. As that number is cast to a float, it becomes 1 resetting the counter back to 1 second. Calling `number_format( (float) $diff, $precision, '.', '' );` make it transform it to `1000.00`, which keeps the counter the way we need.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3987

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - WP-CLI sync timer resetting after 16 minutes

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @columbian-chris

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
