### PR TITLE
Pass autosuggest query args to Elasticsearch->query()

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -457,38 +457,38 @@ class Autosuggest extends Feature {
 
 		add_filter( 'posts_pre_query', [ $features->get_registered_feature( $this->slug ), 'return_empty_posts' ], 100, 1 ); // after ES Query to ensure we are not falling back to DB in any case
 
-		new \WP_Query(
-			/**
-			 * Filter WP Query args of the autosuggest query template.
-			 *
-			 * If you want to display 20 posts in autosuggest:
-			 *
-			 * ```
-			 * add_filter(
-			 *     'ep_autosuggest_query_args',
-			 *     function( $args ) {
-			 *         $args['posts_per_page'] = 20;
-			 *         return $args;
-			 *     }
-			 * );
-			 * ```
-			 *
-			 * @since 4.4.0
-			 * @hook ep_autosuggest_query_args
-			 * @param {array} $args Query args
-			 * @return {array} New query args
-			 */
-			apply_filters(
-				'ep_autosuggest_query_args',
-				[
-					'post_type'            => $post_type,
-					'post_status'          => $post_status,
-					's'                    => $placeholder,
-					'ep_integrate'         => true,
-					'ep_intercept_request' => true,
-				]
-			)
+		/**
+		 * Filter WP Query args of the autosuggest query template.
+		 *
+		 * If you want to display 20 posts in autosuggest:
+		 *
+		 * ```
+		 * add_filter(
+		 *     'ep_autosuggest_query_args',
+		 *     function( $args ) {
+		 *         $args['posts_per_page'] = 20;
+		 *         return $args;
+		 *     }
+		 * );
+		 * ```
+		 *
+		 * @since 4.4.0
+		 * @hook ep_autosuggest_query_args
+		 * @param {array} $args Query args
+		 * @return {array} New query args
+		 */
+		$args = apply_filters(
+			'ep_autosuggest_query_args',
+			[
+				'post_type'            => $post_type,
+				'post_status'          => $post_status,
+				's'                    => $placeholder,
+				'ep_integrate'         => true,
+				'ep_intercept_request' => true,
+			]
 		);
+
+		new \WP_Query( $args );
 
 		remove_filter( 'posts_pre_query', [ $features->get_registered_feature( $this->slug ), 'return_empty_posts' ], 100 );
 
@@ -499,6 +499,7 @@ class Autosuggest extends Feature {
 		return [
 			'body'        => $this->autosuggest_query,
 			'placeholder' => $placeholder,
+			'query_vars'  => $args,
 		];
 	}
 
@@ -654,12 +655,14 @@ class Autosuggest extends Feature {
 		 */
 		do_action( 'ep_epio_pre_send_autosuggest_allowed' );
 
+		$search_query = $this->generate_search_query();
+
 		/**
 		 * The same ES query sent by autosuggest.
 		 *
 		 * Sometimes it'll be a string, sometimes it'll be already an array.
 		 */
-		$es_search_query = $this->generate_search_query()['body'];
+		$es_search_query = $search_query['body'];
 		$es_search_query = ( is_array( $es_search_query ) ) ? $es_search_query : json_decode( $es_search_query, true );
 
 		/**
@@ -683,7 +686,7 @@ class Autosuggest extends Feature {
 
 		add_filter( 'ep_format_request_headers', [ $this, 'add_ep_set_autosuggest_header' ] );
 
-		Elasticsearch::factory()->query( $index, 'post', $es_search_query, [] );
+		Elasticsearch::factory()->query( $index, 'post', $es_search_query, $search_query['query_vars'] );
 
 		remove_filter( 'ep_format_request_headers', [ $this, 'add_ep_set_autosuggest_header' ] );
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - [Autosuggest] WP_Query arguments are now passed to Elasticsearch->query() when setting allowed parameters

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
