### PR TITLE
Instant Results: Numbered Pagination

### DIFF
--- a/assets/css/instant-results/pagination-button.css
+++ b/assets/css/instant-results/pagination-button.css
@@ -3,4 +3,12 @@
 	&[disabled] {
 		visibility: hidden;
 	}
+
+	.is-numbered & {
+
+		&.is-current {
+			font-weight: 600;
+		}
+	}
 }
+

--- a/assets/css/instant-results/pagination.css
+++ b/assets/css/instant-results/pagination.css
@@ -4,6 +4,20 @@
 	grid-template-columns: 1fr 1fr 1fr;
 	margin-top: auto;
 	text-align: center;
+
+	&.is-numbered {
+		display: block;
+
+		& .ep-search-pagination__list {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 8px;
+			justify-content: center;
+			list-style: none;
+			margin: 8px 0 0;
+			padding: 0;
+		}
+	}
 }
 
 .rtl .ep-search-pagination {

--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -199,6 +199,16 @@ export const ApiSearchProvider = ({
 	};
 
 	/**
+	 * Set the result offset.
+	 *
+	 * @param {number} offset Result offset.
+	 * @returns {void}
+	 */
+	const setOffset = (offset) => {
+		dispatch({ type: 'SET_OFFSET', offset });
+	};
+
+	/**
 	 * Set search args from popped history state.
 	 *
 	 * @param {object} args Search args.
@@ -366,6 +376,7 @@ export const ApiSearchProvider = ({
 		search,
 		searchFor,
 		setResults,
+		setOffset,
 		nextPage,
 		previousPage,
 		totalResults,

--- a/assets/js/api-search/src/reducer.js
+++ b/assets/js/api-search/src/reducer.js
@@ -89,6 +89,11 @@ export default (state, action) => {
 			newState.args.offset = Math.max(newState.args.offset - newState.args.per_page, 0);
 			break;
 		}
+		case 'SET_OFFSET': {
+			const offset = Number.isFinite(action.offset) ? action.offset : 0;
+			newState.args.offset = Math.max(offset, 0);
+			break;
+		}
 		case 'POP_STATE': {
 			const { isOn, args } = action.args;
 

--- a/assets/js/instant-results/components/layout/results.js
+++ b/assets/js/instant-results/components/layout/results.js
@@ -23,6 +23,7 @@ export default () => {
 		args: { offset, per_page, highlight },
 		nextPage,
 		previousPage,
+		setOffset,
 		searchResults,
 		searchTerm,
 		totalResults,
@@ -45,6 +46,15 @@ export default () => {
 	 */
 	const onPrevious = () => {
 		previousPage();
+	};
+
+	/**
+	 * Handle clicking a page number.
+	 *
+	 * @param {number} page Page number.
+	 */
+	const onPage = (page) => {
+		setOffset((page - 1) * per_page);
 	};
 
 	/**
@@ -103,6 +113,7 @@ export default () => {
 			<Pagination
 				offset={offset}
 				onNext={onNext}
+				onPage={onPage}
 				onPrevious={onPrevious}
 				perPage={per_page}
 				total={totalResults}

--- a/assets/js/instant-results/components/results/pagination.js
+++ b/assets/js/instant-results/components/results/pagination.js
@@ -2,7 +2,13 @@
  * WordPress dependencies.
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { WPElement } from '@wordpress/element';
+import { Component, FunctionComponent, WPElement } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies.
+ */
+import { isNumberedPagination } from '../../config';
 
 /**
  * Search results component.
@@ -11,64 +17,182 @@ import { WPElement } from '@wordpress/element';
  * @param {number} props.offset Current items offset.
  * @param {Function} props.onNext Next button handler.
  * @param {Function} props.onPrevious Previous button handler.
+ * @param {Function} props.onPage Page button handler.
  * @param {number} props.perPage Items per page.
  * @param {number} props.total Total number of items.
  * @returns {WPElement} Element.
  */
-export default ({ offset, onNext, onPrevious, perPage, total }) => {
-	/**
-	 * Current page number.
-	 */
-	const currentPage = (offset + perPage) / perPage;
+const Pagination = ({ offset, onNext, onPage = {}, onPrevious, perPage, total }) => {
+	if (perPage <= 0) {
+		return null;
+	}
 
-	/**
-	 * Whether there are more pages.
-	 */
-	const nextIsAvailable = total > offset + perPage;
-
-	/**
-	 * Whether the are previous pages.
-	 */
-	const previousIsAvailable = offset > 0;
-
-	/**
-	 * Total pages.
-	 */
 	const totalPages = Math.ceil(total / perPage);
+	const isNumbered = isNumberedPagination;
+
+	const createPageItem = (pageNumber) => ({
+		key: `page-${pageNumber}`,
+		type: 'page',
+		value: pageNumber,
+	});
+
+	const createEllipsisItem = (position) => ({
+		key: `ellipsis-${position}`,
+		type: 'ellipsis',
+	});
+
+	const getPageRange = (start, end) => {
+		const pages = [];
+
+		for (let page = start; page <= end; page++) {
+			pages.push(createPageItem(page));
+		}
+
+		return pages;
+	};
+
+	const getPages = (currentPage) => {
+		const maxVisiblePages = 10;
+
+		if (totalPages <= maxVisiblePages) {
+			return getPageRange(1, totalPages);
+		}
+
+		const windowSize = maxVisiblePages - 2;
+		const halfWindow = Math.floor(windowSize / 2);
+		const maxStart = totalPages - windowSize;
+		const start = Math.max(2, Math.min(currentPage - halfWindow, maxStart));
+		const end = Math.min(totalPages - 1, start + windowSize - 1);
+
+		const pages = [createPageItem(1)];
+
+		if (start > 2) {
+			pages.push(createEllipsisItem('start'));
+		}
+
+		pages.push(...getPageRange(start, end));
+
+		if (end < totalPages - 1) {
+			pages.push(createEllipsisItem('end'));
+		}
+
+		pages.push(createPageItem(totalPages));
+
+		return pages;
+	};
+
+	const renderCount = (currentPage) => (
+		<div className="ep-search-pagination__count" role="status">
+			{total > 0 &&
+				sprintf(
+					/* translators: %1$d: current page. %2$d: total pages. */
+					__('Page %1$d of %2$d', 'elasticpress'),
+					currentPage,
+					totalPages,
+				)}
+		</div>
+	);
+
+	const renderButtonNavigation = () => {
+		const currentPage = (offset + perPage) / perPage;
+		const nextIsAvailable = total > offset + perPage;
+		const previousIsAvailable = offset > 0;
+
+		return (
+			<>
+				<div className="ep-search-pagination__previous">
+					<button
+						className="ep-search-pagination-button ep-search-pagination-button--previous"
+						disabled={!previousIsAvailable}
+						onClick={onPrevious}
+						type="button"
+					>
+						{__('Previous', 'elasticpress')}
+					</button>
+				</div>
+
+				{renderCount(currentPage)}
+
+				<div className="ep-search-pagination__next">
+					<button
+						className="ep-search-pagination-button ep-search-pagination-button--next"
+						disabled={!nextIsAvailable}
+						onClick={onNext}
+						type="button"
+					>
+						{__('Next', 'elasticpress')}
+					</button>
+				</div>
+			</>
+		);
+	};
+
+	const renderNumberedNavigation = () => {
+		if (totalPages <= 0) {
+			return null;
+		}
+
+		const rawCurrentPage = Math.floor(offset / perPage) + 1;
+		const currentPage = Math.min(Math.max(rawCurrentPage, 1), totalPages);
+		const pages = getPages(currentPage);
+		const onPageHandler = typeof onPage === 'function' ? onPage : undefined;
+
+		return (
+			<>
+				{renderCount(currentPage)}
+
+				<ul className="ep-search-pagination__list">
+					{pages.map((page) => {
+						if (page.type === 'ellipsis') {
+							return (
+								<li
+									key={page.key}
+									className="ep-search-pagination__item ep-search-pagination__ellipsis"
+								>
+									<span aria-hidden="true">...</span>
+								</li>
+							);
+						}
+
+						const isCurrent = page.value === currentPage;
+
+						return (
+							<li key={page.key} className="ep-search-pagination__item">
+								<button
+									className={`ep-search-pagination-button${isCurrent ? ' is-current' : ''}`}
+									type="button"
+									onClick={() => {
+										if (!isCurrent) {
+											onPageHandler?.(page.value);
+										}
+									}}
+									aria-current={isCurrent ? 'page' : undefined}
+									aria-label={sprintf(__('Page %d', 'elasticpress'), page.value)}
+								>
+									{page.value}
+								</button>
+							</li>
+						);
+					})}
+				</ul>
+			</>
+		);
+	};
 
 	return (
-		<nav className="ep-search-pagination">
-			<div className="ep-search-pagination__previous">
-				<button
-					className="ep-search-pagination-button ep-search-pagination-button--previous"
-					disabled={!previousIsAvailable}
-					onClick={onPrevious}
-					type="button"
-				>
-					{__('Previous', 'elasticpress')}
-				</button>
-			</div>
-
-			<div className="ep-search-pagination__count" role="status">
-				{total > 0 &&
-					sprintf(
-						/* translators: %1$d: current page. %2$d: total pages. */
-						__('Page %1$d of %2$d', 'elasticpress'),
-						currentPage,
-						totalPages,
-					)}
-			</div>
-
-			<div className="ep-search-pagination__next">
-				<button
-					className="ep-search-pagination-button ep-search-pagination-button--next"
-					disabled={!nextIsAvailable}
-					onClick={onNext}
-					type="button"
-				>
-					{__('Next', 'elasticpress')}
-				</button>
-			</div>
+		<nav className={`ep-search-pagination ${isNumbered ? 'is-numbered' : ''}`}>
+			{isNumbered ? renderNumberedNavigation() : renderButtonNavigation()}
 		</nav>
 	);
 };
+
+/**
+ * Filter the Pagination component.
+ *
+ * @filter ep.InstantResults.Pagination
+ * @since 5.3.3
+ *
+ * @param {Component|FunctionComponent} Pagination Pagination component.
+ * @returns {Component|FunctionComponent} Pagination component.
+ */
+export default applyFilters('ep.InstantResults.Pagination', Pagination);

--- a/assets/js/instant-results/components/results/pagination.js
+++ b/assets/js/instant-results/components/results/pagination.js
@@ -52,33 +52,39 @@ const Pagination = ({ offset, onNext, onPage = {}, onPrevious, perPage, total })
 	};
 
 	const getPages = (currentPage) => {
-		const maxVisiblePages = 10;
+		const firstBlock = 5;
+		const lastBlock = 5;
 
-		if (totalPages <= maxVisiblePages) {
+		if (totalPages <= firstBlock + 1) {
 			return getPageRange(1, totalPages);
 		}
 
-		const windowSize = maxVisiblePages - 2;
-		const halfWindow = Math.floor(windowSize / 2);
-		const maxStart = totalPages - windowSize;
-		const start = Math.max(2, Math.min(currentPage - halfWindow, maxStart));
-		const end = Math.min(totalPages - 1, start + windowSize - 1);
-
-		const pages = [createPageItem(1)];
-
-		if (start > 2) {
-			pages.push(createEllipsisItem('start'));
+		if (currentPage <= firstBlock - 1) {
+			return [
+				...getPageRange(1, firstBlock),
+				createEllipsisItem('end'),
+				createPageItem(totalPages),
+			];
 		}
 
-		pages.push(...getPageRange(start, end));
-
-		if (end < totalPages - 1) {
-			pages.push(createEllipsisItem('end'));
+		if (currentPage >= totalPages - (lastBlock - 2)) {
+			return [
+				createPageItem(1),
+				createEllipsisItem('start'),
+				...getPageRange(totalPages - (lastBlock - 1), totalPages),
+			];
 		}
 
-		pages.push(createPageItem(totalPages));
+		const middleStart = currentPage - 1;
+		const middleEnd = currentPage + 1;
 
-		return pages;
+		return [
+			createPageItem(1),
+			createEllipsisItem('start'),
+			...getPageRange(middleStart, middleEnd),
+			createEllipsisItem('end'),
+			createPageItem(totalPages),
+		];
 	};
 
 	const renderCount = (currentPage) => (

--- a/assets/js/instant-results/config.js
+++ b/assets/js/instant-results/config.js
@@ -15,6 +15,7 @@ const {
 	isWooCommerce,
 	locale,
 	matchType,
+	numberedPagination,
 	paramPrefix,
 	postTypeLabels,
 	taxonomyLabels,
@@ -23,6 +24,8 @@ const {
 	showSuggestions,
 	suggestionsBehavior,
 } = window.epInstantResults;
+
+const isNumberedPagination = String(numberedPagination || '0') === '1';
 
 /**
  * Sorting options configuration.
@@ -70,6 +73,7 @@ export {
 	currencyCode,
 	facets,
 	isWooCommerce,
+	isNumberedPagination,
 	locale,
 	matchType,
 	paramPrefix,

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -80,11 +80,12 @@ class InstantResults extends Feature {
 		$this->is_woocommerce = function_exists( 'WC' );
 
 		$this->default_settings = [
-			'highlight_tag'   => 'mark',
-			'facets'          => 'post_type,tax-category,tax-post_tag',
-			'match_type'      => 'all',
-			'term_count'      => '1',
-			'per_page'        => get_option( 'posts_per_page', 6 ),
+			'highlight_tag' => 'mark',
+			'facets' => 'post_type,tax-category,tax-post_tag',
+			'match_type' => 'all',
+			'term_count' => '1',
+			'numbered_pagination' => '0',
+			'per_page' => get_option( 'posts_per_page', 6 ),
 			'search_behavior' => '0',
 		];
 
@@ -240,6 +241,7 @@ class InstantResults extends Feature {
 				'paramPrefix'         => 'ep-',
 				'postTypeLabels'      => $this->get_post_type_labels(),
 				'termCount'           => $this->settings['term_count'],
+				'numberedPagination'  => $this->settings['numbered_pagination'],
 				'requestIdBase'       => Utils\get_request_id_base(),
 				'showSuggestions'     => \ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->is_active(),
 				'suggestionsBehavior' => $this->settings['search_behavior'],
@@ -893,6 +895,13 @@ class InstantResults extends Feature {
 				'help'    => __( 'Enable to show the number of matching results next to filter options.', 'elasticpress' ),
 				'key'     => 'term_count',
 				'label'   => __( 'Show filter counts', 'elasticpress' ),
+				'type'    => 'checkbox',
+			],
+			[
+				'default' => '0',
+				'help'    => __( 'Enable to show numbered pagination links instead of previous/next buttons.', 'elasticpress' ),
+				'key'     => 'numbered_pagination',
+				'label'   => __( 'Numbered pagination', 'elasticpress' ),
 				'type'    => 'checkbox',
 			],
 			[

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -80,13 +80,13 @@ class InstantResults extends Feature {
 		$this->is_woocommerce = function_exists( 'WC' );
 
 		$this->default_settings = [
-			'highlight_tag' => 'mark',
-			'facets' => 'post_type,tax-category,tax-post_tag',
-			'match_type' => 'all',
-			'term_count' => '1',
+			'highlight_tag'       => 'mark',
+			'facets'              => 'post_type,tax-category,tax-post_tag',
+			'match_type'          => 'all',
+			'term_count'          => '1',
 			'numbered_pagination' => '0',
-			'per_page' => get_option( 'posts_per_page', 6 ),
-			'search_behavior' => '0',
+			'per_page'            => get_option( 'posts_per_page', 6 ),
+			'search_behavior'     => '0',
 		];
 
 		$this->settings = $this->get_settings();

--- a/tests/e2e/src/specs/instant-results.spec.ts
+++ b/tests/e2e/src/specs/instant-results.spec.ts
@@ -629,12 +629,8 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 		test('Can use numbered pagination when enabled', async ({ loggedInPage }) => {
 			await maybeEnableFeature('instant-results');
 
-			const perPageRaw = await wpCliEval("echo get_option( 'posts_per_page' );");
-			const perPage = parseInt(perPageRaw.toString(), 10);
-
-			await wpCliEval("update_option( 'posts_per_page', 2 );");
 			await wpCliEval(`
-				for ( $i = 1; $i <= 6; $i++ ) {
+				for ( $i = 1; $i <= 12; $i++ ) {
 					wp_insert_post(
 						[
 							'post_title'   => 'Pagination Test ' . $i,
@@ -644,6 +640,7 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 					);
 				}
 			`);
+			await wpCli('wp elasticpress sync');
 
 			await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress');
 			const apiResponsePromise = loggedInPage.waitForResponse(
@@ -655,10 +652,20 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 			await loggedInPage.getByRole('button', { name: 'Save changes' }).click();
 			await apiResponsePromise;
 
+			const perPageRaw = await wpCliEval(`
+				$settings = get_option( 'ep_feature_settings', [] );
+				echo $settings['instant-results']['per_page'] ?? '';
+			`);
+			const perPage = parseInt(perPageRaw.toString(), 10);
+			if (!perPage) {
+				throw new Error('Instant Results per_page setting not found.');
+			}
+
 			await loggedInPage.goto('/');
-			const responsePromise = instantResultRequestPromise(loggedInPage, 'search=pagination');
+			const responsePromise = instantResultRequestPromise(loggedInPage, 'offset=0');
 			await searchFor(loggedInPage, 'pagination');
 			await responsePromise;
+			await expect(loggedInPage).toHaveURL(/.*ep-offset=0/);
 
 			const pagination = loggedInPage.locator('.ep-search-pagination');
 
@@ -668,12 +675,10 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 			await expect(pagination.getByText('Previous', { exact: true })).toHaveCount(0);
 			await expect(pagination.getByText('Next', { exact: true })).toHaveCount(0);
 
-			const pageTwoResponse = instantResultRequestPromise(loggedInPage, 'offset=2');
+			const pageTwoResponse = instantResultRequestPromise(loggedInPage, `offset=${perPage}`);
 			await pagination.getByRole('button', { name: 'Page 2' }).click();
 			await pageTwoResponse;
-			await expect(loggedInPage).toHaveURL(/.*ep-offset=2/);
-
-			await wpCliEval(`update_option( 'posts_per_page', ${perPage} );`);
+			await expect(loggedInPage).toHaveURL(new RegExp(`ep-offset=${perPage}`));
 			await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress');
 			const apiResponsePromise2 = loggedInPage.waitForResponse(
 				'**/wp-json/elasticpress/v1/features*',

--- a/tests/e2e/src/specs/instant-results.spec.ts
+++ b/tests/e2e/src/specs/instant-results.spec.ts
@@ -625,5 +625,64 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 			 */
 			await expect(loggedInPage.locator('#ep-sort').first()).toHaveValue('date_desc');
 		});
+
+		test('Can use numbered pagination when enabled', async ({ loggedInPage }) => {
+			await maybeEnableFeature('instant-results');
+
+			const perPageRaw = await wpCliEval("echo get_option( 'posts_per_page' );");
+			const perPage = parseInt(perPageRaw.toString(), 10);
+
+			await wpCliEval("update_option( 'posts_per_page', 2 );");
+			await wpCliEval(`
+				for ( $i = 1; $i <= 6; $i++ ) {
+					wp_insert_post(
+						[
+							'post_title'   => 'Pagination Test ' . $i,
+							'post_content' => 'Pagination test content ' . $i,
+							'post_status'  => 'publish',
+						]
+					);
+				}
+			`);
+
+			await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress');
+			const apiResponsePromise = loggedInPage.waitForResponse(
+				'**/wp-json/elasticpress/v1/features*',
+			);
+			await loggedInPage.getByRole('button', { name: 'Live Search' }).click();
+			await loggedInPage.getByRole('button', { name: 'Instant Results' }).click();
+			await loggedInPage.getByRole('checkbox', { name: 'Numbered pagination' }).check();
+			await loggedInPage.getByRole('button', { name: 'Save changes' }).click();
+			await apiResponsePromise;
+
+			await loggedInPage.goto('/');
+			const responsePromise = instantResultRequestPromise(loggedInPage, 'search=pagination');
+			await searchFor(loggedInPage, 'pagination');
+			await responsePromise;
+
+			const pagination = loggedInPage.locator('.ep-search-pagination');
+
+			await expect(pagination.locator('.ep-search-pagination__list')).toBeVisible();
+			await expect(pagination.getByText('1', { exact: true })).toBeVisible();
+			await expect(pagination.getByText('2', { exact: true })).toBeVisible();
+			await expect(pagination.getByText('Previous', { exact: true })).toHaveCount(0);
+			await expect(pagination.getByText('Next', { exact: true })).toHaveCount(0);
+
+			const pageTwoResponse = instantResultRequestPromise(loggedInPage, 'offset=2');
+			await pagination.getByRole('button', { name: 'Page 2' }).click();
+			await pageTwoResponse;
+			await expect(loggedInPage).toHaveURL(/.*ep-offset=2/);
+
+			await wpCliEval(`update_option( 'posts_per_page', ${perPage} );`);
+			await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress');
+			const apiResponsePromise2 = loggedInPage.waitForResponse(
+				'**/wp-json/elasticpress/v1/features*',
+			);
+			await loggedInPage.getByRole('button', { name: 'Live Search' }).click();
+			await loggedInPage.getByRole('button', { name: 'Instant Results' }).click();
+			await loggedInPage.getByRole('checkbox', { name: 'Numbered pagination' }).uncheck();
+			await loggedInPage.getByRole('button', { name: 'Save changes' }).click();
+			await apiResponsePromise2;
+		});
 	});
 });

--- a/tests/php/features/TestInstantResults.php
+++ b/tests/php/features/TestInstantResults.php
@@ -52,7 +52,7 @@ class TestInstantResults extends BaseTestCase {
 		$settings_keys = wp_list_pluck( $settings_schema, 'key' );
 
 		$this->assertSame(
-			[ 'active', 'highlight_tag', 'facets', 'match_type', 'term_count', 'per_page', 'search_behavior' ],
+			[ 'active', 'highlight_tag', 'facets', 'match_type', 'term_count', 'numbered_pagination', 'per_page', 'search_behavior' ],
 			$settings_keys
 		);
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Instant Results currently supports next/prev pagination. This implements a numbered pagination option, toggled off by default, where you can click a specific page to go to.

<img width="500" height="auto" style="object-fit: cover;display: block;" alt="Screenshot 2026-01-23 at 1 23 46 PM" src="https://github.com/user-attachments/assets/6a787248-325a-47c1-9da0-c27c00da0c23" />
<img width="500" height="auto" style="object-fit: cover;display: block;"" alt="Screenshot 2026-01-23 at 1 23 54 PM" src="https://github.com/user-attachments/assets/a9733170-317c-421a-a8d0-2fd0abd975c0" />
<img width="500" height="auto" style="object-fit: cover;display: block;" alt="Screenshot 2026-01-23 at 1 24 08 PM" src="https://github.com/user-attachments/assets/a333fbe3-d78e-413f-ae26-d439e0bf3ea3" />
<img width="500" height="auto" alt="Screenshot 2026-01-23 at 1 50 49 PM" src="https://github.com/user-attachments/assets/abe54c39-56a4-4188-b7bc-ab0d8c1a66b1" />
<br><br>


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4273

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
- Ensure the option is off by default. 
- Enable the option in the Instant Results feature. 
- Add enough sample posts to have multiple pages.
- Confirm pagination works as expected
- Recommended: try with a large enough amount of posts to have 10+ pages. You can try changing ep-per_page to 2 in the url for an easy test.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Numbered pagination option for Instant Results

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ZacharyRener 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
