### PR TITLE
Es8 remove side from edgegram

### DIFF
--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -138,7 +138,6 @@ return array(
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
 				'edge_ngram'     => array(
-					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',


### PR DESCRIPTION
### Description of the Change

```
Warning: 299 Elasticsearch-8.18.1-df116ec6455476a07daafc3ded80e2bb1a3385ed &quot;The [side] parameter is deprecated and will be removed. Use a [reverse] before and after the [edge_ngram] instead.&quot;
```
It defaults to `front`, so we can safely remove it from the mapping w/o affecting existing indexes on older versions: https://www.elastic.co/guide/en/elasticsearch/reference/8.18/analysis-edgengram-tokenfilter.html#analysis-edgengram-tokenfilter-configure-parms 

### How to test the Change
Index on 8.18 and see no more deprecation message thrown

### Changelog Entry

> Deprecated - Remove deprecated side param from edge_ngram filter for ES 8.16.x compatibility

### Credits
Props @rebeccahum 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
