### PR TITLE
ES 8.16 compat: Remove side from edge_ngram tokenizer on term and comment as well

### DIFF
--- a/includes/mappings/comment/7-0.php
+++ b/includes/mappings/comment/7-0.php
@@ -101,7 +101,6 @@ return [
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
 				'edge_ngram'     => [
-					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',

--- a/includes/mappings/term/7-0.php
+++ b/includes/mappings/term/7-0.php
@@ -65,7 +65,6 @@ return [
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
 				'edge_ngram'     => [
-					'side'     => 'front',
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',


### PR DESCRIPTION
### Description of the Change
Similar to https://github.com/10up/ElasticPress/pull/4155

Removes the below warning:
```
Warning: 299 Elasticsearch-8.18.2-c6b8d8d951c631db715485edc1a74190cdce4189 &quot;The [side] parameter is deprecated and will be removed. Use a [reverse] before and after the [edge_ngram] instead.
```

### How to test the Change
### Changelog Entry
> Deprecated - Remove deprecated side param from edge_ngram filter on term and comment mapping for ES 8.16.x compatibility

### Credits
Props @rebeccahum 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
