### PR TITLE
Disconsider the force_inactive value when comparing settings

### DIFF
--- a/assets/js/features/provider.js
+++ b/assets/js/features/provider.js
@@ -63,7 +63,18 @@ export const FeatureSettingsProvider = ({
 	/**
 	 * Whether the settings have changes.
 	 */
-	const isModified = useMemo(() => !isEqual(settings, savedSettings), [settings, savedSettings]);
+	const isModified = useMemo(() => {
+		// The force_inactive attribute is something that is not controlled via UI, so we remove it before comparing things.
+		const deleteForceInactive = (settings) => {
+			Object.keys(settings).forEach((feature) => {
+				delete settings[feature].force_inactive;
+			});
+		};
+		deleteForceInactive(settings);
+		deleteForceInactive(savedSettings);
+
+		return !isEqual(settings, savedSettings);
+	}, [settings, savedSettings]);
 
 	/**
 	 * Return whether a setting change will require a sync, based on the


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4115

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Discard Changes button coming back when saving the feature twice.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
