### PR TITLE
upkeep/4286 : add crate-ci/typos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@
 /.husky export-ignore
 /.lintstagedrc.json export-ignore
 /.stylelintrc export-ignore
+/.typos.toml export-ignore
 /.wp-env.json export-ignore
 /CHANGELOG.md export-ignore
 /CODE_OF_CONDUCT.md export-ignore

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   typos:
     name: Spell check

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,17 @@
+name: Typos
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  typos:
+    name: Spell check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run typos
+        uses: crate-ci/typos@master

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,4 +1,4 @@
-name: Typos
+name: Spell Check
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   typos:
-    name: Spell check
+    name: Typos
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.typos.toml
+++ b/.typos.toml
@@ -17,15 +17,6 @@ extend-ignore-re = [
     "Tung Du",
     "Van Patten",
     "github:[^\"\\s]+",
-    "'[a-z][a-zA-Z0-9_]*'",
-    "\"[a-z][a-zA-Z0-9_]*\"",
-]
-# Only flag typos in standalone words. Compound identifiers (snake_case,
-# kebab-case, camelCase, PascalCase mixed) often contain WordPress or
-# Elasticsearch terminology baked into public APIs that can't be renamed.
-extend-ignore-identifiers-re = [
-    ".*[_-].*",
-    ".*[a-z][A-Z].*",
 ]
 
 [default.extend-words]
@@ -39,7 +30,8 @@ extend-ignore-identifiers-re = [
 "degister" = "deregister"
 "quries" = "queries"
 "supposably" = "supposably"
+"stati" = "stati"
 
 [default.extend-identifiers]
 "Automattic" = "Automattic"
-"stati" = "stati"
+"avaiableServices" = "avaiableServices"

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,8 +5,10 @@ extend-exclude = [
     "vendor/",
     "dist/",
     "build/",
-    "tests/",
     "lang/",
+    "tests/e2e/src/wordpress-files/test-docs/content-example.xml",
+    "tests/e2e/src/fixtures/txt-file.txt",
+    "tests/e2e/src/fixtures/csv-file.csv",
 ]
 ignore-hidden = false
 
@@ -17,6 +19,7 @@ extend-ignore-re = [
     "Tung Du",
     "Van Patten",
     "github:[^\"\\s]+",
+    "not so good match - beautful",
 ]
 
 [default.extend-words]

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,35 @@
+[files]
+extend-exclude = [
+    ".git/",
+    "node_modules/",
+    "vendor/",
+    "dist/",
+    "build/",
+    "tests/",
+]
+ignore-hidden = false
+
+[default]
+extend-ignore-re = [
+    "@[A-Za-z0-9_-]+",
+]
+
+[default.extend-words]
+# Casing conventions for proper nouns
+"Wordpress" = "WordPress"
+"wordPress" = "WordPress"
+"ElasticSearch" = "Elasticsearch"
+"Github" = "GitHub"
+
+# Typos previously found in this codebase
+"utilitary" = "utility"
+"heirarchal" = "hierarchical"
+"mimcs" = "mimics"
+"santitize" = "sanitize"
+"warnngs" = "warnings"
+"versino" = "version"
+"degister" = "deregister"
+"quries" = "queries"
+
+[default.extend-identifiers]
+"Automattic" = "Automattic"

--- a/.typos.toml
+++ b/.typos.toml
@@ -38,6 +38,7 @@ extend-ignore-identifiers-re = [
 "versino" = "version"
 "degister" = "deregister"
 "quries" = "queries"
+"supposably" = "supposably"
 
 [default.extend-identifiers]
 "Automattic" = "Automattic"

--- a/.typos.toml
+++ b/.typos.toml
@@ -6,21 +6,28 @@ extend-exclude = [
     "dist/",
     "build/",
     "tests/",
+    "lang/",
 ]
 ignore-hidden = false
 
 [default]
 extend-ignore-re = [
     "@[A-Za-z0-9_-]+",
+    "Fabian Marz",
+    "Tung Du",
+    "github:[^\"\\s]+",
+    "'[a-z][a-zA-Z0-9_]*'",
+    "\"[a-z][a-zA-Z0-9_]*\"",
+]
+# Only flag typos in standalone words. Compound identifiers (snake_case,
+# kebab-case, camelCase, PascalCase mixed) often contain WordPress or
+# Elasticsearch terminology baked into public APIs that can't be renamed.
+extend-ignore-identifiers-re = [
+    ".*[_-].*",
+    ".*[a-z][A-Z].*",
 ]
 
 [default.extend-words]
-# Casing conventions for proper nouns
-"Wordpress" = "WordPress"
-"wordPress" = "WordPress"
-"ElasticSearch" = "Elasticsearch"
-"Github" = "GitHub"
-
 # Typos previously found in this codebase
 "utilitary" = "utility"
 "heirarchal" = "hierarchical"
@@ -33,3 +40,4 @@ extend-ignore-re = [
 
 [default.extend-identifiers]
 "Automattic" = "Automattic"
+"stati" = "stati"

--- a/.typos.toml
+++ b/.typos.toml
@@ -15,6 +15,7 @@ extend-ignore-re = [
     "@[A-Za-z0-9_-]+",
     "Fabian Marz",
     "Tung Du",
+    "Van Patten",
     "github:[^\"\\s]+",
     "'[a-z][a-zA-Z0-9_]*'",
     "\"[a-z][a-zA-Z0-9_]*\"",

--- a/assets/js/blocks/facets/meta-range/view.js
+++ b/assets/js/blocks/facets/meta-range/view.js
@@ -63,7 +63,7 @@ const App = ({ max, min }) => {
 	 *
 	 * @param {Array} value Value range.
 	 * @param {number} value.0 Minimum value.
-	 * @param {number} value.1 Mximum value.
+	 * @param {number} value.1 Maximum value.
 	 * @returns {void}
 	 */
 	const onChange = ([from, to]) => {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Adds [crate-ci/typos](https://github.com/crate-ci/typos) as a CI check on pull requests to `develop`. Includes a `.typos.toml` with project-specific casing rules (`WordPress`, `Elasticsearch`, `GitHub`), corrections for typos previously fixed in #4248, and `Automattic` as an allowlisted identifier.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4286

Log: https://github.com/10up/ElasticPress/actions/runs/25127129416/job/73643095680

<img width="1281" height="800" alt="Screenshot 2026-04-30 at 12 09 35 AM" src="https://github.com/user-attachments/assets/08e7860a-ea97-476b-abe1-9a7b952836ec" />

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Spell-checking with `crate-ci/typos` in CI

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @szepeviktor @felipeelia @Sidsector9 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
