### PR TITLE
Fix the Sync Complete message behavior

### DIFF
--- a/assets/js/sync-ui/apps/sync.js
+++ b/assets/js/sync-ui/apps/sync.js
@@ -55,13 +55,20 @@ export default () => {
 	};
 
 	/**
-	 * Handle a completed sync.
+	 * Display a notice when a sync is complete.
+	 */
+	const onCompleteDisplayNotice = () => {
+		if (isComplete) {
+			createNotice('success', __('Sync completed.', 'elasticpress'));
+		}
+	};
+
+	/**
+	 * Handle logs and errors count when a sync is complete.
 	 */
 	const onComplete = () => {
 		if (isComplete) {
 			const newErrorCount = errorCounts.reduce((c, e) => c + e.count, 0);
-
-			createNotice('success', __('Sync completed.', 'elasticpress'));
 
 			if (newErrorCount > errorCount) {
 				setIsLogOpen(true);
@@ -101,6 +108,7 @@ export default () => {
 		logMessage(__('Starting sync…', 'elasticpress'), 'info');
 	};
 
+	useEffect(onCompleteDisplayNotice, [createNotice, isComplete]);
 	useEffect(onComplete, [createNotice, errorCount, errorCounts, isComplete]);
 	useEffect(onInit, [autoIndex, logMessage, startSync, syncTrigger]);
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4113 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - The Sync Complete message being displayed when the log is cleared.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
