### PR TITLE
Handle errors while calling prepare_document

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -40,6 +40,7 @@
         "wp-content/plugins/shorten-autosave.php": "./tests/e2e/src/wordpress-files/test-plugins/shorten-autosave.php",
         "wp-content/plugins/show-comments-and-terms.php": "./tests/e2e/src/wordpress-files/test-plugins/show-comments-and-terms.php",
         "wp-content/plugins/sync-error.php": "./tests/e2e/src/wordpress-files/test-plugins/sync-error.php",
+        "wp-content/plugins/sync-error-specific-post.php": "./tests/e2e/src/wordpress-files/test-plugins/sync-error-specific-post.php",
         "wp-content/plugins/unsupported-server-software.php": "./tests/e2e/src/wordpress-files/test-plugins/unsupported-server-software.php",
         "wp-content/plugins/unsupported-elasticsearch-version.php": "./tests/e2e/src/wordpress-files/test-plugins/unsupported-elasticsearch-version.php",
         "wp-content/plugins/multiple-required-features.php": "./tests/e2e/src/wordpress-files/test-plugins/multiple-required-features.php",

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -266,7 +266,11 @@ abstract class Indexable {
 	 * @return object|boolean
 	 */
 	public function index( $object_id, $blocking = false ) {
-		$document = $this->prepare_document( $object_id );
+		try {
+			$document = $this->prepare_document( $object_id );
+		} catch ( \Throwable $th ) {
+			return false;
+		}
 
 		if ( false === $document ) {
 			return false;
@@ -331,6 +335,8 @@ abstract class Indexable {
 	public function bulk_index( $object_ids ) {
 		$body = '';
 
+		$non_es_errors = [];
+
 		foreach ( $object_ids as $object_id ) {
 			$action_args = array(
 				'index' => array(
@@ -338,7 +344,20 @@ abstract class Indexable {
 				),
 			);
 
-			$document = $this->prepare_document( $object_id );
+			try {
+				$document = $this->prepare_document( $object_id );
+			} catch ( \Throwable $th ) {
+				$non_es_errors[] = [
+					'index' => [
+						'_id'   => absint( $object_id ),
+						'error' => [
+							'type'   => 'prepare_document_error',
+							'reason' => $th->getMessage(),
+						],
+					],
+				];
+				continue;
+			}
 
 			/**
 			 * Conditionally kill indexing on a specific object
@@ -356,6 +375,11 @@ abstract class Indexable {
 		}
 
 		$result = Elasticsearch::factory()->bulk_index( $this->get_index_name(), $this->slug, $body );
+
+		if ( ! empty( $non_es_errors ) ) {
+			$result['errors'] = true;
+			$result['items']  = isset( $result['items'] ) ? array_merge( $result['items'], $non_es_errors ) : $non_es_errors;
+		}
 
 		/**
 		 * Perform actions after a bulk indexing is completed
@@ -380,6 +404,8 @@ abstract class Indexable {
 	public function bulk_index_dynamically( $object_ids ) {
 		$documents = [];
 
+		$non_es_errors = [];
+
 		foreach ( $object_ids as $object_id ) {
 			$action_args = array(
 				'index' => array(
@@ -387,7 +413,20 @@ abstract class Indexable {
 				),
 			);
 
-			$document = $this->prepare_document( $object_id );
+			try {
+				$document = $this->prepare_document( $object_id );
+			} catch ( \Throwable $th ) {
+				$non_es_errors[] = [
+					'index' => [
+						'_id'   => absint( $object_id ),
+						'error' => [
+							'type'   => 'prepare_document_error',
+							'reason' => $th->getMessage(),
+						],
+					],
+				];
+				continue;
+			}
 
 			if ( empty( $document ) ) {
 				continue;
@@ -410,12 +449,31 @@ abstract class Indexable {
 		}
 
 		if ( empty( $documents ) ) {
-			return [
-				new \WP_Error( 'ep_bulk_index_no_documents', esc_html__( 'It was not possible to create a body request with the document IDs provided.', 'elasticpress' ), $object_ids ),
-			];
+			return ( ! empty( $non_es_errors ) ? [
+				[
+					'errors' => true,
+					'items'  => $non_es_errors,
+				],
+			] : [
+				new \WP_Error(
+					'ep_bulk_index_no_documents',
+					esc_html__( 'It was not possible to create a body request with the document IDs provided.', 'elasticpress' ),
+					$object_ids
+				),
+			] );
 		}
 
 		$results = $this->send_bulk_index_request( $documents );
+
+		if ( ! empty( $non_es_errors ) ) {
+			$results = [
+				[
+					'errors' => true,
+					'items'  => $non_es_errors,
+				],
+				...$results,
+			];
+		}
 
 		/**
 		 * Perform actions after a dynamic bulk indexing is completed

--- a/tests/e2e/src/specs/dashboard-sync.spec.ts
+++ b/tests/e2e/src/specs/dashboard-sync.spec.ts
@@ -238,5 +238,32 @@ test.describe('Dashboard Sync', { tag: '@group2' }, () => {
 		await expect(loggedInPage.locator('.ep-sync-errors')).toContainText(
 			'No errors found in the log.',
 		);
+
+		// Activate error plugin for a specific post
+		await activatePlugin(loggedInPage, 'sync-error-specific-post', 'wpCli');
+		await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress-sync');
+
+		const responsePromise2 = loggedInPage.waitForResponse(
+			(response) => {
+				return (
+					response.url().includes('/wp-json/elasticpress/v1/sync') &&
+					response.json().then((data) => data.data.message === 'Sync complete')
+				);
+			},
+			{ timeout: getSyncTimeout() },
+		);
+		await loggedInPage.getByRole('button', { name: 'Start sync' }).click();
+		await responsePromise2;
+
+		await expect(loggedInPage.locator('.ep-sync-errors__table')).toBeVisible();
+		await expect(loggedInPage.locator('.ep-sync-errors tr')).toHaveCount(2);
+		await expect(loggedInPage.locator('.ep-sync-errors tr').locator('nth=1')).toContainText(
+			'1 (Post): [prepare_document_error] Something went wrong.',
+		);
+		await expect(loggedInPage.locator('.ep-sync-errors tr').locator('nth=1')).not.toContainText(
+			'Number of posts index errors',
+		);
+
+		await deactivatePlugin(loggedInPage, 'sync-error-specific-post', 'wpCli');
 	});
 });

--- a/tests/e2e/src/wordpress-files/test-plugins/sync-error-specific-post.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/sync-error-specific-post.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: Sync Error - Specific Post
+ * Description: Cause an error during sync, for test purposes, for a specific post.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+namespace ElasticPress\Tests\E2E\SyncErrorSpecificPost;
+
+/**
+ * Throw an exception for the specific post.
+ *
+ * @param array $args The arguments for the post sync.
+ * @return array The arguments for the post sync.
+ * @throws \Exception If the post ID is 1.
+ */
+function throw_exception( $args ) {
+	if ( 1 === $args['post_id'] ) {
+		throw new \Exception( 'Something went wrong.' );
+	}
+	return $args;
+}
+add_filter( 'ep_post_sync_args_post_prepare_meta', __NAMESPACE__ . '\throw_exception' );

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1182,6 +1182,44 @@ class TestCommands extends BaseTestCase {
 	}
 
 	/**
+	 * Test the `sync` command when an exception is thrown
+	 *
+	 * This is not a "unit test" in the traditional sense, but it's needed so we are sure
+	 * the error message is displayed correctly when an exception is thrown.
+	 *
+	 * @since 5.3.0
+	 * @group commands
+	 */
+	public function test_error_message_when_exception_is_thrown() {
+
+		$post_id_1 = $this->ep_factory->post->create();
+		$this->ep_factory->post->create();
+
+		$throw_exception = function ( $args ) use ( $post_id_1 ) {
+			if ( $args['post_id'] === $post_id_1 ) {
+				throw new \Exception( 'Something went wrong.' );
+			}
+			return $args;
+		};
+		add_filter( 'ep_post_sync_args_post_prepare_meta', $throw_exception );
+
+		$this->command->sync( [], [ 'show-errors' => true ] );
+
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( $post_id_1 . ' (Post): [prepare_document_error] Something went wrong.', $output );
+
+		if ( $this->is_network_activate() ) {
+			$this->assertStringContainsString( 'Number of posts index errors on site 1: 1', $output );
+			$this->assertStringContainsString( 'Number of posts indexed on site 1: 1', $output );
+		} else {
+			$this->assertStringContainsString( 'Number of posts index errors: 1', $output );
+			$this->assertStringContainsString( 'Number of posts indexed: 1', $output );
+		}
+
+		remove_filter( 'ep_post_sync_args_post_prepare_meta', $throw_exception );
+	}
+
+	/**
 	 * Test commands throws deprecated warning.
 	 *
 	 *  @expectedDeprecated get-indexes

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -22,6 +22,13 @@ class TestPost extends BaseTestCase {
 	public $is_404 = false;
 
 	/**
+	 * Post with exception.
+	 *
+	 * @var int|null
+	 */
+	protected $post_with_exception = null;
+
+	/**
 	 * Setup each test.
 	 *
 	 * @since 0.1.0
@@ -10221,5 +10228,162 @@ class TestPost extends BaseTestCase {
 			$initial_status_and_summary,
 			$sync_manager->maybe_add_doc_status_to_admin_bar_status( $initial_status_and_summary )
 		);
+	}
+
+	/**
+	 * Test the `index` method
+	 *
+	 * @since 5.3.0
+	 * @group post
+	 */
+	public function test_index() {
+		$post_indexable = new \ElasticPress\Indexable\Post\Post();
+		$post_id        = $this->ep_factory->post->create();
+		$this->assertIsObject( $post_indexable->index( $post_id, true ) );
+
+		// We should test the object attributes.
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test the `index` method with an exception
+	 *
+	 * @since 5.3.0
+	 * @group post
+	 */
+	public function test_index_with_exception() {
+		$post_indexable = new \ElasticPress\Indexable\Post\Post();
+
+		add_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'throw_exception' ] );
+		$this->post_with_exception = $this->ep_factory->post->create();
+		$this->assertFalse( $post_indexable->index( $this->post_with_exception, true ) );
+		remove_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'throw_exception' ] );
+	}
+
+	/**
+	 * Test the `bulk_index` method
+	 *
+	 * @since 5.3.0
+	 * @group post
+	 */
+	public function test_bulk_index() {
+		$post_id_1 = $this->ep_factory->post->create();
+		$post_id_2 = $this->ep_factory->post->create();
+
+		$post_indexable = new \ElasticPress\Indexable\Post\Post();
+		$posts          = [ $post_id_1, $post_id_2 ];
+
+		$result = $post_indexable->bulk_index( $posts );
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result['errors'] );
+
+		// We should test other array indices.
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test the `bulk_index` method with an exception
+	 *
+	 * @since 5.3.0
+	 * @group post
+	 */
+	public function test_bulk_index_with_exception() {
+		$post_id_1 = $this->ep_factory->post->create();
+		$post_id_2 = $this->ep_factory->post->create();
+
+		$this->post_with_exception = $post_id_1;
+
+		$post_indexable = new \ElasticPress\Indexable\Post\Post();
+		$posts          = [ $post_id_1, $post_id_2 ];
+
+		add_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'throw_exception' ] );
+		$result = $post_indexable->bulk_index( $posts );
+		remove_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'throw_exception' ] );
+
+		$error_item = [
+			'index' => [
+				'_id'   => $post_id_1,
+				'error' => [
+					'type'   => 'prepare_document_error',
+					'reason' => 'Something went wrong.',
+				],
+			],
+		];
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['errors'] );
+		$this->assertContains( $error_item, $result['items'] );
+	}
+
+	/**
+	 * Test the `bulk_index_dynamically` method
+	 *
+	 * @since 5.3.0
+	 * @group post
+	 */
+	public function test_bulk_index_dynamically() {
+		$post_id_1 = $this->ep_factory->post->create();
+		$post_id_2 = $this->ep_factory->post->create();
+
+		$post_indexable = new \ElasticPress\Indexable\Post\Post();
+		$posts          = [ $post_id_1, $post_id_2 ];
+
+		$results = $post_indexable->bulk_index_dynamically( $posts );
+		$this->assertIsArray( $results );
+		foreach ( $results as $result ) {
+			$this->assertEmpty( $result['errors'] );
+		}
+
+		// We should test other array indices.
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test the `bulk_index_dynamically` method with an exception
+	 *
+	 * @since 5.3.0
+	 * @group post
+	 */
+	public function test_bulk_index_dynamically_with_exception() {
+		$post_id_1 = $this->ep_factory->post->create();
+		$post_id_2 = $this->ep_factory->post->create();
+
+		$this->post_with_exception = $post_id_1;
+
+		$post_indexable = new \ElasticPress\Indexable\Post\Post();
+		$posts          = [ $post_id_1, $post_id_2 ];
+
+		add_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'throw_exception' ] );
+		$results = $post_indexable->bulk_index_dynamically( $posts );
+		remove_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'throw_exception' ] );
+
+		$error_item = [
+			'index' => [
+				'_id'   => $post_id_1,
+				'error' => [
+					'type'   => 'prepare_document_error',
+					'reason' => 'Something went wrong.',
+				],
+			],
+		];
+
+		$this->assertIsArray( $results );
+		$this->assertTrue( $results[0]['errors'] );
+		$this->assertContains( $error_item, $results[0]['items'] );
+	}
+
+	/**
+	 * Throw an exception for the specific post.
+	 *
+	 * @since 5.3.0
+	 * @param array $args The arguments for the post sync.
+	 * @return array The arguments for the post sync.
+	 * @throws \Exception If the post ID is the same as the post with exception.
+	 */
+	public function throw_exception( $args ) {
+		if ( $args['post_id'] === $this->post_with_exception ) {
+			throw new \Exception( 'Something went wrong.' );
+		}
+		return $args;
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Exceptions thrown during a post sync will now become error messages in sync processes

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
