### PR TITLE
fix/4159: Fix sync indexing all public meta when Post Search is disabled

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -12,6 +12,7 @@ use WP_Query;
 use WP_User;
 use ElasticPress\Elasticsearch;
 use ElasticPress\Indexable;
+use ElasticPress\Feature\Search\Weighting;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	// @codeCoverageIgnoreStart
@@ -852,8 +853,10 @@ class Post extends Indexable {
 	public function filter_allowed_metas( $metas, $post ) {
 		$filtered_metas = [];
 
-		$search = \ElasticPress\Features::factory()->get_registered_feature( 'search' );
-		if ( $search && ! empty( $search->weighting ) && 'manual' === $search->weighting->get_meta_mode() ) {
+		$search    = \ElasticPress\Features::factory()->get_registered_feature( 'search' );
+		$weighting = ( $search && ! empty( $search->weighting ) ) ? $search->weighting : new Weighting();
+
+		if ( 'manual' === $weighting->get_meta_mode() ) {
 			$filtered_metas = $this->filter_allowed_metas_manual( $metas, $post );
 		} else {
 			$filtered_metas = $this->filter_allowed_metas_auto( $metas, $post );
@@ -2552,8 +2555,10 @@ class Post extends Indexable {
 			return $filtered_metas;
 		}
 
-		$weighting     = $search_feature->weighting->get_weighting_configuration_with_defaults();
-		$is_searchable = in_array( $search_feature, $search_feature->get_searchable_post_types(), true );
+		$weighting_obj = ( $search_feature && ! empty( $search_feature->weighting ) ) ? $search_feature->weighting : new \ElasticPress\Feature\Search\Weighting();
+		$weighting     = $weighting_obj->get_weighting_configuration_with_defaults();
+		$is_searchable = $search_feature && in_array( $post->post_type, $search_feature->get_searchable_post_types(), true );
+
 		if ( empty( $weighting[ $post->post_type ] ) && $is_searchable ) {
 			return $filtered_metas;
 		}

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -4041,6 +4041,40 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test that filter_allowed_metas keeps manual mode when the Search
+	 * feature is disabled (its `weighting` property is unavailable).
+	 *
+	 * @since 5.4.0
+	 * @group post
+	 */
+	public function testPrepareMetaWithSearchDisabled() {
+		if ( $this->is_network_activate() ) {
+			$this->markTestSkipped();
+		}
+
+		$search             = ElasticPress\Features::factory()->get_registered_feature( 'search' );
+		$original_weighting = $search->weighting;
+		$search->weighting  = null;
+
+		$post_id = $this->ep_factory->post->create(
+			[
+				'meta_input' => [
+					'test_key1'        => 'allowed value',
+					'not_allowed_key1' => 'disallowed value',
+				],
+			]
+		);
+
+		$post          = get_post( $post_id );
+		$prepared_meta = ElasticPress\Indexables::factory()->get( 'post' )->prepare_meta( $post );
+
+		$this->assertArrayHasKey( 'test_key1', $prepared_meta );
+		$this->assertArrayNotHasKey( 'not_allowed_key1', $prepared_meta );
+
+		$search->weighting = $original_weighting;
+	}
+
+	/**
 	 * Helper method for filtering private meta keys
 	 *
 	 * @param  array $meta_keys Meta keys


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

- When the "Post Search" feature is disabled, `$search->weighting` is null because `Search::setup()` never runs. This caused `filter_allowed_metas()` to fall through to `filter_allowed_metas_auto()`, indexing all public meta.
- Fix by instantiating a fallback Weighting object when `$search->weighting` is unavailable, so `get_meta_mode()` still returns 'manual'.
- Apply the same fallback in `filter_allowed_metas_manual()` to prevent a fatal error when accessing `$search_feature->weighting` while Search is disabled.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4159 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - sync indexing all public meta when Post Search is disabled

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @Sidsector9 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
