### PR TITLE
Guard Instant Results facets against invalid taxonomy values

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -626,6 +626,14 @@ class InstantResults extends Feature {
 		$taxonomies = apply_filters( 'ep_facet_include_taxonomies', $taxonomies );
 
 		foreach ( $taxonomies as $slug => $taxonomy ) {
+			if ( is_string( $taxonomy ) ) {
+				$slug     = $taxonomy;
+				$taxonomy = get_taxonomy( $slug );
+			}
+
+			if ( ! ( $taxonomy instanceof \WP_Taxonomy ) ) {
+				continue;
+			}
 			$name   = 'tax-' . $slug;
 			$labels = get_taxonomy_labels( $taxonomy );
 

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -631,21 +631,22 @@ class InstantResults extends Feature {
 				$taxonomy = get_taxonomy( $slug );
 			}
 
-				if ( ! ( $taxonomy instanceof \WP_Taxonomy ) ) {
-					_doing_it_wrong(
-						__METHOD__,
-						sprintf(
-							/* translators: %s is a taxonomy slug. */
-							esc_html__(
-								'Invalid taxonomy "%s" returned via ep_facet_include_taxonomies filter',
-								'elasticpress'
-							),
-							$slug
+			if ( ! ( $taxonomy instanceof \WP_Taxonomy ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+					/* translators: %s is a taxonomy slug. */
+						esc_html__(
+							'Invalid taxonomy "%s" returned via ep_facet_include_taxonomies filter',
+							'elasticpress'
 						),
-						'ElasticPress 5.3.2'
-					);
-					continue;
-				}
+						esc_html( $slug )
+					),
+					'ElasticPress 5.3.3'
+				);
+				continue;
+			}
+
 			$name   = 'tax-' . $slug;
 			$labels = get_taxonomy_labels( $taxonomy );
 

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -631,9 +631,21 @@ class InstantResults extends Feature {
 				$taxonomy = get_taxonomy( $slug );
 			}
 
-			if ( ! ( $taxonomy instanceof \WP_Taxonomy ) ) {
-				continue;
-			}
+				if ( ! ( $taxonomy instanceof \WP_Taxonomy ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						sprintf(
+							/* translators: %s is a taxonomy slug. */
+							esc_html__(
+								'Invalid taxonomy "%s" returned via ep_facet_include_taxonomies filter',
+								'elasticpress'
+							),
+							$slug
+						),
+						'ElasticPress 5.3.2'
+					);
+					continue;
+				}
 			$name   = 'tax-' . $slug;
 			$labels = get_taxonomy_labels( $taxonomy );
 

--- a/tests/php/features/TestInstantResults.php
+++ b/tests/php/features/TestInstantResults.php
@@ -221,12 +221,12 @@ class TestInstantResults extends BaseTestCase {
 		$feature->after_update_feature( 'instant-results', [], [ 'active' => false ] );
 	}
 		/**
-	 * Ensure invalid taxonomy values returned from ep_facet_include_taxonomies
-	 * are skipped and logged via _doing_it_wrong().
-	 *
-	 * @group instant-results
-	 * @since 5.3.2
-	 */
+		 * Ensure invalid taxonomy values returned from ep_facet_include_taxonomies
+		 * are skipped and logged via _doing_it_wrong().
+		 *
+		 * @group instant-results
+		 * @since 5.3.3
+		 */
 	public function test_invalid_taxonomy_from_facet_filter_triggers_doing_it_wrong_and_is_skipped() {
 		$this->setExpectedIncorrectUsage(
 			\ElasticPress\Feature\InstantResults\InstantResults::class . '::get_facets'
@@ -259,7 +259,7 @@ class TestInstantResults extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'tax-not-a-real-taxonomy', $facets );
 
 		$this->assertNotEmpty( $calls );
-		$this->assertSame( 'ElasticPress 5.3.2', $calls[0]['version'] );
+		$this->assertSame( 'ElasticPress 5.3.3', $calls[0]['version'] );
 		$this->assertSame(
 			\ElasticPress\Feature\InstantResults\InstantResults::class . '::get_facets',
 			$calls[0]['function']
@@ -275,5 +275,4 @@ class TestInstantResults extends BaseTestCase {
 		remove_action( 'doing_it_wrong_run', $listener, 10 );
 		remove_filter( 'ep_facet_include_taxonomies', $taxonomy_filter, 1 );
 	}
-
 }

--- a/tests/php/features/TestInstantResults.php
+++ b/tests/php/features/TestInstantResults.php
@@ -220,4 +220,60 @@ class TestInstantResults extends BaseTestCase {
 		);
 		$feature->after_update_feature( 'instant-results', [], [ 'active' => false ] );
 	}
+		/**
+	 * Ensure invalid taxonomy values returned from ep_facet_include_taxonomies
+	 * are skipped and logged via _doing_it_wrong().
+	 *
+	 * @group instant-results
+	 * @since 5.3.2
+	 */
+	public function test_invalid_taxonomy_from_facet_filter_triggers_doing_it_wrong_and_is_skipped() {
+		$this->setExpectedIncorrectUsage(
+			\ElasticPress\Feature\InstantResults\InstantResults::class . '::get_facets'
+		);
+
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+
+		$calls = [];
+
+		$listener = function ( $function_name, $message, $version ) use ( &$calls ) {
+			$calls[] = [
+				'function' => $function_name,
+				'message'  => $message,
+				'version'  => $version,
+			];
+		};
+
+		add_action( 'doing_it_wrong_run', $listener, 10, 3 );
+
+		$taxonomy_filter = function ( $taxonomies ) {
+			$taxonomies['not-a-real-taxonomy'] = 'not-a-real-taxonomy';
+			return $taxonomies;
+		};
+
+		add_filter( 'ep_facet_include_taxonomies', $taxonomy_filter, 1, 1 );
+
+		$feature = \ElasticPress\Features::factory()->get_registered_feature( 'instant-results' );
+		$facets  = $feature->get_facets();
+
+		$this->assertArrayNotHasKey( 'tax-not-a-real-taxonomy', $facets );
+
+		$this->assertNotEmpty( $calls );
+		$this->assertSame( 'ElasticPress 5.3.2', $calls[0]['version'] );
+		$this->assertSame(
+			\ElasticPress\Feature\InstantResults\InstantResults::class . '::get_facets',
+			$calls[0]['function']
+		);
+
+		$message = html_entity_decode( $calls[0]['message'] );
+
+		$this->assertStringContainsString( 'not-a-real-taxonomy', $message );
+		$this->assertStringContainsString( 'Invalid taxonomy', $message );
+		$this->assertStringContainsString( 'returned via ep_facet_include_taxonomies', $message );
+
+		remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		remove_action( 'doing_it_wrong_run', $listener, 10 );
+		remove_filter( 'ep_facet_include_taxonomies', $taxonomy_filter, 1 );
+	}
+
 }

--- a/tests/php/features/TestInstantResults.php
+++ b/tests/php/features/TestInstantResults.php
@@ -220,13 +220,14 @@ class TestInstantResults extends BaseTestCase {
 		);
 		$feature->after_update_feature( 'instant-results', [], [ 'active' => false ] );
 	}
-		/**
-		 * Ensure invalid taxonomy values returned from ep_facet_include_taxonomies
-		 * are skipped and logged via _doing_it_wrong().
-		 *
-		 * @group instant-results
-		 * @since 5.3.3
-		 */
+
+	/**
+	 * Ensure invalid taxonomy values returned from ep_facet_include_taxonomies
+	 * are skipped and logged via _doing_it_wrong().
+	 *
+	 * @group instant-results
+	 * @since 5.3.3
+	 */
 	public function test_invalid_taxonomy_from_facet_filter_triggers_doing_it_wrong_and_is_skipped() {
 		$this->setExpectedIncorrectUsage(
 			\ElasticPress\Feature\InstantResults\InstantResults::class . '::get_facets'


### PR DESCRIPTION
<!--
Filling out this template is required. Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion. All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR prevents a fatal error in Instant Results taxonomy facets when the `ep_facet_include_taxonomies` filter returns unexpected values (e.g., a taxonomy slug string such as `internal_tags` rather than a `WP_Taxonomy` object).

`InstantResults::get_facets()` currently assumes each filtered taxonomy entry is a `WP_Taxonomy` object and passes it directly to `get_taxonomy_labels()`. If a third-party integration appends a slug string, WordPress core fatals when it tries to treat a string as an object (e.g., `Attempt to assign property "labels" on string` in `wp-includes/taxonomy.php`).

This change adds a defensive guard in the taxonomy facets loop:
- If the value is a string slug, normalize it via `get_taxonomy( $slug )`
- If the value cannot be resolved to `WP_Taxonomy`, skip it

This prevents wp-admin lockouts while preserving existing behavior for correctly shaped data.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4254

### How to test the Change

1. Install and activate ElasticPress 5.3.2 and enable Instant Results.
2. Add the reproduction filter from issue #4254 (appends `internal_tags` as a string via `ep_facet_include_taxonomies`).
3. Log in to wp-admin and visit:
   - `/wp-admin/`
   - `/wp-admin/admin.php?page=elasticpress`
4. Confirm both pages load successfully and no fatal error occurs.

Verified on: WordPress 6.9; PHP 8.4.

### Changelog Entry

> Fixed - Prevent fatal error in Instant Results facets when `ep_facet_include_taxonomies` returns non-`WP_Taxonomy` values.

### Credits

Props @laraib15

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
