### PR TITLE
[WIP] Feature: (GH4123 Req 2) - Persistent Feature Selection on Reload

### DIFF
--- a/assets/js/features/apps/features.js
+++ b/assets/js/features/apps/features.js
@@ -4,6 +4,9 @@
 import { Button, Flex, FlexItem, Notice, Panel, PanelBody, TabPanel } from '@wordpress/components';
 import { useMemo, useState, WPElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { create as createPersistence } from '@wordpress/preferences-persistence';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
+import { store as prefsStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies.
@@ -18,6 +21,15 @@ import Tab from '../components/tab';
  * Styles.
  */
 import '../style.css';
+
+/**
+ * Keeps persistence of the last active feature setting across page reloads.
+ */
+wp.data.dispatch('core/preferences').setPersistenceLayer(createPersistence());
+
+dispatch(prefsStore).setDefaults('elasticpress', {
+	activeFeature: false,
+});
 
 /**
  * Feature settings dashboard app.
@@ -128,6 +140,14 @@ export default () => {
 			};
 		});
 
+	const activeFeature =
+		useSelect(
+			(select) => select('core/preferences').get('elasticpress', 'activeFeature'),
+			[],
+		) ?? tabs[0].name;
+
+	const { set } = useDispatch('core/preferences');
+
 	/**
 	 * Error handler.
 	 *
@@ -228,7 +248,13 @@ export default () => {
 							{isSyncingNotice}
 						</Notice>
 					) : null}
-					<TabPanel className="ep-dashboard-tabs" orientation="vertical" tabs={tabs}>
+					<TabPanel
+						className="ep-dashboard-tabs"
+						orientation="vertical"
+						tabs={tabs}
+						initialTabName={activeFeature}
+						onSelect={(name) => set('elasticpress', 'activeFeature', name)}
+					>
 						{({ name }) => <Feature feature={name} key={name} />}
 					</TabPanel>
 				</PanelBody>

--- a/tests/cypress/integration/features/choice-persists-on-reload.cy.js
+++ b/tests/cypress/integration/features/choice-persists-on-reload.cy.js
@@ -1,0 +1,54 @@
+describe('Feature Selection Persistence', () => {
+	/**
+	 * @constant {string} TAB_CONTAINER - Selector for the feature tabs container.
+	 */
+	const tabContainerSelector = '#ep-dashboard .components-tab-panel__tabs';
+
+	/**
+	 * @type {string} savedTabId - ID of the last clicked tab.
+	 */
+	let savedTabId;
+
+	beforeEach(() => {
+		/**
+		 * Log in to WordPress admin.
+		 */
+		cy.login();
+
+		/**
+		 * Navigate to the ElasticPress settings page.
+		 */
+		cy.visit('/wp-admin/admin.php?page=elasticpress');
+
+		/**
+		 * Alias the tabs container for reuse in tests.
+		 */
+		cy.get(tabContainerSelector).as('tabsContainer');
+	});
+
+	/**
+	 * Verifies that the tabs are clickable and change their content.
+	 */
+	it('has clickable tabs that change their content', () => {
+		// eslint-disable-next-line cypress/unsafe-to-chain-command
+		cy.get('@tabsContainer')
+			.find('button#tab-panel-0-did-you-mean')
+			.click()
+			.invoke('attr', 'id')
+			.then((id) => {
+				savedTabId = id;
+				const viewId = `${id}-view`;
+				const selector = `#${CSS.escape(viewId)}`;
+				cy.get(selector).should('have.attr', 'data-open', 'true');
+			});
+	});
+
+	/**
+	 * Verifies that the last selected feature is retained on page reload.
+	 */
+	it('retains its last selected feature on page reload', () => {
+		cy.reload();
+		const selector = `#${CSS.escape(savedTabId)}`;
+		cy.get(selector).should('have.attr', 'data-active-item', 'true');
+	});
+});


### PR DESCRIPTION
[WIP]
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
> Keep the current feature on reload: Currently, if you reload, you always go to the first feature. Reloading and staying in the current feature would be ideal

#4123 Request 2 (Selected Feature Persistence)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
> Developer - Non-functional update

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ZacharyRener

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
