### PR TITLE
Fix: 36px default size is deprecated since version 6.8

### DIFF
--- a/assets/js/blocks/facets/common/components/facet-meta-control.js
+++ b/assets/js/blocks/facets/common/components/facet-meta-control.js
@@ -51,6 +51,7 @@ export default ({ onChange, value }) => {
 			options={options}
 			value={value}
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 		/>
 	);
 };

--- a/assets/js/blocks/facets/common/components/facet-order-control.js
+++ b/assets/js/blocks/facets/common/components/facet-order-control.js
@@ -53,6 +53,7 @@ export default ({ onChange, orderby, order }) => {
 			options={options}
 			value={`${orderby}/${order}`}
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 		/>
 	);
 };

--- a/assets/js/blocks/facets/common/components/facet-search-placeholder-control.js
+++ b/assets/js/blocks/facets/common/components/facet-search-placeholder-control.js
@@ -20,6 +20,7 @@ export default ({ onChange, value }) => {
 			value={value}
 			onChange={onChange}
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 		/>
 	);
 };

--- a/assets/js/blocks/facets/common/components/facet-taxonomy-control.js
+++ b/assets/js/blocks/facets/common/components/facet-taxonomy-control.js
@@ -45,6 +45,7 @@ export default ({ onChange, value }) => {
 			options={options}
 			value={value}
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 		/>
 	);
 };

--- a/assets/js/blocks/facets/meta-range/edit.js
+++ b/assets/js/blocks/facets/meta-range/edit.js
@@ -95,6 +95,7 @@ export default ({ attributes, name, setAttributes }) => {
 								onChange={onChangePrefix}
 								value={prefix}
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 							/>
 						</FlexItem>
 						<FlexItem>
@@ -103,6 +104,7 @@ export default ({ attributes, name, setAttributes }) => {
 								onChange={onChangeSuffix}
 								value={suffix}
 								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 							/>
 						</FlexItem>
 					</Flex>

--- a/assets/js/features/components/control.js
+++ b/assets/js/features/components/control.js
@@ -186,6 +186,7 @@ export default ({
 									suggestions={suggestions}
 									value={values}
 									__nextHasNoMarginBottom
+									__next40pxDefaultSize
 								/>
 							);
 						}
@@ -211,6 +212,7 @@ export default ({
 									disabled={isDisabled}
 									value={value}
 									__nextHasNoMarginBottom
+									__next40pxDefaultSize
 								/>
 							);
 						}
@@ -234,6 +236,7 @@ export default ({
 									onChange={onChange}
 									disabled={isDisabled}
 									value={value}
+									__nextHasNoMarginBottom
 								/>
 							);
 						}
@@ -247,6 +250,7 @@ export default ({
 									value={value}
 									type={type}
 									__nextHasNoMarginBottom
+									__next40pxDefaultSize
 								/>
 							);
 						}

--- a/assets/js/instant-results/admin/components/facet-selector.js
+++ b/assets/js/instant-results/admin/components/facet-selector.js
@@ -74,6 +74,8 @@ export default ({ defaultValue, ...props }) => {
 				onChange={onChange}
 				suggestions={suggestions}
 				value={value}
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 			/>
 			<input type="hidden" value={selectedFacets.join(',')} {...props} />
 		</>

--- a/assets/js/sync-ui/components/include.js
+++ b/assets/js/sync-ui/components/include.js
@@ -54,6 +54,7 @@ export default () => {
 				saveTransform={saveTransform}
 				value={args.include}
 				__nextHasNoMarginBottom
+				__next40pxDefaultSize
 			/>
 		</div>
 	);

--- a/assets/js/sync-ui/components/limits.js
+++ b/assets/js/sync-ui/components/limits.js
@@ -57,6 +57,7 @@ export default () => {
 					type="number"
 					value={args.lower_limit_object_id}
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</FlexItem>
 			<FlexItem grow="2">
@@ -69,6 +70,7 @@ export default () => {
 					type="number"
 					value={args.upper_limit_object_id}
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</FlexItem>
 		</Flex>

--- a/assets/js/sync-ui/components/offset.js
+++ b/assets/js/sync-ui/components/offset.js
@@ -30,6 +30,7 @@ export default () => {
 			type="number"
 			value={args.offset}
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 		/>
 	);
 };

--- a/assets/js/synonyms/components/common/edit-panel.js
+++ b/assets/js/synonyms/components/common/edit-panel.js
@@ -70,6 +70,7 @@ const EditPanel = (
 							onChange={onChangePrimary}
 							value={primaryValue.map((p) => p.value).join('')}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					) : null}
 					{mode === 'replacements' ? (
@@ -79,6 +80,7 @@ const EditPanel = (
 							onChange={onChangePrimary}
 							value={primaryValue.map((p) => p.value)}
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 						/>
 					) : null}
 					<FormTokenField
@@ -87,6 +89,7 @@ const EditPanel = (
 						onChange={onChangeSynonyms}
 						value={synonymsValue.map((h) => h.value)}
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 					<Flex justify="start">
 						<FlexItem>

--- a/assets/js/weighting/components/field.js
+++ b/assets/js/weighting/components/field.js
@@ -72,6 +72,7 @@ export default ({ label, onChange, onDelete, value, showTooltip }) => {
 						onChange={onChangeWeight}
 						value={weight}
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 				</div>
 				<div className="ep-weighting-field__actions">

--- a/assets/js/weighting/components/group.js
+++ b/assets/js/weighting/components/group.js
@@ -185,6 +185,7 @@ export default ({ group, postType }) => {
 						placeholder={__('Metadata key', 'elasticpress')}
 						value={toAdd}
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 					<Button disabled={!toAdd} isSecondary onClick={onClick} variant="secondary">
 						{__('Add', 'elasticpress')}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes deprecated warnings `36px default size for wp.components.TextControl is deprecated since version 6.8 and will be removed in version 7.1`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Deprecated warnings `36px default size is deprecated`
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
