### PR TITLE
Fix: Taxonomy label were encoded in Instant Results

### DIFF
--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -642,8 +642,8 @@ class InstantResults extends Feature {
 				'type'       => 'taxonomy',
 				'post_types' => $post_types,
 				'labels'     => array(
-					'admin'    => wp_specialchars_decode( $admin_label ),
-					'frontend' => wp_specialchars_decode( $labels->singular_name ),
+					'admin'    => wp_specialchars_decode( $admin_label, ENT_QUOTES ),
+					'frontend' => wp_specialchars_decode( $labels->singular_name, ENT_QUOTES ),
 				),
 				'aggs'       => array(
 					$name => array(

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -642,8 +642,8 @@ class InstantResults extends Feature {
 				'type'       => 'taxonomy',
 				'post_types' => $post_types,
 				'labels'     => array(
-					'admin'    => $admin_label,
-					'frontend' => $labels->singular_name,
+					'admin'    => wp_specialchars_decode( $admin_label ),
+					'frontend' => wp_specialchars_decode( $labels->singular_name ),
 				),
 				'aggs'       => array(
 					$name => array(


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where special characters in taxonomy labels were displayed as encoded HTML instead of rendering correctly.

<img width="506" height="187" alt="image" src="https://github.com/user-attachments/assets/5d31781c-6217-42b2-93e2-7785071e4c98" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4271 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Register a taxonomy with Special Character within the label, like `esc_html__( 'Check & Radio', 'elasticpress' )`
### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Instant Results displayed special characters as HTML encoded text.
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @wparslans

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
