### PR TITLE
Assumption safety checks for queried object

### DIFF
--- a/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
@@ -72,10 +72,9 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 		$this->display_count = $instance['displayCount'];
 
 		if ( ! is_search() ) {
+			$post_type = Utils\get_post_type_for_tax_query();
 
-			if ( is_tax() ) {
-				$post_type = get_taxonomy( get_queried_object()->taxonomy )->object_type;
-			} else {
+			if ( empty( $post_type ) ) {
 				$post_type = $wp_query->get( 'post_type' ) ? $wp_query->get( 'post_type' ) : 'post';
 			}
 

--- a/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
+++ b/includes/classes/Feature/Facets/Types/Taxonomy/Renderer.php
@@ -72,7 +72,7 @@ class Renderer extends \ElasticPress\Feature\Facets\Renderer {
 		$this->display_count = $instance['displayCount'];
 
 		if ( ! is_search() ) {
-			$post_type = Utils\get_post_type_for_tax_query();
+			$post_type = Utils\get_post_types_for_tax_query();
 
 			if ( empty( $post_type ) ) {
 				$post_type = $wp_query->get( 'post_type' ) ? $wp_query->get( 'post_type' ) : 'post';

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -246,7 +246,7 @@ class QueryIntegration {
 		 * If not search and not set, default to post. If not set and is search, use searchable post types.
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
-			$tax_post_type = Utils\get_post_type_for_tax_query( $query );
+			$tax_post_type = Utils\get_post_types_for_tax_query( $query );
 
 			if ( ! empty( $tax_post_type ) ) {
 				$query_vars['post_type'] = $tax_post_type;

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -246,13 +246,15 @@ class QueryIntegration {
 		 * If not search and not set default to post. If not set and is search, use searchable post types
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
-			if ( $query->is_tax() && $query->get_queried_object() ) {
-				$query_vars['post_type'] = get_taxonomy( $query->get_queried_object()->taxonomy )->object_type;
-			} elseif ( empty( $query_vars['s'] ) ) {
-				$query_vars['post_type'] = 'post';
-			} else {
-				$query_vars['post_type'] = array_values( get_post_types( array( 'exclude_from_search' => false ) ) );
-			}
+			$query_vars['post_type'] = Utils\get_post_type_for_tax_query( $query );
+		}
+
+		if ( empty( $query_vars['post_type'] ) && ! empty( $query_vars['s'] ) ) {
+			$query_vars['post_type'] = array_values( get_post_types( array( 'exclude_from_search' => false ) ) );
+		}
+
+		if ( empty( $query_vars['post_type'] ) ) {
+			$query_vars['post_type'] = 'post';
 		}
 
 		/**

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -243,18 +243,18 @@ class QueryIntegration {
 		}
 
 		/**
-		 * If not search and not set default to post. If not set and is search, use searchable post types
+		 * If not search and not set default to post. If not set and is search, use searchable post types.
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
-			$query_vars['post_type'] = Utils\get_post_type_for_tax_query( $query );
-		}
+			$tax_post_type = Utils\get_post_type_for_tax_query( $query );
 
-		if ( empty( $query_vars['post_type'] ) && ! empty( $query_vars['s'] ) ) {
-			$query_vars['post_type'] = array_values( get_post_types( array( 'exclude_from_search' => false ) ) );
-		}
-
-		if ( empty( $query_vars['post_type'] ) ) {
-			$query_vars['post_type'] = 'post';
+			if ( ! empty( $tax_post_type ) ) {
+				$query_vars['post_type'] = $tax_post_type;
+			} elseif ( empty( $query_vars['s'] ) ) {
+				$query_vars['post_type'] = 'post';
+			} else {
+				$query_vars['post_type'] = array_values( get_post_types( array( 'exclude_from_search' => false ) ) );
+			}
 		}
 
 		/**

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -243,7 +243,7 @@ class QueryIntegration {
 		}
 
 		/**
-		 * If not search and not set default to post. If not set and is search, use searchable post types.
+		 * If not search and not set, default to post. If not set and is search, use searchable post types.
 		 */
 		if ( empty( $query_vars['post_type'] ) ) {
 			$tax_post_type = Utils\get_post_type_for_tax_query( $query );

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -935,29 +935,34 @@ function is_top_level_admin_context() {
  * Safely resolve the post type(s) for a taxonomy query.
  *
  * Guards against null queried objects, missing taxonomy properties,
- * and deregistered taxonomies that would otherwise cause fatal errors
- * when chaining get_queried_object()->taxonomy through get_taxonomy().
- *
- * Returns null when the query is not a taxonomy query, allowing callers
- * to distinguish "not a tax query" from "tax query that failed to resolve."
+ * deregistered taxonomies, and non-post-type object types that would
+ * otherwise cause unexpected behavior when chaining
+ * get_queried_object()->taxonomy through get_taxonomy().
  *
  * @since 5.3.3
  *
  * @param \WP_Query|null $query Optional. WP_Query instance. Defaults to the global query.
- * @return array|null Post type array on success, null otherwise.
+ * @return array Registered post type names on success, empty array otherwise.
  */
-function get_post_type_for_tax_query( $query = null ) {
-	$is_tax = $query instanceof \WP_Query ? $query->is_tax() : is_tax();
-	if ( ! $is_tax ) {
-		return null;
+function get_post_types_for_tax_query( ?\WP_Query $query = null ): array {
+	if ( null === $query ) {
+		global $wp_query;
+		$query = $wp_query;
 	}
 
-	$queried_object = $query instanceof \WP_Query ? $query->get_queried_object() : get_queried_object();
+	if ( ! $query instanceof \WP_Query || ! $query->is_tax() ) {
+		return [];
+	}
+
+	$queried_object = $query->get_queried_object();
 	if ( ! $queried_object || ! isset( $queried_object->taxonomy ) ) {
-		return null;
+		return [];
 	}
 
 	$taxonomy_object = get_taxonomy( $queried_object->taxonomy );
+	if ( ! $taxonomy_object || ! is_array( $taxonomy_object->object_type ) ) {
+		return [];
+	}
 
-	return $taxonomy_object ? $taxonomy_object->object_type : null;
+	return array_values( array_filter( $taxonomy_object->object_type, 'post_type_exists' ) );
 }

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -930,3 +930,28 @@ function is_top_level_admin_context() {
 	$is_network = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK;
 	return $is_network ? is_network_admin() : is_admin();
 }
+
+/**
+ * Safely resolve the post type(s) for a taxonomy query.
+ *
+ * Guards against null queried objects, missing taxonomy properties,
+ * and deregistered taxonomies that would otherwise cause fatal errors
+ * when chaining get_queried_object()->taxonomy through get_taxonomy().
+ *
+ * @since 5.3.3
+ *
+ * @param \WP_Query|null $query Optional. WP_Query instance. Defaults to the global query.
+ * @return array|string Post type array on success, empty string on failure.
+ */
+function get_post_type_for_tax_query( $query = null ) {
+	$is_tax         = $query instanceof \WP_Query ? $query->is_tax() : is_tax();
+	$queried_object = $query instanceof \WP_Query ? $query->get_queried_object() : get_queried_object();
+
+	if ( ! $is_tax || ! $queried_object || ! isset( $queried_object->taxonomy ) ) {
+		return '';
+	}
+
+	$taxonomy_object = get_taxonomy( $queried_object->taxonomy );
+
+	return $taxonomy_object ? $taxonomy_object->object_type : '';
+}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -944,10 +944,13 @@ function is_top_level_admin_context() {
  * @return array|string Post type array on success, empty string on failure.
  */
 function get_post_type_for_tax_query( $query = null ) {
-	$is_tax         = $query instanceof \WP_Query ? $query->is_tax() : is_tax();
-	$queried_object = $query instanceof \WP_Query ? $query->get_queried_object() : get_queried_object();
+	$is_tax = $query instanceof \WP_Query ? $query->is_tax() : is_tax();
+	if ( ! $is_tax ) {
+		return '';
+	}
 
-	if ( ! $is_tax || ! $queried_object || ! isset( $queried_object->taxonomy ) ) {
+	$queried_object = $query instanceof \WP_Query ? $query->get_queried_object() : get_queried_object();
+	if ( ! $queried_object || ! isset( $queried_object->taxonomy ) ) {
 		return '';
 	}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -941,7 +941,7 @@ function is_top_level_admin_context() {
  * Returns null when the query is not a taxonomy query, allowing callers
  * to distinguish "not a tax query" from "tax query that failed to resolve."
  *
- * @since 5.3.0
+ * @since 5.3.3
  *
  * @param \WP_Query|null $query Optional. WP_Query instance. Defaults to the global query.
  * @return array|null Post type array on success, null otherwise.

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -945,8 +945,9 @@ function is_top_level_admin_context() {
  * @return array Registered post type names on success, empty array otherwise.
  */
 function get_post_types_for_tax_query( ?\WP_Query $query = null ): array {
+	global $wp_query;
+
 	if ( null === $query ) {
-		global $wp_query;
 		$query = $wp_query;
 	}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -938,23 +938,26 @@ function is_top_level_admin_context() {
  * and deregistered taxonomies that would otherwise cause fatal errors
  * when chaining get_queried_object()->taxonomy through get_taxonomy().
  *
- * @since 5.3.3
+ * Returns null when the query is not a taxonomy query, allowing callers
+ * to distinguish "not a tax query" from "tax query that failed to resolve."
+ *
+ * @since 5.3.0
  *
  * @param \WP_Query|null $query Optional. WP_Query instance. Defaults to the global query.
- * @return array|string Post type array on success, empty string on failure.
+ * @return array|null Post type array on success, null otherwise.
  */
 function get_post_type_for_tax_query( $query = null ) {
 	$is_tax = $query instanceof \WP_Query ? $query->is_tax() : is_tax();
 	if ( ! $is_tax ) {
-		return '';
+		return null;
 	}
 
 	$queried_object = $query instanceof \WP_Query ? $query->get_queried_object() : get_queried_object();
 	if ( ! $queried_object || ! isset( $queried_object->taxonomy ) ) {
-		return '';
+		return null;
 	}
 
 	$taxonomy_object = get_taxonomy( $queried_object->taxonomy );
 
-	return $taxonomy_object ? $taxonomy_object->object_type : '';
+	return $taxonomy_object ? $taxonomy_object->object_type : null;
 }

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -625,17 +625,17 @@ class TestUtils extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_post_type_for_tax_query does not error when is_tax is true
+	 * Test get_post_types_for_tax_query does not error when is_tax is true
 	 * but the queried object is invalid.
 	 *
 	 * @since 5.3.3
 	 * @group utils
 	 */
-	public function test_get_post_type_for_tax_query_invalid_queried_object() {
+	public function test_get_post_types_for_tax_query_invalid_queried_object() {
 		$query                 = new \WP_Query();
 		$query->is_tax         = true;
 		$query->queried_object = new \stdClass();
 
-		$this->assertNull( Utils\get_post_type_for_tax_query( $query ) );
+		$this->assertSame( [], Utils\get_post_types_for_tax_query( $query ) );
 	}
 }

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -623,4 +623,19 @@ class TestUtils extends BaseTestCase {
 			$this->assertTrue( Utils\is_top_level_admin_context() );
 		}
 	}
+
+	/**
+	 * Test get_post_type_for_tax_query does not error when is_tax is true
+	 * but the queried object is invalid.
+	 *
+	 * @since 5.3.3
+	 * @group utils
+	 */
+	public function test_get_post_type_for_tax_query_invalid_queried_object() {
+		$query                 = new \WP_Query();
+		$query->is_tax         = true;
+		$query->queried_object = new \stdClass();
+
+		$this->assertSame( '', Utils\get_post_type_for_tax_query( $query ) );
+	}
 }

--- a/tests/php/TestUtils.php
+++ b/tests/php/TestUtils.php
@@ -636,6 +636,6 @@ class TestUtils extends BaseTestCase {
 		$query->is_tax         = true;
 		$query->queried_object = new \stdClass();
 
-		$this->assertSame( '', Utils\get_post_type_for_tax_query( $query ) );
+		$this->assertNull( Utils\get_post_type_for_tax_query( $query ) );
 	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #3331 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Error when trying to use queried object that doesn't exist

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @tomjn @ZacharyRener 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
