### PR TITLE
Fix: Date Query handles array for Compare IN and NOT IN

### DIFF
--- a/includes/classes/Indexable/Post/DateQuery.php
+++ b/includes/classes/Indexable/Post/DateQuery.php
@@ -263,11 +263,11 @@ class DateQuery extends WP_Date_Query {
 				} elseif ( '!=' === $compare ) {
 					$date_terms['must_not'][]['term'][ "date_terms.{$param}" ] = $value;
 				} elseif ( 'IN' === $compare ) {
-					foreach ( $value as $in_value ) {
+					foreach ( (array) $value as $in_value ) {
 						$date_terms['should'][]['term'][ "date_terms.{$param}" ] = $in_value;
 					}
 				} elseif ( 'NOT IN' === $compare ) {
-					foreach ( $value as $in_value ) {
+					foreach ( (array) $value as $in_value ) {
 						$date_terms['must_not'][]['term'][ "date_terms.{$param}" ] = $in_value;
 					}
 				} elseif ( 'BETWEEN' === $compare ) {

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5969,6 +5969,124 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test a date query with IN comparison
+	 *
+	 * @group post
+	 */
+	public function test_date_query_compare_in() {
+		$this->ep_factory->post->create(
+			[
+				'post_date' => '2023-01-01',
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => '2024-01-01',
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => '2025-01-01',
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+				'date_query'   => [
+					[
+						'year'    => 2023,
+						'compare' => 'IN',
+					],
+				],
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+				'date_query'   => [
+					[
+						'year'    => [ 2023, 2025 ],
+						'compare' => 'IN',
+					],
+				],
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+	}
+
+	/**
+	 * Test a date query with NOT IN comparison
+	 *
+	 * @group post
+	 */
+	public function test_date_query_compare_not_in() {
+		$this->ep_factory->post->create(
+			[
+				'post_date' => '2023-01-01',
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => '2024-01-01',
+			]
+		);
+
+		$this->ep_factory->post->create(
+			[
+				'post_date' => '2025-01-01',
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+				'date_query'   => [
+					[
+						'year'    => 2024,
+						'compare' => 'NOT IN',
+					],
+				],
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 2, $query->post_count );
+		$this->assertEquals( 2, $query->found_posts );
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+				'date_query'   => [
+					[
+						'year'    => [ 2023, 2025 ],
+						'compare' => 'NOT IN',
+					],
+				],
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+	}
+
+	/**
 	 * Check if elasticpress_enabled() properly handles an object without the is_search() method.
 	 *
 	 * @group post


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the plugin was throwing a warning message and was unable to handle values in array format when the comparison operator was 'IN' or 'NOT IN'.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4164 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Add support to handle values in array format when the comparison operator was 'IN' or 'NOT IN'.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
