### PR TITLE
Add the Date, Meta and Meta Range Filter widget

### DIFF
--- a/assets/css/facets.css
+++ b/assets/css/facets.css
@@ -9,7 +9,8 @@
 }
 
 .widget_ep-facet,
-.wp-block-elasticpress-facet {
+.wp-block-elasticpress-facet,
+.wp-widget-elasticpress-facet {
 
 	& input[type="search"] {
 		margin-bottom: 1rem;

--- a/elasticpress.php
+++ b/elasticpress.php
@@ -221,6 +221,7 @@ function register_indexable_posts() {
 	get_container()->set( '\ElasticPress\QueryLogger', $query_logger, true );
 
 	get_container()->set( '\ElasticPress\BlockTemplateUtils', new \ElasticPress\BlockTemplateUtils(), true );
+	get_container()->set( '\ElasticPress\ElementorUtils', new \ElasticPress\ElementorUtils(), true );
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\register_indexable_posts' );
 

--- a/includes/classes/ElementorUtils.php
+++ b/includes/classes/ElementorUtils.php
@@ -19,7 +19,7 @@ class ElementorUtils {
 	const CACHE_KEY = 'ep_elementor_widgets';
 
 	/**
-	 * Hook cache cleanup calls.
+	 * Setup.
 	 */
 	public function setup() {
 		// Bail if Elementor is not installed.
@@ -50,9 +50,7 @@ class ElementorUtils {
 		$widgets = array_values(
 			array_filter(
 				$this->get_all_widgets_in_all_templates(),
-				function ( $widget ) use ( $widget_name ) {
-					return ( $widget['widgetType'] === $widget_name );
-				}
+				fn ( $widget ) => $widget['widgetType'] === $widget_name
 			)
 		);
 
@@ -60,9 +58,7 @@ class ElementorUtils {
 	}
 
 	/**
-	 * Get all widgets in all elementor templates
-	 *
-	 * It returns a flat list of all widgets, including innerWidgets.
+	 * Get all widgets in all elementor templates.
 	 *
 	 * @return array
 	 */

--- a/includes/classes/ElementorUtils.php
+++ b/includes/classes/ElementorUtils.php
@@ -80,14 +80,24 @@ class ElementorUtils {
 			return (array) $pre_all_widgets;
 		}
 
-		$all_widgets         = [];
-
-		$elementor_templates = get_posts(
+		/**
+		 * Filter the query arguments used to get Elementor templates.
+		 *
+		 * @since 5.3.0
+		 * @hook ep_elementor_templates_query_args
+		 * @param {array} $query_args Query arguments
+		 * @return {array} Modified query arguments
+		 */
+		$query_args = apply_filters(
+			'ep_elementor_templates_query_args',
 			[
 				'post_type'      => [ 'elementor_library' ],
-				'posts_per_page' => -1,
+				'posts_per_page' => 999, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 			]
 		);
+
+		$elementor_templates = get_posts( $query_args );
+		$all_widgets         = [];
 
 		foreach ( $elementor_templates as $elementor_template ) {
 			$template_content = get_post_meta( $elementor_template->ID, '_elementor_data', true );
@@ -100,6 +110,7 @@ class ElementorUtils {
 				$this->recursively_get_inner_widgets( $template_content )
 			);
 		}
+
 		set_transient( self::CACHE_KEY, $all_widgets, MONTH_IN_SECONDS );
 		return $all_widgets;
 	}

--- a/includes/classes/ElementorUtils.php
+++ b/includes/classes/ElementorUtils.php
@@ -47,11 +47,13 @@ class ElementorUtils {
 	 * @return array
 	 */
 	public function get_specific_widget_in_all_templates( string $widget_name ): array {
-		$widgets = array_filter(
-			$this->get_all_widgets_in_all_templates(),
-			function ( $widget ) use ( $widget_name ) {
-				return ( $widget['widgetType'] === $widget_name );
-			}
+		$widgets = array_values(
+			array_filter(
+				$this->get_all_widgets_in_all_templates(),
+				function ( $widget ) use ( $widget_name ) {
+					return ( $widget['widgetType'] === $widget_name );
+				}
+			)
 		);
 
 		return $widgets;
@@ -124,7 +126,7 @@ class ElementorUtils {
 	protected function recursively_get_inner_widgets( array $template_content ): array {
 		$widgets = [];
 		foreach ( $template_content as $element ) {
-			if ( isset( $element['widgetType'] ) && ! empty( $element['widgetType'] ) ) {
+			if ( ! empty( $element['widgetType'] ) ) {
 				$widgets[] = $element;
 			}
 			if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {

--- a/includes/classes/ElementorUtils.php
+++ b/includes/classes/ElementorUtils.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Elementor Utils class
+ *
+ * @since 5.3.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Elementor Utils class
+ */
+class ElementorUtils {
+	const CACHE_KEY = 'ep_elementor_widgets';
+
+	/**
+	 * Hook cache cleanup calls.
+	 */
+	public function setup() {
+		// Bail if Elementor is not installed.
+		if ( ! class_exists( '\Elementor\Plugin' ) ) {
+			return;
+		}
+
+		add_action( 'save_post_elementor_library', [ $this, 'regenerate_cache' ] );
+	}
+
+	/**
+	 * Delete and regenerate the cache
+	 */
+	public function regenerate_cache() {
+		delete_transient( self::CACHE_KEY );
+
+		// Simply calling it will reset the transient (if the `ep_elementor_widgets_pre_all_widgets` filter isn't in use.)
+		$this->get_all_widgets_in_all_templates();
+	}
+
+	/**
+	 * Given a widget name, return all its instances across all elementor templates.
+	 *
+	 * @param string $widget_name The widget name, e.g., `wp-widget-ep-facet-meta`
+	 * @return array
+	 */
+	public function get_specific_widget_in_all_templates( string $widget_name ): array {
+		$widgets = array_filter(
+			$this->get_all_widgets_in_all_templates(),
+			function ( $widget ) use ( $widget_name ) {
+				return ( $widget['widgetType'] === $widget_name );
+			}
+		);
+
+		return $widgets;
+	}
+
+	/**
+	 * Get all widgets in all elementor templates
+	 *
+	 * It returns a flat list of all widgets, including innerWidgets.
+	 *
+	 * @return array
+	 */
+	public function get_all_widgets_in_all_templates(): array {
+		/**
+		 * Short-circuits the process of getting all widgets of a template.
+		 *
+		 * Returning a non-null value will effectively short-circuit the function.
+		 *
+		 * @since 5.3.0
+		 * @hook ep_elementor_widgets_pre_all_widgets
+		 * @param {null}   $widgets Widgets array
+		 * @return {null|array} Widgets array or `null` to keep default behavior
+		 */
+		$pre_all_widgets = apply_filters( 'ep_elementor_widgets_pre_all_widgets', null );
+		if ( null !== $pre_all_widgets ) {
+			return (array) $pre_all_widgets;
+		}
+
+		$all_widgets         = [];
+
+		$elementor_templates = get_posts(
+			[
+				'post_type'      => [ 'elementor_library' ],
+				'posts_per_page' => -1,
+			]
+		);
+
+		foreach ( $elementor_templates as $elementor_template ) {
+			$template_content = get_post_meta( $elementor_template->ID, '_elementor_data', true );
+			if ( ! $template_content ) {
+				continue;
+			}
+			$template_content = json_decode( $template_content, true );
+			$all_widgets      = array_merge(
+				$all_widgets,
+				$this->recursively_get_inner_widgets( $template_content )
+			);
+		}
+		set_transient( self::CACHE_KEY, $all_widgets, MONTH_IN_SECONDS );
+		return $all_widgets;
+	}
+
+	/**
+	 * Get all inner widgets recursively.
+	 *
+	 * @param array $template_content Template content to analyze.
+	 * @return array
+	 */
+	protected function recursively_get_inner_widgets( array $template_content ): array {
+		$widgets = [];
+		foreach ( $template_content as $element ) {
+			if ( isset( $element['widgetType'] ) && ! empty( $element['widgetType'] ) ) {
+				$widgets[] = $element;
+			}
+			if ( ! empty( $element['elements'] ) && is_array( $element['elements'] ) ) {
+				$widgets = array_merge( $widgets, $this->recursively_get_inner_widgets( $element['elements'] ) );
+			}
+		}
+		return $widgets;
+	}
+}

--- a/includes/classes/Feature/Facets/FacetType.php
+++ b/includes/classes/Feature/Facets/FacetType.php
@@ -122,4 +122,36 @@ abstract class FacetType {
 			)
 		);
 	}
+
+	/**
+	 * Get all meta fields selected in all elementor widgets.
+	 *
+	 * @param string $widget_name The widget name, e.g., `wp-widget-ep-facet-meta`
+	 * @return array
+	 */
+	protected function elementor_template_meta_fields( string $widget_name ): array {
+		$elementor_utils = \ElasticPress\get_container()->get( '\ElasticPress\ElementorUtils' );
+		$ep_widgets      = $elementor_utils->get_specific_widget_in_all_templates( $widget_name );
+
+		// Early return if no widgets found
+		if ( empty( $ep_widgets ) ) {
+			return [];
+		}
+
+		$meta_fields = [];
+		foreach ( $ep_widgets as $widget ) {
+			if ( $widget['widgetType'] !== $widget_name ) {
+				continue;
+			}
+
+			// Skip if facet setting is empty
+			if ( empty( $widget['settings']['wp']['facet'] ) ) {
+				continue;
+			}
+
+			$meta_fields[] = $widget['settings']['wp']['facet'];
+		}
+
+		return array_filter( $meta_fields );
+	}
 }

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -538,6 +538,7 @@ class Facets extends Feature {
 		$widgets[] = 'ep-facet';
 		$widgets[] = 'ep-facet-date';
 		$widgets[] = 'ep-facet-meta';
+		$widgets[] = 'ep-facet-meta-range';
 
 		return $widgets;
 	}

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -536,7 +536,8 @@ class Facets extends Feature {
 	 */
 	public function hide_legacy_widget( $widgets ) {
 		$widgets[] = 'ep-facet';
-		$widgets[] = 'ep-date-facet';
+		$widgets[] = 'ep-facet-date';
+		$widgets[] = 'ep-facet-meta';
 
 		return $widgets;
 	}

--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -536,6 +536,7 @@ class Facets extends Feature {
 	 */
 	public function hide_legacy_widget( $widgets ) {
 		$widgets[] = 'ep-facet';
+		$widgets[] = 'ep-date-facet';
 
 		return $widgets;
 	}

--- a/includes/classes/Feature/Facets/Types/Date/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/Date/FacetType.php
@@ -30,7 +30,7 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	 * Setup hooks and filters for feature
 	 */
 	public function setup() {
-		add_action( 'widgets_init', [ $this, 'register_widgets' ] );
+		add_action( 'widgets_init', [ $this, 'register_widget' ] );
 		add_filter( 'ep_facet_query_filters', [ $this, 'add_query_filters' ] );
 		add_filter( 'ep_facets_date_script_data', [ $this, 'add_filter_name' ] );
 
@@ -39,12 +39,12 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	}
 
 	/**
-	 * Register facet widget(s).
+	 * Register facet widget.
 	 *
 	 * @since 5.3.0
 	 * @return void
 	 */
-	public function register_widgets(): void {
+	public function register_widget(): void {
 		register_widget( __NAMESPACE__ . '\\Widget' );
 	}
 

--- a/includes/classes/Feature/Facets/Types/Date/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/Date/FacetType.php
@@ -30,11 +30,22 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	 * Setup hooks and filters for feature
 	 */
 	public function setup() {
+		add_action( 'widgets_init', [ $this, 'register_widgets' ] );
 		add_filter( 'ep_facet_query_filters', [ $this, 'add_query_filters' ] );
 		add_filter( 'ep_facets_date_script_data', [ $this, 'add_filter_name' ] );
 
 		$this->block = new Block();
 		$this->block->setup();
+	}
+
+	/**
+	 * Register facet widget(s).
+	 *
+	 * @since 5.3.0
+	 * @return void
+	 */
+	public function register_widgets(): void {
+		register_widget( __NAMESPACE__ . '\\Widget' );
 	}
 
 	/**

--- a/includes/classes/Feature/Facets/Types/Date/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Date/Renderer.php
@@ -33,6 +33,23 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 	 * @param array $instance Instance settings
 	 */
 	public function render( $args, $instance ) {
+		$instance = wp_parse_args(
+			$instance,
+			[
+				'title' => '',
+			]
+		);
+
+		$args = wp_parse_args(
+			$args,
+			[
+				'before_widget' => '',
+				'before_title'  => '',
+				'after_title'   => '',
+				'after_widget'  => '',
+			]
+		);
+
 		$this->display_custom_date = $instance['displayCustomDate'] ?? false;
 		$feature                   = Features::factory()->get_registered_feature( 'facets' );
 
@@ -42,6 +59,12 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 		$applied_dates    = isset( $selected_filters[ $facet_type->get_filter_type() ]['terms'] ) ? array_keys( $selected_filters[ $facet_type->get_filter_type() ]['terms'] ) : [];
 
 		$action = $feature->build_query_url( $selected_filters );
+
+		echo wp_kses_post( $args['before_widget'] );
+
+		if ( ! empty( $instance['title'] ) ) {
+			echo wp_kses_post( $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'] );
+		}
 		?>
 
 		<form class="ep-facet-date-form" action="<?php echo esc_url( $action ); ?>" method="GET">
@@ -91,6 +114,8 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 		// Enqueue Script & Styles
 		wp_enqueue_script( 'elasticpress-facets' );
 		wp_enqueue_style( 'elasticpress-facets' );
+
+		echo wp_kses_post( $args['after_widget'] );
 	}
 
 	/**

--- a/includes/classes/Feature/Facets/Types/Date/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Date/Renderer.php
@@ -33,7 +33,7 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 	 * @param array $instance Instance settings
 	 */
 	public function render( $args, $instance ) {
-		$this->display_custom_date = $instance['displayCustomDate'];
+		$this->display_custom_date = $instance['displayCustomDate'] ?? false;
 		$feature                   = Features::factory()->get_registered_feature( 'facets' );
 
 		$facet_type       = $feature->types['date'];

--- a/includes/classes/Feature/Facets/Types/Date/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Date/Renderer.php
@@ -36,7 +36,8 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 		$instance = wp_parse_args(
 			$instance,
 			[
-				'title' => '',
+				'title'             => '',
+				'displayCustomDate' => false,
 			]
 		);
 
@@ -50,7 +51,7 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 			]
 		);
 
-		$this->display_custom_date = $instance['displayCustomDate'] ?? false;
+		$this->display_custom_date = $instance['displayCustomDate'];
 		$feature                   = Features::factory()->get_registered_feature( 'facets' );
 
 		$facet_type       = $feature->types['date'];

--- a/includes/classes/Feature/Facets/Types/Date/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Date/Renderer.php
@@ -33,14 +33,6 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 	 * @param array $instance Instance settings
 	 */
 	public function render( $args, $instance ) {
-		$instance = wp_parse_args(
-			$instance,
-			[
-				'title'             => '',
-				'displayCustomDate' => false,
-			]
-		);
-
 		$args = wp_parse_args(
 			$args,
 			[
@@ -48,6 +40,14 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 				'before_title'  => '',
 				'after_title'   => '',
 				'after_widget'  => '',
+			]
+		);
+
+		$instance = wp_parse_args(
+			$instance,
+			[
+				'title'             => '',
+				'displayCustomDate' => false,
 			]
 		);
 

--- a/includes/classes/Feature/Facets/Types/Date/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Date/Widget.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Date Facet Widget class
  */
 class Widget extends \WP_Widget {
+
 	/**
 	 * Create widget.
 	 */
@@ -86,7 +87,7 @@ class Widget extends \WP_Widget {
 	public function update( $new_instance, $old_instance ) {
 		$instance                      = [];
 		$instance['title']             = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
-		$instance['displayCustomDate'] = ! empty( $new_instance['displayCustomDate'] ) ? true : false;
+		$instance['displayCustomDate'] = ! empty( $new_instance['displayCustomDate'] );
 
 		return $instance;
 	}

--- a/includes/classes/Feature/Facets/Types/Date/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Date/Widget.php
@@ -52,7 +52,14 @@ class Widget extends \WP_Widget {
 	 * @param array $instance Instance settings
 	 */
 	public function form( $instance ) {
-		$display_custom_date = $instance['displayCustomDate'] ?? false;
+		$instance = wp_parse_args(
+			$instance,
+			[
+				'title'             => '',
+				'displayCustomDate' => false,
+			]
+		);
+
 		?>
 		<div class="widget-ep-facet-date">
 			<p>
@@ -60,7 +67,7 @@ class Widget extends \WP_Widget {
 				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 			</p>
 			<p>
-				<input class="checkbox" type="checkbox" <?php checked( $display_custom_date ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCustomDate' ) ); ?>" />
+				<input class="checkbox" type="checkbox" <?php checked( $instance['displayCustomDate'] ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCustomDate' ) ); ?>" />
 				<label for="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>">
 					<?php esc_html_e( 'Display custom date option', 'elasticpress' ); ?>
 				</label>

--- a/includes/classes/Feature/Facets/Types/Date/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Date/Widget.php
@@ -23,9 +23,10 @@ class Widget extends \WP_Widget {
 		$options = array(
 			'description'           => esc_html__( 'Let visitors filter your content by post date.', 'elasticpress' ),
 			'show_instance_in_rest' => true,
+			'classname'             => 'wp-widget-elasticpress-facet widget_ep-facet-date',
 		);
 
-		parent::__construct( 'ep-date-facet', esc_html__( 'ElasticPress - Filter by Post Date', 'elasticpress' ), $options );
+		parent::__construct( 'ep-facet-date', esc_html__( 'ElasticPress - Filter by Post Date', 'elasticpress' ), $options );
 	}
 
 	/**
@@ -53,7 +54,11 @@ class Widget extends \WP_Widget {
 	public function form( $instance ) {
 		$display_custom_date = $instance['displayCustomDate'] ?? false;
 		?>
-		<div class="widget-ep-date-facet">
+		<div class="widget-ep-facet-date">
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'elasticpress' ); ?></label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+			</p>
 			<p>
 				<input class="checkbox" type="checkbox" <?php checked( $display_custom_date ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCustomDate' ) ); ?>" />
 				<label for="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>">
@@ -73,6 +78,7 @@ class Widget extends \WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 		$instance                      = [];
+		$instance['title']             = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
 		$instance['displayCustomDate'] = ! empty( $new_instance['displayCustomDate'] ) ? true : false;
 
 		return $instance;

--- a/includes/classes/Feature/Facets/Types/Date/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Date/Widget.php
@@ -51,7 +51,7 @@ class Widget extends \WP_Widget {
 	 * @param array $instance Instance settings
 	 */
 	public function form( $instance ) {
-		$display_custom_date = isset( $instance['displayCustomDate'] ) ? (bool) $instance['displayCustomDate'] : true;
+		$display_custom_date = $instance['displayCustomDate'] ?? false;
 		?>
 		<div class="widget-ep-date-facet">
 			<p>

--- a/includes/classes/Feature/Facets/Types/Date/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Date/Widget.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Date Facet Widget
+ *
+ * @since 5.3.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress\Feature\Facets\Types\Date;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Date Facet Widget class
+ */
+class Widget extends \WP_Widget {
+	/**
+	 * Create widget
+	 */
+	public function __construct() {
+		$options = array(
+			'description'           => esc_html__( 'Add a date facet to an archive or search results page.', 'elasticpress' ),
+			'show_instance_in_rest' => true,
+		);
+
+		parent::__construct( 'ep-date-facet', esc_html__( 'ElasticPress - Filter by Date', 'elasticpress' ), $options );
+	}
+
+	/**
+	 * Output widget
+	 *
+	 * @param array $args Widget args
+	 * @param array $instance Instance settings
+	 */
+	public function widget( $args, $instance ) {
+		// Enqueue the front-end script.
+		wp_enqueue_script( 'ep-facets-date-block-view-script' );
+
+		/** This filter is documented in includes/classes/Feature/Facets/Types/Taxonomy/Block.php */
+		$renderer_class = apply_filters( 'ep_facet_renderer_class', __NAMESPACE__ . '\\Renderer', 'date', 'widget', $instance );
+		$renderer       = new $renderer_class();
+
+		$renderer->render( $args, $instance );
+	}
+
+	/**
+	 * Output widget form
+	 *
+	 * @param array $instance Instance settings
+	 */
+	public function form( $instance ) {
+		$display_custom_date = isset( $instance['displayCustomDate'] ) ? (bool) $instance['displayCustomDate'] : true;
+		?>
+		<div class="widget-ep-date-facet">
+			<p>
+				<input class="checkbox" type="checkbox" <?php checked( $display_custom_date ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCustomDate' ) ); ?>" />
+				<label for="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>">
+					<?php esc_html_e( 'Allow custom date range', 'elasticpress' ); ?>
+				</label>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Sanitize fields
+	 *
+	 * @param array $new_instance New instance settings
+	 * @param array $old_instance Old instance settings
+	 * @return array
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance                      = [];
+		$instance['displayCustomDate'] = ! empty( $new_instance['displayCustomDate'] ) ? 1 : 0;
+
+		return $instance;
+	}
+}

--- a/includes/classes/Feature/Facets/Types/Date/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Date/Widget.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Widget extends \WP_Widget {
 	/**
-	 * Create widget
+	 * Create widget.
 	 */
 	public function __construct() {
 		$options = array(
@@ -29,7 +29,7 @@ class Widget extends \WP_Widget {
 	}
 
 	/**
-	 * Output widget
+	 * Output widget.
 	 *
 	 * @param array $args Widget args
 	 * @param array $instance Instance settings
@@ -46,7 +46,7 @@ class Widget extends \WP_Widget {
 	}
 
 	/**
-	 * Output widget form
+	 * Output widget form.
 	 *
 	 * @param array $instance Instance settings
 	 */
@@ -65,7 +65,7 @@ class Widget extends \WP_Widget {
 	}
 
 	/**
-	 * Sanitize fields
+	 * Update widget settings
 	 *
 	 * @param array $new_instance New instance settings
 	 * @param array $old_instance Old instance settings
@@ -73,7 +73,7 @@ class Widget extends \WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 		$instance                      = [];
-		$instance['displayCustomDate'] = ! empty( $new_instance['displayCustomDate'] ) ? 1 : 0;
+		$instance['displayCustomDate'] = ! empty( $new_instance['displayCustomDate'] ) ? true : false;
 
 		return $instance;
 	}

--- a/includes/classes/Feature/Facets/Types/Date/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Date/Widget.php
@@ -21,11 +21,11 @@ class Widget extends \WP_Widget {
 	 */
 	public function __construct() {
 		$options = array(
-			'description'           => esc_html__( 'Add a date facet to an archive or search results page.', 'elasticpress' ),
+			'description'           => esc_html__( 'Let visitors filter your content by post date.', 'elasticpress' ),
 			'show_instance_in_rest' => true,
 		);
 
-		parent::__construct( 'ep-date-facet', esc_html__( 'ElasticPress - Filter by Date', 'elasticpress' ), $options );
+		parent::__construct( 'ep-date-facet', esc_html__( 'ElasticPress - Filter by Post Date', 'elasticpress' ), $options );
 	}
 
 	/**
@@ -57,7 +57,7 @@ class Widget extends \WP_Widget {
 			<p>
 				<input class="checkbox" type="checkbox" <?php checked( $display_custom_date ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCustomDate' ) ); ?>" />
 				<label for="<?php echo esc_attr( $this->get_field_id( 'displayCustomDate' ) ); ?>">
-					<?php esc_html_e( 'Allow custom date range', 'elasticpress' ); ?>
+					<?php esc_html_e( 'Display custom date option', 'elasticpress' ); ?>
 				</label>
 			</p>
 		</div>

--- a/includes/classes/Feature/Facets/Types/Meta/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/Meta/FacetType.php
@@ -49,7 +49,7 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	 * Register meta facet widget
 	 */
 	public function register_widget() {
-		register_widget( __NAMESPACE__ . '\Widget' );
+		register_widget( __NAMESPACE__ . '\\Widget' );
 	}
 
 	/**

--- a/includes/classes/Feature/Facets/Types/Meta/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/Meta/FacetType.php
@@ -315,6 +315,13 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 			);
 		}
 
+		if ( class_exists( '\Elementor\Plugin' ) ) {
+			$facets_meta_fields = array_merge(
+				$facets_meta_fields,
+				$this->elementor_template_meta_fields( 'wp-widget-ep-facet-meta' )
+			);
+		}
+
 		/**
 		 * Filter meta fields to be used in aggregations.
 		 *

--- a/includes/classes/Feature/Facets/Types/Meta/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/Meta/FacetType.php
@@ -39,8 +39,17 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 		add_action( 'ep_after_index_post', [ $this, 'invalidate_meta_values_cache' ] );
 		add_action( 'ep_after_bulk_index', [ $this, 'invalidate_meta_values_cache_after_bulk' ], 10, 2 );
 
+		add_action( 'widgets_init', [ $this, 'register_widget' ] );
+
 		$this->block = new Block();
 		$this->block->setup();
+	}
+
+	/**
+	 * Register meta facet widget
+	 */
+	public function register_widget() {
+		register_widget( __NAMESPACE__ . '\Widget' );
 	}
 
 	/**
@@ -286,6 +295,17 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 			}
 
 			$facets_meta_fields = array_merge( $facets_meta_fields, $matches[1] );
+		}
+
+		// Get meta fields from classic widgets
+		$widgets = get_option( 'widget_ep-facet-meta' );
+		if ( is_array( $widgets ) ) {
+			foreach ( $widgets as $widget ) {
+				if ( ! is_array( $widget ) || empty( $widget['facet'] ) ) {
+					continue;
+				}
+				$facets_meta_fields[] = $widget['facet'];
+			}
 		}
 
 		if ( current_theme_supports( 'block-templates' ) ) {

--- a/includes/classes/Feature/Facets/Types/Meta/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Widget.php
@@ -1,7 +1,9 @@
 <?php
 /**
+ *
  * Meta Facet Widget
  *
+ * @since 5.3.0
  * @package elasticpress
  */
 
@@ -54,12 +56,17 @@ class Widget extends \WP_Widget {
 	public function form( $instance ) {
 		$meta_fields = \ElasticPress\Indexables::factory()->get( 'post' )->get_distinct_meta_field_keys();
 
-		$title              = $instance['title'] ?? '';
-		$facet              = $instance['facet'] ?? '';
-		$orderby            = $instance['orderby'] ?? 'count';
-		$order              = $instance['order'] ?? 'desc';
-		$display_count      = ! empty( $instance['displayCount'] );
-		$search_placeholder = $instance['searchPlaceholder'] ?? __( 'Search', 'elasticpress' );
+		$instance = wp_parse_args(
+			$instance,
+			[
+				'title'             => '',
+				'facet'             => '',
+				'orderby'           => 'count',
+				'order'             => 'desc',
+				'displayCount'      => false,
+				'searchPlaceholder' => esc_html__( 'Search', 'elasticpress' ),
+			]
+		);
 
 		$orderby_options = [
 			[
@@ -86,7 +93,7 @@ class Widget extends \WP_Widget {
 				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
 					<?php esc_html_e( 'Title:', 'elasticpress' ); ?>
 				</label>
-				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 			</p>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'facet' ) ); ?>">
@@ -94,7 +101,7 @@ class Widget extends \WP_Widget {
 				</label>
 				<select id="<?php echo esc_attr( $this->get_field_id( 'facet' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'facet' ) ); ?>" class="widefat">
 					<?php foreach ( $meta_fields as $meta_field ) : ?>
-						<option <?php selected( $facet, $meta_field ); ?> value="<?php echo esc_attr( $meta_field ); ?>"><?php echo esc_html( $meta_field ); ?></option>
+						<option <?php selected( $instance['facet'], $meta_field ); ?> value="<?php echo esc_attr( $meta_field ); ?>"><?php echo esc_html( $meta_field ); ?></option>
 					<?php endforeach; ?>
 				</select>
 				<small>
@@ -112,10 +119,10 @@ class Widget extends \WP_Widget {
 				<label for="<?php echo esc_attr( $this->get_field_id( 'searchPlaceholder' ) ); ?>">
 					<?php esc_html_e( 'Search field placeholder:', 'elasticpress' ); ?>
 				</label>
-				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'searchPlaceholder' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'searchPlaceholder' ) ); ?>" type="text" value="<?php echo esc_attr( $search_placeholder ); ?>" />
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'searchPlaceholder' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'searchPlaceholder' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['searchPlaceholder'] ); ?>" />
 			</p>
 			<p>
-				<input class="checkbox" type="checkbox" <?php checked( $display_count ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCount' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCount' ) ); ?>" />
+				<input class="checkbox" type="checkbox" <?php checked( $instance['displayCount'] ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCount' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCount' ) ); ?>" />
 				<label for="<?php echo esc_attr( $this->get_field_id( 'displayCount' ) ); ?>">
 					<?php esc_html_e( 'Display count', 'elasticpress' ); ?>
 				</label>
@@ -126,7 +133,7 @@ class Widget extends \WP_Widget {
 				</label><br>
 				<select id="<?php echo esc_attr( $this->get_field_id( 'orderby_order' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'orderby_order' ) ); ?>" class="widefat">
 					<?php foreach ( $orderby_options as $option ) : ?>
-						<option <?php selected( $orderby . '/' . $order, $option['value'] ); ?> value="<?php echo esc_attr( $option['value'] ); ?>"><?php echo esc_html( $option['label'] ); ?></option>
+						<option <?php selected( $instance['orderby'] . '/' . $instance['order'], $option['value'] ); ?> value="<?php echo esc_attr( $option['value'] ); ?>"><?php echo esc_html( $option['label'] ); ?></option>
 					<?php endforeach; ?>
 				</select>
 			</p>

--- a/includes/classes/Feature/Facets/Types/Meta/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Widget.php
@@ -54,7 +54,10 @@ class Widget extends \WP_Widget {
 	 * @param array $instance Widget instance settings
 	 */
 	public function form( $instance ) {
-		$meta_fields = \ElasticPress\Indexables::factory()->get( 'post' )->get_distinct_meta_field_keys();
+		$meta_fields = array_merge(
+			[ '' => __( 'Select key', 'elasticpress' ) ],
+			\ElasticPress\Indexables::factory()->get( 'post' )->get_distinct_meta_field_keys()
+		);
 
 		$instance = wp_parse_args(
 			$instance,

--- a/includes/classes/Feature/Facets/Types/Meta/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Widget.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Meta Facet Widget
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPress\Feature\Facets\Types\Meta;
+
+use ElasticPress\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Meta Facet Widget class
+ */
+class Widget extends \WP_Widget {
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		parent::__construct(
+			'ep-facet-meta',
+			esc_html__( 'ElasticPress - Filter by Metadata', 'elasticpress' ),
+			[
+				'description'           => esc_html__( 'Add a meta facet filter to your sidebar or widget area.', 'elasticpress' ),
+				'show_instance_in_rest' => true,
+				'classname'             => 'wp-widget-elasticpress-facet widget_ep-facet-meta',
+			]
+		);
+	}
+
+	/**
+	 * Output the widget content
+	 *
+	 * @param array $args     Widget args
+	 * @param array $instance Widget instance settings
+	 */
+	public function widget( $args, $instance ) {
+		/** This filter is documented in includes/classes/Feature/Facets/Types/Taxonomy/Block.php */
+		$renderer_class = apply_filters( 'ep_facet_renderer_class', __NAMESPACE__ . '\\Renderer', 'meta', 'widget', $instance );
+		$renderer       = new $renderer_class();
+
+		$renderer->render( $args, $instance );
+	}
+
+	/**
+	 * Output the widget settings form
+	 *
+	 * @param array $instance Widget instance settings
+	 */
+	public function form( $instance ) {
+		$meta_fields = \ElasticPress\Indexables::factory()->get( 'post' )->get_distinct_meta_field_keys();
+
+		$title              = $instance['title'] ?? '';
+		$facet              = $instance['facet'] ?? '';
+		$orderby            = $instance['orderby'] ?? 'count';
+		$order              = $instance['order'] ?? 'desc';
+		$display_count      = ! empty( $instance['displayCount'] );
+		$search_placeholder = $instance['searchPlaceholder'] ?? __( 'Search', 'elasticpress' );
+
+		$orderby_options = [
+			[
+				'label' => __( 'Highest to lowest count', 'elasticpress' ),
+				'value' => 'count/desc',
+			],
+			[
+				'label' => __( 'Lowest to highest count', 'elasticpress' ),
+				'value' => 'count/asc',
+			],
+			[
+				'label' => _x( 'A → Z', 'label for ordering posts by title in ascending order', 'elasticpress' ),
+				'value' => 'name/asc',
+			],
+			[
+				'label' => _x( 'Z → A', 'label for ordering posts by title in descending order', 'elasticpress' ),
+				'value' => 'name/desc',
+			],
+		];
+
+		?>
+		<div class="widget-ep-facet-meta">
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
+					<?php esc_html_e( 'Title:', 'elasticpress' ); ?>
+				</label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+			</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'facet' ) ); ?>">
+					<?php esc_html_e( 'Filter by:', 'elasticpress' ); ?>
+				</label>
+				<select id="<?php echo esc_attr( $this->get_field_id( 'facet' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'facet' ) ); ?>" class="widefat">
+					<?php foreach ( $meta_fields as $meta_field ) : ?>
+						<option <?php selected( $facet, $meta_field ); ?> value="<?php echo esc_attr( $meta_field ); ?>"><?php echo esc_html( $meta_field ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				<small>
+					<?php
+					printf(
+						/* translators: %s: URL to sync content */
+						esc_html__( 'This is the list of metadata fields indexed in Elasticsearch. If your desired field does not appear in this list please try to %1$ssync your content%2$s', 'elasticpress' ),
+						'<a href="' . esc_url( Utils\get_sync_url( true ) ) . '">',
+						'</a>'
+					);
+					?>
+				</small>
+			</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'searchPlaceholder' ) ); ?>">
+					<?php esc_html_e( 'Search field placeholder:', 'elasticpress' ); ?>
+				</label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'searchPlaceholder' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'searchPlaceholder' ) ); ?>" type="text" value="<?php echo esc_attr( $search_placeholder ); ?>" />
+			</p>
+			<p>
+				<input class="checkbox" type="checkbox" <?php checked( $display_count ); ?> id="<?php echo esc_attr( $this->get_field_id( 'displayCount' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'displayCount' ) ); ?>" />
+				<label for="<?php echo esc_attr( $this->get_field_id( 'displayCount' ) ); ?>">
+					<?php esc_html_e( 'Display count', 'elasticpress' ); ?>
+				</label>
+			</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'orderby_custom' ) ); ?>">
+					<?php esc_html_e( 'Order by:', 'elasticpress' ); ?>
+				</label><br>
+				<select id="<?php echo esc_attr( $this->get_field_id( 'orderby_order' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'orderby_order' ) ); ?>" class="widefat">
+					<?php foreach ( $orderby_options as $option ) : ?>
+						<option <?php selected( $orderby . '/' . $order, $option['value'] ); ?> value="<?php echo esc_attr( $option['value'] ); ?>"><?php echo esc_html( $option['label'] ); ?></option>
+					<?php endforeach; ?>
+				</select>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Sanitize and save widget settings
+	 *
+	 * @param array $new_instance New settings
+	 * @param array $old_instance Old settings
+	 * @return array Sanitized settings
+	 */
+	public function update( $new_instance, $old_instance ) {
+		// Parse order and orderby from combined field or individual fields
+		$orderby_order = ! empty( $new_instance['orderby_order'] ) ? explode( '/', $new_instance['orderby_order'] ) : [];
+		$order         = ! empty( $orderby_order[1] ) ? $orderby_order[1] : $new_instance['order'];
+		$orderby       = ! empty( $orderby_order[0] ) ? $orderby_order[0] : $new_instance['orderby'];
+
+		// Sanitize and store all widget settings
+		$instance = [
+			'title'             => sanitize_text_field( $new_instance['title'] ?? '' ),
+			'facet'             => sanitize_text_field( $new_instance['facet'] ?? '' ),
+			'orderby'           => sanitize_text_field( $orderby ),
+			'order'             => sanitize_text_field( $order ),
+			'displayCount'      => ! empty( $new_instance['displayCount'] ) ? 1 : 0,
+			'searchPlaceholder' => sanitize_text_field( $new_instance['searchPlaceholder'] ?? '' ),
+		];
+
+		return $instance;
+	}
+}

--- a/includes/classes/Feature/Facets/Types/Meta/Widget.php
+++ b/includes/classes/Feature/Facets/Types/Meta/Widget.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Meta Facet Widget class
  */
 class Widget extends \WP_Widget {
+
 	/**
 	 * Constructor
 	 */
@@ -35,7 +36,7 @@ class Widget extends \WP_Widget {
 	}
 
 	/**
-	 * Output the widget content
+	 * Output the widget content.
 	 *
 	 * @param array $args     Widget args
 	 * @param array $instance Widget instance settings
@@ -49,7 +50,7 @@ class Widget extends \WP_Widget {
 	}
 
 	/**
-	 * Output the widget settings form
+	 * Output the widget settings form.
 	 *
 	 * @param array $instance Widget instance settings
 	 */

--- a/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
@@ -32,9 +32,17 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	public function setup() {
 		add_filter( 'ep_facet_query_filters', [ $this, 'add_query_filters' ], 10, 2 );
 		add_filter( 'ep_facet_wp_query_aggs_facet', [ $this, 'set_wp_query_aggs' ] );
+		add_action( 'widgets_init', [ $this, 'register_widgets' ] );
 
 		$this->block = new Block();
 		$this->block->setup();
+	}
+
+	/**
+	 * Register facet widgets
+	 */
+	public function register_widgets() {
+		register_widget( __NAMESPACE__ . '\Widget' );
 	}
 
 	/**
@@ -220,13 +228,14 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	}
 
 	/**
-	 * Get all fields selected in all Facet blocks
+	 * Get all fields selected in all Facet blocks and widgets
 	 *
 	 * @return array
 	 */
 	public function get_facets_meta_fields() {
 		$facets_meta_fields = [];
 
+		// Get fields from block widgets
 		$widget_block_instances = ( new \WP_Widget_Block() )->get_settings();
 		foreach ( $widget_block_instances as $instance ) {
 			if ( ! isset( $instance['content'] ) ) {
@@ -242,6 +251,16 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 			}
 
 			$facets_meta_fields = array_merge( $facets_meta_fields, $matches[1] );
+		}
+
+		// Get fields from classic widgets
+		$widget_instances = get_option( 'widget_ep-facet-meta-range' );
+		if ( ! empty( $widget_instances ) && is_array( $widget_instances ) ) {
+			foreach ( $widget_instances as $instance ) {
+				if ( ! empty( $instance['facet'] ) ) {
+					$facets_meta_fields[] = $instance['facet'];
+				}
+			}
 		}
 
 		if ( current_theme_supports( 'block-templates' ) ) {

--- a/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
@@ -32,16 +32,19 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	public function setup() {
 		add_filter( 'ep_facet_query_filters', [ $this, 'add_query_filters' ], 10, 2 );
 		add_filter( 'ep_facet_wp_query_aggs_facet', [ $this, 'set_wp_query_aggs' ] );
-		add_action( 'widgets_init', [ $this, 'register_widgets' ] );
+		add_action( 'widgets_init', [ $this, 'register_widget' ] );
 
 		$this->block = new Block();
 		$this->block->setup();
 	}
 
 	/**
-	 * Register facet widgets
+	 * Register facet widget.
+	 *
+	 * @since 5.3.0
+	 * @return void
 	 */
-	public function register_widgets() {
+	public function register_widget() {
 		register_widget( __NAMESPACE__ . '\Widget' );
 	}
 
@@ -228,7 +231,7 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	}
 
 	/**
-	 * Get all fields selected in all Facet blocks and widgets
+	 * Get all fields selected in all Facet blocks and widgets.
 	 *
 	 * @return array
 	 */

--- a/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
@@ -45,7 +45,7 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 	 * @return void
 	 */
 	public function register_widget() {
-		register_widget( __NAMESPACE__ . '\Widget' );
+		register_widget( __NAMESPACE__ . '\\Widget' );
 	}
 
 	/**

--- a/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/FacetType.php
@@ -270,6 +270,13 @@ class FacetType extends \ElasticPress\Feature\Facets\FacetType {
 			);
 		}
 
+		if ( class_exists( '\Elementor\Plugin' ) ) {
+			$facets_meta_fields = array_merge(
+				$facets_meta_fields,
+				$this->elementor_template_meta_fields( 'wp-widget-ep-facet-meta-range' )
+			);
+		}
+
 		/**
 		 * Filter meta fields to be used in aggregations related to meta range blocks.
 		 *

--- a/includes/classes/Feature/Facets/Types/MetaRange/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Renderer.php
@@ -39,6 +39,26 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 	 * @param array $instance Instance settings
 	 */
 	public function render( $args, $instance ) {
+		$args = wp_parse_args(
+			$args,
+			[
+				'before_widget' => '',
+				'before_title'  => '',
+				'after_title'   => '',
+				'after_widget'  => '',
+			]
+		);
+
+		$instance = wp_parse_args(
+			$instance,
+			[
+				'title'  => '',
+				'facet'  => '',
+				'prefix' => '',
+				'suffix' => '',
+			]
+		);
+
 		$this->meta_field = $instance['facet'];
 		if ( empty( $this->meta_field ) ) {
 			if ( $instance['is_preview'] ) {
@@ -89,6 +109,12 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 		$action_url  = wp_parse_url( $form_action );
 
 		wp_parse_str( $action_url['query'] ?? '', $filter_fields );
+
+		echo wp_kses_post( $args['before_widget'] );
+
+		if ( ! empty( $instance['title'] ) ) {
+			echo wp_kses_post( $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'] );
+		}
 		?>
 		<form action="<?php echo esc_url( $form_action ); ?>" class="ep-facet-meta-range">
 			<input type="hidden" data-prefix="<?php echo esc_attr( $instance['prefix'] ); ?>" data-suffix="<?php echo esc_attr( $instance['suffix'] ); ?>" name="<?php echo esc_attr( $min_field_name ); ?>" min="<?php echo absint( $min ); ?>" max="<?php echo absint( $max ); ?>" value="<?php echo esc_attr( $selected_min_value ); ?>">
@@ -99,6 +125,8 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 			<?php } ?>
 		</form>
 		<?php
+
+		echo wp_kses_post( $args['after_widget'] );
 	}
 
 	/**

--- a/includes/classes/Feature/Facets/Types/MetaRange/Widget.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Widget.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Meta Range Facets widget class
  */
 class Widget extends \WP_Widget {
+
 	/**
 	 * Create widget
 	 */

--- a/includes/classes/Feature/Facets/Types/MetaRange/Widget.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Widget.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Meta Range Facets widget
+ *
+ * @since 5.3.0
+ * @package elasticpress
+ */
+
+namespace ElasticPress\Feature\Facets\Types\MetaRange;
+
+use ElasticPress\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Meta Range Facets widget class
+ */
+class Widget extends \WP_Widget {
+	/**
+	 * Create widget
+	 */
+	public function __construct() {
+		$options = array(
+			'description'           => esc_html__( 'Let visitors filter your content by a range of metadata values.', 'elasticpress' ),
+			'show_instance_in_rest' => true,
+			'classname'             => 'wp-widget-elasticpress-facet widget_ep-facet-meta-range',
+		);
+
+		parent::__construct( 'ep-facet-meta-range', esc_html__( 'ElasticPress - Filter by Metadata Range - Beta', 'elasticpress' ), $options );
+	}
+
+	/**
+	 * Output widget
+	 *
+	 * @param  array $args Widget args
+	 * @param  array $instance Instance settings
+	 */
+	public function widget( $args, $instance ) {
+		// Enqueue the front-end script
+		wp_enqueue_script( 'ep-facets-meta-range-block-view-script' );
+
+		/** This filter is documented in includes/classes/Feature/Facets/Types/MetaRange/Block.php */
+		$renderer_class = apply_filters( 'ep_facet_renderer_class', __NAMESPACE__ . '\Renderer', 'meta-range', 'widget', $instance );
+		$renderer       = new $renderer_class();
+
+		echo wp_kses_post( $args['before_widget'] );
+
+		if ( ! empty( $instance['title'] ) ) {
+			echo wp_kses_post( $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'] );
+		}
+
+		$renderer->render( $args, $instance );
+
+		echo wp_kses_post( $args['after_widget'] );
+	}
+
+	/**
+	 * Output widget form
+	 *
+	 * @param  array $instance Instance settings
+	 */
+	public function form( $instance ) {
+		$instance = wp_parse_args(
+			$instance,
+			[
+				'title'  => '',
+				'facet'  => '',
+				'prefix' => '',
+				'suffix' => '',
+			]
+		);
+
+		$meta_fields = array_merge(
+			[ '' => __( 'Select key', 'elasticpress' ) ],
+			\ElasticPress\Indexables::factory()->get( 'post' )->get_distinct_meta_field_keys()
+		);
+
+		?>
+		<div class="widget-ep-facet-meta-range">
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
+					<?php esc_html_e( 'Title:', 'elasticpress' ); ?>
+				</label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+			</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'facet' ) ); ?>">
+					<?php esc_html_e( 'Filter by:', 'elasticpress' ); ?>
+				</label>
+				<select id="<?php echo esc_attr( $this->get_field_id( 'facet' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'facet' ) ); ?>" class="widefat">
+					<?php foreach ( $meta_fields as $meta_field ) : ?>
+						<option <?php selected( $instance['facet'], $meta_field ); ?> value="<?php echo esc_attr( $meta_field ); ?>"><?php echo esc_html( $meta_field ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				<small>
+					<?php
+					printf(
+						/* translators: %s: URL to sync content */
+						esc_html__( 'This is the list of metadata fields indexed in Elasticsearch. If your desired field does not appear in this list please try to %1$ssync your content%2$s', 'elasticpress' ),
+						'<a href="' . esc_url( Utils\get_sync_url( true ) ) . '">',
+						'</a>'
+					);
+					?>
+				</small>
+			</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'prefix' ) ); ?>">
+					<?php esc_html_e( 'Value Prefix:', 'elasticpress' ); ?>
+				</label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'prefix' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'prefix' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['prefix'] ); ?>" />
+			</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'suffix' ) ); ?>">
+					<?php esc_html_e( 'Value Suffix:', 'elasticpress' ); ?>
+				</label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'suffix' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'suffix' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['suffix'] ); ?>" />
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Sanitize fields
+	 *
+	 * @param  array $new_instance New instance settings
+	 * @param  array $old_instance Old instance settings
+	 * @return array
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance = [];
+
+		$instance['title']  = sanitize_text_field( $new_instance['title'] );
+		$instance['facet']  = sanitize_text_field( $new_instance['facet'] );
+		$instance['prefix'] = sanitize_text_field( $new_instance['prefix'] );
+		$instance['suffix'] = sanitize_text_field( $new_instance['suffix'] );
+
+		return $instance;
+	}
+}

--- a/includes/classes/Feature/Facets/Types/MetaRange/Widget.php
+++ b/includes/classes/Feature/Facets/Types/MetaRange/Widget.php
@@ -45,15 +45,7 @@ class Widget extends \WP_Widget {
 		$renderer_class = apply_filters( 'ep_facet_renderer_class', __NAMESPACE__ . '\Renderer', 'meta-range', 'widget', $instance );
 		$renderer       = new $renderer_class();
 
-		echo wp_kses_post( $args['before_widget'] );
-
-		if ( ! empty( $instance['title'] ) ) {
-			echo wp_kses_post( $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'] );
-		}
-
 		$renderer->render( $args, $instance );
-
-		echo wp_kses_post( $args['after_widget'] );
 	}
 
 	/**

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -1215,9 +1215,9 @@ abstract class Indexable {
 
 		try {
 			if ( version_compare( (string) Elasticsearch::factory()->get_elasticsearch_version(), '7.0', '<' ) ) {
-				$meta_fields = $mapping[ $this->get_index_name( $blog_id ) ]['mappings']['post']['properties']['meta']['properties'];
+				$meta_fields = (array) $mapping[ $this->get_index_name( $blog_id ) ]['mappings']['post']['properties']['meta']['properties'];
 			} else {
-				$meta_fields = $mapping[ $this->get_index_name( $blog_id ) ]['mappings']['properties']['meta']['properties'];
+				$meta_fields = (array) $mapping[ $this->get_index_name( $blog_id ) ]['mappings']['properties']['meta']['properties'];
 			}
 			$meta_keys = array_values( array_keys( $meta_fields ) );
 			sort( $meta_keys );

--- a/tests/php/TestElementorUtils.php
+++ b/tests/php/TestElementorUtils.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Test the ElementorUtils class methods
+ *
+ * @since 5.3.0
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress\ElementorUtils;
+
+/**
+ * TestElementorUtils test class
+ */
+class TestElementorUtils extends BaseTestCase {
+
+	/**
+	 * Setup the test environment
+	 */
+	public function set_up(): void {
+		register_post_type( 'elementor_library' );
+
+		parent::set_up();
+	}
+
+	/**
+	 * Test the `regenerate_cache` method.
+	 *
+	 * @group elementor_utils
+	 */
+	public function test_regenerate_cache() {
+		$elementor_utils = new ElementorUtils();
+
+		set_transient( $elementor_utils::CACHE_KEY, 'test' );
+		$elementor_utils->regenerate_cache();
+
+		$this->assertIsArray( get_transient( $elementor_utils::CACHE_KEY ) );
+	}
+
+	/**
+	 * Test the `get_all_widgets_in_all_templates` method.
+	 *
+	 * @group elementor_utils
+	 */
+	public function test_get_all_widgets_in_all_templates() {
+		$elementor_utils = new ElementorUtils();
+		$this->ep_factory->post->create(
+			[
+				'post_type'  => 'elementor_library',
+				'meta_input' => [
+					'_elementor_data' => $this->get_elementor_template_content(),
+				],
+			]
+		);
+
+		$all_widgets = $elementor_utils->get_all_widgets_in_all_templates();
+		$this->assertCount( 2, $all_widgets );
+	}
+
+	/**
+	 * Test the `get_specific_widget_in_all_templates` method
+	 *
+	 * @group elementor_utils
+	 */
+	public function test_get_specific_widget_in_all_templates() {
+		$elementor_utils = new ElementorUtils();
+		$this->ep_factory->post->create(
+			[
+				'post_type'  => 'elementor_library',
+				'meta_input' => [
+					'_elementor_data' => $this->get_elementor_template_content(),
+				],
+			]
+		);
+
+		$meta_widget = $elementor_utils->get_specific_widget_in_all_templates( 'wp-widget-ep-facet-meta' );
+		$this->assertCount( 1, $meta_widget );
+		$this->assertEquals( 'wp-widget-ep-facet-meta', $meta_widget[0]['widgetType'] );
+
+		$meta_range_widget = $elementor_utils->get_specific_widget_in_all_templates( 'wp-widget-ep-facet-meta-range' );
+		$this->assertCount( 1, $meta_range_widget );
+		$this->assertEquals( 'wp-widget-ep-facet-meta-range', $meta_range_widget[0]['widgetType'] );
+	}
+
+	/**
+	 * Get the elementor template content.
+	 *
+	 * @return string
+	 */
+	protected function get_elementor_template_content(): string {
+		$content = [
+			[
+				'id'       => '1',
+				'elType'   => 'container',
+				'elements' => [
+					[
+						'id'       => '2',
+						'elType'   => 'container',
+						'settings' => [
+							'_column_size' => '25',
+						],
+						'elements' => [
+							[
+								'id'         => '3',
+								'elType'     => 'widget',
+								'settings'   => [
+									'wp' => [
+										'title'         => '',
+										'facet'         => '_regular_price',
+										'searchPlaceholder' => 'Search',
+										'orderby_order' => 'count/desc',
+									],
+								],
+								'elements'   => [],
+								'widgetType' => 'wp-widget-ep-facet-meta',
+							],
+							[
+								'id'       => '4',
+								'elType'   => 'container',
+								'settings' => [
+									'container_type' => 'grid',
+									'presetTitle'    => 'Grid',
+								],
+								'elements' => [
+									[
+										'id'         => '5',
+										'elType'     => 'widget',
+										'settings'   => [
+											'wp' => [
+												'title'  => '',
+												'facet'  => '_regular_price',
+												'prefix' => '',
+												'suffix' => '',
+											],
+										],
+										'elements'   => [],
+										'widgetType' => 'wp-widget-ep-facet-meta-range',
+									],
+								],
+								'isInner'  => true,
+							],
+						],
+						'isInner'  => true,
+					],
+				],
+				'isInner'  => false,
+			],
+		];
+
+		return wp_json_encode( $content );
+	}
+}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds the a widget for the Date Filter

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4153

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Add new widget for Date Filter
 
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
