### PR TITLE
Fix: Keep the sync running when code outputs directly in the post content

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -44,7 +44,8 @@
         "wp-content/plugins/unsupported-server-software.php": "./tests/e2e/src/wordpress-files/test-plugins/unsupported-server-software.php",
         "wp-content/plugins/unsupported-elasticsearch-version.php": "./tests/e2e/src/wordpress-files/test-plugins/unsupported-elasticsearch-version.php",
         "wp-content/plugins/multiple-required-features.php": "./tests/e2e/src/wordpress-files/test-plugins/multiple-required-features.php",
-        "wp-content/uploads/content-example.xml": "./tests/e2e/src/wordpress-files/test-docs/content-example.xml"
+        "wp-content/uploads/content-example.xml": "./tests/e2e/src/wordpress-files/test-docs/content-example.xml",
+        "wp-content/plugins/echo-shortcode.php": "./tests/e2e/src/wordpress-files/test-plugins/echo-shortcode.php"
       }
     }
   }

--- a/assets/js/sync/src/hooks.js
+++ b/assets/js/sync/src/hooks.js
@@ -20,6 +20,24 @@ export const useIndex = (apiUrl, nonce) => {
 	const abort = useRef(new AbortController());
 	const request = useRef(null);
 
+	/**
+	 * Extract valid JSON from a response body that may contain stray output.
+	 * This is a workaround for plugins that echo the output in the shortcode.
+	 *
+	 * @param {string} responseBody The raw response body.
+	 * @returns {string} The extracted JSON string.
+	 */
+	const extractJson = (responseBody) => {
+		const jsonStart = responseBody.indexOf('{"data"');
+
+		// if not found or is at the beginning, return the entire response body.
+		if (jsonStart === -1 || jsonStart === 0) {
+			return responseBody;
+		}
+
+		return responseBody.substring(jsonStart);
+	};
+
 	const onResponse = useCallback(
 		/**
 		 * Handle the response to the request.
@@ -76,7 +94,7 @@ export const useIndex = (apiUrl, nonce) => {
 			 * Parse the response and throw an error if it fails.
 			 */
 			try {
-				return JSON.parse(responseBody);
+				return JSON.parse(extractJson(responseBody));
 			} catch (e) {
 				/**
 				 * Log the raw response to the console to assist with

--- a/tests/e2e/src/specs/dashboard-sync.spec.ts
+++ b/tests/e2e/src/specs/dashboard-sync.spec.ts
@@ -7,6 +7,7 @@ import {
 	setDefaultFeatureSettings,
 	setPerIndexCycle,
 	wpCli,
+	wpCliEval,
 } from '../utils.js';
 
 const indexNames = process.env?.EP_INDEX_NAMES || [];
@@ -265,5 +266,25 @@ test.describe('Dashboard Sync', { tag: '@group2' }, () => {
 		);
 
 		await deactivatePlugin(loggedInPage, 'sync-error-specific-post', 'wpCli');
+	});
+
+	test('Can sync via Dashboard successfully even when a shortcode outputs content', async ({
+		loggedInPage,
+	}) => {
+		await wpCliEval(`
+			wp_insert_post([
+				'post_title'   => 'Test Post with Echo Shortcode',
+				'post_content' => '[echo-shortcode]',
+				'post_status'  => 'publish',
+			]);
+		`);
+
+		await goToAdminPage(loggedInPage, '/admin.php?page=elasticpress-sync');
+		await loggedInPage.getByRole('button', { name: 'Start sync' }).click();
+
+		await expect(loggedInPage.locator('.ep-sync-progress strong')).toContainText(
+			'Sync complete',
+			{ timeout: getSyncTimeout() },
+		);
 	});
 });

--- a/tests/e2e/src/wordpress-files/test-plugins/echo-shortcode.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/echo-shortcode.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Echo Shortcode
+ * Description: A plugin that outputs a shortcode.
+ * Version:     1.0.0
+ * Author:      ElasticPress
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_shortcode(
+	'echo-shortcode',
+	function () {
+		echo 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum';
+	}
+);


### PR DESCRIPTION
…tent.

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the sync stopped in the dashboard when the post content was output directly.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3328

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Create a shortcode that `echo` the output. 
2. Add the shortcode in the post body.
3. Run the Sync from the dashboard. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Keep the sync running when code outputs directly in the post content.
 
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @tomjn @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
