### PR TITLE
Fix: Create search template for all sites.

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1545,11 +1545,16 @@ class Command extends WP_CLI_Command {
 	 * : Delete the template for all sites in the network if plugin is network activated. Otherwise, delete the template for the current site only.
 	 *
 	 * @since 4.5.0
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
 	 * @subcommand delete-search-template
 	 */
-	public function delete_search_template() {
+	public function delete_search_template( $args, $assoc_args ) {
+		$network_wide    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network-wide', false );
 		$instant_results = Features::factory()->get_registered_feature( 'instant-results' );
-		$instant_results->epio_delete_search_template();
+
+		$instant_results->epio_delete_site_search_template( $network_wide );
+
 		WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );
 	}
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1517,17 +1517,32 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Saves the Instant Results search template to EPIO.
 	 *
+	 * ## OPTIONS
+	 *
+	 * [--network-wide]
+	 * : Save the template for all sites in the network if plugin is network activated. Otherwise, save the template for the current site only.
+	 *
 	 * @since 4.5.0
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
 	 * @subcommand put-search-template
 	 */
-	public function put_search_template() {
+	public function put_search_template( $args, $assoc_args ) {
+		$network_wide    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network-wide', false );
 		$instant_results = Features::factory()->get_registered_feature( 'instant-results' );
-		$instant_results->epio_save_search_template();
+
+		$instant_results->epio_save_site_search_template( $network_wide );
+
 		WP_CLI::success( esc_html__( 'Done.', 'elasticpress' ) );
 	}
 
 	/**
 	 * Deletes the Instant Results search template.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--network-wide]
+	 * : Delete the template for all sites in the network if plugin is network activated. Otherwise, delete the template for the current site only.
 	 *
 	 * @since 4.5.0
 	 * @subcommand delete-search-template

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -175,7 +175,7 @@ class InstantResults extends Feature {
 		add_filter( 'ep_formatted_args', [ $this, 'maybe_apply_aggs_args' ], 10, 3 );
 		add_filter( 'ep_post_mapping', [ $this, 'add_mapping_properties' ] );
 		add_filter( 'ep_post_sync_args', [ $this, 'add_post_sync_args' ], 10, 2 );
-		add_filter( 'ep_after_sync_index', [ $this, 'epio_save_search_template' ] );
+		add_action( 'ep_after_sync_index', [ $this, 'on_sync_complete' ] );
 		add_filter( 'ep_saved_weighting_configuration', [ $this, 'epio_save_search_template' ] );
 		add_action( 'pre_get_posts', [ $this, 'maybe_apply_product_visibility' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend_assets' ] );
@@ -918,5 +918,37 @@ class InstantResults extends Feature {
 				'type'             => 'radio',
 			],
 		];
+	}
+
+	/**
+	 * Callback for ep_after_sync_index to save search templates.
+	 *
+	 * @param array $args Sync arguments containing network_wide flag.
+	 * @return void
+	 */
+	public function on_sync_complete( array $args ): void {
+		$network_wide = isset( $args['network_wide'] ) && ! is_null( $args['network_wide'] );
+		$this->epio_save_site_search_template( $network_wide );
+	}
+
+	/**
+	 * Save the search template for the current site or all network sites.
+	 *
+	 * @param bool $network_wide Whether to save templates for all sites in the network.
+	 * @return void
+	 */
+	public function epio_save_site_search_template( bool $network_wide = false ): void {
+		if ( ! $network_wide ) {
+			$this->epio_save_search_template();
+			return;
+		}
+
+		$sites = Utils\get_sites( 0, true );
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+			$this->index = Indexables::factory()->get( 'post' )->get_index_name();
+			$this->epio_save_search_template();
+			restore_current_blog();
+		}
 	}
 }

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -948,8 +948,28 @@ class InstantResults extends Feature {
 		$sites = Utils\get_sites( 0, true );
 		foreach ( $sites as $site ) {
 			switch_to_blog( $site['blog_id'] );
-			$this->index = Indexables::factory()->get( 'post' )->get_index_name();
 			$this->epio_save_search_template();
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Delete the search template for the current site or all network sites.
+	 *
+	 * @param bool $network_wide Whether to delete templates for all sites in the network.
+	 * @return void
+	 * @since 5.3.3
+	 */
+	public function epio_delete_site_search_template( bool $network_wide = false ): void {
+		if ( ! $network_wide ) {
+			$this->epio_delete_search_template();
+			return;
+		}
+
+		$sites = Utils\get_sites( 0, true );
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site['blog_id'] );
+			$this->epio_delete_search_template();
 			restore_current_blog();
 		}
 	}

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -925,6 +925,7 @@ class InstantResults extends Feature {
 	 *
 	 * @param array $args Sync arguments containing network_wide flag.
 	 * @return void
+	 * @since 5.3.3
 	 */
 	public function on_sync_complete( array $args ): void {
 		$network_wide = isset( $args['network_wide'] ) && ! is_null( $args['network_wide'] );
@@ -936,6 +937,7 @@ class InstantResults extends Feature {
 	 *
 	 * @param bool $network_wide Whether to save templates for all sites in the network.
 	 * @return void
+	 * @since 5.3.3
 	 */
 	public function epio_save_site_search_template( bool $network_wide = false ): void {
 		if ( ! $network_wide ) {

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -943,12 +943,14 @@ class InstantResults extends Feature {
 			return;
 		}
 
-		$sites = Utils\get_sites( 0, true );
+		$original_blog_index = $this->index;
+		$sites               = Utils\get_sites( 0, true );
 		foreach ( $sites as $site ) {
 			switch_to_blog( $site['blog_id'] );
 			$this->index = Indexables::factory()->get( 'post' )->get_index_name();
 			$this->epio_save_search_template();
 			restore_current_blog();
 		}
+		$this->index = $original_blog_index;
 	}
 }

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -75,8 +75,6 @@ class InstantResults extends Feature {
 
 		$this->host = trailingslashit( Utils\get_host() );
 
-		$this->index = Indexables::factory()->get( 'post' )->get_index_name();
-
 		$this->is_woocommerce = function_exists( 'WC' );
 
 		$this->default_settings = [
@@ -214,6 +212,7 @@ class InstantResults extends Feature {
 
 		wp_set_script_translations( 'elasticpress-instant-results', 'elasticpress' );
 
+		$index = Indexables::factory()->get( 'post' )->get_index_name();
 		/**
 		 * The search API endpoint.
 		 *
@@ -222,7 +221,7 @@ class InstantResults extends Feature {
 		 * @param {string} $endpoint Endpoint path.
 		 * @param {string} $index Elasticsearch index.
 		 */
-		$api_endpoint = apply_filters( 'ep_instant_results_search_endpoint', "api/v1/search/posts/{$this->index}", $this->index );
+		$api_endpoint = apply_filters( 'ep_instant_results_search_endpoint', "api/v1/search/posts/{$index}", $index );
 
 		wp_localize_script(
 			'elasticpress-instant-results',
@@ -253,6 +252,7 @@ class InstantResults extends Feature {
 	 * @return string Instant Results search template endpoint.
 	 */
 	public function get_template_endpoint(): string {
+		$index = Indexables::factory()->get( 'post' )->get_index_name();
 		/**
 		 * Filters the search template API endpoint.
 		 *
@@ -262,7 +262,7 @@ class InstantResults extends Feature {
 		 * @param {string} $index Elasticsearch index.
 		 * @returns {string} Search template API endpoint.
 		 */
-		return apply_filters( 'ep_instant_results_template_endpoint', "api/v1/search/posts/{$this->index}/template/", $this->index );
+		return apply_filters( 'ep_instant_results_template_endpoint', "api/v1/search/posts/{$index}/template/", $index );
 	}
 
 	/**
@@ -943,14 +943,12 @@ class InstantResults extends Feature {
 			return;
 		}
 
-		$original_blog_index = $this->index;
-		$sites               = Utils\get_sites( 0, true );
+		$sites = Utils\get_sites( 0, true );
 		foreach ( $sites as $site ) {
 			switch_to_blog( $site['blog_id'] );
 			$this->index = Indexables::factory()->get( 'post' )->get_index_name();
 			$this->epio_save_search_template();
 			restore_current_blog();
 		}
-		$this->index = $original_blog_index;
 	}
 }

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -953,9 +953,10 @@ class IndexHelper {
 		 * Fires after executing a reindex
 		 *
 		 * @since 4.0.0
+		 * @param array $args Sync arguments.
 		 * @hook ep_after_sync_index
 		 */
-		do_action( 'ep_after_sync_index' );
+		do_action( 'ep_after_sync_index', $this->args );
 
 		/**
 		 * Fires after executing a reindex

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1336,7 +1336,7 @@ class TestCommands extends BaseTestCase {
 		add_filter(
 			'ep_do_intercept_request',
 			function ( $response, $query ) use ( &$called_indices ) {
-				if ( isset( $query['url'] ) && str_contains( $query['url'], 'api/v1/search/posts/' ) ) {
+				if ( str_contains( $query['url'], 'api/v1/search/posts/' ) ) {
 					$called_indices++;
 				}
 
@@ -1352,6 +1352,42 @@ class TestCommands extends BaseTestCase {
 		$this->command->put_search_template( [], [ 'network-wide' => true ] );
 		$output = $this->getActualOutputForAssertion();
 		$this->assertStringContainsString( 'Done.', $output );
+
+		$this->assertEquals( count( $sites ), $called_indices );
+	}
+
+	/**
+	 * Test delete-search-template command deletes the search template for all sites.
+	 *
+	 * @group skip-on-single-site
+	 * @since 5.3.3
+	 */
+	public function test_delete_search_template_with_network_wide_flag() {
+		$this->factory->blog->create_many( 2 );
+
+		$sites          = ElasticPress\Utils\get_sites();
+		$called_indices = 0;
+
+		add_filter( 'ep_intercept_remote_request', '__return_true' );
+		add_filter(
+			'ep_do_intercept_request',
+			function ( $response, $query ) use ( &$called_indices ) {
+				if ( 'DELETE' === $query['args']['method'] && str_contains( $query['url'], 'api/v1/search/posts/' ) ) {
+					$called_indices++;
+				}
+
+				return [
+					'body'     => '{}',
+					'response' => [ 'code' => 200 ],
+				];
+			},
+			10,
+			2
+		);
+
+		$this->command->delete_search_template( [], [ 'network-wide' => true ] );
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Done', $output );
 
 		$this->assertEquals( count( $sites ), $called_indices );
 	}

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1324,6 +1324,7 @@ class TestCommands extends BaseTestCase {
 	 * Test put-search-template command saves the search template for all sites.
 	 *
 	 * @group skip-on-single-site
+	 * @since 5.3.3
 	 */
 	public function test_put_search_template_with_network_wide_flag() {
 		$this->factory->blog->create_many( 2 );

--- a/tests/php/TestCommands.php
+++ b/tests/php/TestCommands.php
@@ -1319,4 +1319,39 @@ class TestCommands extends BaseTestCase {
 		$output = $this->getActualOutputForAssertion();
 		$this->assertStringContainsString( 'This command is deprecated. Please use stop-sync instead.', $output );
 	}
+
+	/**
+	 * Test put-search-template command saves the search template for all sites.
+	 *
+	 * @group skip-on-single-site
+	 */
+	public function test_put_search_template_with_network_wide_flag() {
+		$this->factory->blog->create_many( 2 );
+
+		$sites          = ElasticPress\Utils\get_sites();
+		$called_indices = 0;
+
+		add_filter( 'ep_intercept_remote_request', '__return_true' );
+		add_filter(
+			'ep_do_intercept_request',
+			function ( $response, $query ) use ( &$called_indices ) {
+				if ( isset( $query['url'] ) && str_contains( $query['url'], 'api/v1/search/posts/' ) ) {
+					$called_indices++;
+				}
+
+				return [
+					'body'     => '{}',
+					'response' => [ 'code' => 200 ],
+				];
+			},
+			10,
+			2
+		);
+
+		$this->command->put_search_template( [], [ 'network-wide' => true ] );
+		$output = $this->getActualOutputForAssertion();
+		$this->assertStringContainsString( 'Done.', $output );
+
+		$this->assertEquals( count( $sites ), $called_indices );
+	}
 }

--- a/tests/php/features/TestInstantResults.php
+++ b/tests/php/features/TestInstantResults.php
@@ -8,6 +8,7 @@
 
 namespace ElasticPressTest;
 
+use ElasticPress\Indexables;
 /**
  * Instants Results test class.
  */
@@ -124,7 +125,8 @@ class TestInstantResults extends BaseTestCase {
 	 */
 	public function test_template_endpoint() {
 		$feature = \ElasticPress\Features::factory()->get_registered_feature( 'instant-results' );
-		$this->assertSame( 'api/v1/search/posts/exampleorg-post-1/template/', $feature->get_template_endpoint() );
+		$index = Indexables::factory()->get( 'post' )->get_index_name();
+		$this->assertSame( "api/v1/search/posts/{$index}/template/", $feature->get_template_endpoint() );
 	}
 
 	/**

--- a/tests/php/features/TestInstantResults.php
+++ b/tests/php/features/TestInstantResults.php
@@ -125,7 +125,7 @@ class TestInstantResults extends BaseTestCase {
 	 */
 	public function test_template_endpoint() {
 		$feature = \ElasticPress\Features::factory()->get_registered_feature( 'instant-results' );
-		$index = Indexables::factory()->get( 'post' )->get_index_name();
+		$index   = Indexables::factory()->get( 'post' )->get_index_name();
 		$this->assertSame( "api/v1/search/posts/{$index}/template/", $feature->get_template_endpoint() );
 	}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR ensures that the sync creates the search template across the network when the plugin is network-wide. It also adds support for the `network-wide` flag for `put-search-template` command.

Additionally, we don’t need to set the `index` property during the constructor because if we run `epio_save_site_search_template`, the index property still holds the old value, which can cause incorrect endpoints.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4227 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable the ElasticPress network-wide.
2. Enable the Instant Results.
3. Create a new site. 
4. Run Sync and ensure that Instant Results works find on newly created site. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Ensure the Sync creates the Instant Resutls templates for all the sites

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @anjulahettige 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
