### PR TITLE
Fix: Comment query when orderby set to none

### DIFF
--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -1171,6 +1171,15 @@ class Comment extends Indexable {
 			}
 		}
 
+		/**
+		 * If `orderby` is 'none', WordPress will let the database decide on what should be used to order.
+		 * It will use the primary key ASC.
+		 */
+		if ( 'none' === $orderby ) {
+			$orderby = 'ID';
+			$order   = 'asc';
+		}
+
 		$orderby = $from_to[ $orderby ] ?? $orderby;
 
 		$sort[] = array(

--- a/tests/php/indexables/TestComment.php
+++ b/tests/php/indexables/TestComment.php
@@ -2649,4 +2649,44 @@ class TestComment extends BaseTestCase {
 		$index_settings = $settings[ $index_name ]['settings'];
 		$this->assertSame( '_arabic_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
 	}
+
+	/**
+	 * Test comment query with orderby none.
+	 *
+	 * @since 5.3.0
+	 * @group comment
+	 */
+	public function test_comment_query_orderby_none() {
+		$post_id = $this->ep_factory->post->create();
+
+		$comment_1_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+				'comment_content' => 'Test comment 1',
+			]
+		);
+
+		$comment_2_id = $this->ep_factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+				'comment_content' => 'Test comment 2',
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$comments_query = new \WP_Comment_Query(
+			[
+				'ep_integrate' => true,
+				'orderby'      => 'none',
+			]
+		);
+
+		$this->assertTrue( $comments_query->elasticsearch_success );
+		$this->assertEquals( 2, $comments_query->found_comments );
+
+		$comments = $comments_query->get_comments();
+		$this->assertEquals( $comment_1_id, $comments[0]->comment_ID );
+		$this->assertEquals( $comment_2_id, $comments[1]->comment_ID );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue when the orderby set to none in Comment query


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Comment query when orderby set to none
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
