### PR TITLE
overwrite babel/runtime version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2008,13 +2008,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -8188,18 +8184,6 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/element/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/env": {
       "version": "10.18.0",
       "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.18.0.tgz",
@@ -8302,18 +8286,6 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/escape-html/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
@@ -8640,18 +8612,6 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/icons/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/jest-console": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.29.0.tgz",
@@ -8698,18 +8658,6 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/primitives/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@wordpress/warning": {
@@ -23879,11 +23827,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-    },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
@@ -27832,7 +27775,7 @@
         "@babel/preset-env": "^7.23.7",
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
-        "@babel/runtime": "^7.23.7",
+        "@babel/runtime": "^7.27.6",
         "@wordpress/babel-plugin-import-jsx-pragma": "^4.31.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
         "core-js": "^3.35.0"
@@ -29062,12 +29005,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
-      "requires": {
-        "regenerator-runtime": "^0.14.0"
-      }
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="
     },
     "@babel/template": {
       "version": "7.25.9",
@@ -30341,7 +30281,7 @@
       "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
       "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
       "requires": {
-        "@babel/runtime": "^7.26.7",
+        "@babel/runtime": "^7.27.6",
         "css-box-model": "^1.2.1",
         "raf-schd": "^4.0.3",
         "react-redux": "^9.2.0",
@@ -32259,7 +32199,7 @@
         "@babel/plugin-transform-runtime": "^7.16.0",
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
-        "@babel/runtime": "^7.16.0",
+        "@babel/runtime": "^7.27.6",
         "@wordpress/babel-plugin-import-jsx-pragma": "^4.41.0",
         "@wordpress/browserslist-config": "^5.41.0",
         "@wordpress/warning": "^2.58.0",
@@ -32288,7 +32228,7 @@
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.18.0.tgz",
       "integrity": "sha512-38wA2ta4GGOxuKofmyNP+EWA03bqBwUufQNQNd8GgcaKo4N/j+0wQMouLC/2g6n9MU5B0DH4tIv9uP9qR1miYg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
+        "@babel/runtime": "^7.27.6",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
         "@wordpress/escape-html": "^3.18.0",
@@ -32296,16 +32236,6 @@
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/env": {
@@ -32376,17 +32306,7 @@
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.18.0.tgz",
       "integrity": "sha512-5hcsoIin5IYAEejuRJqnFQB5q5C0q8VII/H7wWOWoe8IXiRQCiju/DWRC25AL2xWdUdaqiG84JuiPq+7Npb8gw==",
       "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@babel/runtime": "^7.27.6"
       }
     },
     "@wordpress/eslint-plugin": {
@@ -32568,19 +32488,9 @@
       "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.18.0.tgz",
       "integrity": "sha512-stWW0msTspv6wCB3Pcu7PtVoFQBRr4R+oOvXlxVnpsUKuUz+mIAS08Sme9bTkHiVtHBZRK6YGpt4wYK6W0FXcw==",
       "requires": {
-        "@babel/runtime": "7.25.7",
+        "@babel/runtime": "^7.27.6",
         "@wordpress/element": "^6.18.0",
         "@wordpress/primitives": "^4.18.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/jest-console": {
@@ -32589,7 +32499,7 @@
       "integrity": "sha512-/9PZJhyszdRX4mka7t1WzoooM+Q/DwC4jkNVtJxqci5lbL3Lrhy1cCJGCgMr1n/9w+zs7eLmExFBvV4v44iyNw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.16.0",
+        "@babel/runtime": "^7.27.6",
         "jest-matcher-utils": "^29.6.2"
       }
     },
@@ -32605,19 +32515,9 @@
       "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.18.0.tgz",
       "integrity": "sha512-c/8wC1MgbiQc/8kQlxuNuzeDeEW65jHSK0/qZ/afvHL1T4AmYmyC791nabpyGM+Le1kwe1LCDbPo/x2Oig0nbA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
+        "@babel/runtime": "^7.27.6",
         "@wordpress/element": "^6.18.0",
         "clsx": "^2.1.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/warning": {
@@ -39436,7 +39336,7 @@
       "integrity": "sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.5"
+        "@babel/runtime": "^7.27.6"
       }
     },
     "media-typer": {
@@ -41927,18 +41827,13 @@
         "regenerate": "^1.4.2"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-    },
     "regenerator-transform": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
       "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.4"
+        "@babel/runtime": "^7.27.6"
       }
     },
     "regexp.prototype.flags": {

--- a/package.json
+++ b/package.json
@@ -109,5 +109,8 @@
       "woocommerce-order-search-styles": "./assets/css/woocommerce/admin/orders.css"
     },
     "wpDependencyExternals": true
+  },
+  "overrides": {
+    "@babel/runtime": "^7.27.6"
   }
 }


### PR DESCRIPTION
### Description of the Change
Due to a [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2025-27789), we need to overwrite @babel/runtime package. This package is a dependency from several @wordpress core packages and it seems like there's an [ongoing discussion](https://github.com/WordPress/gutenberg/issues/69557) around this topic but it's not expected to be fixed soon. Because of that we're adding an overwrite to `package.json`
Also noting that dependabot tried to fix this here https://github.com/10up/ElasticPress/security/dependabot/83 but cannot

### How to test the Change
- Clone the repo
- run npm install
- validate node_modules/@babel/runtime is the expected version: `7.27.6`

### Changelog Entry

> Security - Vulnerability
Overwrite package @babel/runtime coming from core packages due to a vulnerability

### Credits
Props @hugosolar 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
