### PR TITLE
Fix: Use 'ep_' . $indexable->slug . '_sync_kill' to prevent indexing the object

### DIFF
--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -193,7 +193,7 @@ abstract class Feature {
 		/**
 		 * Filter feature requirement status
 		 *
-		 * @hook ep_{indexable_slug}_index_kill
+		 * @hook ep_feature_requirements_status
 		 * @param  {FeatureRequirementStatus} $status Current feature requirement status
 		 * @param {Feature} $feature Current feature
 		 * @since  2.2

--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -576,9 +576,9 @@ class OrdersAutosuggest {
 	 * @param int       $object_id The object ID
 	 * @return null|bool
 	 */
-	public function sync_password_protected_orders( $new_skip, bool $skip, $object_id ) {
+	public function sync_password_protected_orders( $new_skip, $skip, $object_id ) {
 		if ( 'shop_order' === get_post_type( $object_id ) ) {
-			return $skip;
+			return (bool) $skip;
 		}
 
 		return $new_skip;

--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -571,6 +571,7 @@ class OrdersAutosuggest {
 	/**
 	 * Short-circuit the sync for password protected orders.
 	 *
+	 * @since 5.3.3
 	 * @param null|bool $new_skip Short-circuit flag
 	 * @param bool      $skip     Current value of $skip
 	 * @param int       $object_id The object ID

--- a/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
+++ b/includes/classes/Feature/WooCommerce/OrdersAutosuggest.php
@@ -84,6 +84,7 @@ class OrdersAutosuggest {
 		add_action( 'ep_woocommerce_shop_order_search_fields', [ $this, 'set_search_fields' ], 10, 2 );
 		add_filter( 'ep_index_posts_args', [ $this, 'maybe_query_password_protected_posts' ] );
 		add_filter( 'posts_where', [ $this, 'maybe_set_posts_where' ], 10, 2 );
+		add_filter( 'ep_pre_kill_sync_for_password_protected', [ $this, 'sync_password_protected_orders' ], 10, 3 );
 	}
 
 	/**
@@ -104,6 +105,7 @@ class OrdersAutosuggest {
 		remove_action( 'ep_woocommerce_shop_order_search_fields', [ $this, 'set_search_fields' ] );
 		remove_filter( 'ep_index_posts_args', [ $this, 'maybe_query_password_protected_posts' ] );
 		remove_filter( 'posts_where', [ $this, 'maybe_set_posts_where' ] );
+		remove_filter( 'ep_pre_kill_sync_for_password_protected', [ $this, 'sync_password_protected_orders' ] );
 	}
 
 	/**
@@ -564,6 +566,22 @@ class OrdersAutosuggest {
 		];
 
 		return $settings_schema;
+	}
+
+	/**
+	 * Short-circuit the sync for password protected orders.
+	 *
+	 * @param null|bool $new_skip Short-circuit flag
+	 * @param bool      $skip     Current value of $skip
+	 * @param int       $object_id The object ID
+	 * @return null|bool
+	 */
+	public function sync_password_protected_orders( $new_skip, bool $skip, $object_id ) {
+		if ( 'shop_order' === get_post_type( $object_id ) ) {
+			return $skip;
+		}
+
+		return $new_skip;
 	}
 
 	/**

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -1195,7 +1195,7 @@ class IndexHelper {
 		$ep_indexable_index_kill = apply_filters_deprecated(
 			'ep_' . $indexable->slug . '_index_kill',
 			[ false, $indexable_object->ID ],
-			'5.3.3',
+			'ElasticPress 5.3.3',
 			'ep_' . $indexable->slug . '_sync_kill'
 		);
 

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -1191,15 +1191,7 @@ class IndexHelper {
 			'ep_' . $indexable->slug . '_sync_kill'
 		);
 
-		/**
-		 * Conditionally kill indexing for an object
-		 *
-		 * @deprecated 5.3.3 Use ep_{indexable_slug}_sync_kill instead
-		 * @hook ep_{indexable_slug}_index_kill
-		 * @param  {bool} $index True means dont index
-		 * @param  {int} $object_id Object ID
-		 * @return {bool} New value
-		 */
+		/** This filter is documented in includes/classes/Indexable.php */
 		$ep_indexable_index_kill = apply_filters_deprecated(
 			'ep_' . $indexable->slug . '_index_kill',
 			[ false, $indexable_object->ID ],

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -1207,14 +1207,7 @@ class IndexHelper {
 			'ep_' . $indexable->slug . '_sync_kill'
 		);
 
-		/**
-		 * Conditionally kill indexing for an object
-		 *
-		 * @hook ep_{indexable_slug}_sync_kill
-		 * @param  {bool} $kill True means dont sync
-		 * @param  {int} $object_id Object ID
-		 * @return {bool} New value
-		 */
+		/** This filter is documented in includes/classes/Indexable.php */
 		$ep_indexable_sync_kill = apply_filters( 'ep_' . $indexable->slug . '_sync_kill', false, $indexable_object->ID );
 
 		return $ep_item_sync_kill || $ep_indexable_sync_kill || $ep_indexable_index_kill;

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -1178,24 +1178,46 @@ class IndexHelper {
 		 * Filter whether to not sync specific item in dashboard or not
 		 *
 		 * @since  2.1
+		 * @deprecated 5.3.3 Use ep_{indexable_slug}_sync_kill instead
 		 * @hook ep_item_sync_kill
 		 * @param  {boolean} $kill False means dont sync
 		 * @param  {array} $indexable_object Object to sync
 		 * @return {Indexable} Indexable that object belongs to
 		 */
-		$ep_item_sync_kill = apply_filters( 'ep_item_sync_kill', false, $indexable_object, $indexable );
+		$ep_item_sync_kill = apply_filters_deprecated(
+			'ep_item_sync_kill',
+			[ false, $indexable_object, $indexable ],
+			'5.3.3',
+			'ep_' . $indexable->slug . '_sync_kill'
+		);
 
 		/**
-		 * Conditionally kill indexing for a post
+		 * Conditionally kill indexing for an object
 		 *
+		 * @deprecated 5.3.3 Use ep_{indexable_slug}_sync_kill instead
 		 * @hook ep_{indexable_slug}_index_kill
 		 * @param  {bool} $index True means dont index
 		 * @param  {int} $object_id Object ID
 		 * @return {bool} New value
 		 */
-		$ep_indexable_sync_kill = apply_filters( 'ep_' . $indexable->slug . '_index_kill', false, $indexable_object->ID );
+		$ep_indexable_index_kill = apply_filters_deprecated(
+			'ep_' . $indexable->slug . '_index_kill',
+			[ false, $indexable_object->ID ],
+			'5.3.3',
+			'ep_' . $indexable->slug . '_sync_kill'
+		);
 
-		return $ep_item_sync_kill || $ep_indexable_sync_kill;
+		/**
+		 * Conditionally kill indexing for an object
+		 *
+		 * @hook ep_{indexable_slug}_sync_kill
+		 * @param  {bool} $kill True means dont sync
+		 * @param  {int} $object_id Object ID
+		 * @return {bool} New value
+		 */
+		$ep_indexable_sync_kill = apply_filters( 'ep_' . $indexable->slug . '_sync_kill', false, $indexable_object->ID );
+
+		return $ep_item_sync_kill || $ep_indexable_sync_kill || $ep_indexable_index_kill;
 	}
 
 	/**

--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -1187,7 +1187,7 @@ class IndexHelper {
 		$ep_item_sync_kill = apply_filters_deprecated(
 			'ep_item_sync_kill',
 			[ false, $indexable_object, $indexable ],
-			'5.3.3',
+			'ElasticPress 5.3.3',
 			'ep_' . $indexable->slug . '_sync_kill'
 		);
 

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -286,7 +286,7 @@ abstract class Indexable {
 		 * @since  3.0
 		 * @return {bool}  New kill value
 		 */
-		if ( apply_filters_deprecated( 'ep_' . $this->slug . '_index_kill', [ false, $object_id ], '5.3.3', 'ep_' . $this->slug . '_sync_kill' ) ) {
+		if ( apply_filters_deprecated( 'ep_' . $this->slug . '_index_kill', [ false, $object_id ], 'ElasticPress 5.3.3', 'ep_' . $this->slug . '_sync_kill' ) ) {
 			return false;
 		}
 

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -279,13 +279,27 @@ abstract class Indexable {
 		/**
 		 * Conditionally kill indexing on a specific object
 		 *
+		 * @deprecated 5.3.3 Use ep_{indexable_slug}_sync_kill instead
 		 * @hook ep_{indexable_slug}_index_kill
 		 * @param  {bool} $kill True to not index
 		 * @param {int} $object_id Id of object to index
 		 * @since  3.0
 		 * @return {bool}  New kill value
 		 */
-		if ( apply_filters( 'ep_' . $this->slug . '_index_kill', false, $object_id ) ) {
+		if ( apply_filters_deprecated( 'ep_' . $this->slug . '_index_kill', [ false, $object_id ], '5.3.3', 'ep_' . $this->slug . '_sync_kill' ) ) {
+			return false;
+		}
+
+		/**
+		 * Conditionally kill indexing for an object.
+		 *
+		 * @hook ep_{$this->slug}_sync_kill
+		 * @param  {bool} $kill True means dont sync
+		 * @param  {int} $object_id Object ID
+		 * @return {bool} New value
+		 */
+		$ep_indexable_sync_kill = apply_filters( 'ep_' . $this->slug . '_sync_kill', false, $object_id );
+		if ( $ep_indexable_sync_kill ) {
 			return false;
 		}
 

--- a/tests/php/features/TestProtectedContent.php
+++ b/tests/php/features/TestProtectedContent.php
@@ -224,12 +224,12 @@ class TestProtectedContent extends BaseTestCase {
 	}
 
 	/**
-	 * Check if passwords on posts are synced when feature not active
+	 * Check if password protected post is not synced when feature is disabled
 	 *
 	 * @since 4.0.0
 	 * @group protected-content
 	 */
-	public function testNoSyncPasswordedPost() {
+	public function test_password_protected_post_is_not_synced_when_feature_is_disabled() {
 		add_filter( 'ep_post_sync_args', array( $this, 'filter_post_sync_args' ), 10, 1 );
 
 		$post_id = $this->ep_factory->post->create( array( 'post_password' => 'test' ) );
@@ -241,8 +241,7 @@ class TestProtectedContent extends BaseTestCase {
 
 		// Check if password was synced
 		$post = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
-
-		$this->assertArrayNotHasKey( 'post_password', $post );
+		$this->assertEmpty( $post );
 	}
 
 	/**

--- a/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceOrdersAutosuggest.php
@@ -36,7 +36,6 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		ElasticPress\Features::factory()->activate_feature( 'protected_content' );
 		ElasticPress\Features::factory()->activate_feature( 'woocommerce' );
 
 		$this->woocommerce_feature = ElasticPress\Features::factory()->get_registered_feature( 'woocommerce' );
@@ -45,6 +44,11 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 		}
 
 		ElasticPress\Features::factory()->setup_features();
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->reset_sync_queue();
 
 		$this->orders_autosuggest = $this->woocommerce_feature->orders_autosuggest;
 	}
@@ -437,5 +441,47 @@ class TestWooCommerceOrdersAutosuggest extends BaseTestCase {
 	public function test_get_setting_help_message_feature_not_available() {
 		$new_settings_schema = $this->orders_autosuggest->add_settings_schema( [] );
 		$this->assertStringContainsString( 'Due to the sensitive nature of orders', $new_settings_schema[0]['help'] );
+	}
+
+	/**
+	 * Test shop_order with password is synced without Protected Content feature enabled.
+	 *
+	 * @since 5.3.3
+	 * @group woocommerce
+	 * @group woocommerce-orders-autosuggest
+	 */
+	public function test_order_with_password_is_synced() {
+		add_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_true' );
+
+		/**
+		 * Enable the orders autosuggest feature.
+		 */
+		$filter = function () {
+			return [
+				'woocommerce' => [
+					'orders' => '1',
+				],
+			];
+		};
+		add_filter( 'pre_site_option_ep_feature_settings', $filter );
+		add_filter( 'pre_option_ep_feature_settings', $filter );
+
+		$this->orders_autosuggest->setup();
+
+		$order = new \WC_Order();
+		$order->set_order_key( '1234567890' ); // save in the post_password field
+		$order->save();
+
+		$order_id = $order->get_id();
+
+		ElasticPress\Indexables::factory()->get( 'post' )->index( $order_id );
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$order = ElasticPress\Indexables::factory()->get( 'post' )->get( $order_id );
+		$this->assertNotEmpty( $order );
+
+		remove_filter( 'ep_woocommerce_orders_autosuggest_available', '__return_true' );
+		remove_filter( 'pre_option_ep_feature_settings', $filter );
+		remove_filter( 'pre_site_option_ep_feature_settings', $filter );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR ensures that using `ep_' . $indexable->slug . '_sync_kill` is sufficient to prevent the object from being indexed, either through sync or post update.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4278 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - : Ensure ep_{$indexable->slug}_sync_kill properly prevents object indexing during sync and post updates.
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia @matthijsch

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
