### PR TITLE
Fix: Term sync issue during the pagination

### DIFF
--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -248,24 +248,8 @@ class Term extends Indexable {
 			);
 			add_filter( 'terms_clauses', array( $this, 'bulk_indexing_filter_terms_where' ), 9999, 3 );
 
-			/**
-			 * Filter database arguments for term count query
-			 *
-			 * @hook ep_term_all_query_db_args
-			 * @param  {array} $args Query arguments based to `wp_count_terms()`
-			 * @since  3.4
-			 * @return {array} New arguments
-			 */
-			$total_objects = wp_count_terms( apply_filters( 'ep_term_all_query_db_args', $all_query_args, $args ) );
-			$total_objects = ! is_wp_error( $total_objects ) ? (int) $total_objects : 0;
-
-			if ( ! empty( $args['offset'] ) ) {
-				if ( (int) $args['offset'] >= $total_objects ) {
-					$total_objects = 0;
-				}
-			}
-
-			$query = new WP_Term_Query( $args );
+			$query         = new WP_Term_Query( $args );
+			$total_objects = $this->get_total_objects_for_query( $args );
 
 			remove_filter( 'terms_clauses', array( $this, 'bulk_indexing_filter_terms_where' ), 9999, 3 );
 		} else {
@@ -343,6 +327,35 @@ class Term extends Indexable {
 		}
 
 		return $clauses;
+	}
+
+	/**
+	 * Get the total number of terms for a given query.
+	 *
+	 * @param array $query_args The query args.
+	 * @return int The total number of terms.
+	 */
+	protected function get_total_objects_for_query( $query_args ) {
+		static $object_counts = [];
+
+		// Reset the pagination-related args for optimal caching.
+		$normalized_query_args = array_merge(
+			$query_args,
+			[
+				'offset'                               => 0,
+				'paged'                                => 1,
+				'posts_per_page'                       => 1,
+				'no_found_rows'                        => false,
+				'ep_indexing_last_processed_object_id' => null,
+			]
+		);
+
+		$cache_key = md5( get_current_blog_id() . wp_json_encode( $normalized_query_args ) );
+		if ( ! isset( $object_counts[ $cache_key ] ) ) {
+			$object_counts[ $cache_key ] = wp_count_terms( $normalized_query_args );
+		}
+
+		return $object_counts[ $cache_key ];
 	}
 
 	/**

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1483,7 +1483,7 @@ class TestTerm extends BaseTestCase {
 		);
 
 		$this->assertCount( 3, $results['objects'] );
-		$this->assertSame( 4, $results['total_objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
 
 		$results = $term_indexable->query_db(
 			[
@@ -1498,14 +1498,14 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertSame( 0, $results['total_objects'] );
+		$this->assertEquals( 0, $results['total_objects'] );
 
 		// create new term
 		$term_1_id = $this->ep_factory->term->create();
 
 		// test only one term is returned
 		$results = $term_indexable->query_db( [ 'include' => $term_1_id ] );
-		$this->assertSame( 1, $results['total_objects'] );
+		$this->assertEquals( 1, $results['total_objects'] );
 
 		// test query returns all terms except one
 		$results = $term_indexable->query_db(
@@ -1514,7 +1514,7 @@ class TestTerm extends BaseTestCase {
 				'taxonomy' => 'post_tag',
 			]
 		);
-		$this->assertSame( 4, $results['total_objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
 
 		// create 5 new terms
 		$this->ep_factory->term->create_many( 2 );
@@ -1528,7 +1528,7 @@ class TestTerm extends BaseTestCase {
 				'taxonomy'                          => 'post_tag',
 			]
 		);
-		$this->assertSame( 5, $results['total_objects'] );
+		$this->assertEquals( 5, $results['total_objects'] );
 
 		// Test when lower limit is set and it returns only 3 terms.
 		$results = $term_indexable->query_db(
@@ -1537,7 +1537,7 @@ class TestTerm extends BaseTestCase {
 				'taxonomy'                          => 'post_tag',
 			]
 		);
-		$this->assertSame( 3, $results['total_objects'] );
+		$this->assertEquals( 3, $results['total_objects'] );
 
 		// Test when both upper and lower limit is set and it returns only 4 terms.
 		$results = $term_indexable->query_db(
@@ -1547,7 +1547,72 @@ class TestTerm extends BaseTestCase {
 				'taxonomy'                          => 'post_tag',
 			]
 		);
-		$this->assertSame( 4, $results['total_objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
+	}
+
+	/**
+	 * Tests the pagination of the query_db method.
+	 *
+	 * @since 5.2.0
+	 * @group term
+	 */
+	public function test_query_db_with_last_processed_object_id() {
+		$term_1_id = $this->ep_factory->term->create();
+		$term_2_id = $this->ep_factory->term->create();
+		$term_3_id = $this->ep_factory->term->create();
+
+		$term_indexable = new \ElasticPress\Indexable\Term\Term();
+
+		$results = $term_indexable->query_db(
+			[
+				'per_page' => 1,
+				'taxonomy' => 'post_tag',
+			]
+		);
+
+		$term_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $term_3_id, $term_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 3, $results['total_objects'] );
+
+		// Second loop.
+		$results = $term_indexable->query_db(
+			[
+				'per_page'                             => 1,
+				'taxonomy'                             => 'post_tag',
+				'ep_indexing_last_processed_object_id' => $term_3_id,
+			]
+		);
+
+		$term_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $term_2_id, $term_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 3, $results['total_objects'] );
+	}
+
+	/**
+	 * Tests that the query_db method returns results sorted by ID.
+	 *
+	 * @since 5.2.0
+	 * @group term
+	 */
+	public function test_query_db_sort_by() {
+		$term_1_id = $this->ep_factory->term->create();
+		$term_2_id = $this->ep_factory->term->create();
+		$term_3_id = $this->ep_factory->term->create();
+
+		$term_indexable = new \ElasticPress\Indexable\Term\Term();
+		$results        = $term_indexable->query_db(
+			[
+				'taxonomy' => 'post_tag',
+			]
+		);
+
+		$term_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( 3, $results['total_objects'] );
+		$this->assertEquals( $term_3_id, $term_ids[0] );
+		$this->assertEquals( $term_2_id, $term_ids[1] );
+		$this->assertEquals( $term_1_id, $term_ids[2] );
 	}
 
 	/**

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1641,17 +1641,18 @@ class TestTerm extends BaseTestCase {
 
 		$results = $term_indexable->query_db(
 			[
-				'taxonomy' => 'post_tag',
+				'taxonomy'     => 'post_tag',
+				'cache_buster' => wp_generate_uuid4(), // get_total_objects_for_query returns a cached value because test_query_db_sort_by calls query_db with the same query args.
 			]
 		);
 
-		$this->assertSame( 4, $results['total_objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
 
 		$term_ids = wp_list_pluck( $results['objects'], 'ID' );
-		$this->assertSame( $term_4_id, $term_ids[0] );
-		$this->assertSame( $term_3_id, $term_ids[1] );
-		$this->assertSame( $term_2_id, $term_ids[2] );
-		$this->assertSame( $term_1_id, $term_ids[3] );
+		$this->assertEquals( $term_4_id, $term_ids[0] );
+		$this->assertEquals( $term_3_id, $term_ids[1] );
+		$this->assertEquals( $term_2_id, $term_ids[2] );
+		$this->assertEquals( $term_1_id, $term_ids[3] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where an incorrect number of terms were synced when pagination was used. The problem started occurring after merging this change https://github.com/10up/ElasticPress/issues/3654.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Run `wp elasticpress sync --setup --show-errors --yes  --indexables=term --per-page=10` command and confirm if all the terms are synced.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Term sync issue
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
