### PR TITLE
Add ordering by ID for posts and terms in query_db

### DIFF
--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -832,6 +832,8 @@ class Comment extends Indexable {
 			$args['ep_indexing_advanced_pagination'] = false;
 		}
 
+		add_filter( 'comments_clauses', [ $this, 'set_orderby' ], 9999, 2 );
+
 		// Enforce the following query args during advanced pagination to ensure things work correctly.
 		if ( $args['ep_indexing_advanced_pagination'] ) {
 			$args = array_merge(
@@ -844,16 +846,18 @@ class Comment extends Indexable {
 					'offset'           => 0,
 				]
 			);
-			add_filter( 'comments_clauses', array( $this, 'bulk_indexing_filter_comments_where' ), 9999, 2 );
+			add_filter( 'comments_clauses', [ $this, 'bulk_indexing_filter_comments_where' ], 9999, 2 );
 
 			$query         = new WP_Comment_Query( $args );
 			$total_objects = $query->found_comments;
 
-			remove_filter( 'comments_clauses', array( $this, 'bulk_indexing_filter_comments_where' ), 9999, 2 );
+			remove_filter( 'comments_clauses', [ $this, 'bulk_indexing_filter_comments_where' ], 9999, 2 );
 		} else {
 			$query         = new WP_Comment_Query( $args );
 			$total_objects = $query->found_comments;
 		}
+
+		remove_filter( 'comments_clauses', [ $this, 'set_orderby' ], 9999, 2 );
 
 		if ( is_array( $query->comments ) ) {
 			array_walk( $query->comments, [ $this, 'remap_comments' ] );
@@ -1159,5 +1163,20 @@ class Comment extends Indexable {
 	 */
 	public function get_query_var( $query, $query_var, $default_value = '' ) {
 		return $query->query_vars[ $query_var ] ?? $default_value;
+	}
+
+	/**
+	 * Sets the ORDER BY clause for comment queries to order comments by their ID.
+	 *
+	 * @param array $clauses The SQL clauses array to modify.
+	 * @return array The modified SQL clauses array with the ORDERBY clause set.
+	 *
+	 * @since 5.2.0
+	 */
+	public function set_orderby( $clauses ) {
+		global $wpdb;
+
+		$clauses['orderby'] = "{$wpdb->comments}.comment_ID DESC";
+		return $clauses;
 	}
 }

--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -832,6 +832,7 @@ class Comment extends Indexable {
 			$args['ep_indexing_advanced_pagination'] = false;
 		}
 
+		// Explicitly set the orderby to ID to prevent accidental modifications by other code.
 		add_filter( 'comments_clauses', [ $this, 'set_orderby' ], 9999, 2 );
 
 		// Enforce the following query args during advanced pagination to ensure things work correctly.
@@ -1169,7 +1170,7 @@ class Comment extends Indexable {
 	 * Sets the ORDER BY clause for comment queries to order comments by their ID.
 	 *
 	 * @param array $clauses The SQL clauses array to modify.
-	 * @return array The modified SQL clauses array with the ORDERBY clause set.
+	 * @return array The modified SQL clauses array with the ORDER BY clause set.
 	 *
 	 * @since 5.2.0
 	 */

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -104,6 +104,9 @@ class Post extends Indexable {
 			$args['ep_indexing_advanced_pagination'] = false;
 		}
 
+		// Explicitly set the orderby to ID to prevent accidental modifications by other code.
+		add_filter( 'posts_orderby', [ $this, 'set_posts_orderby' ], 9999, 2 );
+
 		// Enforce the following query args during advanced pagination to ensure things work correctly.
 		if ( $args['ep_indexing_advanced_pagination'] ) {
 			$args = array_merge(
@@ -127,6 +130,8 @@ class Post extends Indexable {
 			$query         = new WP_Query( $args );
 			$total_objects = $query->found_posts;
 		}
+
+		remove_filter( 'posts_orderby', [ $this, 'set_posts_orderby' ], 9999, 2 );
 
 		return [
 			'objects'       => $query->posts,
@@ -3014,5 +3019,17 @@ class Post extends Indexable {
 		}
 
 		return array_unique( $all_allowed_metas );
+	}
+
+	/**
+	 * Sets the ORDERBY clause to sort posts by post ID in descending order.
+	 *
+	 * @return string The modified order by clause.
+	 *
+	 * @since 5.2.0
+	 */
+	public function set_posts_orderby(): string {
+		global $wpdb;
+		return "{$wpdb->posts}.ID DESC";
 	}
 }

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -120,12 +120,12 @@ class Post extends Indexable {
 					'no_found_rows'    => true,
 				]
 			);
-			add_filter( 'posts_where', array( $this, 'bulk_indexing_filter_posts_where' ), 9999, 2 );
+			add_filter( 'posts_where', [ $this, 'bulk_indexing_filter_posts_where' ], 9999, 2 );
 
 			$query         = new WP_Query( $args );
 			$total_objects = $this->get_total_objects_for_query( $args );
 
-			remove_filter( 'posts_where', array( $this, 'bulk_indexing_filter_posts_where' ), 9999, 2 );
+			remove_filter( 'posts_where', [ $this, 'bulk_indexing_filter_posts_where' ], 9999, 2 );
 		} else {
 			$query         = new WP_Query( $args );
 			$total_objects = $query->found_posts;
@@ -3022,7 +3022,7 @@ class Post extends Indexable {
 	}
 
 	/**
-	 * Sets the ORDERBY clause to sort posts by post ID in descending order.
+	 * Sets the ORDER BY clause to sort posts by post ID in descending order.
 	 *
 	 * @return string The modified order by clause.
 	 *

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -234,6 +234,9 @@ class Term extends Indexable {
 			$args['ep_indexing_advanced_pagination'] = false;
 		}
 
+		// Explicitly set the orderby to ID to prevent accidental modifications by other code.
+		add_filter( 'terms_clauses', array( $this, 'set_orderby' ), 9999, 3 );
+
 		// Enforce the following query args during advanced pagination to ensure things work correctly.
 		if ( $args['ep_indexing_advanced_pagination'] ) {
 			$args = array_merge(
@@ -289,6 +292,8 @@ class Term extends Indexable {
 
 			$query = new WP_Term_Query( $args );
 		}
+
+		remove_filter( 'terms_clauses', array( $this, 'set_orderby' ), 9999, 3 );
 
 		if ( is_array( $query->terms ) ) {
 			array_walk( $query->terms, array( $this, 'remap_terms' ) );
@@ -1235,5 +1240,18 @@ class Term extends Indexable {
 		}
 
 		return $formatted_args;
+	}
+
+	/**
+	 * Sets the ORDERBY clause for term queries to order terms by their term_id.
+	 *
+	 * @param array $clauses The SQL clauses array to modify.
+	 * @return array The modified SQL clauses array with the ORDER BY clause set to term_id.
+	 *
+	 * @since 5.2.0
+	 */
+	public function set_orderby( $clauses ): array {
+		$clauses['orderby'] = 'ORDER BY t.term_id';
+		return $clauses;
 	}
 }

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -235,7 +235,7 @@ class Term extends Indexable {
 		}
 
 		// Explicitly set the orderby to ID to prevent accidental modifications by other code.
-		add_filter( 'terms_clauses', array( $this, 'set_orderby' ), 9999, 3 );
+		add_filter( 'terms_clauses', [ $this, 'set_orderby' ], 9999, 3 );
 
 		// Enforce the following query args during advanced pagination to ensure things work correctly.
 		if ( $args['ep_indexing_advanced_pagination'] ) {
@@ -249,7 +249,7 @@ class Term extends Indexable {
 					'offset'           => 0,
 				]
 			);
-			add_filter( 'terms_clauses', array( $this, 'bulk_indexing_filter_terms_where' ), 9999, 3 );
+			add_filter( 'terms_clauses', [ $this, 'bulk_indexing_filter_terms_where' ], 9999, 3 );
 
 			/**
 			 * Filter database arguments for term count query
@@ -270,7 +270,7 @@ class Term extends Indexable {
 
 			$query = new WP_Term_Query( $args );
 
-			remove_filter( 'terms_clauses', array( $this, 'bulk_indexing_filter_terms_where' ), 9999, 3 );
+			remove_filter( 'terms_clauses', [ $this, 'bulk_indexing_filter_terms_where' ], 9999, 3 );
 		} else {
 
 			/**
@@ -293,7 +293,7 @@ class Term extends Indexable {
 			$query = new WP_Term_Query( $args );
 		}
 
-		remove_filter( 'terms_clauses', array( $this, 'set_orderby' ), 9999, 3 );
+		remove_filter( 'terms_clauses', [ $this, 'set_orderby' ], 9999, 3 );
 
 		if ( is_array( $query->terms ) ) {
 			array_walk( $query->terms, array( $this, 'remap_terms' ) );
@@ -1243,7 +1243,7 @@ class Term extends Indexable {
 	}
 
 	/**
-	 * Sets the ORDERBY clause for term queries to order terms by their term_id.
+	 * Sets the ORDER BY clause for term queries to order terms by their term_id.
 	 *
 	 * @param array $clauses The SQL clauses array to modify.
 	 * @return array The modified SQL clauses array with the ORDER BY clause set to term_id.

--- a/tests/php/indexables/TestComment.php
+++ b/tests/php/indexables/TestComment.php
@@ -2252,6 +2252,57 @@ class TestComment extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that query_db always returns terms ordered by ID in descending order.
+	 *
+	 * @since 5.2.0
+	 * @group term
+	 */
+	public function test_query_db_orderby() {
+		$post_id = $this->ep_factory->post->create();
+
+		$comment_1_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_2_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_3_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+			]
+		);
+
+		$comment_indexable = new \ElasticPress\Indexable\Comment\Comment();
+
+		// change the orderby and make sure it's still ordered by ID.
+		add_filter(
+			'comments_clauses',
+			function ( $clauses ) {
+				global $wpdb;
+
+				$clauses['orderby'] = "{$wpdb->comments}.comment_type ASC";
+				return $clauses;
+			}
+		);
+
+		$results = $comment_indexable->query_db( [] );
+
+		$this->assertSame( 3, $results['total_objects'] );
+
+		$comment_ids = wp_list_pluck( $results['objects'], 'ID' );
+
+		$this->assertSame( $comment_3_id, (int) $comment_ids[0] );
+		$this->assertSame( $comment_2_id, (int) $comment_ids[1] );
+		$this->assertSame( $comment_1_id, (int) $comment_ids[2] );
+	}
+
+	/**
 	 * Test Comment Indexable query_db with WooCommerce feature enabled.
 	 *
 	 * @since 3.6.0

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -6311,6 +6311,37 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that query_db always returns posts ordered by ID in descending order.
+	 *
+	 * @return void
+	 * @group post
+	 */
+	public function test_query_db_orderby() {
+		$post_id_1 = $this->ep_factory->post->create();
+		$post_id_2 = $this->ep_factory->post->create();
+		$post_id_3 = $this->ep_factory->post->create();
+
+		$post_indexable = new \ElasticPress\Indexable\Post\Post();
+
+		// change the orderby and make sure it's still ordered by ID.
+		add_filter(
+			'posts_orderby',
+			function () {
+				global $wpdb;
+				return "{$wpdb->posts}.menu_order";
+			}
+		);
+
+		$result = $post_indexable->query_db( [] );
+
+		$post_ids = wp_list_pluck( $result['objects'], 'ID' );
+
+		$this->assertEquals( $post_id_3, $post_ids[0] );
+		$this->assertEquals( $post_id_2, $post_ids[1] );
+		$this->assertEquals( $post_id_1, $post_ids[2] );
+	}
+
+	/**
 	 * Tests fallback code inside prepare_document.
 	 *
 	 * @return void

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1582,7 +1582,7 @@ class TestTerm extends BaseTestCase {
 
 		$this->assertSame( 4, $results['total_objects'] );
 
-		$term_ids = wp_list_pluck( $result['objects'], 'ID' );
+		$term_ids = wp_list_pluck( $results['objects'], 'ID' );
 		$this->assertSame( $term_4_id, $term_ids[0] );
 		$this->assertSame( $term_3_id, $term_ids[1] );
 		$this->assertSame( $term_2_id, $term_ids[2] );

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1551,10 +1551,49 @@ class TestTerm extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that query_db always returns terms ordered by ID in descending order.
+	 *
+	 * @since 5.2.0
+	 * @group term
+	 */
+	public function test_query_db_orderby() {
+		$term_1_id = $this->ep_factory->term->create();
+		$term_2_id = $this->ep_factory->term->create();
+		$term_3_id = $this->ep_factory->term->create();
+		$term_4_id = $this->ep_factory->term->create();
+
+		$term_indexable = new \ElasticPress\Indexable\Term\Term();
+
+		// change the orderby and make sure it's still ordered by ID.
+		add_filter(
+			'terms_clauses',
+			function ( $clauses ) {
+
+				$clauses['orderby'] = 'ORDER BY t.term_order';
+				return $clauses;
+			}
+		);
+
+		$results = $term_indexable->query_db(
+			[
+				'taxonomy' => 'post_tag',
+			]
+		);
+
+		$this->assertSame( 4, $results['total_objects'] );
+
+		$term_ids = wp_list_pluck( $result['objects'], 'ID' );
+		$this->assertSame( $term_4_id, $term_ids[0] );
+		$this->assertSame( $term_3_id, $term_ids[1] );
+		$this->assertSame( $term_2_id, $term_ids[2] );
+		$this->assertSame( $term_1_id, $term_ids[3] );
+	}
+
+	/**
 	 * Tests additional logic in put_mapping().
 	 *
 	 * @return void
-	 * @group post
+	 * @group term
 	 */
 	public function testPutMapping() {
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR explicitly adds the filter to ensure that query in Post and Term indexable always use orderby ID. This prevents other plugins, such as Post Types Order, from modifying the order.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3275

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Install the Post Types Order plugin
Run a sync.
Ensure all posts are successfully synced.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Prevent other code from modifying the ORDERBY clause in Post and Term indexable queries.
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
