### PR TITLE
fix(i18n): resolve translation warnings in make-pot

### DIFF
--- a/assets/js/features/components/control.js
+++ b/assets/js/features/components/control.js
@@ -162,14 +162,14 @@ const Control = ({
 		}
 		if (titles.length === 2) {
 			return sprintf(
-				/* translators: %1$s: first feature name, %2$s: second feature name */
+				/* translators: %1$s: feature name(s), %2$s: last feature name */
 				__('%1$s and %2$s', 'elasticpress'),
 				titles[0],
 				titles[1],
 			);
 		}
 		return sprintf(
-			/* translators: %1$s: comma-separated list of feature names, %2$s: last feature name */
+			/* translators: %1$s: feature name(s), %2$s: last feature name */
 			__('%1$s and %2$s', 'elasticpress'),
 			titles.slice(0, -1).join(__(', ', 'elasticpress')),
 			titles[titles.length - 1],

--- a/assets/js/features/components/control.js
+++ b/assets/js/features/components/control.js
@@ -162,14 +162,14 @@ const Control = ({
 		}
 		if (titles.length === 2) {
 			return sprintf(
-				/* translators: %1$s: feature name(s), %2$s: last feature name */
+				/* translators: %1$s: feature name, %2$s: last feature name */
 				_x('%1$s and %2$s', 'two feature names', 'elasticpress'),
 				titles[0],
 				titles[1],
 			);
 		}
 		return sprintf(
-			/* translators: %1$s: feature name(s), %2$s: last feature name */
+			/* translators: %1$s: feature names, %2$s: last feature name */
 			_x('%1$s and %2$s', 'multiple feature names', 'elasticpress'),
 			titles.slice(0, -1).join(__(', ', 'elasticpress')),
 			titles[titles.length - 1],

--- a/assets/js/features/components/control.js
+++ b/assets/js/features/components/control.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 import { safeHTML } from '@wordpress/dom';
 import { RawHTML, WPElement } from '@wordpress/element';
-import { _n, __, sprintf } from '@wordpress/i18n';
+import { _n, __, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -163,14 +163,14 @@ const Control = ({
 		if (titles.length === 2) {
 			return sprintf(
 				/* translators: %1$s: feature name(s), %2$s: last feature name */
-				__('%1$s and %2$s', 'elasticpress'),
+				_x('%1$s and %2$s', 'two feature names', 'elasticpress'),
 				titles[0],
 				titles[1],
 			);
 		}
 		return sprintf(
 			/* translators: %1$s: feature name(s), %2$s: last feature name */
-			__('%1$s and %2$s', 'elasticpress'),
+			_x('%1$s and %2$s', 'multiple feature names', 'elasticpress'),
 			titles.slice(0, -1).join(__(', ', 'elasticpress')),
 			titles[titles.length - 1],
 		);

--- a/assets/js/instant-results/components/results/pagination.js
+++ b/assets/js/instant-results/components/results/pagination.js
@@ -173,6 +173,7 @@ const Pagination = ({ offset, onNext, onPage = {}, onPrevious, perPage, total })
 										}
 									}}
 									aria-current={isCurrent ? 'page' : undefined}
+									/* translators: %d: Page number. */
 									aria-label={sprintf(__('Page %d', 'elasticpress'), page.value)}
 								>
 									{page.value}

--- a/assets/js/synonyms/apps/synonyms-settings.js
+++ b/assets/js/synonyms/apps/synonyms-settings.js
@@ -83,7 +83,7 @@ export default () => {
 			title: (
 				<GroupTab isValid={!synonyms.some((s) => !s.valid)}>
 					{
-						/* translators: Synonyms count */
+						/* translators: %d: Number of synonyms. */
 						sprintf(__('Synonyms (%d)', 'elasticpress'), synonyms.length)
 					}
 				</GroupTab>
@@ -94,7 +94,7 @@ export default () => {
 			title: (
 				<GroupTab isValid={!hyponyms.some((s) => !s.valid)}>
 					{
-						/* translators: Hyponyms count */
+						/* translators: %d: Number of hyponyms. */
 						sprintf(__('Hyponyms (%d)', 'elasticpress'), hyponyms.length)
 					}
 				</GroupTab>
@@ -105,7 +105,7 @@ export default () => {
 			title: (
 				<GroupTab isValid={!replacements.some((s) => !s.valid)}>
 					{
-						/* translators: Replacements count */
+						/* translators: %d: Number of replacements. */
 						sprintf(__('Replacements (%d)', 'elasticpress'), replacements.length)
 					}
 				</GroupTab>


### PR DESCRIPTION
## Summary

Running `wp i18n make-pot` produced two warnings in the JS files: one duplicate translator comment on the string `%1$s and %2$s` and one missing translator comment on `Page %d`. This change unifies the comments and adds the missing ones so the POT file builds cleanly.

Fixes #4313

## Changes

### `assets/js/features/components/control.js`

**Before:**
```js
/* translators: %1$s: first feature name, %2$s: second feature name */
__('%1$s and %2$s', 'elasticpress'),
// ...
/* translators: %1$s: comma-separated list of feature names, %2$s: last feature name */
__('%1$s and %2$s', 'elasticpress'),
```

**After:**
```js
/* translators: %1$s: feature name(s), %2$s: last feature name */
__('%1$s and %2$s', 'elasticpress'),
// ...
/* translators: %1$s: feature name(s), %2$s: last feature name */
__('%1$s and %2$s', 'elasticpress'),
```

**Why:** The same string literal had two different translator comments, which triggers a make-pot warning. A single comment describing both placeholders works for both call sites.

### `assets/js/instant-results/components/results/pagination.js`

**Before:**
```js
aria-label={sprintf(__('Page %d', 'elasticpress'), page.value)}
```

**After:**
```js
/* translators: %d: Page number. */
aria-label={sprintf(__('Page %d', 'elasticpress'), page.value)}
```

**Why:** `%d` needs a translator comment to explain it is the page number.

### `assets/js/synonyms/apps/synonyms-settings.js`

**Before:**
```js
/* translators: Synonyms count */
sprintf(__('Synonyms (%d)', 'elasticpress'), synonyms.length)
```

**After:**
```js
/* translators: %d: Number of synonyms. */
sprintf(__('Synonyms (%d)', 'elasticpress'), synonyms.length)
```

**Why:** The `%d` placeholder is clearer for translators when the comment references it directly. Same change applied to hyponyms and replacements tabs.

## Testing

**Test 1: Generate POT file**
1. Go to the plugin folder.
2. Run `wp i18n make-pot . lang/elasticpress.pot`.

Result: No warnings. POT file builds successfully.

## Screenshots
**Before:**
<img width="1017" height="437" alt="SCR-20260619-ttck" src="https://github.com/user-attachments/assets/767aebcf-0ca3-43d1-9422-eb9275520b78" />

**After:**
<img width="1017" height="437" alt="image" src="https://github.com/user-attachments/assets/f8146507-4943-47f1-9b28-52cefdef8ec9" />
