### PR TITLE
fix: fallback if term orderby is set to none

### DIFF
--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -613,6 +613,10 @@ class Term extends Indexable {
 			$from_to['name'] = version_compare( (string) $es_version, '7.0', '<' ) ? 'name.raw' : 'name.sortable';
 		}
 
+		if ( 'none' === $orderby ) {
+			$orderby = 'id';
+		}
+
 		$orderby = $from_to[ $orderby ] ?? $orderby;
 
 		$sort[] = array(


### PR DESCRIPTION
### Description of the Change
On my local setup at some point I came across a term query which has set the `orderby` argument set to `none`. This resulted in a ES exception since there was no field to order on. This PR addresses the fix similar to https://github.com/10up/ElasticPress/pull/3318

### Todo
- [ ] Add test

### Changelog Entry
> Fixed - Added fallback if term orderby is set to none

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
