### PR TITLE
Fix: Settings notice layout issue

### DIFF
--- a/assets/js/features/style.css
+++ b/assets/js/features/style.css
@@ -10,8 +10,11 @@
 
 	& .components-notice__actions {
 		display: inline-flex;
-		margin-left: 6px;
 		margin-top: 0;
+
+		& .is-link {
+			margin-left: 12px;
+		}
 	}
 
 	& .components-checkbox-control:has([disabled]) {

--- a/assets/js/features/style.css
+++ b/assets/js/features/style.css
@@ -10,6 +10,8 @@
 
 	& .components-notice__actions {
 		display: inline-flex;
+		margin-left: 6px;
+		margin-top: 0;
 	}
 
 	& .components-checkbox-control:has([disabled]) {
@@ -21,7 +23,7 @@
 	}
 
 	& .components-base-control:not(:focus-within) {
-		
+
 		& .components-form-toggle__track,
 		& .components-form-toggle__thumb {
 			transition: none;
@@ -125,7 +127,7 @@
 }
 
 .ep-dashboard-tab {
-	
+
 	/* Base tab styling */
 	align-items: center;
 	background: transparent;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes a styling issue where the notice on the settings page during sync does not look good in WordPress 7.0. The fix ensures there is no visual change. The appearance remains the same as it does in WordPress 6.9.

Before
<img width="864" height="231" alt="image" src="https://github.com/user-attachments/assets/68bcc889-3437-45e4-ad7d-f6a28794811c" />

After
<img width="864" height="231" alt="image" src="https://github.com/user-attachments/assets/3224065d-c6eb-4753-843a-4cdca45716f9" />

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Settings notice layout issue

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
