### PR TITLE
Fix Warning: Value prop on  should not be null

### DIFF
--- a/assets/js/sync-ui/provider.js
+++ b/assets/js/sync-ui/provider.js
@@ -26,11 +26,11 @@ export const SyncSettingsProvider = ({ autoIndex, children, indexables, postType
 	const [args, setArgs] = useState({
 		include: [],
 		indexables: [],
-		lower_limit_object_id: null,
+		lower_limit_object_id: '',
 		offset: 0,
 		put_mapping: false,
 		post_type: [],
-		upper_limit_object_id: null,
+		upper_limit_object_id: '',
 	});
 
 	const [showLog, setShowLog] = useState(false);


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where React throws a warning message when clicking on the "A range of IDs"  `Warning: `value` prop on "input" should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components`

<img width="1070" height="602" alt="image" src="https://github.com/user-attachments/assets/e3210bdc-79a5-41d1-a6a7-c4a54e294a23" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Warning: `value` prop on "input" should not be null.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
