### PR TITLE
Disable Custom Search Results button during the loading state

### DIFF
--- a/assets/js/ordering/pointers.js
+++ b/assets/js/ordering/pointers.js
@@ -20,6 +20,8 @@ apiFetch.use(apiFetch.createRootURLMiddleware(window.epOrdering.restApiRoot));
 export class Pointers extends Component {
 	titleInput = null;
 
+	publishButton = null;
+
 	debouncedDefaultResults = debounce(() => {
 		this.getDefaultResults();
 	}, 200);
@@ -55,6 +57,7 @@ export class Pointers extends Component {
 
 		// We need to know the title of the page and react to changes since this is the query we search for
 		this.titleInput = document.getElementById('title');
+		this.publishButton = document.getElementById('publish');
 
 		this.state = {
 			pointers: window.epOrdering.pointers,
@@ -75,11 +78,27 @@ export class Pointers extends Component {
 		if (title?.length > 0) {
 			this.getDefaultResults();
 		}
+
+		this.updatePublishButtonState();
+	}
+
+	componentDidUpdate() {
+		this.updatePublishButtonState();
 	}
 
 	componentWillUnmount() {
 		this.titleInput.removeEventListener('keyup', this.debouncedHandleTitleChange);
 	}
+
+	/**
+	 * Updates the publish button disabled state based on loading status.
+	 */
+	updatePublishButtonState = () => {
+		const { title, defaultResults } = this.state;
+		const isLoading = title.length === 0 || !defaultResults[title];
+
+		this.publishButton.disabled = isLoading;
+	};
 
 	handleTitleChange = () => {
 		this.setState({ title: this.titleInput.value });


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR disables the publish/update button while posts are loading. With this change, the nonce will always be available.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4205 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Prevent saving Custom Results while posts are loading. 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
