### PR TITLE
Fix: Date query not apply correctly when inclusive is set to true

### DIFF
--- a/includes/classes/Indexable/Post/DateQuery.php
+++ b/includes/classes/Indexable/Post/DateQuery.php
@@ -211,7 +211,7 @@ class DateQuery extends WP_Date_Query {
 
 		if ( ! empty( $query['before'] ) ) {
 			$range_filters                   = empty( $range_filters[ $column ] ) ? array( "{$column}" => array( "{$lt}" => [] ) ) : $range_filters;
-			$range_filters[ $column ][ $lt ] = $this->build_mysql_datetime( $query['before'] );
+			$range_filters[ $column ][ $lt ] = $this->build_mysql_datetime( $query['before'], $inclusive );
 		}
 
 		if ( ! empty( $query['after'] ) || ! empty( $query['before'] ) ) {

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5375,6 +5375,66 @@ class TestPost extends BaseTestCase {
 		$this->assertEquals( $query->found_posts, 1 );
 	}
 
+	/**
+	 * Test the date query returns the correct results within the range when inclusive is set to true
+	 *
+	 * @group post
+	 */
+	public function test_date_query_within_range() {
+		$this->ep_factory->post->create(
+			[
+				'post_date' => wp_date( 'Y-m-d H:i:s', strtotime( 'January 1st, 2025 00:01:01' ) ),
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => wp_date( 'Y-m-d H:i:s', strtotime( 'February 1st, 2025 00:01:01' ) ),
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => wp_date( 'Y-m-d H:i:s', strtotime( 'February 15th, 2025 00:01:01' ) ),
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => wp_date( 'Y-m-d H:i:s', strtotime( 'February 28th, 2025 23:59:59' ) ),
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => wp_date( 'Y-m-d H:i:s', strtotime( 'March 1st, 2025 00:01:01' ) ),
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$args = [
+			'ep_integrate' => true,
+			'date_query'   => [
+				[
+					'after'     => [
+						'year'  => 2025,
+						'month' => 2,
+					],
+					'before'    => [
+						'year'  => 2025,
+						'month' => 2,
+					],
+					'inclusive' => true,
+				],
+			],
+		];
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 3, $query->post_count );
+	}
 
 	/**
 	 * Test a date query with multiple eltries


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the date query doesn't return the expected results when the inclusive is set.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4090

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Date Query returns no result whenthe  before and after range is the same and inclusive is set to true


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @ErikBrendel

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
