### PR TITLE
[WIP] Feature Selection Persistence (GH4123 Req 2)

### DIFF
--- a/assets/js/features/apps/features.js
+++ b/assets/js/features/apps/features.js
@@ -2,7 +2,7 @@
  * WordPress dependencies.
  */
 import { Button, Flex, FlexItem, Notice, Panel, PanelBody, TabPanel } from '@wordpress/components';
-import { useMemo, useState, WPElement } from '@wordpress/element';
+import { useMemo, useState, WPElement, useRef, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { create as createPersistence } from '@wordpress/preferences-persistence';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
@@ -28,7 +28,11 @@ import '../style.css';
 wp.data.dispatch('core/preferences').setPersistenceLayer(createPersistence());
 
 dispatch(prefsStore).setDefaults('elasticpress', {
-	activeFeature: false,
+	// userSetFeatures keeps track of 1. the active group and 2. the active feature within that group
+	userSetFeatures: {
+		activeGroup: '',
+		activeFeature: '',
+	},
 });
 
 /**
@@ -48,6 +52,20 @@ export default () => {
 		saveSettings,
 		setIsSyncing,
 	} = useFeatureSettings();
+
+	const userSetFeatures = useSelect(
+		(select) => select('core/preferences').get('elasticpress', 'userSetFeatures'),
+		[],
+	);
+
+	// Flag to track initial render and prevent unnecessary updates
+	const initialRenderRef = useRef(true);
+	const userSetFeaturesRef = useRef(userSetFeatures);
+
+	// Update the ref whenever userSetFeatures changes
+	useEffect(() => {
+		userSetFeaturesRef.current = userSetFeatures;
+	}, [userSetFeatures]);
 
 	/**
 	 * URL to start a sync.
@@ -140,12 +158,6 @@ export default () => {
 				group: f.group,
 			};
 		});
-
-	const activeFeature =
-		useSelect(
-			(select) => select('core/preferences').get('elasticpress', 'activeFeature'),
-			[],
-		) ?? tabs[0].name;
 
 	const { set } = useDispatch('core/preferences');
 
@@ -240,9 +252,37 @@ export default () => {
 		createNotice('success', resetNotice);
 	};
 
+	const setUserSetFeatures = (activeGroup, activeFeature) => {
+		// Skip setting userSetFeatures during initial render
+		if (initialRenderRef.current) {
+			return;
+		}
+
+		// Only update if values are actually changing to prevent unnecessary re-renders
+		if (
+			userSetFeaturesRef.current.activeGroup !== activeGroup ||
+			userSetFeaturesRef.current.activeFeature !== activeFeature
+		) {
+			userSetFeaturesRef.current = { activeGroup, activeFeature };
+			set('elasticpress', 'userSetFeatures', { activeGroup, activeFeature });
+		}
+	};
+
 	const renderFeatureTabs = (group) => {
+		const updatedTabs = group.tabs.map((tab) => ({
+			...tab,
+			isActive: tab.name === userSetFeatures.activeFeature,
+		}));
+
+		// Find initial tab - use stored preference if possible
+		const initialTab =
+			userSetFeatures.activeFeature &&
+			group.tabs.some((tab) => tab.name === userSetFeatures.activeFeature)
+				? userSetFeatures.activeFeature
+				: updatedTabs[0]?.name;
+
 		return (
-			<Panel className="ep-dashboard-panel">
+			<Panel className="ep-dashboard-panel" key={group.title}>
 				<PanelBody>
 					{isSyncing ? (
 						<Notice actions={isSyncingActions} isDismissible={false} status="warning">
@@ -252,9 +292,13 @@ export default () => {
 					<TabPanel
 						className="ep-dashboard-tabs"
 						orientation="vertical"
-						tabs={group.tabs}
-						initialTabName={activeFeature}
-						onSelect={(name) => set('elasticpress', 'activeFeature', name)}
+						initialTabName={initialTab}
+						onSelect={(name) => {
+							if (!initialRenderRef.current) {
+								setUserSetFeatures(group.title, name);
+							}
+						}}
+						tabs={updatedTabs}
 					>
 						{({ name }) => <Feature feature={name} key={name} />}
 					</TabPanel>
@@ -272,6 +316,13 @@ export default () => {
 	const renderFeatureGroup = (groupTabs) => {
 		if (!groupTabs.length) return null;
 
+		// Determine initial group tab
+		const initialGroup =
+			userSetFeatures.activeGroup &&
+			groupTabs.some((group) => group.title === userSetFeatures.activeGroup)
+				? userSetFeatures.activeGroup
+				: groupTabs[0].title;
+
 		return (
 			<TabPanel
 				className="ep-dashboard-outer-tabs"
@@ -280,9 +331,23 @@ export default () => {
 					name: group.title,
 					title: group.title,
 				}))}
+				initialTabName={initialGroup}
+				onSelect={(name) => {
+					if (initialRenderRef.current) {
+						return;
+					}
+
+					const selectedGroup = groupTabs.find((group) => group.title === name);
+					if (!selectedGroup) return;
+
+					const selectedFeatureWithinGroup = selectedGroup.tabs[0].name;
+					setUserSetFeatures(selectedGroup.title, selectedFeatureWithinGroup);
+				}}
 			>
 				{({ name }) => {
 					const group = groupTabs.find((g) => g.title === name);
+					if (!group) return null;
+
 					return renderFeatureTabs(group);
 				}}
 			</TabPanel>
@@ -309,6 +374,16 @@ export default () => {
 
 		return groupsWithTabs;
 	}, [features, tabs]);
+
+	// Set initialRenderRef to false after component mounts to allow updates in callbacks
+	useEffect(() => {
+		// Wait for a tick to ensure the initial rendering completes
+		const timeoutId = setTimeout(() => {
+			initialRenderRef.current = false;
+		}, 100);
+
+		return () => clearTimeout(timeoutId);
+	}, []);
 
 	return (
 		<form onReset={onReset} onSubmit={onSubmit}>

--- a/assets/js/features/apps/features.js
+++ b/assets/js/features/apps/features.js
@@ -125,6 +125,7 @@ export default () => {
 			return {
 				name: f.slug,
 				title: <Tab feature={f.slug} />,
+				group: f.group,
 			};
 		});
 
@@ -219,20 +220,77 @@ export default () => {
 		createNotice('success', resetNotice);
 	};
 
-	return (
-		<form onReset={onReset} onSubmit={onSubmit}>
+	const renderFeatureTabs = (group) => {
+		return (
 			<Panel className="ep-dashboard-panel">
 				<PanelBody>
-					{isSyncing ? (
-						<Notice actions={isSyncingActions} isDismissible={false} status="warning">
-							{isSyncingNotice}
-						</Notice>
-					) : null}
-					<TabPanel className="ep-dashboard-tabs" orientation="vertical" tabs={tabs}>
+					<TabPanel
+						className="ep-dashboard-tabs"
+						orientation="vertical"
+						tabs={group.tabs}
+					>
 						{({ name }) => <Feature feature={name} key={name} />}
 					</TabPanel>
 				</PanelBody>
 			</Panel>
+		);
+	};
+
+	/**
+	 * Render a feature group.
+	 *
+	 * @param {Array} groupTabs Group tabs.
+	 * @returns {WPElement|null}
+	 * */
+	const renderFeatureGroup = (groupTabs) => {
+		if (!groupTabs.length) return null;
+
+		return (
+			<TabPanel
+				className="ep-dashboard-outer-tabs"
+				orientation="horizontal"
+				tabs={groupTabs.map((group) => ({
+					name: group.title,
+					title: group.title,
+				}))}
+			>
+				{({ name }) => {
+					const group = groupTabs.find((g) => g.title === name);
+					return renderFeatureTabs(group);
+				}}
+			</TabPanel>
+		);
+	};
+
+	const groupedTabs = useMemo(() => {
+		// Get unique groups from features
+		const groups = [...new Set(features.map((f) => f.group).filter((slug) => slug))];
+		// Group tabs by their group property
+		const groupsWithTabs = groups.map((group) => ({
+			title: group,
+			tabs: tabs.filter((t) => t.group === group),
+		}));
+
+		// Add "Other" group for tabs without a group
+		const otherTabs = tabs.filter((t) => !t.group || !groups.includes(t.group));
+		if (otherTabs.length > 0) {
+			groupsWithTabs.push({
+				title: __('Other', 'elasticpress'),
+				tabs: otherTabs,
+			});
+		}
+
+		return groupsWithTabs;
+	}, [features, tabs]);
+
+	return (
+		<form onReset={onReset} onSubmit={onSubmit}>
+			{renderFeatureGroup(groupedTabs)}
+			{isSyncing && (
+				<Notice actions={isSyncingActions} isDismissible={false} status="warning">
+					{isSyncingNotice}
+				</Notice>
+			)}
 			<Flex justify="start">
 				<FlexItem>
 					<Button

--- a/assets/js/features/apps/features.js
+++ b/assets/js/features/apps/features.js
@@ -4,6 +4,9 @@
 import { Button, Flex, FlexItem, Notice, Panel, PanelBody, TabPanel } from '@wordpress/components';
 import { useMemo, useState, WPElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { create as createPersistence } from '@wordpress/preferences-persistence';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
+import { store as prefsStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies.
@@ -18,6 +21,15 @@ import Tab from '../components/tab';
  * Styles.
  */
 import '../style.css';
+
+/**
+ * Keeps persistence of the last active feature setting across page reloads.
+ */
+wp.data.dispatch('core/preferences').setPersistenceLayer(createPersistence());
+
+dispatch(prefsStore).setDefaults('elasticpress', {
+	activeFeature: false,
+});
 
 /**
  * Feature settings dashboard app.
@@ -129,6 +141,14 @@ export default () => {
 			};
 		});
 
+	const activeFeature =
+		useSelect(
+			(select) => select('core/preferences').get('elasticpress', 'activeFeature'),
+			[],
+		) ?? tabs[0].name;
+
+	const { set } = useDispatch('core/preferences');
+
 	/**
 	 * Error handler.
 	 *
@@ -224,10 +244,17 @@ export default () => {
 		return (
 			<Panel className="ep-dashboard-panel">
 				<PanelBody>
+					{isSyncing ? (
+						<Notice actions={isSyncingActions} isDismissible={false} status="warning">
+							{isSyncingNotice}
+						</Notice>
+					) : null}
 					<TabPanel
 						className="ep-dashboard-tabs"
 						orientation="vertical"
 						tabs={group.tabs}
+						initialTabName={activeFeature}
+						onSelect={(name) => set('elasticpress', 'activeFeature', name)}
 					>
 						{({ name }) => <Feature feature={name} key={name} />}
 					</TabPanel>

--- a/assets/js/features/style.css
+++ b/assets/js/features/style.css
@@ -5,7 +5,7 @@
 	}
 
 	& .components-panel {
-		margin-bottom: 16px;
+		height: calc(100% - 2px);
 	}
 
 	& .components-notice__actions {
@@ -23,8 +23,8 @@
 
 .ep-dashboard-tabs {
 	display: grid;
-	grid-gap: 40px;
-	grid-template-columns: 1fr 3fr;
+	grid-gap: 16px;
+	grid-template-columns: 2fr 5fr;
 
 	& .components-tab-panel__tab-content {
 		padding-top: 14px;
@@ -98,15 +98,46 @@
 	min-height: 20px;
 }
 
-.ep-dashboard-outer-tabs > .components-tab-panel__tabs {
-	flex-wrap: wrap;
+.ep-dashboard-outer-tabs {
+	display: grid;
+	grid-template-columns: 1fr 4fr;
 	margin-bottom: 16px;
-
-	& .components-tab-panel__tabs-item.is-active {
-		color: var(--wp-admin-theme-color);
+	
+	& .components-tab-panel__tab-content .components-panel__body {
+		padding-bottom: 32px;
 	}
+}
 
-	& .components-tab-panel__tabs-item:not(.is-active) {
-		border-bottom: 1px solid #ccd0d4;
+@media (max-width: 782px) {
+	
+	.ep-dashboard-outer-tabs {
+		grid-template-columns: 1fr;
+	}
+}
+
+.ep-dashboard-outer-tabs > .components-tab-panel__tabs {
+	align-content: baseline;
+	background: #fff;
+	border: 1px solid #e0e0e0;
+	border-right: none;
+	flex-wrap: wrap;
+	
+	
+	& .components-tab-panel__tabs-item {
+		text-align: left;
+		width: 100%;
+
+		&.is-active {
+			background: #f0f0f0;
+			font-weight: 500;
+			
+			&::after {
+				content: none;
+			}
+		}
+
+		&:not(.is-active) {
+			font-weight: 400;
+		}
 	}
 }

--- a/assets/js/features/style.css
+++ b/assets/js/features/style.css
@@ -1,8 +1,11 @@
-.ep-dashboard-panel {
-	margin-bottom: 16px;
+#ep-dashboard {
 
 	& .components-notice {
-		margin: 0 0 16px 0;
+		margin: 16px 0;
+	}
+
+	& .components-panel {
+		margin-bottom: 16px;
 	}
 
 	& .components-notice__actions {
@@ -21,7 +24,7 @@
 .ep-dashboard-tabs {
 	display: grid;
 	grid-gap: 40px;
-	grid-template-columns: max-content auto;
+	grid-template-columns: 1fr 3fr;
 
 	& .components-tab-panel__tab-content {
 		padding-top: 14px;
@@ -93,4 +96,17 @@
 	gap: 8px;
 	justify-content: space-between;
 	min-height: 20px;
+}
+
+.ep-dashboard-outer-tabs > .components-tab-panel__tabs {
+	flex-wrap: wrap;
+	margin-bottom: 16px;
+
+	& .components-tab-panel__tabs-item.is-active {
+		color: var(--wp-admin-theme-color);
+	}
+
+	& .components-tab-panel__tabs-item:not(.is-active) {
+		border-bottom: 1px solid #ccd0d4;
+	}
 }

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -148,7 +148,7 @@ abstract class Feature {
 	 * @since 5.2.0
 	 * @var false|string
 	 */
-	protected $group = false;
+	public $group = false;
 
 	/**
 	 * Run on every page load for feature to set itself up

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -143,6 +143,14 @@ abstract class Feature {
 	protected $is_powered_by_epio = false;
 
 	/**
+	 * The name of a group that a feature may belong to.
+	 *
+	 * @since 5.2.0
+	 * @var false|string
+	 */
+	protected $group = false;
+
+	/**
 	 * Run on every page load for feature to set itself up
 	 *
 	 * @since  2.1
@@ -551,6 +559,7 @@ abstract class Feature {
 			'reqStatusCode'     => $requirements_status->code,
 			'reqStatusMessages' => (array) $requirements_status->message,
 			'settingsSchema'    => $this->get_settings_schema(),
+			'group'             => $this->group,
 		];
 
 		return $feature_desc;

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -145,7 +145,7 @@ abstract class Feature {
 	/**
 	 * The name of a group that a feature may belong to.
 	 *
-	 * @since 5.2.0
+	 * @since 5.3.0
 	 * @var false|string
 	 */
 	public $group = false;

--- a/includes/classes/Feature/AcfRepeater/AcfRepeater.php
+++ b/includes/classes/Feature/AcfRepeater/AcfRepeater.php
@@ -37,7 +37,7 @@ class AcfRepeater extends Feature {
 	 * Initialize feature setting it's config
 	 */
 	public function __construct() {
-		$this->slug  = 'acf_repeater';
+		$this->slug = 'acf_repeater';
 		parent::__construct();
 	}
 

--- a/includes/classes/Feature/AcfRepeater/AcfRepeater.php
+++ b/includes/classes/Feature/AcfRepeater/AcfRepeater.php
@@ -38,7 +38,6 @@ class AcfRepeater extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'acf_repeater';
-		$this->group = '3rd Party Plugins';
 		parent::__construct();
 	}
 
@@ -47,6 +46,8 @@ class AcfRepeater extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'ACF Repeater Field Compatibility', 'elasticpress' );
+
+		$this->group = esc_html__( '3rd Party Plugins', 'elasticpress' );
 
 		$this->short_title = esc_html__( 'ACF Repeater Field', 'elasticpress' );
 

--- a/includes/classes/Feature/AcfRepeater/AcfRepeater.php
+++ b/includes/classes/Feature/AcfRepeater/AcfRepeater.php
@@ -37,8 +37,8 @@ class AcfRepeater extends Feature {
 	 * Initialize feature setting it's config
 	 */
 	public function __construct() {
-		$this->slug = 'acf_repeater';
-
+		$this->slug  = 'acf_repeater';
+		$this->group = '3rd Party Plugins';
 		parent::__construct();
 	}
 

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -38,7 +38,8 @@ class Autosuggest extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug = 'autosuggest';
+		$this->slug  = 'autosuggest';
+		$this->group = 'Live Search';
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -38,7 +38,7 @@ class Autosuggest extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug  = 'autosuggest';
+		$this->slug = 'autosuggest';
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -39,7 +39,6 @@ class Autosuggest extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'autosuggest';
-		$this->group = 'Live Search';
 
 		$this->requires_install_reindex = true;
 
@@ -64,6 +63,8 @@ class Autosuggest extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Autosuggest', 'elasticpress' );
+
+		$this->group = esc_html__( 'Live Search', 'elasticpress' );
 
 		$this->short_title = esc_html__( 'Autosuggest', 'elasticpress' );
 

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -20,7 +20,6 @@ class DidYouMean extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'did-you-mean';
-		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = true;
 
@@ -43,6 +42,8 @@ class DidYouMean extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Did You Mean', 'elasticpress' );
+
+		$this->group = esc_html__( 'Core Search', 'elasticpress' );
 
 		$this->summary = '<p>' . __( '"Did You Mean" search feature provides alternative suggestions for misspelled or ambiguous search queries, enhancing search accuracy and user experience. To display suggestions in your theme, please follow <a href="https://www.elasticpress.io/documentation/article/did-you-mean/">this tutorial</a>.', 'elasticpress' ) . '</p>';
 

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -19,7 +19,7 @@ class DidYouMean extends Feature {
 	 * Initialize feature, setting it's config.
 	 */
 	public function __construct() {
-		$this->slug  = 'did-you-mean';
+		$this->slug = 'did-you-mean';
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -19,7 +19,8 @@ class DidYouMean extends Feature {
 	 * Initialize feature, setting it's config.
 	 */
 	public function __construct() {
-		$this->slug = 'did-you-mean';
+		$this->slug  = 'did-you-mean';
+		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -23,7 +23,8 @@ class Documents extends Feature {
 	 * @since  2.6
 	 */
 	public function __construct() {
-		$this->slug = 'documents';
+		$this->slug  = 'documents';
+		$this->group = 'Indexing Options';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -24,7 +24,6 @@ class Documents extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'documents';
-		$this->group = 'Indexing Options';
 
 		$this->requires_install_reindex = false;
 
@@ -39,6 +38,8 @@ class Documents extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Documents', 'elasticpress' );
+
+		$this->group = esc_html__( 'Indexing Options', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Website search results will include popular document file types, using file names as well as their content. Supported file types include: ppt, pptx, doc, docx, xls, xlsx, pdf, csv, txt.', 'elasticpress' ) . '</p>';
 

--- a/includes/classes/Feature/Documents/Documents.php
+++ b/includes/classes/Feature/Documents/Documents.php
@@ -23,7 +23,7 @@ class Documents extends Feature {
 	 * @since  2.6
 	 */
 	public function __construct() {
-		$this->slug  = 'documents';
+		$this->slug = 'documents';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/Facets/Block.php
+++ b/includes/classes/Feature/Facets/Block.php
@@ -29,5 +29,5 @@ abstract class Block {
 	 * @param array $attributes Block attributes.
 	 * @return string
 	 */
-	abstract  public function render_block( $attributes );
+	abstract public function render_block( $attributes );
 }

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -37,7 +37,6 @@ class Facets extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'facets';
-		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 
@@ -94,6 +93,8 @@ class Facets extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Filters', 'elasticpress' );
+
+		$this->group = esc_html__( 'Core Search', 'elasticpress' );
 
 		$this->summary = '<p>' .
 		( wp_is_block_theme()

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -36,7 +36,7 @@ class Facets extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug  = 'facets';
+		$this->slug = 'facets';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -36,7 +36,8 @@ class Facets extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug = 'facets';
+		$this->slug  = 'facets';
+		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -66,7 +66,6 @@ class InstantResults extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'instant-results';
-		$this->group = 'Live Search';
 
 		$this->host = trailingslashit( Utils\get_host() );
 
@@ -102,6 +101,8 @@ class InstantResults extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Instant Results', 'elasticpress' );
+
+		$this->group = esc_html__( 'Live Search', 'elasticpress' );
 
 		$this->short_title = esc_html__( 'Instant Results', 'elasticpress' );
 

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -65,7 +65,7 @@ class InstantResults extends Feature {
 	 * @return void
 	 */
 	public function __construct() {
-		$this->slug  = 'instant-results';
+		$this->slug = 'instant-results';
 
 		$this->host = trailingslashit( Utils\get_host() );
 

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -65,7 +65,8 @@ class InstantResults extends Feature {
 	 * @return void
 	 */
 	public function __construct() {
-		$this->slug = 'instant-results';
+		$this->slug  = 'instant-results';
+		$this->group = 'Live Search';
 
 		$this->host = trailingslashit( Utils\get_host() );
 

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -28,7 +28,8 @@ class ProtectedContent extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug = 'protected_content';
+		$this->slug  = 'protected_content';
+		$this->group = 'Indexing Options';
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -29,7 +29,6 @@ class ProtectedContent extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'protected_content';
-		$this->group = 'Indexing Options';
 
 		$this->requires_install_reindex = true;
 
@@ -46,6 +45,8 @@ class ProtectedContent extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Protected Content', 'elasticpress' );
+
+		$this->group = esc_html__( 'Indexing Options', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Syncs unpublished content — including private, draft, and scheduled posts — improving load times in places like the administrative dashboard where WordPress needs to include protected content in a query.', 'elasticpress' ) . '</p>' .
 		'<p><em>' . __( 'We recommend using a secured Elasticsearch setup, such as ElasticPress.io, to prevent potential exposure of content not intended for the public.', 'elasticpress' ) . '</em></p>';

--- a/includes/classes/Feature/ProtectedContent/ProtectedContent.php
+++ b/includes/classes/Feature/ProtectedContent/ProtectedContent.php
@@ -28,7 +28,7 @@ class ProtectedContent extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug  = 'protected_content';
+		$this->slug = 'protected_content';
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -24,7 +24,8 @@ class RelatedPosts extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug = 'related_posts';
+		$this->slug  = 'related_posts';
+		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -25,7 +25,6 @@ class RelatedPosts extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'related_posts';
-		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 
@@ -40,6 +39,8 @@ class RelatedPosts extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Related Posts', 'elasticpress' );
+
+		$this->group = esc_html__( 'Core Search', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Instantly deliver engaging and precise related content with no impact on site performance. Output related content using our block or directly in your theme using our <a href="https://www.elasticpress.io/documentation/article/related-posts-api/">API functions</a>.', 'elasticpress' ) . '</p>';
 

--- a/includes/classes/Feature/RelatedPosts/RelatedPosts.php
+++ b/includes/classes/Feature/RelatedPosts/RelatedPosts.php
@@ -24,7 +24,7 @@ class RelatedPosts extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug  = 'related_posts';
+		$this->slug = 'related_posts';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -51,7 +51,6 @@ class Search extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'search';
-		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 
@@ -76,6 +75,8 @@ class Search extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Post Search', 'elasticpress' );
+
+		$this->group = esc_html__( 'Core Search', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Instantly find the content you’re looking for. The first time.', 'elasticpress' ) . '</p>' .
 		'<p>' . __( 'Overcome higher-end performance and functional limits posed by the traditional WordPress structured (SQL) database to deliver superior keyword search, instantly. ElasticPress indexes custom fields, tags, and other metadata to improve search results. Fuzzy matching accounts for misspellings and verb tenses.', 'elasticpress' ) . '</p>';

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -50,7 +50,8 @@ class Search extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug = 'search';
+		$this->slug  = 'search';
+		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -50,7 +50,7 @@ class Search extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug  = 'search';
+		$this->slug = 'search';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -50,7 +50,7 @@ class SearchOrdering extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug  = 'searchordering';
+		$this->slug = 'searchordering';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -50,7 +50,8 @@ class SearchOrdering extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug = 'searchordering';
+		$this->slug  = 'searchordering';
+		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -51,7 +51,6 @@ class SearchOrdering extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'searchordering';
-		$this->group = 'Core Search';
 
 		$this->requires_install_reindex = false;
 
@@ -68,6 +67,8 @@ class SearchOrdering extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'Custom Search Results', 'elasticpress' );
+
+		$this->group = esc_html__( 'Core Search', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Selected posts will be inserted into search results in the specified position.', 'elasticpress' ) . '</p>';
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -52,7 +52,8 @@ class WooCommerce extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug = 'woocommerce';
+		$this->slug  = 'woocommerce';
+		$this->group = 'WooCommerce';
 
 		$this->requires_install_reindex = true;
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -53,7 +53,6 @@ class WooCommerce extends Feature {
 	 */
 	public function __construct() {
 		$this->slug  = 'woocommerce';
-		$this->group = 'WooCommerce';
 
 		$this->requires_install_reindex = true;
 
@@ -80,6 +79,8 @@ class WooCommerce extends Feature {
 	 */
 	public function set_i18n_strings(): void {
 		$this->title = esc_html__( 'WooCommerce', 'elasticpress' );
+
+		$this->group = esc_html__( 'WooCommerce', 'elasticpress' );
 
 		$this->summary = '<p>' . __( 'Most caching and performance tools can’t keep up with the nearly infinite ways your visitors might filter or navigate your products. No matter how many products, filters, or customers you have, ElasticPress will keep your online store performing quickly. If used in combination with the Protected Content feature, ElasticPress will also accelerate order searches and back end product management.', 'elasticpress' ) . '</p>';
 

--- a/includes/classes/Feature/WooCommerce/WooCommerce.php
+++ b/includes/classes/Feature/WooCommerce/WooCommerce.php
@@ -52,7 +52,7 @@ class WooCommerce extends Feature {
 	 * @since  3.0
 	 */
 	public function __construct() {
-		$this->slug  = 'woocommerce';
+		$this->slug = 'woocommerce';
 
 		$this->requires_install_reindex = true;
 

--- a/tests/cypress/integration/features/choice-persists-on-reload.cy.js
+++ b/tests/cypress/integration/features/choice-persists-on-reload.cy.js
@@ -1,13 +1,25 @@
 describe('Feature Selection Persistence', () => {
 	/**
-	 * @constant {string} TAB_CONTAINER - Selector for the feature tabs container.
+	 * @constant {string} OUTER_TAB_CONTAINER - Selector for the group tabs container.
 	 */
-	const tabContainerSelector = '#ep-dashboard .components-tab-panel__tabs';
+	const outerTabContainerSelector =
+		'#ep-dashboard .ep-dashboard-outer-tabs .components-tab-panel__tabs';
 
 	/**
-	 * @type {string} savedTabId - ID of the last clicked tab.
+	 * @constant {string} INNER_TAB_CONTAINER - Selector for the feature tabs container.
 	 */
-	let savedTabId;
+	const innerTabContainerSelector =
+		'#ep-dashboard .ep-dashboard-tabs .components-tab-panel__tabs';
+
+	/**
+	 * @type {string} savedGroupId - ID of the selected group tab.
+	 */
+	let savedGroupId;
+
+	/**
+	 * @type {string} savedFeatureId - ID of the selected feature tab.
+	 */
+	let savedFeatureId;
 
 	beforeEach(() => {
 		/**
@@ -21,34 +33,64 @@ describe('Feature Selection Persistence', () => {
 		cy.visit('/wp-admin/admin.php?page=elasticpress');
 
 		/**
-		 * Alias the tabs container for reuse in tests.
+		 * Alias the tabs containers for reuse in tests.
 		 */
-		cy.get(tabContainerSelector).as('tabsContainer');
+		cy.get(outerTabContainerSelector).as('groupTabsContainer');
+		cy.get(innerTabContainerSelector).as('featureTabsContainer');
 	});
 
 	/**
-	 * Verifies that the tabs are clickable and change their content.
+	 * Verifies that the group and feature tabs are clickable and persist their selections.
 	 */
-	it('has clickable tabs that change their content', () => {
+	it('allows selecting groups and features, and persists selections on reload', () => {
+		// First select a group (for example, the second group)
 		// eslint-disable-next-line cypress/unsafe-to-chain-command
-		cy.get('@tabsContainer')
-			.find('button#tab-panel-0-did-you-mean')
+		cy.get('@groupTabsContainer')
+			.find('button')
+			.eq(1) // Select the second group
 			.click()
 			.invoke('attr', 'id')
 			.then((id) => {
-				savedTabId = id;
-				const viewId = `${id}-view`;
-				const selector = `#${CSS.escape(viewId)}`;
-				cy.get(selector).should('have.attr', 'data-open', 'true');
-			});
-	});
+				savedGroupId = id;
 
-	/**
-	 * Verifies that the last selected feature is retained on page reload.
-	 */
-	it('retains its last selected feature on page reload', () => {
-		cy.reload();
-		const selector = `#${CSS.escape(savedTabId)}`;
-		cy.get(selector).should('have.attr', 'data-active-item', 'true');
+				// Now that we've selected a group, select a feature within it (for example, the second feature)
+				// eslint-disable-next-line cypress/unsafe-to-chain-command
+				cy.get('@featureTabsContainer')
+					.find('button')
+					.eq(1) // Select the second feature
+					.click()
+					.invoke('attr', 'id')
+					.then((featureId) => {
+						savedFeatureId = featureId;
+
+						// Verify the feature is active
+						cy.get(`#${CSS.escape(featureId)}`).should(
+							'have.attr',
+							'data-active-item',
+							'true',
+						);
+
+						// Reload the page to test persistence
+						cy.reload();
+
+						// Wait for UI to load completely
+						cy.get(outerTabContainerSelector).should('be.visible');
+						cy.get(innerTabContainerSelector).should('be.visible');
+
+						// Verify group selection persisted
+						cy.get(`#${CSS.escape(savedGroupId)}`).should(
+							'have.attr',
+							'data-active-item',
+							'true',
+						);
+
+						// Verify feature selection persisted
+						cy.get(`#${CSS.escape(savedFeatureId)}`).should(
+							'have.attr',
+							'data-active-item',
+							'true',
+						);
+					});
+			});
 	});
 });

--- a/tests/cypress/integration/features/choice-persists-on-reload.cy.js
+++ b/tests/cypress/integration/features/choice-persists-on-reload.cy.js
@@ -1,0 +1,54 @@
+describe('Feature Selection Persistence', () => {
+	/**
+	 * @constant {string} TAB_CONTAINER - Selector for the feature tabs container.
+	 */
+	const tabContainerSelector = '#ep-dashboard .components-tab-panel__tabs';
+
+	/**
+	 * @type {string} savedTabId - ID of the last clicked tab.
+	 */
+	let savedTabId;
+
+	beforeEach(() => {
+		/**
+		 * Log in to WordPress admin.
+		 */
+		cy.login();
+
+		/**
+		 * Navigate to the ElasticPress settings page.
+		 */
+		cy.visit('/wp-admin/admin.php?page=elasticpress');
+
+		/**
+		 * Alias the tabs container for reuse in tests.
+		 */
+		cy.get(tabContainerSelector).as('tabsContainer');
+	});
+
+	/**
+	 * Verifies that the tabs are clickable and change their content.
+	 */
+	it('has clickable tabs that change their content', () => {
+		// eslint-disable-next-line cypress/unsafe-to-chain-command
+		cy.get('@tabsContainer')
+			.find('button#tab-panel-0-did-you-mean')
+			.click()
+			.invoke('attr', 'id')
+			.then((id) => {
+				savedTabId = id;
+				const viewId = `${id}-view`;
+				const selector = `#${CSS.escape(viewId)}`;
+				cy.get(selector).should('have.attr', 'data-open', 'true');
+			});
+	});
+
+	/**
+	 * Verifies that the last selected feature is retained on page reload.
+	 */
+	it('retains its last selected feature on page reload', () => {
+		cy.reload();
+		const selector = `#${CSS.escape(savedTabId)}`;
+		cy.get(selector).should('have.attr', 'data-active-item', 'true');
+	});
+});

--- a/tests/cypress/integration/features/comments.cy.js
+++ b/tests/cypress/integration/features/comments.cy.js
@@ -252,6 +252,7 @@ describe('Comments Feature', { tags: '@slow' }, () => {
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+		cy.contains('button', 'Other').click();
 		cy.contains('button', 'Comments').click();
 		cy.contains('label', 'Enable').click();
 		cy.contains('button', 'Save and sync now').click();

--- a/tests/cypress/integration/features/documents.cy.js
+++ b/tests/cypress/integration/features/documents.cy.js
@@ -2,7 +2,7 @@ describe('Documents Feature', () => {
 	function enableDocumentsFeature() {
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
-
+		cy.contains('button', 'Indexing Options').click();
 		cy.contains('button', 'Documents').click();
 		cy.contains('label', 'Enable').click();
 		cy.contains('button', 'Save changes').click();

--- a/tests/cypress/integration/features/facets.cy.js
+++ b/tests/cypress/integration/features/facets.cy.js
@@ -583,6 +583,7 @@ describe('Facets Feature', { tags: '@slow' }, () => {
 			cy.visitAdminPage('admin.php?page=elasticpress');
 			cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+			cy.contains('button', 'Core Search').click();
 			cy.contains('button', 'Filters').click();
 			cy.contains('label', 'Show results that match any selected filter').click();
 			cy.contains('button', 'Save changes').click();

--- a/tests/cypress/integration/features/groups.cy.js
+++ b/tests/cypress/integration/features/groups.cy.js
@@ -1,0 +1,74 @@
+describe('Feature Grouping', () => {
+	/**
+	 * CSS selector for the tabs container within the ElasticPress dashboard.
+	 * @constant {string}
+	 */
+	const tabContainerSelector =
+		'#ep-dashboard .ep-dashboard-outer-tabs > .components-tab-panel__tabs';
+
+	beforeEach(() => {
+		/**
+		 * Log in to WordPress admin.
+		 */
+		cy.login();
+
+		/**
+		 * Navigate to the ElasticPress settings page.
+		 */
+		cy.visit('/wp-admin/admin.php?page=elasticpress');
+
+		/**
+		 * Alias the tabs container for reuse in tests.
+		 */
+		cy.get(tabContainerSelector).as('tabsContainer');
+	});
+
+	it('renders feature group tabs', () => {
+		/**
+		 * Verifies the tabs container exists, is visible,
+		 * and contains at least one feature tab.
+		 */
+		cy.get('@tabsContainer')
+			.should('exist')
+			.and('be.visible')
+			.find('button')
+			.should('have.length.at.least', 1);
+	});
+
+	it('switches content when clicking a tab', () => {
+		/**
+		 * Clicks the second tab and verifies the corresponding
+		 * panel is opened by checking the data-open attribute.
+		 */
+		// eslint-disable-next-line cypress/unsafe-to-chain-command
+		cy.get('@tabsContainer')
+			.find('button')
+			.eq(1)
+			.click()
+			.then(($btn) => {
+				/** @type {string} ID of the clicked tab button. */
+				const buttonId = $btn.attr('id');
+				// eslint-disable-next-line no-unused-expressions
+				expect(buttonId, 'tab button id').to.be.a('string').and.not.be.empty;
+
+				/**
+				 * Create the panel ID and escape any special characters (including spaces).
+				 * Uses the built-in CSS.escape() to safely escape the ID value.
+				 * @constant {string}
+				 */
+				const rawPanelId = `${buttonId}-view`;
+				const escapedPanelId = CSS.escape(rawPanelId);
+
+				/**
+				 * Construct the panel selector using the escaped ID.
+				 * @constant {string}
+				 */
+				const panelSelector = `#${escapedPanelId}`;
+
+				/**
+				 * Assert that the panel element has data-open="true".
+				 */
+				cy.get(panelSelector).should('have.attr', 'data-open', 'true');
+			});
+	});
+});

--- a/tests/cypress/integration/features/groups.cy.js
+++ b/tests/cypress/integration/features/groups.cy.js
@@ -23,9 +23,9 @@ describe('Feature Grouping', () => {
 		cy.get(tabContainerSelector).as('tabsContainer');
 	});
 
-	it('renders feature group tabs', () => {
+	it('renders feature group tabs and handles tab switching', () => {
 		/**
-		 * Verifies the tabs container exists, is visible,
+		 * Test 1: Verifies the tabs container exists, is visible,
 		 * and contains at least one feature tab.
 		 */
 		cy.get('@tabsContainer')
@@ -33,11 +33,9 @@ describe('Feature Grouping', () => {
 			.and('be.visible')
 			.find('button')
 			.should('have.length.at.least', 1);
-	});
 
-	it('switches content when clicking a tab', () => {
 		/**
-		 * Clicks the second tab and verifies the corresponding
+		 * Test 2: Clicks the second tab and verifies the corresponding
 		 * panel is opened by checking the data-open attribute.
 		 */
 		// eslint-disable-next-line cypress/unsafe-to-chain-command

--- a/tests/cypress/integration/features/instant-results.cy.js
+++ b/tests/cypress/integration/features/instant-results.cy.js
@@ -66,6 +66,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 
 		cy.visitAdminPage('admin.php?page=elasticpress');
 
+		cy.contains('button', 'Live Search').click();
 		cy.contains('button', 'Instant Results').click();
 		cy.contains('.components-notice', 'To use this feature you need').should('exist');
 		cy.get('.components-form-toggle__input').should('be.disabled');
@@ -89,6 +90,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 			cy.visitAdminPage('admin.php?page=elasticpress');
 			cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+			cy.contains('button', 'Live Search').click();
 			cy.contains('button', 'Instant Results').click();
 
 			const noticeShould = isEpIo ? 'not.contain.text' : 'contain.text';
@@ -141,6 +143,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.visitAdminPage('admin.php?page=elasticpress');
 				cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+				cy.contains('button', 'Live Search').click();
 				cy.contains('button', 'Instant Results').click();
 				cy.get('.components-form-token-field__input').type('prod{downArrow}{enter}{esc}');
 				cy.contains('button', 'Save changes').click();
@@ -241,6 +244,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.visitAdminPage('admin.php?page=elasticpress');
 				cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+				cy.contains('button', 'Live Search').click();
 				cy.contains('button', 'Instant Results').click();
 				cy.get('.components-form-token-field__input').type(
 					'{backspace}{backspace}{backspace}price{downArrow}{enter}{esc}',
@@ -395,6 +399,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				 */
 				cy.visitAdminPage('admin.php?page=elasticpress');
 				cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
+				cy.contains('button', 'Live Search').click();
 				cy.contains('button', 'Instant Results').click();
 				cy.get('.components-form-token-field__input').type(
 					'{backspace}{backspace}{backspace}post type{downArrow}{enter}{esc}',
@@ -420,6 +425,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				 */
 				cy.visitAdminPage('admin.php?page=elasticpress');
 				cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
+				cy.contains('button', 'Live Search').click();
 				cy.contains('button', 'Instant Results').click();
 				cy.contains('.components-form-token-field__token', 'Post type')
 					.find('button')
@@ -450,6 +456,7 @@ describe('Instant Results Feature', { tags: '@slow' }, () => {
 				cy.visitAdminPage('admin.php?page=elasticpress');
 				cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+				cy.contains('button', 'Live Search').click();
 				cy.contains('button', 'Instant Results').click();
 				cy.get('.components-form-token-field__input').type(
 					'{backspace}{backspace}{backspace}(category){downArrow}{enter}{esc}',

--- a/tests/cypress/integration/features/protected-content.cy.js
+++ b/tests/cypress/integration/features/protected-content.cy.js
@@ -5,6 +5,7 @@ describe('Protected Content Feature', () => {
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+		cy.contains('button', 'Indexing Options').click();
 		cy.contains('button', 'Protected Content').click();
 		cy.contains('label', 'Enable').click();
 		cy.contains('button', 'Save and sync now').click();

--- a/tests/cypress/integration/features/search/search.cy.js
+++ b/tests/cypress/integration/features/search/search.cy.js
@@ -111,6 +111,7 @@ describe('Post Search Feature', { tags: '@slow' }, () => {
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+		cy.contains('button', 'Core Search').click();
 		cy.contains('button', 'Post Search').click();
 		cy.contains('label', 'Weight results by date').click();
 		cy.contains('button', 'Save changes').click();

--- a/tests/cypress/integration/features/terms.cy.js
+++ b/tests/cypress/integration/features/terms.cy.js
@@ -25,6 +25,7 @@ describe('Terms Feature', { tags: '@slow' }, () => {
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
+		cy.contains('button', 'Other').click();
 		cy.contains('button', 'Terms').click();
 		cy.contains('label', 'Enable').click();
 		cy.contains('button', 'Save and sync now').click();

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -38,7 +38,8 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 		cy.visitAdminPage('admin.php?page=elasticpress');
 		cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
-		cy.contains('button', 'WooCommerce').click();
+		cy.get('#tab-panel-0-WooCommerce').click();
+		cy.get('#tab-panel-0-WooCommerce-view button').contains('WooCommerce').click();
 		cy.contains('label', 'Enable').click();
 		cy.contains('button', 'Save and sync now').click();
 
@@ -351,12 +352,11 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 			cy.visitAdminPage('admin.php?page=elasticpress');
 			cy.intercept('/wp-json/elasticpress/v1/features*').as('apiRequest');
 
-			cy.contains('button', 'WooCommerce').click();
-
 			/**
 			 * Enable the feature.
 			 */
-			cy.contains('button', 'WooCommerce').click();
+			cy.get('#tab-panel-0-WooCommerce').click();
+			cy.get('#tab-panel-0-WooCommerce-view button').contains('WooCommerce').click();
 
 			cy.contains('label', 'Show suggestions')
 				.closest('.components-base-control')

--- a/tests/cypress/integration/features/woocommerce.cy.js
+++ b/tests/cypress/integration/features/woocommerce.cy.js
@@ -26,7 +26,8 @@ describe('WooCommerce Feature', { tags: '@slow' }, () => {
 		cy.activatePlugin('woocommerce');
 
 		cy.visitAdminPage('admin.php?page=elasticpress');
-		cy.get('#tab-panel-0-woocommerce').click();
+		cy.get('#tab-panel-0-WooCommerce').click();
+		cy.get('#tab-panel-0-WooCommerce-view button').click();
 		cy.get('.components-form-toggle__input').should('be.checked');
 	});
 

--- a/tests/php/TestFeature.php
+++ b/tests/php/TestFeature.php
@@ -57,6 +57,59 @@ class TestFeature extends BaseTestCase {
 					'type'             => 'toggle',
 				],
 			],
+			'group'             => false,
+		];
+
+		$this->assertSame( $expected, $stub->get_json() );
+	}
+
+	/**
+	 * Test get_json with group.
+	 *
+	 * @group feature
+	 */
+	public function test_get_json_with_group() {
+		$stub                   = $this->getMockForAbstractClass( '\ElasticPress\Feature' );
+		$stub->slug             = 'slug';
+		$stub->group            = 'Example Group A';
+		$stub->title            = 'title';
+		$stub->short_title      = 'short_title';
+		$stub->summary          = 'summary';
+		$stub->docs_url         = 'https://elasticpress.io/';
+		$stub->default_settings = [];
+		$stub->order            = 1;
+
+		add_filter(
+			'ep_feature_requirements_status',
+			function () {
+				return new \ElasticPress\FeatureRequirementsStatus( 2, 'Testing' );
+			}
+		);
+
+		$expected = [
+			'slug'              => 'slug',
+			'title'             => 'title',
+			'shortTitle'        => 'short_title',
+			'summary'           => 'summary',
+			'docsUrl'           => 'https://elasticpress.io/',
+			'defaultSettings'   => [],
+			'order'             => 1,
+			'isAvailable'       => false, // Set by status code 2
+			'isPoweredByEpio'   => false,
+			'isVisible'         => true,
+			'reqStatusCode'     => 2,
+			'reqStatusMessages' => [ 'Testing' ],
+			'settingsSchema'    => [
+				[
+					'default'          => false,
+					'key'              => 'active',
+					'label'            => __( 'Enable', 'elasticpress' ),
+					'requires_feature' => false,
+					'requires_sync'    => false,
+					'type'             => 'toggle',
+				],
+			],
+			'group'             => 'Example Group A',
 		];
 
 		$this->assertSame( $expected, $stub->get_json() );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
> Keep the current feature on reload: Currently, if you reload, you always go to the first feature. Reloading and staying in the current feature would be ideal

This makes it to where the current group - and current feature within that group - that are selected will persist across page reloads. It accomplishes this using the @wordpress/preferences-persistence package.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
#4123 Request 2 (Feature Persistence)

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Select a group, and select a feature within that group.
2. Reload the page
3. Confirm that the group and feature are both preselected

![enter image description here](https://wp.zacharyrener.com/wp-content/uploads/2025/04/persistence-v3.gif)

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature: Selected features and groups now persist across reload

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ZacharyRener

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
