### PR TITLE
BUG FIX: The Field Grouping change should retain old fields values

### DIFF
--- a/assets/js/features/components/control.js
+++ b/assets/js/features/components/control.js
@@ -10,9 +10,6 @@ import {
 	TextControl,
 	TextareaControl,
 	ToggleControl,
-	Card,
-	CardHeader,
-	CardBody,
 } from '@wordpress/components';
 import { safeHTML } from '@wordpress/dom';
 import { RawHTML, WPElement } from '@wordpress/element';
@@ -38,7 +35,6 @@ import { useFeatureSettings } from '../provider';
  * @param {boolean|string} props.syncedValue Setting value at last sync.
  * @param {string} props.type Control type.
  * @param {boolean|string} props.value Setting value.
- * @param {object} props.fields (optional) Fields for field group control.
  * @returns {WPElement} Reports component.
  */
 const Control = ({
@@ -53,7 +49,6 @@ const Control = ({
 	syncedValue,
 	type,
 	value,
-	fields,
 }) => {
 	const { getFeature, isBusy, settings, willSettingRequireSync } = useFeatureSettings();
 
@@ -243,90 +238,6 @@ const Control = ({
 									value={value}
 									__nextHasNoMarginBottom
 								/>
-							);
-						}
-						case 'field_group': {
-							const shouldRenderField = (requiresFields) => {
-								if (!requiresFields || Object.keys(requiresFields).length === 0) {
-									return true;
-								}
-
-								const conditions = requiresFields.conditions ?? false;
-								let relationship = requiresFields.relationship ?? 'AND';
-
-								if (relationship !== 'OR' && relationship !== 'AND') {
-									relationship = 'AND';
-								}
-
-								if (!conditions) {
-									return true;
-								}
-
-								// Helper function to check individual condition
-								const checkCondition = ([fieldKey, requiredValue]) => {
-									let actualValue;
-
-									// For fields that are part of the field group, check there first
-									if (fields.some((f) => f.key === fieldKey)) {
-										actualValue = value?.[fieldKey];
-									} else {
-										// For fields not in the group, check parent settings
-										actualValue = settings['instant-results']?.[fieldKey];
-									}
-
-									return actualValue === requiredValue;
-								};
-
-								// Apply the appropriate logic based on relationship
-								if (relationship === 'OR') {
-									return Object.entries(conditions).some(checkCondition);
-								}
-								return Object.entries(conditions).every(checkCondition);
-							};
-
-							return (
-								<div className="ep-field-group">
-									<Card>
-										{label && (
-											<CardHeader>
-												<strong>{label}</strong>
-											</CardHeader>
-										)}
-										<CardBody>
-											{fields.map((field) => {
-												const shouldRender = shouldRenderField(
-													field.requires_fields,
-												);
-
-												// Skip rendering if the field's requirements aren't met
-												if (!shouldRender) {
-													return null;
-												}
-
-												// Get the current value for this field
-												const fieldValue = value?.[field.key];
-
-												return (
-													<Control
-														key={field.key}
-														{...field}
-														value={fieldValue}
-														onChange={(newValue) => {
-															// Create a new object with the updated field value
-															const updatedValue = {
-																...value,
-																[field.key]: newValue,
-															};
-
-															// Call the parent onChange with the updated nested value
-															onChange(updatedValue);
-														}}
-													/>
-												);
-											})}
-										</CardBody>
-									</Card>
-								</div>
 							);
 						}
 						default: {

--- a/assets/js/features/components/settings.js
+++ b/assets/js/features/components/settings.js
@@ -135,54 +135,12 @@ export default ({ feature, settingsSchema }) => {
 	let groupEntries = [];
 	let groupCounter = 0;
 
-	settingsSchema.forEach((entry) => {
-		const groupSlug = entry.field_group_slug;
-
-		if (groupSlug) {
-			if (currentGroup !== groupSlug) {
-				if (groupEntries.length > 0) {
-					rendered.push(
-						<div className="ep-field-group" key={`${currentGroup}-${groupCounter}`}>
-							<Card>
-								{groupEntries[0].field_group_label && (
-									<CardHeader>
-										<strong>{groupEntries[0].field_group_label}</strong>
-									</CardHeader>
-								)}
-								<CardBody>{groupEntries.map(renderControl)}</CardBody>
-							</Card>
-						</div>,
-					);
-					groupEntries = [];
-					groupCounter++;
-				}
-				currentGroup = groupSlug;
-			}
-			groupEntries.push(entry);
-		} else {
-			if (groupEntries.length > 0) {
-				rendered.push(
-					<div className="ep-field-group" key={`${currentGroup}-${groupCounter}`}>
-						<Card>
-							{groupEntries[0].field_group_label && (
-								<CardHeader>
-									<strong>{groupEntries[0].field_group_label}</strong>
-								</CardHeader>
-							)}
-							<CardBody>{groupEntries.map(renderControl)}</CardBody>
-						</Card>
-					</div>,
-				);
-				groupEntries = [];
-				groupCounter++;
-				currentGroup = null;
-			}
-			rendered.push(renderControl(entry));
+	const pushGroup = () => {
+		if (groupEntries.length === 0) {
+			return;
 		}
-	});
-	if (groupEntries.length > 0) {
 		rendered.push(
-			<div className="ep-field-group" key={`${currentGroup}-${groupCounter}-final`}>
+			<div className="ep-field-group" key={`${currentGroup}-${groupCounter}`}>
 				<Card>
 					{groupEntries[0].field_group_label && (
 						<CardHeader>
@@ -193,7 +151,29 @@ export default ({ feature, settingsSchema }) => {
 				</Card>
 			</div>,
 		);
-	}
+		groupEntries = [];
+		groupCounter++;
+	};
+
+	settingsSchema.forEach((entry) => {
+		const groupSlug = entry.field_group_slug;
+
+		if (groupSlug && currentGroup !== groupSlug) {
+			pushGroup();
+			currentGroup = groupSlug;
+		}
+
+		if (groupSlug) {
+			groupEntries.push(entry);
+			return;
+		}
+
+		pushGroup();
+		currentGroup = null;
+		rendered.push(renderControl(entry));
+	});
+
+	pushGroup();
 
 	if (rendered.length > 1) {
 		return rendered;

--- a/assets/js/features/components/settings.js
+++ b/assets/js/features/components/settings.js
@@ -130,6 +130,10 @@ export default ({ feature, settingsSchema }) => {
 		);
 	};
 
+	const fieldLabelMap = {
+		highlight_group: 'Highlight Group',
+	};
+
 	const rendered = [];
 	let currentGroup = null;
 	let groupEntries = [];
@@ -142,9 +146,9 @@ export default ({ feature, settingsSchema }) => {
 		rendered.push(
 			<div className="ep-field-group" key={`${currentGroup}-${groupCounter}`}>
 				<Card>
-					{groupEntries[0].field_group_label && (
+					{fieldLabelMap[groupEntries[0].field_group_slug] && (
 						<CardHeader>
-							<strong>{groupEntries[0].field_group_label}</strong>
+							<strong>{fieldLabelMap[groupEntries[0].field_group_slug]}</strong>
 						</CardHeader>
 					)}
 					<CardBody>{groupEntries.map(renderControl)}</CardBody>

--- a/assets/js/features/components/settings.js
+++ b/assets/js/features/components/settings.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { WPElement } from '@wordpress/element';
+import { Card, CardHeader, CardBody } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -83,7 +84,25 @@ export default ({ feature, settingsSchema }) => {
 		}
 	};
 
-	return settingsSchema.map((s) => {
+	// Group settingsSchema entries by 'field_group_slug' and store group labels
+	const grouped = {};
+	const groupLabels = {};
+	const ungrouped = [];
+	settingsSchema.forEach((entry) => {
+		if (entry.field_group_slug) {
+			if (!grouped[entry.field_group_slug]) {
+				grouped[entry.field_group_slug] = [];
+				// Store the label for this group (first occurrence wins)
+				groupLabels[entry.field_group_slug] = entry.field_group_label || '';
+			}
+			grouped[entry.field_group_slug].push(entry);
+		} else {
+			ungrouped.push(entry);
+		}
+	});
+
+	// Helper to render a Control from a schema entry
+	const renderControl = (s) => {
 		const {
 			default: defaultValue,
 			disabled,
@@ -98,9 +117,6 @@ export default ({ feature, settingsSchema }) => {
 			fields,
 		} = s;
 
-		/**
-		 * Skip rendering if the control should not be rendered based on requires_fields.
-		 */
 		if (!shouldRenderControl(requires_fields)) {
 			return null;
 		}
@@ -108,9 +124,6 @@ export default ({ feature, settingsSchema }) => {
 		let value =
 			typeof settings[feature]?.[key] !== 'undefined' ? settings[feature][key] : defaultValue;
 
-		/**
-		 * If the feature is unavailable, the active toggle should be off.
-		 */
 		if (key === 'active' && !isAvailable) {
 			value = false;
 		}
@@ -132,5 +145,25 @@ export default ({ feature, settingsSchema }) => {
 				fields={fields}
 			/>
 		);
-	});
+	};
+
+	return (
+		<>
+			{/* Render grouped controls */}
+			{Object.entries(grouped).map(([groupSlug, entries]) => (
+				<div className="ep-field-group" key={groupSlug}>
+					<Card>
+						{groupLabels[groupSlug] && (
+							<CardHeader>
+								<strong>{groupLabels[groupSlug]}</strong>
+							</CardHeader>
+						)}
+						<CardBody>{entries.map(renderControl)}</CardBody>
+					</Card>
+				</div>
+			))}
+			{/* Render ungrouped controls */}
+			{ungrouped.map(renderControl)}
+		</>
+	);
 };

--- a/assets/js/features/components/settings.js
+++ b/assets/js/features/components/settings.js
@@ -84,23 +84,6 @@ export default ({ feature, settingsSchema }) => {
 		}
 	};
 
-	// Group settingsSchema entries by 'field_group_slug' and store group labels
-	const grouped = {};
-	const groupLabels = {};
-	const ungrouped = [];
-	settingsSchema.forEach((entry) => {
-		if (entry.field_group_slug) {
-			if (!grouped[entry.field_group_slug]) {
-				grouped[entry.field_group_slug] = [];
-				// Store the label for this group (first occurrence wins)
-				groupLabels[entry.field_group_slug] = entry.field_group_label || '';
-			}
-			grouped[entry.field_group_slug].push(entry);
-		} else {
-			ungrouped.push(entry);
-		}
-	});
-
 	// Helper to render a Control from a schema entry
 	const renderControl = (s) => {
 		const {
@@ -147,23 +130,76 @@ export default ({ feature, settingsSchema }) => {
 		);
 	};
 
-	return (
-		<>
-			{/* Render grouped controls */}
-			{Object.entries(grouped).map(([groupSlug, entries]) => (
-				<div className="ep-field-group" key={groupSlug}>
-					<Card>
-						{groupLabels[groupSlug] && (
-							<CardHeader>
-								<strong>{groupLabels[groupSlug]}</strong>
-							</CardHeader>
-						)}
-						<CardBody>{entries.map(renderControl)}</CardBody>
-					</Card>
-				</div>
-			))}
-			{/* Render ungrouped controls */}
-			{ungrouped.map(renderControl)}
-		</>
-	);
+	const rendered = [];
+	let currentGroup = null;
+	let groupEntries = [];
+	let groupCounter = 0;
+
+	settingsSchema.forEach((entry) => {
+		const groupSlug = entry.field_group_slug;
+
+		if (groupSlug) {
+			if (currentGroup !== groupSlug) {
+				if (groupEntries.length > 0) {
+					rendered.push(
+						<div className="ep-field-group" key={`${currentGroup}-${groupCounter}`}>
+							<Card>
+								{groupEntries[0].field_group_label && (
+									<CardHeader>
+										<strong>{groupEntries[0].field_group_label}</strong>
+									</CardHeader>
+								)}
+								<CardBody>{groupEntries.map(renderControl)}</CardBody>
+							</Card>
+						</div>,
+					);
+					groupEntries = [];
+					groupCounter++;
+				}
+				currentGroup = groupSlug;
+			}
+			groupEntries.push(entry);
+		} else {
+			if (groupEntries.length > 0) {
+				rendered.push(
+					<div className="ep-field-group" key={`${currentGroup}-${groupCounter}`}>
+						<Card>
+							{groupEntries[0].field_group_label && (
+								<CardHeader>
+									<strong>{groupEntries[0].field_group_label}</strong>
+								</CardHeader>
+							)}
+							<CardBody>{groupEntries.map(renderControl)}</CardBody>
+						</Card>
+					</div>,
+				);
+				groupEntries = [];
+				groupCounter++;
+				currentGroup = null;
+			}
+			rendered.push(renderControl(entry));
+		}
+	});
+	if (groupEntries.length > 0) {
+		rendered.push(
+			<div className="ep-field-group" key={`${currentGroup}-${groupCounter}-final`}>
+				<Card>
+					{groupEntries[0].field_group_label && (
+						<CardHeader>
+							<strong>{groupEntries[0].field_group_label}</strong>
+						</CardHeader>
+					)}
+					<CardBody>{groupEntries.map(renderControl)}</CardBody>
+				</Card>
+			</div>,
+		);
+	}
+
+	if (rendered.length > 1) {
+		return rendered;
+	}
+	if (rendered.length === 1) {
+		return rendered[0];
+	}
+	return null;
 };

--- a/assets/js/features/components/settings.js
+++ b/assets/js/features/components/settings.js
@@ -21,7 +21,7 @@ import Control from './control';
 export default ({ feature, settingsSchema }) => {
 	const { getFeature, settings, setSettings, syncedSettings } = useFeatureSettings();
 
-	const { isAvailable, defaultSettings } = getFeature(feature);
+	const { isAvailable, defaultSettings, fieldGroups } = getFeature(feature);
 
 	/**
 	 * Change event handler.
@@ -130,10 +130,6 @@ export default ({ feature, settingsSchema }) => {
 		);
 	};
 
-	const fieldLabelMap = {
-		highlight_group: 'Highlight Group',
-	};
-
 	const rendered = [];
 	let currentGroup = null;
 	let groupEntries = [];
@@ -146,9 +142,9 @@ export default ({ feature, settingsSchema }) => {
 		rendered.push(
 			<div className="ep-field-group" key={`${currentGroup}-${groupCounter}`}>
 				<Card>
-					{fieldLabelMap[groupEntries[0].field_group_slug] && (
+					{fieldGroups[groupEntries[0].field_group_slug] && (
 						<CardHeader>
-							<strong>{fieldLabelMap[groupEntries[0].field_group_slug]}</strong>
+							<strong>{fieldGroups[groupEntries[0].field_group_slug].label}</strong>
 						</CardHeader>
 					)}
 					<CardBody>{groupEntries.map(renderControl)}</CardBody>

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -560,6 +560,7 @@ abstract class Feature {
 			'reqStatusMessages' => (array) $requirements_status->message,
 			'settingsSchema'    => $this->get_settings_schema(),
 			'group'             => $this->group,
+			'fieldGroups'       => $this->get_field_group_map(),
 		];
 
 		return $feature_desc;
@@ -639,5 +640,28 @@ abstract class Feature {
 	 * @since 5.2.0
 	 */
 	public function set_i18n_strings(): void {
+	}
+
+	/**
+	 * Get the field group map for the feature.
+	 *
+	 * @since 5.3.0
+	 * @return array
+	 */
+	public function get_field_group_map(): array {
+		$field_groups = [
+			'highlight_group' => [
+				'label' => esc_html__( 'Highlighting Options', 'elasticpress' ),
+			],
+		];
+		/**
+		 * Filter available field groups.
+		 *
+		 * @hook ep_feature_field_groups
+		 * @since 5.3.0
+		 * @param  {array} $field_groups Current field groups
+		 * @return {array} New field groups
+		 */
+		return apply_filters( 'ep_feature_field_groups', $field_groups );
 	}
 }

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -151,6 +151,14 @@ abstract class Feature {
 	public $group = false;
 
 	/**
+	 * Field groups available to a feature
+	 *
+	 * @since 5.3.0
+	 * @var array
+	 */
+	protected $field_group_map = [];
+
+	/**
 	 * Run on every page load for feature to set itself up
 	 *
 	 * @since  2.1
@@ -649,11 +657,6 @@ abstract class Feature {
 	 * @return array
 	 */
 	public function get_field_group_map(): array {
-		$field_groups = [
-			'highlight_group' => [
-				'label' => esc_html__( 'Highlighting Options', 'elasticpress' ),
-			],
-		];
 		/**
 		 * Filter available field groups.
 		 *
@@ -662,6 +665,6 @@ abstract class Feature {
 		 * @param  {array} $field_groups Current field groups
 		 * @return {array} New field groups
 		 */
-		return apply_filters( 'ep_feature_field_groups', $field_groups );
+		return apply_filters( 'ep_feature_field_groups', $this->field_group_map );
 	}
 }

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -66,12 +66,6 @@ class Search extends Feature {
 
 		$this->available_during_installation = true;
 
-		$this->field_group_map = [
-			'highlight_group' => [
-				'label' => esc_html__( 'Highlighting Options', 'elasticpress' ),
-			],
-		];
-
 		parent::__construct();
 	}
 
@@ -88,6 +82,12 @@ class Search extends Feature {
 		'<p>' . __( 'Overcome higher-end performance and functional limits posed by the traditional WordPress structured (SQL) database to deliver superior keyword search, instantly. ElasticPress indexes custom fields, tags, and other metadata to improve search results. Fuzzy matching accounts for misspellings and verb tenses.', 'elasticpress' ) . '</p>';
 
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#post-search', 'elasticpress' );
+
+		$this->field_group_map = [
+			'highlight_group' => [
+				'label' => esc_html__( 'Highlighting Options', 'elasticpress' ),
+			],
+		];
 	}
 
 	/**

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -82,10 +82,6 @@ class Search extends Feature {
 		'<p>' . __( 'Overcome higher-end performance and functional limits posed by the traditional WordPress structured (SQL) database to deliver superior keyword search, instantly. ElasticPress indexes custom fields, tags, and other metadata to improve search results. Fuzzy matching accounts for misspellings and verb tenses.', 'elasticpress' ) . '</p>';
 
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#post-search', 'elasticpress' );
-
-		$this->field_group_map = [
-			'highlight_group' => __( 'Highlight Group', 'elasticpress' ),
-		];
 	}
 
 	/**
@@ -898,29 +894,27 @@ class Search extends Feature {
 				'type'    => 'radio',
 			],
 			[
-				'default'           => '0',
-				'help'              => __( 'Enable to wrap search terms in HTML tags in results for custom styling. The wrapping HTML tag comes with the <code>ep-highlight</code> class for easy styling.', 'elasticpress' ),
-				'key'               => 'highlight_enabled',
-				'label'             => __( 'Highlight search terms', 'elasticpress' ),
-				'type'              => 'checkbox',
-				'field_group_slug'  => 'highlight_group',
-				'field_group_label' => $this->field_group_map['highlight_group'],
+				'default'          => '0',
+				'help'             => __( 'Enable to wrap search terms in HTML tags in results for custom styling. The wrapping HTML tag comes with the <code>ep-highlight</code> class for easy styling.', 'elasticpress' ),
+				'key'              => 'highlight_enabled',
+				'label'            => __( 'Highlight search terms', 'elasticpress' ),
+				'type'             => 'checkbox',
+				'field_group_slug' => 'highlight_group',
 			],
 			[
-				'default'           => '0',
-				'help'              => __( 'By default, WordPress strips HTML from content excerpts. Enable when using <code>the_excerpt()</code> to display search results.', 'elasticpress' ),
-				'key'               => 'highlight_excerpt',
-				'label'             => __( 'Highlight search terms in excerpts', 'elasticpress' ),
-				'type'              => 'checkbox',
-				'field_group_slug'  => 'highlight_group',
-				'field_group_label' => $this->field_group_map['highlight_group'],
+				'default'          => '0',
+				'help'             => __( 'By default, WordPress strips HTML from content excerpts. Enable when using <code>the_excerpt()</code> to display search results.', 'elasticpress' ),
+				'key'              => 'highlight_excerpt',
+				'label'            => __( 'Highlight search terms in excerpts', 'elasticpress' ),
+				'type'             => 'checkbox',
+				'field_group_slug' => 'highlight_group',
 			],
 			[
-				'default'           => 'mark',
-				'help'              => __( 'Select the HTML tag used to highlight search terms.', 'elasticpress' ),
-				'key'               => 'highlight_tag',
-				'label'             => __( 'Highlight tag', 'elasticpress' ),
-				'options'           => [
+				'default'          => 'mark',
+				'help'             => __( 'Select the HTML tag used to highlight search terms.', 'elasticpress' ),
+				'key'              => 'highlight_tag',
+				'label'            => __( 'Highlight tag', 'elasticpress' ),
+				'options'          => [
 					[
 						'label' => 'mark',
 						'value' => 'mark',
@@ -942,16 +936,15 @@ class Search extends Feature {
 						'value' => 'i',
 					],
 				],
-				'type'              => 'select',
-				'requires_fields'   => [
+				'type'             => 'select',
+				'requires_fields'  => [
 					'relationship' => 'OR',
 					'conditions'   => [
 						'highlight_enabled' => '1',
 						'highlight_excerpt' => '1',
 					],
 				],
-				'field_group_slug'  => 'highlight_group',
-				'field_group_label' => $this->field_group_map['highlight_group'],
+				'field_group_slug' => 'highlight_group',
 			],
 			[
 				'default' => 'simple',

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -82,6 +82,10 @@ class Search extends Feature {
 		'<p>' . __( 'Overcome higher-end performance and functional limits posed by the traditional WordPress structured (SQL) database to deliver superior keyword search, instantly. ElasticPress indexes custom fields, tags, and other metadata to improve search results. Fuzzy matching accounts for misspellings and verb tenses.', 'elasticpress' ) . '</p>';
 
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#post-search', 'elasticpress' );
+
+		$this->field_group_map = [
+			'highlight_group' => __( 'Highlight Group' ),
+		];
 	}
 
 	/**
@@ -894,61 +898,60 @@ class Search extends Feature {
 				'type'    => 'radio',
 			],
 			[
-				'type'   => 'field_group',
-				'key'    => 'highlighting',
-				'label'  => __( 'Highlighting Options', 'elasticpress' ),
-				'fields' => [
+				'default'           => '0',
+				'help'              => __( 'Enable to wrap search terms in HTML tags in results for custom styling. The wrapping HTML tag comes with the <code>ep-highlight</code> class for easy styling.', 'elasticpress' ),
+				'key'               => 'highlight_enabled',
+				'label'             => __( 'Highlight search terms', 'elasticpress' ),
+				'type'              => 'checkbox',
+				'field_group_slug'  => 'highlight_group',
+				'field_group_label' => $this->field_group_map['highlight_group'],
+			],
+			[
+				'default'           => '0',
+				'help'              => __( 'By default, WordPress strips HTML from content excerpts. Enable when using <code>the_excerpt()</code> to display search results.', 'elasticpress' ),
+				'key'               => 'highlight_excerpt',
+				'label'             => __( 'Highlight search terms in excerpts', 'elasticpress' ),
+				'type'              => 'checkbox',
+				'field_group_slug'  => 'highlight_group',
+				'field_group_label' => $this->field_group_map['highlight_group'],
+			],
+			[
+				'default'           => 'mark',
+				'help'              => __( 'Select the HTML tag used to highlight search terms.', 'elasticpress' ),
+				'key'               => 'highlight_tag',
+				'label'             => __( 'Highlight tag', 'elasticpress' ),
+				'options'           => [
 					[
-						'default' => '0',
-						'help'    => __( 'Enable to wrap search terms in HTML tags in results for custom styling. The wrapping HTML tag comes with the <code>ep-highlight</code> class for easy styling.', 'elasticpress' ),
-						'key'     => 'highlight_enabled',
-						'label'   => __( 'Highlight search terms', 'elasticpress' ),
-						'type'    => 'checkbox',
+						'label' => 'mark',
+						'value' => 'mark',
 					],
 					[
-						'default' => '0',
-						'help'    => __( 'By default, WordPress strips HTML from content excerpts. Enable when using <code>the_excerpt()</code> to display search results.', 'elasticpress' ),
-						'key'     => 'highlight_excerpt',
-						'label'   => __( 'Highlight search terms in excerpts', 'elasticpress' ),
-						'type'    => 'checkbox',
+						'label' => 'span',
+						'value' => 'span',
 					],
 					[
-						'default'         => 'mark',
-						'help'            => __( 'Select the HTML tag used to highlight search terms.', 'elasticpress' ),
-						'key'             => 'highlight_tag',
-						'label'           => __( 'Highlight tag', 'elasticpress' ),
-						'options'         => [
-							[
-								'label' => 'mark',
-								'value' => 'mark',
-							],
-							[
-								'label' => 'span',
-								'value' => 'span',
-							],
-							[
-								'label' => 'strong',
-								'value' => 'strong',
-							],
-							[
-								'label' => 'em',
-								'value' => 'em',
-							],
-							[
-								'label' => 'i',
-								'value' => 'i',
-							],
-						],
-						'type'            => 'select',
-						'requires_fields' => [
-							'relationship' => 'OR',
-							'conditions'   => [
-								'highlight_enabled' => '1',
-								'highlight_excerpt' => '1',
-							],
-						],
+						'label' => 'strong',
+						'value' => 'strong',
+					],
+					[
+						'label' => 'em',
+						'value' => 'em',
+					],
+					[
+						'label' => 'i',
+						'value' => 'i',
 					],
 				],
+				'type'              => 'select',
+				'requires_fields'   => [
+					'relationship' => 'OR',
+					'conditions'   => [
+						'highlight_enabled' => '1',
+						'highlight_excerpt' => '1',
+					],
+				],
+				'field_group_slug'  => 'highlight_group',
+				'field_group_label' => $this->field_group_map['highlight_group'],
 			],
 			[
 				'default' => 'simple',

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -84,7 +84,7 @@ class Search extends Feature {
 		$this->docs_url = __( 'https://www.elasticpress.io/documentation/article/configuring-elasticpress-via-the-plugin-dashboard/#post-search', 'elasticpress' );
 
 		$this->field_group_map = [
-			'highlight_group' => __( 'Highlight Group' ),
+			'highlight_group' => __( 'Highlight Group', 'elasticpress' ),
 		];
 	}
 

--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -66,6 +66,12 @@ class Search extends Feature {
 
 		$this->available_during_installation = true;
 
+		$this->field_group_map = [
+			'highlight_group' => [
+				'label' => esc_html__( 'Highlighting Options', 'elasticpress' ),
+			],
+		];
+
 		parent::__construct();
 	}
 

--- a/tests/php/TestFeature.php
+++ b/tests/php/TestFeature.php
@@ -58,6 +58,7 @@ class TestFeature extends BaseTestCase {
 				],
 			],
 			'group'             => false,
+			'fieldGroups'       => [],
 		];
 
 		$this->assertSame( $expected, $stub->get_json() );
@@ -110,6 +111,7 @@ class TestFeature extends BaseTestCase {
 				],
 			],
 			'group'             => 'Example Group A',
+			'fieldGroups'       => [],
 		];
 
 		$this->assertSame( $expected, $stub->get_json() );

--- a/tests/php/features/TestSearch.php
+++ b/tests/php/features/TestSearch.php
@@ -346,7 +346,7 @@ class TestSearch extends BaseTestCase {
 
 		$settings_keys = wp_list_pluck( $settings_schema, 'key' );
 
-		$expected = [ 'active', 'decaying_enabled', 'highlighting', 'synonyms_editor_mode' ];
+		$expected = [ 'active', 'decaying_enabled', 'highlight_enabled', 'highlight_excerpt', 'highlight_tag', 'synonyms_editor_mode' ];
 		if ( ! is_multisite() ) {
 			$expected[] = 'additional_links';
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Previously, I had set up a new settings schema type: field_group. It was rendering a whole new Control, and nesting the stored values. This would lead to the old values not being retained once moved into a field_group, and didn't have great retrocompatibility.

To address this, I've changed how field_groups work. Now, there is no field_group type. Instead, fields stay flat, but now have a `field_group_slug` and `field_group_label` key/value pair. That keeps things working with retrocompatibility, and retains the old values. Its now the same exact fields: the frontend just renders them in a group visually. This also helped reduced some repetitive logic surrounding conditional fields.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4170 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
```
public function set_i18n_strings(): void {
        ...
	$this->field_group_map = [
		'highlight_group' => __( 'Highlight Group', 'elasticpress' ),
	];
        ...
}
```


```
protected function set_settings_schema() {
...
$this->settings_schema = [
	[
		...
		'key'               => 'highlight_enabled',
		'field_group_slug'  => 'highlight_group',
		'field_group_label' => $this->field_group_map['highlight_group'],
	],
	[
			...
		'key'               => 'highlight_excerpt',
		'field_group_slug'  => 'highlight_group',
		'field_group_label' => $this->field_group_map['highlight_group'],
	],
...
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Field groups weren't retaining old values

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ZacharyRener 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
