### PR TITLE
Update link to compatibility documentation in admin notices

### DIFF
--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -519,7 +519,7 @@ class AdminNotices {
 			return false;
 		}
 
-		$doc_url = 'https://www.elasticpress.io/documentation/article/compatibility/';
+		$doc_url = 'https://www.elasticpress.io/resources/articles/compatibility/';
 		$html    = sprintf(
 			/* translators: Document page URL */
 			__( 'Your server software is not supported. To learn more about server compatibility please <a href="%s">visit our documentation</a>.', 'elasticpress' ),

--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -519,7 +519,7 @@ class AdminNotices {
 			return false;
 		}
 
-		$doc_url = 'https://10up.github.io/ElasticPress/tutorial-compatibility.html';
+		$doc_url = 'https://www.elasticpress.io/documentation/article/compatibility/';
 		$html    = sprintf(
 			/* translators: Document page URL */
 			__( 'Your server software is not supported. To learn more about server compatibility please <a href="%s">visit our documentation</a>.', 'elasticpress' ),

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ You can report any security bugs found in the source code of ElasticPress throug
 
 = Is ElasticPress compatible with OpenSearch or Elasticsearch X.Y? =
 
-ElasticPress requirements can be found in the [Requirements section](https://github.com/10up/ElasticPress#requirements) of our GitHub repository. If your solution relies on a different server or version, you may find additional information on our [Compatibility documentation page](https://10up.github.io/ElasticPress/tutorial-compatibility.html).
+ElasticPress requirements can be found in the [Requirements section](https://github.com/10up/ElasticPress#requirements) of our GitHub repository. If your solution relies on a different server or version, you may find additional information on our [Compatibility documentation page](https://www.elasticpress.io/documentation/article/compatibility/).
 
 = I really like ElasticPress! Can I contribute? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ You can report any security bugs found in the source code of ElasticPress throug
 
 = Is ElasticPress compatible with OpenSearch or Elasticsearch X.Y? =
 
-ElasticPress requirements can be found in the [Requirements section](https://github.com/10up/ElasticPress#requirements) of our GitHub repository. If your solution relies on a different server or version, you may find additional information on our [Compatibility documentation page](https://www.elasticpress.io/documentation/article/compatibility/).
+ElasticPress requirements can be found in the [Requirements section](https://github.com/10up/ElasticPress#requirements) of our GitHub repository. If your solution relies on a different server or version, you may find additional information on our [Compatibility documentation page](https://www.elasticpress.io/resources/articles/compatibility/).
 
 = I really like ElasticPress! Can I contribute? =
 


### PR DESCRIPTION
### Description of the Change
While reviewing the admin notices, I noticed that the tutorial-compatibility documentation has been moved to a new URL. The reference link in the admin notice should be updated to reflect the new location.

### Credits
Props @dilipbheda

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.