### PR TITLE
Optimize mb_strlen calls during sync process

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -563,9 +563,9 @@ abstract class Indexable {
 
 		$results = [];
 
-		$body = [];
+		$body              = [];
 		$current_body_size = 0;
-		$requests = 0;
+		$requests          = 0;
 
 		/*
 		 * This script will use two main arrays: $body and $documents, being $body the
@@ -574,8 +574,8 @@ abstract class Indexable {
 		 * a buffer as small as possible.
 		 */
 		do {
-			$next_document = array_shift( $documents );
-			$next_document_size = mb_strlen( $next_document );
+			$next_document          = array_shift( $documents );
+			$next_document_size     = mb_strlen( $next_document );
 			$has_buffered_documents = count( $body ) > 0;
 
 			// If the next document alone takes the entire current buffer size,
@@ -596,7 +596,7 @@ abstract class Indexable {
 					continue;
 				}
 
-				$body[] = $next_document;
+				$body[]             = $next_document;
 				$current_body_size += $next_document_size;
 
 				$can_add_more_documents = ( $current_body_size < $current_buffer_size && ! empty( $documents ) );
@@ -606,7 +606,7 @@ abstract class Indexable {
 
 				if ( $current_body_size > $max_buffer_size ) {
 					// The last document added to body made it too big, so let's give it back.
-					$removed_document = array_pop( $body );
+					$removed_document   = array_pop( $body );
 					$current_body_size -= mb_strlen( $removed_document );
 					array_unshift( $documents, $removed_document );
 				}
@@ -649,9 +649,9 @@ abstract class Indexable {
 				}
 
 				if ( count( $body ) === 1 ) {
-					$max_buffer_size = min( $max_buffer_size, $current_body_size );
-					$results[]       = $result;
-					$body            = [];
+					$max_buffer_size   = min( $max_buffer_size, $current_body_size );
+					$results[]         = $result;
+					$body              = [];
 					$current_body_size = 0;
 					continue;
 				}
@@ -663,7 +663,7 @@ abstract class Indexable {
 				}
 
 				// We have a too big buffer. Remove one doc from the body, and set both max and current as its size.
-				$removed_document = array_pop( $body );
+				$removed_document   = array_pop( $body );
 				$current_body_size -= mb_strlen( $removed_document );
 				array_unshift( $documents, $removed_document );
 
@@ -682,7 +682,7 @@ abstract class Indexable {
 
 			$results[] = $result;
 
-			$body = [];
+			$body              = [];
 			$current_body_size = 0;
 		} while ( ! empty( $documents ) );
 

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -564,7 +564,7 @@ abstract class Indexable {
 		$results = [];
 
 		$body = [];
-
+		$current_body_size = 0;
 		$requests = 0;
 
 		/*
@@ -575,13 +575,15 @@ abstract class Indexable {
 		 */
 		do {
 			$next_document = array_shift( $documents );
+			$next_document_size = mb_strlen( $next_document );
+			$has_buffered_documents = count( $body ) > 0;
 
 			// If the next document alone takes the entire current buffer size,
 			// let's add it back to the pipe and send what we have first
-			if ( mb_strlen( $next_document ) > $current_buffer_size && count( $body ) > 0 ) {
+			if ( $next_document_size > $current_buffer_size && $has_buffered_documents ) {
 				array_unshift( $documents, $next_document );
 			} else {
-				if ( mb_strlen( $next_document ) > $max_buffer_size ) {
+				if ( $next_document_size > $max_buffer_size ) {
 					/**
 					 * Perform actions when a post is bigger than the max buffer size.
 					 *
@@ -593,13 +595,20 @@ abstract class Indexable {
 					$results[] = new \WP_Error( 'ep_too_big_request_skipped', 'Indexable too big. Request not sent.' );
 					continue;
 				}
+
 				$body[] = $next_document;
-				if ( mb_strlen( implode( '', $body ) ) < $current_buffer_size && ! empty( $documents ) ) {
+				$current_body_size += $next_document_size;
+
+				$can_add_more_documents = ( $current_body_size < $current_buffer_size && ! empty( $documents ) );
+				if ( $can_add_more_documents ) {
 					continue;
 				}
-				if ( mb_strlen( implode( '', $body ) ) > $max_buffer_size ) {
+
+				if ( $current_body_size > $max_buffer_size ) {
 					// The last document added to body made it too big, so let's give it back.
-					array_unshift( $documents, array_pop( $body ) );
+					$removed_document = array_pop( $body );
+					$current_body_size -= mb_strlen( $removed_document );
+					array_unshift( $documents, $removed_document );
 				}
 			}
 
@@ -626,35 +635,40 @@ abstract class Indexable {
 
 			// It failed, possibly adjust the buffer size and try again.
 			if ( is_wp_error( $result ) ) {
+				$error_code = $result->get_error_code();
+
 				// Too many requests, wait and try again.
-				if ( 429 === $result->get_error_code() ) {
+				if ( 429 === $error_code ) {
 					sleep( 2 );
 				}
 
 				// If the error is not a "Request too big" then we really fail this batch of documents.
-				if ( 413 !== $result->get_error_code() ) {
+				if ( 413 !== $error_code ) {
 					$results[] = $result;
 					continue;
 				}
 
 				if ( count( $body ) === 1 ) {
-					$max_buffer_size = min( $max_buffer_size, mb_strlen( implode( '', $body ) ) );
+					$max_buffer_size = min( $max_buffer_size, $current_body_size );
 					$results[]       = $result;
 					$body            = [];
+					$current_body_size = 0;
 					continue;
 				}
 
 				// As the buffer is as small as possible, return the error.
-				if ( mb_strlen( implode( '', $body ) ) === $min_buffer_size ) {
+				if ( $current_body_size === $min_buffer_size ) {
 					$results[] = $result;
 					continue;
 				}
 
 				// We have a too big buffer. Remove one doc from the body, and set both max and current as its size.
-				array_unshift( $documents, array_pop( $body ) );
+				$removed_document = array_pop( $body );
+				$current_body_size -= mb_strlen( $removed_document );
+				array_unshift( $documents, $removed_document );
 
 				$max_buffer_size = count( $body ) ?
-					max( $min_buffer_size, mb_strlen( implode( '', $body ) ) ) :
+					max( $min_buffer_size, $current_body_size ) :
 					$min_buffer_size;
 
 				$current_buffer_size = $max_buffer_size;
@@ -662,13 +676,14 @@ abstract class Indexable {
 			}
 
 			// Things worked so we can try to bump the buffer size.
-			if ( $current_buffer_size < $max_buffer_size && mb_strlen( implode( '', $body ) ) > $current_buffer_size ) {
+			if ( $current_buffer_size < $max_buffer_size && $current_body_size > $current_buffer_size ) {
 				$current_buffer_size = min( ( $current_buffer_size + $incremental_step ), $max_buffer_size );
 			}
 
 			$results[] = $result;
 
 			$body = [];
+			$current_body_size = 0;
 		} while ( ! empty( $documents ) );
 
 		/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4293

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Optimize mb_strlen calls during sync process

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kasparsd

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
