### PR TITLE
Allow doc status explanation to have multiple lines and lists

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -23,3 +23,19 @@
 		background-color: var(--ep-status-error);
 	}
 }
+
+#wp-admin-bar-ep-doc-status .ab-item {
+	height: auto !important;
+}
+
+#wp-admin-bar-ep-doc-status-explanation {
+
+	& ul {
+		padding-left: 1.5em;
+
+		&,
+		& li {
+			list-style: disc;
+		}
+	}
+}


### PR DESCRIPTION
To be added to #4096 line in 5.2.0 changelog