### PR TITLE
Fix the form action (and use that) for the date filter

### DIFF
--- a/assets/js/blocks/facets/date/view.js
+++ b/assets/js/blocks/facets/date/view.js
@@ -31,7 +31,7 @@ const initFacet = () => {
 					`[name="${filterName}_to"]`,
 				) || '';
 
-			const currentURL = window.location.href;
+			const currentURL = form.action;
 			const newUrl = new URL(currentURL);
 
 			if (value !== 'custom') {

--- a/includes/classes/Feature/Facets/Types/Date/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Date/Renderer.php
@@ -40,9 +40,11 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 		$selected_filters = $feature->get_selected();
 		$is_custom_date   = $this->is_custom_date();
 		$applied_dates    = isset( $selected_filters[ $facet_type->get_filter_type() ]['terms'] ) ? array_keys( $selected_filters[ $facet_type->get_filter_type() ]['terms'] ) : [];
+
+		$action = $feature->build_query_url( $selected_filters );
 		?>
 
-		<form class="ep-facet-date-form">
+		<form class="ep-facet-date-form" action="<?php echo esc_url( $action ); ?>" method="GET">
 			<?php
 			foreach ( $facet_type->get_facet_options() as $date ) :
 				$is_selected   = false;

--- a/tests/cypress/integration/features/facets.cy.js
+++ b/tests/cypress/integration/features/facets.cy.js
@@ -1003,6 +1003,16 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 				.last()
 				.find('input')
 				.should('be.checked');
+
+			/**
+			 * It should go back to page 1 when selecting a filter in page 2.
+			 */
+			cy.visit('/page/2');
+			cy.get('@block').find('.ep-facet-date-option label').first().click();
+			cy.get('@block').find('.wp-element-button').click();
+
+			cy.url().should('include', 'ep_date_filter=last-3-months');
+			cy.url().should('not.include', 'page/2');
 		});
 	});
 });


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4116

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Selecting a value in the date filter not redirecting users back to page 1

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
