### PR TITLE
Fix: Ensure cache_results is set to true for Query

### DIFF
--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -116,16 +116,6 @@ class QueryIntegration {
 			return;
 		}
 
-		/**
-		 * `cache_results` defaults to false but can be enabled.
-		 *
-		 * @since 1.5
-		 */
-		$query->set( 'cache_results', false );
-		if ( ! empty( $query->query['cache_results'] ) ) {
-			$query->set( 'cache_results', true );
-		}
-
 		if ( ! headers_sent() ) {
 			/**
 			 * Manually setting a header as $wp_query isn't yet initialized when we

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -3701,12 +3701,12 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
-	 * Test cache_results is off by default
+	 * Test cache_results is on by default
 	 *
 	 * @since 1.5
 	 * @group post
 	 */
-	public function testCacheResultsDefaultOff() {
+	public function testCacheResultsDefaultOn() {
 		$this->ep_factory->post->create();
 
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
@@ -3718,7 +3718,7 @@ class TestPost extends BaseTestCase {
 		$query = new \WP_Query( $args );
 
 		$this->assertTrue( $query->elasticsearch_success );
-		$this->assertFalse( $query->query_vars['cache_results'] );
+		$this->assertTrue( $query->query_vars['cache_results'] );
 	}
 
 	/**
@@ -3784,7 +3784,8 @@ class TestPost extends BaseTestCase {
 		wp_cache_flush();
 
 		$args = array(
-			'ep_integrate' => true,
+			'ep_integrate'  => true,
+			'cache_results' => false,
 		);
 
 		$query = new \WP_Query( $args );
@@ -10385,5 +10386,141 @@ class TestPost extends BaseTestCase {
 			throw new \Exception( 'Something went wrong.' );
 		}
 		return $args;
+	}
+
+	/**
+	 * Test that post meta and term caches are primed after ES query.
+	 *
+	 * @since 5.3.3
+	 * @group post
+	 */
+	public function test_postmeta_and_term_caches_are_primed_after_ESQuery() {
+		global $wpdb;
+
+		$post_ids = $this->ep_factory->post->create_many(
+			2,
+			[
+				'meta_input' => [
+					'test_meta_key' => 'test_value',
+				],
+				'tax_input'  => [
+					'category' => [ $this->ep_factory->category->create() ],
+				],
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		wp_cache_flush();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+				'post__in'     => $post_ids,
+			]
+		);
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertCount( 2, $query->posts );
+
+		// After the query, post meta should be cached and no additional queries should be made.
+		$queries_before = $wpdb->num_queries;
+
+		foreach ( $post_ids as $post_id ) {
+			get_post_meta( $post_id, 'test_meta_key', true );
+		}
+
+		$queries_after = $wpdb->num_queries;
+		$this->assertSame( $queries_before, $queries_after );
+
+		foreach ( $post_ids as $post_id ) {
+			get_the_terms( $post_id, 'category' );
+		}
+
+		$queries_after = $wpdb->num_queries;
+		$this->assertSame( $queries_before, $queries_after );
+	}
+
+	/**
+	 * Test that update_post_meta_cache query arg respects post meta cache.
+	 *
+	 * @since 5.3.3
+	 * @group post
+	 */
+	public function test_update_post_meta_cache_query_arg_respects_post_meta_cache() {
+		global $wpdb;
+
+		$post_ids = $this->ep_factory->post->create_many(
+			2,
+			[
+				'meta_input' => [
+					'test_meta_key' => 'test_value',
+				],
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		wp_cache_flush();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate'           => true,
+				'post__in'               => $post_ids,
+				'update_post_meta_cache' => false,
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertCount( 2, $query->posts );
+
+		$queries_before = $wpdb->num_queries;
+		foreach ( $post_ids as $post_id ) {
+			get_post_meta( $post_id, 'test_meta_key', true );
+		}
+
+		$queries_after = $wpdb->num_queries;
+		$this->assertGreaterThan( $queries_before, $queries_after );
+	}
+
+	/**
+	 * Test that update_post_term_cache query arg respects term cache.
+	 *
+	 * @since 5.3.3
+	 * @group post
+	 */
+	public function test_update_post_term_cache_query_arg_respects_term_cache() {
+		global $wpdb;
+		$post_ids = $this->ep_factory->post->create_many(
+			2,
+			[
+				'tax_input' => [
+					'category' => [ $this->ep_factory->category->create() ],
+				],
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		wp_cache_flush();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate'           => true,
+				'post__in'               => $post_ids,
+				'update_post_term_cache' => false,
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertCount( 2, $query->posts );
+
+		$queries_before = $wpdb->num_queries;
+
+		foreach ( $post_ids as $post_id ) {
+			get_the_terms( $post_id, 'category' );
+		}
+
+		$queries_after = $wpdb->num_queries;
+		$this->assertGreaterThan( $queries_before, $queries_after );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR makes sure that the `cache_results` always set to true

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4206 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable Protected Content. 
2. Search for posts in the admin panel.
3. Ensure that the number of queries is lower than the default WordPress query count

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Ensure that WordPress caches the meta and term queries.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @maciejmackowiak

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
