### PR TITLE
Try to fix intermitent e2e failures

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,11 +93,21 @@ jobs:
       run: npm run build
 
     - name: Set up database
-      run: npm run e2e:setup -- --wp-version=${{ matrix.core.version }} --wc-version=${{ matrix.core.wcVersion }} --acf-pro-license='${{ secrets.ACF_PRO_LICENSE_KEY }}'
+      run: |
+        if [ "${{ matrix.testGroup }}" == "@paidPlugins" ]; then
+          npm run e2e:setup -- --wp-version=${{ matrix.core.version }} --wc-version=${{ matrix.core.wcVersion }} --acf-pro-license='${{ secrets.ACF_PRO_LICENSE_KEY }}'
+        else
+          npm run e2e:setup -- --wp-version=${{ matrix.core.version }} --wc-version=${{ matrix.core.wcVersion }}
+        fi
       if: matrix.esVersion != 'EP.io'
 
     - name: Set up database (EP.io)
-      run: npm run e2e:setup -- --ep-host=${{ secrets.EPIO_HOST }} --ep-credentials='${{ secrets.EPIO_SHIELD }}' --ep-index-prefix=${{ secrets.EPIO_INDEX_PREFIX }} --wp-version=${{ matrix.core.version }} --wc-version=${{ matrix.core.wcVersion }} --acf-pro-license='${{ secrets.ACF_PRO_LICENSE_KEY }}'
+      run: |
+        if [ "${{ matrix.testGroup }}" == "@paidPlugins" ]; then
+          npm run e2e:setup -- --ep-host=${{ secrets.EPIO_HOST }} --ep-credentials='${{ secrets.EPIO_SHIELD }}' --ep-index-prefix=${{ secrets.EPIO_INDEX_PREFIX }} --wp-version=${{ matrix.core.version }} --wc-version=${{ matrix.core.wcVersion }} --acf-pro-license='${{ secrets.ACF_PRO_LICENSE_KEY }}'
+        else
+          npm run e2e:setup -- --ep-host=${{ secrets.EPIO_HOST }} --ep-credentials='${{ secrets.EPIO_SHIELD }}' --ep-index-prefix=${{ secrets.EPIO_INDEX_PREFIX }} --wp-version=${{ matrix.core.version }} --wc-version=${{ matrix.core.wcVersion }}
+        fi
       if: matrix.esVersion == 'EP.io'
 
     - name: Run Playwright tests

--- a/bin/setup-e2e-env.sh
+++ b/bin/setup-e2e-env.sh
@@ -97,7 +97,22 @@ fi
 
 if [ ! -z $ACF_PRO_LICENSE_KEY ]; then
 	./bin/wp-env-cli tests-wordpress "composer --working-dir=./wp-content config http-basic.connect.advancedcustomfields.com ${ACF_PRO_LICENSE_KEY} https://elasticpress.test"
-	./bin/wp-env-cli tests-wordpress "composer --working-dir=./wp-content install"
+	MAX_RETRIES=3
+	RETRY_COUNT=0
+	while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+		if ./bin/wp-env-cli tests-wordpress "composer --working-dir=./wp-content install"; then
+			break
+		fi
+		RETRY_COUNT=$((RETRY_COUNT + 1))
+		if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+			echo "Composer install failed, retrying ($RETRY_COUNT/$MAX_RETRIES)..."
+			sleep 1
+		fi
+	done
+	if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+		echo "Composer install failed after $MAX_RETRIES attempts"
+		exit 1
+	fi
 	./bin/wp-env-cli tests-wordpress "rm wp-content/auth.json"
 	./bin/wp-env-cli tests-wordpress "wp --allow-root plugin activate advanced-custom-fields-pro"
 	./bin/wp-env-cli tests-wordpress "wp --allow-root config set ACF_PRO_LICENSE ${ACF_PRO_LICENSE_KEY}"
@@ -106,6 +121,7 @@ fi
 ./bin/wp-env-cli tests-wordpress "wp --allow-root core multisite-convert"
 
 SITES_COUNT=$(./bin/wp-env-cli tests-wordpress "wp --allow-root site list --format=count")
+echo "SITES_COUNT: $SITES_COUNT"
 if [ $SITES_COUNT -eq 1 ]; then
 	./bin/wp-env-cli tests-wordpress "wp --allow-root site create --slug=second-site --title='Second Site'"
 	./bin/wp-env-cli tests-wordpress "wp --allow-root search-replace localhost/ localhost:8889/ --all-tables"
@@ -115,6 +131,7 @@ fi
 ./bin/wp-env-cli tests-wordpress "wp --allow-root option set home 'http://localhost:8889'"
 ./bin/wp-env-cli tests-wordpress "wp --allow-root option set siteurl 'http://localhost:8889'"
 
+./bin/wp-env-cli tests-wordpress "wp --allow-root plugin activate wordpress-importer"
 ./bin/wp-env-cli tests-wordpress "wp --allow-root import /var/www/html/wp-content/uploads/content-example.xml --authors=create"
 
 ./bin/wp-env-cli tests-wordpress "wp --allow-root plugin deactivate woocommerce elasticpress-proxy"

--- a/bin/wp-env-cli
+++ b/bin/wp-env-cli
@@ -15,7 +15,7 @@ function spawnCommandDirectly({ container, command, dockerComposeConfigPath }) {
 
 	return new Promise((resolve, reject) => {
 		let output = '';
-		const childProc = spawn('docker compose', composeCommand, {
+		const childProc = spawn(`docker compose ${composeCommand.join(' ')}`, {
 			stdio: 'pipe',
 			shell: true,
 			encoding: 'utf-8',

--- a/tests/e2e/src/specs/instant-results.spec.ts
+++ b/tests/e2e/src/specs/instant-results.spec.ts
@@ -36,6 +36,9 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 		await page.keyboard.press('ArrowDown');
 		await page.keyboard.press('Enter');
 		await page.keyboard.press('Escape');
+
+		// Wait 1 second to make sure the filter is added
+		await page.waitForTimeout(1000);
 	};
 
 	const searchFor = async (page: Page, searchTerm: string) => {

--- a/tests/e2e/src/specs/search/search.spec.ts
+++ b/tests/e2e/src/specs/search/search.spec.ts
@@ -98,14 +98,15 @@ test.describe('Post Search Feature', { tag: '@group1' }, () => {
 	});
 
 	test('Can not see any password protected post', async ({ loggedInPage, page }) => {
+		// Reset features. If the Facets/Filters are enabled, the password protected post will not be visible in the homepage.
+		await setDefaultFeatureSettings();
+
 		const postTitle = `Password Protected ${Date.now()}`;
 		await publishPost(loggedInPage, {
 			title: postTitle,
 			password: 'password',
 		});
 
-		// Reset features. If the Facets/Filters are enabled, the password protected post will not be visible in the homepage.
-		await setDefaultFeatureSettings();
 		await page.goto('/');
 		await expect(
 			page.locator('.site-content article h2', { hasText: postTitle }),


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Fix e2e tests

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
