### PR TITLE
Introduce new ep_asciifolding filter

### DIFF
--- a/includes/mappings/comment/7-0.php
+++ b/includes/mappings/comment/7-0.php
@@ -65,14 +65,14 @@ return [
 				'default'          => [
 					'tokenizer' => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'default_search'   => [
 					'tokenizer'   => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'char_filter' => apply_filters( 'ep_default_search_analyzer_char_filters', [ 'html_strip' ] ),
 					/* This filter is documented above */
@@ -90,26 +90,30 @@ return [
 				],
 			],
 			'filter'     => [
-				'shingle_filter' => [
+				'shingle_filter'  => [
 					'type'             => 'shingle',
 					'min_shingle_size' => 2,
 					'max_shingle_size' => 5,
 				],
-				'ewp_snowball'   => [
+				'ewp_snowball'    => [
 					'type'     => 'snowball',
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
-				'edge_ngram'     => [
+				'edge_ngram'      => [
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
 				],
-				'ep_stop'        => [
+				'ep_stop'         => [
 					'type'        => 'stop',
 					'ignore_case' => true,
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
+				'ep_asciifolding' => [
+					'type'              => 'asciifolding',
+					'preserve_original' => true,
 				],
 			],
 			'normalizer' => [

--- a/includes/mappings/comment/initial.php
+++ b/includes/mappings/comment/initial.php
@@ -49,14 +49,14 @@ return [
 				'default'          => [
 					'tokenizer' => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'default_search'   => [
 					'tokenizer'   => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'char_filter' => apply_filters( 'ep_default_search_analyzer_char_filters', [ 'html_strip' ] ),
 					/* This filter is documented above */
@@ -99,6 +99,10 @@ return [
 					'ignore_case' => true,
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
+				'ep_asciifolding'    => [
+					'type'              => 'asciifolding',
+					'preserve_original' => true,
 				],
 			],
 			'normalizer' => [

--- a/includes/mappings/post/5-2.php
+++ b/includes/mappings/post/5-2.php
@@ -49,7 +49,7 @@ return array(
 				'default'          => array(
 					'tokenizer'   => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ) ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'char_filter' => apply_filters( 'ep_default_analyzer_char_filters', array( 'html_strip' ) ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
@@ -58,7 +58,7 @@ return array(
 				'default_search'   => array(
 					'tokenizer'   => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'standard', 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'standard', 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ) ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'char_filter' => apply_filters( 'ep_default_search_analyzer_char_filters', array( 'html_strip' ) ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
@@ -101,6 +101,10 @@ return array(
 					'ignore_case' => true,
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
+				'ep_asciifolding'    => [
+					'type'              => 'asciifolding',
+					'preserve_original' => true,
 				],
 			),
 			'normalizer' => array(

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -72,7 +72,7 @@ return array(
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters
 					 */
-					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ) ),
 					/**
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *
@@ -102,7 +102,7 @@ return array(
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters
 					 */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball' ) ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', array( 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ) ),
 					/**
 					 * Filter Elasticsearch default analyzer's char_filter
 					 *
@@ -127,26 +127,30 @@ return array(
 				),
 			),
 			'filter'     => array(
-				'shingle_filter' => array(
+				'shingle_filter'  => array(
 					'type'             => 'shingle',
 					'min_shingle_size' => 2,
 					'max_shingle_size' => 5,
 				),
-				'ewp_snowball'   => array(
+				'ewp_snowball'    => array(
 					'type'     => 'snowball',
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				),
-				'edge_ngram'     => array(
+				'edge_ngram'      => array(
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
 				),
-				'ep_stop'        => [
+				'ep_stop'         => [
 					'type'        => 'stop',
 					'ignore_case' => true,
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
+				'ep_asciifolding' => [
+					'type'              => 'asciifolding',
+					'preserve_original' => true,
 				],
 			),
 			'normalizer' => array(

--- a/includes/mappings/term/7-0.php
+++ b/includes/mappings/term/7-0.php
@@ -29,14 +29,14 @@ return [
 				'default'          => [
 					'tokenizer' => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'default_search'   => [
 					'tokenizer'   => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'char_filter' => apply_filters( 'ep_default_search_analyzer_char_filters', [ 'html_strip' ] ),
 					/* This filter is documented above */
@@ -54,26 +54,30 @@ return [
 				],
 			],
 			'filter'     => [
-				'shingle_filter' => [
+				'shingle_filter'  => [
 					'type'             => 'shingle',
 					'min_shingle_size' => 2,
 					'max_shingle_size' => 5,
 				],
-				'ewp_snowball'   => [
+				'ewp_snowball'    => [
 					'type'     => 'snowball',
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'language' => apply_filters( 'ep_analyzer_language', 'english', 'filter_ewp_snowball' ),
 				],
-				'edge_ngram'     => [
+				'edge_ngram'      => [
 					'max_gram' => 10,
 					'min_gram' => 3,
 					'type'     => 'edge_ngram',
 				],
-				'ep_stop'        => [
+				'ep_stop'         => [
 					'type'        => 'stop',
 					'ignore_case' => true,
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
+				'ep_asciifolding' => [
+					'type'              => 'asciifolding',
+					'preserve_original' => true,
 				],
 			],
 			'normalizer' => [

--- a/includes/mappings/term/initial.php
+++ b/includes/mappings/term/initial.php
@@ -19,13 +19,13 @@ return [
 				'default'          => [
 					'tokenizer' => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'    => apply_filters( 'ep_default_analyzer_filters', [ 'standard', 'ewp_word_delimiter', 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					'language'  => apply_filters( 'ep_analyzer_language', 'english', 'analyzer_default' ),
 				],
 				'default_search'   => [
 					'tokenizer'   => 'standard',
 					/* This filter is documented in includes/mappings/post/7-0.php */
-					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball' ] ),
+					'filter'      => apply_filters( 'ep_default_search_analyzer_filters', [ 'lowercase', 'ep_stop', 'ewp_snowball', 'ep_asciifolding' ] ),
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'char_filter' => apply_filters( 'ep_default_search_analyzer_char_filters', [ 'html_strip' ] ),
 					/* This filter is documented above */
@@ -68,6 +68,10 @@ return [
 					'ignore_case' => true,
 					/* This filter is documented in includes/mappings/post/7-0.php */
 					'stopwords'   => apply_filters( 'ep_analyzer_language', 'english', 'filter_ep_stop' ),
+				],
+				'ep_asciifolding'    => [
+					'type'              => 'asciifolding',
+					'preserve_original' => true,
 				],
 			],
 			'normalizer' => [

--- a/tests/php/indexables/TestComment.php
+++ b/tests/php/indexables/TestComment.php
@@ -2651,6 +2651,22 @@ class TestComment extends BaseTestCase {
 	}
 
 	/**
+	 * Test the `ep_asciifolding` filter
+	 *
+	 * @since 5.3.3
+	 * @group comment
+	 */
+	public function test_mapping_ep_asciifolding_filter() {
+		$indexable      = ElasticPress\Indexables::factory()->get( 'comment' );
+		$index_name     = $indexable->get_index_name();
+		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
+		$index_settings = $settings[ $index_name ]['settings'];
+
+		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default.filter'] );
+		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default_search.filter'] );
+	}
+
+	/**
 	 * Test comment query with orderby none.
 	 *
 	 * @since 5.3.0

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -9747,8 +9747,27 @@ class TestPost extends BaseTestCase {
 		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
 		$index_settings = $settings[ $index_name ]['settings'];
 
-		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default.filter'] );
-		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default_search.filter'] );
+		$es_version = ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
+		if ( version_compare( $es_version, '7.0', '<' ) ) {
+			// ES5 format: flattened keys like 'index.analysis.analyzer.default.filter.0', '.1', etc.
+			$default_filter_keys = array_filter(
+				$index_settings,
+				fn( $value, $key ) => str_contains( $key, 'index.analysis.analyzer.default.filter.' ),
+				ARRAY_FILTER_USE_BOTH
+			);
+			$this->assertContains( 'ep_asciifolding', $default_filter_keys );
+
+			$default_search_filter_keys = array_filter(
+				$index_settings,
+				fn( $value, $key ) => str_contains( $key, 'index.analysis.analyzer.default_search.filter.' ),
+				ARRAY_FILTER_USE_BOTH
+			);
+			$this->assertContains( 'ep_asciifolding', $default_search_filter_keys );
+
+		} else {
+			$this->assertContains( 'ep_asciifolding', $index_settings['index']['analysis']['analyzer']['default']['filter'] );
+			$this->assertContains( 'ep_asciifolding', $index_settings['index']['analysis']['analyzer']['default_search']['filter'] );
+		}
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -9736,6 +9736,56 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test the `ep_asciifolding` filter
+	 *
+	 * @since 5.3.3
+	 * @group post
+	 */
+	public function test_mapping_ep_asciifolding_filter() {
+		$indexable      = ElasticPress\Indexables::factory()->get( 'post' );
+		$index_name     = $indexable->get_index_name();
+		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
+		$index_settings = $settings[ $index_name ]['settings'];
+
+		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default.filter'] );
+		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default_search.filter'] );
+	}
+
+	/**
+	 * Test the post returns correct with accented characters
+	 *
+	 * @since 5.3.3
+	 * @group post
+	 */
+	public function test_search_handles_accented_characters_correctly() {
+		$post_id_1 = $this->ep_factory->post->create( [ 'post_title' => 'Coöperàtîôn' ] );
+		$post_id_2 = $this->ep_factory->post->create( [ 'post_title' => 'Fiancéé' ] );
+
+		// disable fuzziness
+		add_filter( 'ep_fuzziness', '__return_zero' );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				's' => 'coöperàtîôn',
+			]
+		);
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( $post_id_1, $query->posts[0]->ID );
+
+		$query = new \WP_Query(
+			[
+				's' => 'fiancee',
+			]
+		);
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( $post_id_2, $query->posts[0]->ID );
+	}
+
+	/**
 	 * Test if aggregations are set
 	 *
 	 * @since 5.1.0

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -9765,8 +9765,8 @@ class TestPost extends BaseTestCase {
 			$this->assertContains( 'ep_asciifolding', $default_search_filter_keys );
 
 		} else {
-			$this->assertContains( 'ep_asciifolding', $index_settings['index']['analysis']['analyzer']['default']['filter'] );
-			$this->assertContains( 'ep_asciifolding', $index_settings['index']['analysis']['analyzer']['default_search']['filter'] );
+			$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default.filter'] );
+			$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default_search.filter'] );
 		}
 	}
 

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1899,4 +1899,20 @@ class TestTerm extends BaseTestCase {
 		$index_settings = $settings[ $index_name ]['settings'];
 		$this->assertSame( '_arabic_', $index_settings['index.analysis.filter.ep_stop.stopwords'] );
 	}
+
+	/**
+	 * Test the `ep_asciifolding` filter
+	 *
+	 * @since 5.3.3
+	 * @group term
+	 */
+	public function test_mapping_ep_asciifolding_filter() {
+		$indexable      = ElasticPress\Indexables::factory()->get( 'term' );
+		$index_name     = $indexable->get_index_name();
+		$settings       = ElasticPress\Elasticsearch::factory()->get_index_settings( $index_name );
+		$index_settings = $settings[ $index_name ]['settings'];
+
+		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default.filter'] );
+		$this->assertContains( 'ep_asciifolding', $index_settings['index.analysis.analyzer.default_search.filter'] );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds a new `ep_asciifolding` filter so that words with accented characters can be searched without any issues.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4212

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - An issue where posts were not returned correctly when the search term contained accented characters.
 
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
