### PR TITLE
fix: sync posts to Elasticsearch when Post Search is disabled

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -97,8 +97,6 @@ class Search extends Feature {
 	 * @since 2.2
 	 */
 	public function setup() {
-		Indexables::factory()->activate( 'post' );
-
 		add_action( 'init', [ $this, 'search_setup' ] );
 
 		// Set up weighting sub-module

--- a/includes/classes/Features.php
+++ b/includes/classes/Features.php
@@ -383,6 +383,12 @@ class Features {
 		 */
 		do_action( 'ep_setup_features' );
 
+		/**
+		 * Activate the post indexable regardless of whether the Post Search
+		 * feature is enabled, so posts continue to sync to Elasticsearch.
+		 */
+		Indexables::factory()->activate( 'post' );
+
 		foreach ( $this->registered_features as $feature ) {
 			$feature->set_i18n_strings();
 

--- a/tests/php/indexables/TestPostSyncWithoutSearch.php
+++ b/tests/php/indexables/TestPostSyncWithoutSearch.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Test post sync when Post Search feature is disabled
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+/**
+ * Test post sync without search feature class
+ */
+class TestPostSyncWithoutSearch extends BaseTestCase {
+
+	/**
+	 * Setup each test.
+	 *
+	 * @since 5.4.0
+	 */
+	public function set_up() {
+		global $wpdb;
+		parent::set_up();
+		$wpdb->suppress_errors();
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		ElasticPress\Elasticsearch::factory()->delete_all_indices();
+
+		/**
+		 * The post indexable should be activated by the plugin bootstrap
+		 * regardless of the Post Search feature state.
+		 */
+		ElasticPress\Indexables::factory()->get( 'post' )->put_mapping();
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->reset_sync_queue();
+
+		$this->setup_test_post_type();
+
+		// Disable Post Search and set up remaining features.
+		ElasticPress\Features::factory()->deactivate_feature( 'search' );
+		ElasticPress\Features::factory()->setup_features();
+	}
+
+	/**
+	 * Test a simple post sync with Post Search disabled
+	 *
+	 * @since 5.4.0
+	 * @group post
+	 */
+	public function testPostSyncWithSearchDisabled() {
+		add_action( 'ep_sync_on_transition', array( $this, 'action_sync_on_transition' ), 10, 0 );
+
+		$post_id = $this->ep_factory->post->create();
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$this->assertTrue( ! empty( $this->fired_actions['ep_sync_on_transition'] ) );
+
+		$post = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
+		$this->assertTrue( ! empty( $post ) );
+	}
+}

--- a/tests/php/indexables/TestPostSyncWithoutSearch.php
+++ b/tests/php/indexables/TestPostSyncWithoutSearch.php
@@ -61,4 +61,27 @@ class TestPostSyncWithoutSearch extends BaseTestCase {
 		$post = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
 		$this->assertTrue( ! empty( $post ) );
 	}
+
+	/**
+	 * Test that WP_Query does not use Elasticsearch for post queries when Post Search is disabled.
+	 *
+	 * Activating the post indexable wires up SyncManager and QueryIntegration, but
+	 * QueryIntegration only takes over a query when the `ep_elasticpress_enabled` filter
+	 * returns true. That filter is only added by Search::search_setup(), which does not run
+	 * when the Search feature is disabled. So enabling sync here should not turn on ES query
+	 * integration for posts.
+	 *
+	 * @since 5.4.0
+	 * @group post
+	 */
+	public function testPostQueryNotIntegratedWithSearchDisabled() {
+		$this->ep_factory->post->create();
+		$this->ep_factory->post->create( array( 'post_content' => 'findme' ) );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query( array( 's' => 'findme' ) );
+
+		$this->assertTrue( empty( $query->elasticsearch_success ) );
+	}
 }


### PR DESCRIPTION
## Summary
Move the Post indexable activation out of the Post Search feature `setup()` so posts continue to sync to Elasticsearch even when the Post Search feature is disabled.

Previously, disabling Post Search prevented `Post::setup()` from being called, which meant the `SyncManager` was never instantiated and `wp_insert_post` / `delete_post` / meta / term hooks were never attached.

Fixes #4158

## Changes
### includes/classes/Features.php
**Before:**
```php
do_action( 'ep_setup_features' );

foreach ( $this->registered_features as $feature ) {
```

**After:**
```php
do_action( 'ep_setup_features' );

/**
 * Activate the post indexable regardless of whether the Post Search
 * feature is enabled, so posts continue to sync to Elasticsearch.
 */
Indexables::factory()->activate( 'post' );

foreach ( $this->registered_features as $feature ) {
```

**Why:** `setup_features()` runs on `init` priority 0 for every request. Activating the post indexable here ensures it is always set up, independent of whether the Search feature is active.

### includes/classes/Feature/Search/Search.php
**Before:**
```php
public function setup() {
    Indexables::factory()->activate( 'post' );

    add_action( 'init', [ $this, 'search_setup' ] );
    // ...
}
```

**After:**
```php
public function setup() {
    add_action( 'init', [ $this, 'search_setup' ] );
    // ...
}
```

**Why:** The Search feature no longer needs to activate the post indexable. Its `setup()` still loads weighting, synonyms, and registers `search_setup` for query integration.

## Testing
**Test 1: Post sync with Post Search disabled**
1. Activate ElasticPress and connect to Elasticsearch.
2. Go to ElasticPress → Features and disable Post Search.
3. Edit any post and save.
4. Verify the document in Elasticsearch reflects the updated content.

Result: works as expected.

**Test 2: Post sync with Post Search enabled (regression)**
1. Enable Post Search.
2. Edit and save a post.
2. Verify the document in Elasticsearch updates.

Result: works as expected.

**Test 3: Automated regression test**
Added `tests/php/indexables/TestPostSyncWithoutSearch.php` with `testPostSyncWithSearchDisabled()` — disables the Search feature, creates a post, and asserts the sync hook fires and the document exists in Elasticsearch. Passes on single-site and multisite test suites.