### PR TITLE
Update label for bulk request timeout in ElasticPress status report

### DIFF
--- a/includes/classes/StatusReport/ElasticPress.php
+++ b/includes/classes/StatusReport/ElasticPress.php
@@ -87,21 +87,11 @@ class ElasticPress extends Report {
 	 * @return array
 	 */
 	protected function get_timeouts() {
-		$default_request_timeout   = 5;
-		$fields['request_timeout'] = [
-			'label' => sprintf(
-				/* translators: default time */
-				__( 'Default Requests Timeout (default: %s)', 'elasticpress' ),
-				$default_request_timeout
-			),
-			'value' => apply_filters( 'http_request_timeout', $default_request_timeout, Utils\get_host() ),
-		];
-
 		$default_index_document_timeout   = 15;
 		$fields['index_document_timeout'] = [
 			'label' => sprintf(
 				/* translators: default time */
-				__( 'Index Document Request Timeout (default: %s)', 'elasticpress' ),
+				__( 'Single Document Sync Requests Timeout (default: %s)', 'elasticpress' ),
 				$default_index_document_timeout
 			),
 			'value' => apply_filters( 'ep_index_document_timeout', $default_index_document_timeout ),
@@ -111,10 +101,20 @@ class ElasticPress extends Report {
 		$fields['bulk_request_timeout'] = [
 			'label' => sprintf(
 				/* translators: default time */
-				__( 'Default Bulk Requests Timeout (default: %s)', 'elasticpress' ),
+				__( 'Multiple Document Sync Requests Timeout (default: %s)', 'elasticpress' ),
 				$default_bulk_request_timeout
 			),
 			'value' => apply_filters( 'bulk_request_timeout', $default_bulk_request_timeout ),
+		];
+
+		$default_request_timeout   = 5;
+		$fields['request_timeout'] = [
+			'label' => sprintf(
+				/* translators: default time */
+				__( 'Other HTTP Requests Timeout (default: %s)', 'elasticpress' ),
+				$default_request_timeout
+			),
+			'value' => apply_filters( 'http_request_timeout', $default_request_timeout, Utils\get_host() ),
 		];
 
 		return [

--- a/includes/classes/StatusReport/ElasticPress.php
+++ b/includes/classes/StatusReport/ElasticPress.php
@@ -111,7 +111,7 @@ class ElasticPress extends Report {
 		$fields['bulk_request_timeout'] = [
 			'label' => sprintf(
 				/* translators: default time */
-				__( 'Default Requests Timeout (default: %s)', 'elasticpress' ),
+				__( 'Default Bulk Requests Timeout (default: %s)', 'elasticpress' ),
 				$default_bulk_request_timeout
 			),
 			'value' => apply_filters( 'bulk_request_timeout', $default_bulk_request_timeout ),

--- a/tests/php/screen/TestStatusReport.php
+++ b/tests/php/screen/TestStatusReport.php
@@ -490,7 +490,7 @@ class TestStatusReport extends WP_Ajax_UnitTestCase {
 						'value' => 15,
 					),
 					'bulk_request_timeout'   => array(
-						'label' => 'Default Requests Timeout (default: 30)',
+						'label' => 'Default Bulk Requests Timeout (default: 30)',
 						'value' => 30,
 					),
 				),

--- a/tests/php/screen/TestStatusReport.php
+++ b/tests/php/screen/TestStatusReport.php
@@ -481,17 +481,17 @@ class TestStatusReport extends WP_Ajax_UnitTestCase {
 			array(
 				'title'  => 'Timeouts',
 				'fields' => array(
-					'request_timeout'        => array(
-						'label' => 'Default Requests Timeout (default: 5)',
-						'value' => 5,
-					),
 					'index_document_timeout' => array(
-						'label' => 'Index Document Request Timeout (default: 15)',
+						'label' => 'Single Document Sync Requests Timeout (default: 15)',
 						'value' => 15,
 					),
 					'bulk_request_timeout'   => array(
-						'label' => 'Default Bulk Requests Timeout (default: 30)',
+						'label' => 'Multiple Document Sync Requests Timeout (default: 30)',
 						'value' => 30,
+					),
+					'request_timeout'        => array(
+						'label' => 'Other HTTP Requests Timeout (default: 5)',
+						'value' => 5,
 					),
 				),
 			),


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR updates the label for Bulk Request in the Status Report. Previously, the label was the same for request_timeout and bulk_request_timeout.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Update label for bulk request timeout in ElasticPress status report
 
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
