### PR TITLE
feat/3494: Add the "Did You Mean" block for Site editor

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -46,7 +46,8 @@
         "wp-content/plugins/unsupported-elasticsearch-version.php": "./tests/e2e/src/wordpress-files/test-plugins/unsupported-elasticsearch-version.php",
         "wp-content/plugins/multiple-required-features.php": "./tests/e2e/src/wordpress-files/test-plugins/multiple-required-features.php",
         "wp-content/uploads/content-example.xml": "./tests/e2e/src/wordpress-files/test-docs/content-example.xml",
-        "wp-content/plugins/echo-shortcode.php": "./tests/e2e/src/wordpress-files/test-plugins/echo-shortcode.php"
+        "wp-content/plugins/echo-shortcode.php": "./tests/e2e/src/wordpress-files/test-plugins/echo-shortcode.php",
+        "wp-content/plugins/enable-did-you-mean-block.php": "./tests/e2e/src/wordpress-files/test-plugins/enable-did-you-mean-block.php"
       }
     }
   }

--- a/assets/js/blocks/did-you-mean/Edit.js
+++ b/assets/js/blocks/did-you-mean/Edit.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies.
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Edit component.
+ *
+ * @returns {Function} Component.
+ */
+const Edit = () => {
+	const blockProps = useBlockProps({
+		className: 'wp-block-elasticpress-did-you-mean',
+	});
+
+	return (
+		<div {...blockProps}>
+			{createInterpolateElement(__('Did you mean <a>Hello</a>?', 'elasticpress'), {
+				a: <a href="#" />, // eslint-disable-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label, jsx-a11y/anchor-is-valid
+			})}
+		</div>
+	);
+};
+
+export default Edit;

--- a/assets/js/blocks/did-you-mean/block.json
+++ b/assets/js/blocks/did-you-mean/block.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "elasticpress/did-you-mean",
+	"title": "Did You Mean",
+	"category": "elasticpress",
+	"description": "Display ElasticPress spelling suggestions for search queries.",
+	"textdomain": "elasticpress",
+	"editorScript": "ep-did-you-mean-block-script"
+}

--- a/assets/js/blocks/did-you-mean/index.js
+++ b/assets/js/blocks/did-you-mean/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies.
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { search } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import Edit from './Edit';
+import { name } from './block.json';
+
+registerBlockType(name, {
+	icon: search,
+	edit: () => <Edit />,
+	save: () => null,
+});

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -8,7 +8,7 @@
 
 namespace ElasticPress\Feature\DidYouMean;
 
-use ElasticPress\{Elasticsearch, Feature, FeatureRequirementsStatus, Features };
+use ElasticPress\{Elasticsearch, Feature, FeatureRequirementsStatus, Utils };
 
 /**
  * Did You Mean feature class.
@@ -61,6 +61,91 @@ class DidYouMean extends Feature {
 		add_filter( 'ep_integrate_search_queries', [ $this, 'set_ep_suggestion' ], 10, 2 );
 		add_action( 'template_redirect', [ $this, 'automatically_redirect_user' ] );
 		add_action( 'ep_suggestions', [ $this, 'the_output' ] );
+
+		if ( $this->is_block_enabled_in_editor() ) {
+			add_action( 'init', [ $this, 'register_block' ] );
+		}
+	}
+
+	/**
+	 * Check if Did You Mean block should be enabled in the editor.
+	 *
+	 * @since 5.4.0
+	 * @return bool
+	 */
+	protected function is_block_enabled_in_editor(): bool {
+		global $pagenow;
+
+		$in_editor = in_array( $pagenow, [ 'post-new.php', 'post.php' ], true );
+
+		/**
+		 * Filter if Did You Mean block should be enabled in the post editor.
+		 *
+		 * @since 5.4.0
+		 * @hook ep_did_you_mean_enabled_in_editor
+		 * @param {bool} $enabled If enabled or not.
+		 * @return {bool} If enabled or not.
+		 */
+		return ! ( $in_editor && ! apply_filters( 'ep_did_you_mean_enabled_in_editor', false ) );
+	}
+
+	/**
+	 * Register Did You Mean block.
+	 *
+	 * @return void
+	 * @since 5.4.0
+	 */
+	public function register_block(): void {
+		/**
+		 * Registering it here so translation works
+		 *
+		 * @see https://core.trac.wordpress.org/ticket/54797#comment:20
+		 */
+		wp_register_script(
+			'ep-did-you-mean-block-script',
+			EP_URL . 'dist/js/did-you-mean-block-script.js',
+			Utils\get_asset_info( 'did-you-mean-block-script', 'dependencies' ),
+			Utils\get_asset_info( 'did-you-mean-block-script', 'version' ),
+			true
+		);
+
+		wp_set_script_translations( 'ep-did-you-mean-block-script', 'elasticpress' );
+
+		register_block_type_from_metadata(
+			EP_PATH . 'assets/js/blocks/did-you-mean',
+			[
+				'render_callback' => [ $this, 'render_block' ],
+			]
+		);
+	}
+
+	/**
+	 * Render Did You Mean block.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string
+	 * @since 5.4.0
+	 */
+	public function render_block( array $attributes = [] ): string {
+		ob_start();
+		do_action( 'ep_suggestions' );
+		$output = ob_get_clean();
+
+		if ( empty( $output ) ) {
+			return '';
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			[
+				'class' => 'wp-block-elasticpress-did-you-mean',
+			]
+		);
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			wp_kses_data( $wrapper_attributes ),
+			wp_kses_post( $output )
+		);
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
       "comments-script": "./assets/js/comments.js",
       "comments-block-script": "./assets/js/blocks/comments/index.js",
       "dashboard-script": "./assets/js/dashboard.js",
+      "did-you-mean-block-script": "./assets/js/blocks/did-you-mean/index.js",
       "facets-script": "./assets/js/facets.js",
       "facets-block-script": "./assets/js/blocks/facets/taxonomy/index.js",
       "facets-date-block-script": "./assets/js/blocks/facets/date/index.js",

--- a/tests/e2e/src/specs/did-you-mean.spec.ts
+++ b/tests/e2e/src/specs/did-you-mean.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../fixtures.js';
+import {
+	activatePlugin,
+	deactivatePlugin,
+	getEditorFrame,
+	goToAdminPage,
+	maybeEnableFeature,
+} from '../utils.js';
+import {
+	closeBlockInserter,
+	getBlocksList,
+	insertBlock,
+	openBlockInserter,
+} from '../block-editor.js';
+
+test.describe('Did You Mean Feature', { tag: '@group2' }, () => {
+	test.beforeAll(async () => {
+		await maybeEnableFeature('did-you-mean');
+	});
+
+	test.beforeEach(async ({ loggedInPage }) => {
+		await activatePlugin(loggedInPage, 'enable-did-you-mean-block', 'wpCli');
+	});
+
+	test.afterEach(async ({ loggedInPage }) => {
+		await deactivatePlugin(loggedInPage, 'enable-did-you-mean-block', 'wpCli');
+	});
+
+	/**
+	 * The block is gated behind the `ep_did_you_mean_enabled_in_editor` filter
+	 * in the post editor (it is intended for the FSE Site Editor). The test
+	 * plugin flips that filter so we can exercise the inserter and the
+	 * placeholder rendering without spinning up a block theme.
+	 */
+	test('Can insert the Did You Mean block and see its placeholder', async ({
+		loggedInPage,
+	}) => {
+		await goToAdminPage(loggedInPage, 'post-new.php');
+
+		await openBlockInserter(loggedInPage);
+		await expect(await getBlocksList(loggedInPage)).toContainText('Did You Mean');
+		await insertBlock(loggedInPage, 'Did You Mean');
+		await closeBlockInserter(loggedInPage);
+
+		const editorFrame = await getEditorFrame(loggedInPage);
+		const block = editorFrame
+			.locator('.wp-block.wp-block-elasticpress-did-you-mean')
+			.first();
+
+		await expect(block).toBeVisible();
+		await expect(block).toContainText('Did you mean Hello?');
+	});
+});

--- a/tests/e2e/src/specs/did-you-mean.spec.ts
+++ b/tests/e2e/src/specs/did-you-mean.spec.ts
@@ -32,9 +32,7 @@ test.describe('Did You Mean Feature', { tag: '@group2' }, () => {
 	 * plugin flips that filter so we can exercise the inserter and the
 	 * placeholder rendering without spinning up a block theme.
 	 */
-	test('Can insert the Did You Mean block and see its placeholder', async ({
-		loggedInPage,
-	}) => {
+	test('Can insert the Did You Mean block and see its placeholder', async ({ loggedInPage }) => {
 		await goToAdminPage(loggedInPage, 'post-new.php');
 
 		await openBlockInserter(loggedInPage);
@@ -43,9 +41,7 @@ test.describe('Did You Mean Feature', { tag: '@group2' }, () => {
 		await closeBlockInserter(loggedInPage);
 
 		const editorFrame = await getEditorFrame(loggedInPage);
-		const block = editorFrame
-			.locator('.wp-block.wp-block-elasticpress-did-you-mean')
-			.first();
+		const block = editorFrame.locator('.wp-block.wp-block-elasticpress-did-you-mean').first();
 
 		await expect(block).toBeVisible();
 		await expect(block).toContainText('Did you mean Hello?');

--- a/tests/e2e/src/wordpress-files/test-plugins/enable-did-you-mean-block.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/enable-did-you-mean-block.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: Enable Did You Mean Block in Editor
+ * Description: Enables the Did You Mean block in the post editor for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_filter( 'ep_did_you_mean_enabled_in_editor', '__return_true' );

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -381,6 +381,61 @@ class TestDidYouMean extends BaseTestCase {
 	}
 
 	/**
+	 * Test Did You Mean block rendering.
+	 */
+	public function testRenderBlock() {
+		global $wp_the_query, $wp_query;
+
+		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				's' => 'teet',
+			]
+		);
+
+		$wp_the_query = $query;
+		$wp_query     = $query;
+
+		$feature = ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' );
+		$feature->register_block();
+
+		$blocks = parse_blocks( '<!-- wp:elasticpress/did-you-mean /-->' );
+		$output = render_block( $blocks[0] );
+
+		$expected = sprintf( '<span class="ep-spell-suggestion">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
+
+		$this->assertStringContainsString( 'wp-block-elasticpress-did-you-mean', $output );
+		$this->assertStringContainsString( $expected, $output );
+	}
+
+	/**
+	 * Test Did You Mean block rendering when no suggestion is available.
+	 */
+	public function testRenderBlockWithoutSuggestion() {
+		global $wp_the_query, $wp_query;
+
+		$this->ep_factory->post->create( [ 'post_content' => 'Test post' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				's' => 'test',
+			]
+		);
+
+		$wp_the_query = $query;
+		$wp_query     = $query;
+
+		$output = ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->render_block();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
 	 * Test maybe_sanitize_suggestion method.
 	 */
 	public function testSuggestionRemovedFromListIfScoreIsLowerThanThreshold() {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Adds a server-side rendered "Did You Mean?" block, which can only be used within the FSE site editor context.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3494 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Activate a block based theme and open the Search Results template in the editor
2. Add the Did You Mean block under or near the search field.
3. Search with a typo in the frontend and wait for the search results page.
4. Verify if you see the "Did you mean: <correct word>?" on the page.

### Screenshots

### Site Editor:

<img width="1704" height="1357" alt="Screenshot 2026-02-17 at 2 50 14 PM" src="https://github.com/user-attachments/assets/b882e59d-d325-418c-9df0-aa44745f974b" />

### Frontend:

<img width="1704" height="1357" alt="Screenshot 2026-02-17 at 2 50 56 PM" src="https://github.com/user-attachments/assets/781454cd-5162-4561-b115-9c20b72c2338" />


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - "Did You Mean" block

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @Sidsector9 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
