### PR TITLE
fix/4264: Add graceful handling of values incorrect return types

### DIFF
--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -833,6 +833,20 @@ class AdminNotices {
 		 */
 		$notices = apply_filters( 'ep_admin_notices', $this->notices );
 
+		if ( ! is_array( $notices ) ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: Detected variable type. */
+					esc_html__( 'Callbacks of filter hook `ep_admin_notices` must return value of type array, %s detected.', 'elasticpress' ),
+					esc_html( gettype( $notices ) )
+				),
+				'5.3.3'
+			);
+
+			$notices = array();
+		}
+
 		// If the plugin is network-activated and not in the network admin, return the notices whose scope is site.
 		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK && ! is_network_admin() ) {
 			$notices = array_filter(

--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -835,16 +835,16 @@ class AdminNotices {
 
 		if ( ! is_array( $notices ) ) {
 			_doing_it_wrong(
-				__FUNCTION__,
+				__METHOD__,
 				sprintf(
 					/* translators: %s: Detected variable type. */
-					esc_html__( 'Callbacks of filter hook `ep_admin_notices` must return value of type array, %s detected.', 'elasticpress' ),
+					esc_html__( 'Callbacks of filter hook `ep_admin_notices` must return a value of type array, %s detected.', 'elasticpress' ),
 					esc_html( gettype( $notices ) )
 				),
-				'5.3.3'
+				'ElasticPress 5.3.3'
 			);
 
-			$notices = array();
+			$notices = [];
 		}
 
 		// If the plugin is network-activated and not in the network admin, return the notices whose scope is site.

--- a/includes/classes/QueryLogger.php
+++ b/includes/classes/QueryLogger.php
@@ -214,7 +214,7 @@ class QueryLogger {
 	 * @param array $notices Current EP notices
 	 * @return array
 	 */
-	public function maybe_add_notice( array $notices ): array {
+	public function maybe_add_notice( $notices ) {
 		if ( ! current_user_can( Utils\get_capability() ) ) {
 			return $notices;
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Adds graceful handling of values incorrect return types from callbacks of the `ep_admin_notices` filter hook.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4264 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

On `develop`, add this code and visit the wp-admin page. It will throw an error.

```php
add_filter( 'ep_admin_notices', function( $n ) {
	return 50;
} );
```

Switch to the fix branch and run the same code, the notice will be logged in the debug log.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Handle incorrect return types gracefully.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @qudwill @felipeelia @Sidsector9 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
