### PR TITLE
Fix: Comment sync issue during the pagination.

### DIFF
--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -935,7 +935,6 @@ class Comment extends Indexable {
 
 		$cache_key = md5( get_current_blog_id() . wp_json_encode( $normalized_query_args ) );
 
-		// this cache domain is used to store the total number of comments for a given query
 		$normalized_query_args['cache_domain'] = 'elasticpress-comment-indexable-' . $cache_key;
 
 		return ( new WP_Comment_Query( $normalized_query_args ) )->found_comments;

--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -838,17 +838,21 @@ class Comment extends Indexable {
 				$args,
 				[
 					'suppress_filters' => false,
-					'orderby'          => 'ID',
-					'order'            => 'DESC',
+					'orderby'          => 'comment_ID',
+					'order'            => 'desc',
 					'paged'            => 1,
 					'offset'           => 0,
 				]
 			);
+
+			// It's important to pass a custom cache domain. By default, WordPress caches results based on the default query arguments and doesn't account for custom arguments. @see \WP_Comment_Query::get_comments()
+			$cache_key            = md5( get_current_blog_id() . wp_json_encode( $args ) );
+			$args['cache_domain'] = 'elasticpress-comment-indexable-' . $cache_key;
+
 			add_filter( 'comments_clauses', array( $this, 'bulk_indexing_filter_comments_where' ), 9999, 2 );
 
 			$query         = new WP_Comment_Query( $args );
-			$total_objects = $query->found_comments;
-
+			$total_objects = $this->get_total_objects_for_query( $args );
 			remove_filter( 'comments_clauses', array( $this, 'bulk_indexing_filter_comments_where' ), 9999, 2 );
 		} else {
 			$query         = new WP_Comment_Query( $args );
@@ -909,6 +913,32 @@ class Comment extends Indexable {
 		}
 
 		return $clauses;
+	}
+
+	/**
+	 * Get the total number of comments for a given query.
+	 *
+	 * @param array $query_args The query args.
+	 * @return int The query result's found_comments.
+	 */
+	protected function get_total_objects_for_query( $query_args ) {
+		$normalized_query_args = array_merge(
+			$query_args,
+			[
+				'offset'                               => 0,
+				'paged'                                => 1,
+				'posts_per_page'                       => 1,
+				'no_found_rows'                        => false,
+				'ep_indexing_last_processed_object_id' => null,
+			]
+		);
+
+		$cache_key = md5( get_current_blog_id() . wp_json_encode( $normalized_query_args ) );
+
+		// this cache domain is used to store the total number of comments for a given query
+		$normalized_query_args['cache_domain'] = 'elasticpress-comment-indexable-' . $cache_key;
+
+		return ( new WP_Comment_Query( $normalized_query_args ) )->found_comments;
 	}
 
 	/**

--- a/tests/php/indexables/TestComment.php
+++ b/tests/php/indexables/TestComment.php
@@ -2217,16 +2217,11 @@ class TestComment extends BaseTestCase {
 		$this->assertArrayHasKey( 'total_objects', $results );
 		$this->assertEquals( 12, $results['total_objects'] );
 
-		// It's important to flush the cache here because WordPress caches results based on the default query arguments and doesn't account for custom arguments. @see \WP_Comment_Query::get_comments()
-		wp_cache_flush_group( 'comment-queries' );
-
 		// Test only 1 comment is returned.
 		$results = $comment_indexable->query_db( [ 'include' => $comment_1_id ] );
 		$this->assertArrayHasKey( 'objects', $results );
 		$this->assertArrayHasKey( 'total_objects', $results );
 		$this->assertEquals( 1, $results['total_objects'] );
-
-		wp_cache_flush_group( 'comment-queries' );
 
 		// Test all comments are returned except the one with ID.
 		$results = $comment_indexable->query_db( [ 'exclude' => $comment_1_id ] );
@@ -2234,21 +2229,107 @@ class TestComment extends BaseTestCase {
 		$this->assertArrayHasKey( 'total_objects', $results );
 		$this->assertEquals( 11, $results['total_objects'] );
 
-		wp_cache_flush_group( 'comment-queries' );
-
 		// Test when upper limit is set and it returns only 2 comments.
 		$results = $comment_indexable->query_db( [ 'ep_indexing_upper_limit_object_id' => $middle_comment_id ] );
 		$this->assertArrayHasKey( 'objects', $results );
 		$this->assertArrayHasKey( 'total_objects', $results );
 		$this->assertEquals( 2, $results['total_objects'] );
 
-		wp_cache_flush_group( 'comment-queries' );
-
 		// Test when lower limit is set and it returns only 11 comments.
 		$results = $comment_indexable->query_db( [ 'ep_indexing_lower_limit_object_id' => $middle_comment_id ] );
 		$this->assertArrayHasKey( 'objects', $results );
 		$this->assertArrayHasKey( 'total_objects', $results );
 		$this->assertEquals( 11, $results['total_objects'] );
+	}
+
+	/**
+	 * Tests the pagination of the query_db method.
+	 *
+	 * @since 5.2.0
+	 * @group comment
+	 */
+	public function test_query_db_with_last_processed_object_id() {
+		$post_id = $this->ep_factory->post->create();
+
+		$comment_1_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_2_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_3_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_indexable = new \ElasticPress\Indexable\Comment\Comment();
+
+		$results = $comment_indexable->query_db(
+			[
+				'per_page' => 1,
+			]
+		);
+
+		$comment_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $comment_3_id, $comment_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 3, $results['total_objects'] );
+
+		// Second loop.
+		$results = $comment_indexable->query_db(
+			[
+				'per_page'                             => 1,
+				'ep_indexing_last_processed_object_id' => $comment_3_id,
+			]
+		);
+
+		$comment_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $comment_2_id, $comment_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 3, $results['total_objects'] );
+	}
+
+	/**
+	 * Tests that the query_db method returns results sorted by ID.
+	 *
+	 * @since 5.2.0
+	 * @group comment
+	 */
+	public function test_query_db_sort_by() {
+		$post_id = $this->ep_factory->post->create();
+
+		$comment_1_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_2_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_3_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_indexable = new \ElasticPress\Indexable\Comment\Comment();
+		$results           = $comment_indexable->query_db( [] );
+
+		$this->assertEquals( 3, $results['total_objects'] );
+		$this->assertEquals( $comment_3_id, $results['objects'][0]->ID );
+		$this->assertEquals( $comment_2_id, $results['objects'][1]->ID );
+		$this->assertEquals( $comment_1_id, $results['objects'][2]->ID );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where an incorrect number of comments were synced when pagination was used. The problem started occurring after merging this change https://github.com/10up/ElasticPress/issues/3654.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Comments sync issue
 
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
