### PR TITLE
feature(instant-results): add filters for labels, options, components, and config

### DIFF
--- a/assets/js/api-search/index.js
+++ b/assets/js/api-search/index.js
@@ -12,6 +12,7 @@ import {
 	WPElement,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
@@ -316,7 +317,18 @@ export const ApiSearchProvider = ({
 					return;
 				}
 
-				setResults(response);
+				/**
+				 * Filter the search results response.
+				 *
+				 * @filter ep.InstantResults.response
+				 * @since 5.3.0
+				 *
+				 * @param {object} response The search results response.
+				 * @returns {object} Filtered search results response.
+				 */
+				const filteredResponse = applyFilters('ep.InstantResults.response', response);
+
+				setResults(filteredResponse || response);
 			} catch (e) {
 				const errorMessage = sprintf(
 					/* translators: Error message */

--- a/assets/js/instant-results/components/facets/facet.js
+++ b/assets/js/instant-results/components/facets/facet.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { WPElement } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
@@ -24,16 +25,36 @@ import TaxonomyTermsFacet from './taxonomy-terms-facet';
 export default ({ index, label, name, postTypes, type }) => {
 	const defaultIsOpen = index < 2;
 
+	/**
+	 * Filter the facet label.
+	 *
+	 * @filter ep.InstantResults.filter.label
+	 * @since 5.3.0
+	 *
+	 * @param {string} label Facet label.
+	 * @param {string} name Facet name.
+	 * @param {string} type Facet type.
+	 * @param {string[]} postTypes Facet post types.
+	 * @returns {string} Filtered facet label.
+	 */
+	const filteredLabel = applyFilters(
+		'ep.InstantResults.filter.label',
+		label,
+		name,
+		type,
+		postTypes,
+	);
+
 	switch (type) {
 		case 'post_type':
-			return <PostTypeFacet defaultIsOpen={defaultIsOpen} label={label} />;
+			return <PostTypeFacet defaultIsOpen={defaultIsOpen} label={filteredLabel} />;
 		case 'price_range':
-			return <PriceRangeFacet defaultIsOpen={defaultIsOpen} label={label} />;
+			return <PriceRangeFacet defaultIsOpen={defaultIsOpen} label={filteredLabel} />;
 		case 'taxonomy':
 			return (
 				<TaxonomyTermsFacet
 					defaultIsOpen={defaultIsOpen}
-					label={label}
+					label={filteredLabel}
 					name={name}
 					postTypes={postTypes}
 				/>

--- a/assets/js/instant-results/components/facets/post-type-facet.js
+++ b/assets/js/instant-results/components/facets/post-type-facet.js
@@ -3,6 +3,7 @@
  */
 import { useCallback, useMemo, WPElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
@@ -61,7 +62,20 @@ export default ({ defaultIsOpen, label }) => {
 	/**
 	 * Reduce buckets to options.
 	 */
-	const options = useMemo(() => buckets.reduce(reduceOptions, []), [buckets, reduceOptions]);
+	const options = useMemo(() => {
+		const reducedOptions = buckets.reduce(reduceOptions, []);
+
+		/**
+		 * Filter the post type filter options.
+		 *
+		 * @filter ep.InstantResults.filter.postType.options
+		 * @since 5.3.0
+		 *
+		 * @param {object[]} options Post type filter options.
+		 * @returns {object[]} Filtered post type filter options.
+		 */
+		return applyFilters('ep.InstantResults.filter.postType.options', reducedOptions);
+	}, [buckets, reduceOptions]);
 
 	/**
 	 * Handle checkbox change event.

--- a/assets/js/instant-results/components/facets/price-range-facet.js
+++ b/assets/js/instant-results/components/facets/price-range-facet.js
@@ -3,6 +3,7 @@
  */
 import { useLayoutEffect, useState, WPElement } from '@wordpress/element';
 import { _x, sprintf } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
@@ -38,8 +39,23 @@ export default ({ defaultIsOpen, label }) => {
 	/**
 	 * Minimum and maximum possible values.
 	 */
-	const max = Math.ceil(maxAgg);
-	const min = Math.floor(minAgg);
+	let max = Math.ceil(maxAgg);
+	let min = Math.floor(minAgg);
+
+	/**
+	 * Filter the price range values.
+	 *
+	 * @filter ep.InstantResults.filter.priceRange.options
+	 * @since 5.3.0
+	 *
+	 * @param {object} range Price range values.
+	 * @param {number} range.min Minimum price.
+	 * @param {number} range.max Maximum price.
+	 * @returns {object} Filtered price range values.
+	 */
+	const range = applyFilters('ep.InstantResults.filter.priceRange.options', { min, max });
+
+	({ min, max } = range);
 
 	/**
 	 * Current minimum and maximum values.

--- a/assets/js/instant-results/components/results/did-you-mean.js
+++ b/assets/js/instant-results/components/results/did-you-mean.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { WPElement, createInterpolateElement } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 import { showSuggestions, suggestionsBehavior } from '../../config';
 
@@ -22,7 +23,7 @@ export default (props) => {
 	// Get other terms by excluding the first term from suggestedTerms
 	const otherTerms = suggestedTerms.slice(1);
 
-	return (
+	const didYouMean = (
 		<>
 			{showSuggestions && suggestedTerms && suggestedTerms?.[0]?.text && (
 				<div className="ep-search-suggestion">
@@ -67,4 +68,16 @@ export default (props) => {
 				)}
 		</>
 	);
+
+	/**
+	 * Filter the did you mean component.
+	 *
+	 * @filter ep.InstantResults.component.didYouMean
+	 * @since 5.3.0
+	 *
+	 * @param {WPElement} didYouMean Did you mean component.
+	 * @param {object} props Props.
+	 * @returns {WPElement} Did you mean component.
+	 */
+	return applyFilters('ep.InstantResults.component.didYouMean', didYouMean, props);
 };

--- a/assets/js/instant-results/components/tools/sort.js
+++ b/assets/js/instant-results/components/tools/sort.js
@@ -3,6 +3,7 @@
  */
 import { useMemo, WPElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
@@ -41,7 +42,7 @@ export default () => {
 		search({ orderby, order });
 	};
 
-	return (
+	const sort = (
 		<label className="ep-search-sort" htmlFor="ep-sort">
 			<span className="ep-search-sort__label">{__('Sort by', 'elasticpress')}</span>{' '}
 			<select
@@ -58,4 +59,18 @@ export default () => {
 			</select>
 		</label>
 	);
+
+	/**
+	 * Filter the sort component.
+	 *
+	 * @filter ep.InstantResults.component.sort
+	 * @since 5.3.0
+	 *
+	 * @param {WPElement} sort Sort component.
+	 * @param {object} context Sort context.
+	 * @param {string} context.orderby Current orderby value.
+	 * @param {string} context.order Current order value.
+	 * @returns {WPElement} Sort component.
+	 */
+	return applyFilters('ep.InstantResults.component.sort', sort, { orderby, order });
 };

--- a/includes/classes/Feature/InstantResults/InstantResults.php
+++ b/includes/classes/Feature/InstantResults/InstantResults.php
@@ -224,27 +224,39 @@ class InstantResults extends Feature {
 		 */
 		$api_endpoint = apply_filters( 'ep_instant_results_search_endpoint', "api/v1/search/posts/{$index}", $index );
 
+		$ep_instant_results_config = array(
+			'apiEndpoint'         => $api_endpoint,
+			'apiHost'             => ( 0 !== strpos( $api_endpoint, 'http' ) ) ? esc_url_raw( $this->host ) : '',
+			'argsSchema'          => $this->get_args_schema(),
+			'currencyCode'        => $this->is_woocommerce ? get_woocommerce_currency() : false,
+			'facets'              => $this->get_facets_for_frontend(),
+			'highlightTag'        => $this->settings['highlight_tag'],
+			'isWooCommerce'       => $this->is_woocommerce,
+			'locale'              => str_replace( '_', '-', get_locale() ),
+			'matchType'           => $this->settings['match_type'],
+			'paramPrefix'         => 'ep-',
+			'postTypeLabels'      => $this->get_post_type_labels(),
+			'termCount'           => $this->settings['term_count'],
+			'numberedPagination'  => $this->settings['numbered_pagination'],
+			'requestIdBase'       => Utils\get_request_id_base(),
+			'showSuggestions'     => \ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->is_active(),
+			'suggestionsBehavior' => $this->settings['search_behavior'],
+		);
+
+		/**
+		 * Filter the Instant Results configuration passed to the front end.
+		 *
+		 * @since 5.3.0
+		 * @hook ep_instant_results_config
+		 * @param {array} $ep_instant_results_config Instant Results configuration.
+		 * @returns {array} Filtered Instant Results configuration.
+		 */
+		$ep_instant_results_config = apply_filters( 'ep_instant_results_config', $ep_instant_results_config );
+
 		wp_localize_script(
 			'elasticpress-instant-results',
 			'epInstantResults',
-			array(
-				'apiEndpoint'         => $api_endpoint,
-				'apiHost'             => ( 0 !== strpos( $api_endpoint, 'http' ) ) ? esc_url_raw( $this->host ) : '',
-				'argsSchema'          => $this->get_args_schema(),
-				'currencyCode'        => $this->is_woocommerce ? get_woocommerce_currency() : false,
-				'facets'              => $this->get_facets_for_frontend(),
-				'highlightTag'        => $this->settings['highlight_tag'],
-				'isWooCommerce'       => $this->is_woocommerce,
-				'locale'              => str_replace( '_', '-', get_locale() ),
-				'matchType'           => $this->settings['match_type'],
-				'paramPrefix'         => 'ep-',
-				'postTypeLabels'      => $this->get_post_type_labels(),
-				'termCount'           => $this->settings['term_count'],
-				'numberedPagination'  => $this->settings['numbered_pagination'],
-				'requestIdBase'       => Utils\get_request_id_base(),
-				'showSuggestions'     => \ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->is_active(),
-				'suggestionsBehavior' => $this->settings['search_behavior'],
-			)
+			$ep_instant_results_config
 		);
 	}
 

--- a/tests/e2e/src/specs/instant-results.spec.ts
+++ b/tests/e2e/src/specs/instant-results.spec.ts
@@ -120,7 +120,7 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 	test.beforeEach(async ({ loggedInPage }) => {
 		await deactivatePlugin(
 			loggedInPage,
-			'custom-instant-results-template open-instant-results-with-buttons filter-instant-results-per-page filter-instant-results-args-schema',
+			'custom-instant-results-template open-instant-results-with-buttons filter-instant-results-per-page filter-instant-results-args-schema filter-instant-results-label filter-instant-results-post-type-options filter-instant-results-price-range filter-instant-results-components filter-instant-results-response filter-instant-results-config filter-instant-results-category-terms',
 			'wpCli',
 		);
 	});
@@ -597,6 +597,149 @@ test.describe('Instant Results Feature', { tag: '@group1' }, () => {
 					'filter-instant-results-category-terms',
 					'wpCli',
 				);
+			});
+
+			test('Can filter facet labels', async ({ loggedInPage }) => {
+				await maybeEnableFeature('instant-results');
+				await activatePlugin(loggedInPage, 'filter-instant-results-label', 'wpCli');
+
+				await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress');
+				const apiResponsePromise = loggedInPage.waitForResponse(
+					'**/wp-json/elasticpress/v1/features*',
+				);
+
+				await loggedInPage.getByRole('button', { name: 'Live Search' }).click();
+				await loggedInPage.getByRole('button', { name: 'Instant Results' }).click();
+				await addInstantResultFilter(loggedInPage, 'post type');
+				await loggedInPage.getByRole('button', { name: 'Save changes' }).click();
+
+				await apiResponsePromise;
+
+				const responsePromise = instantResultRequestPromise(loggedInPage, 'search=new');
+				await loggedInPage.goto('/');
+				await searchFor(loggedInPage, 'new');
+				await responsePromise;
+
+				const postTypeFacet = loggedInPage.locator('.ep-search-panel').filter({
+					has: loggedInPage
+						.locator('.ep-search-panel__button')
+						.filter({ hasText: 'Filtered Type Label' }),
+				});
+				await expect(postTypeFacet).toBeVisible();
+			});
+
+			test('Can filter post type options', async ({ loggedInPage }) => {
+				await maybeEnableFeature('instant-results');
+				await activatePlugin(
+					loggedInPage,
+					'filter-instant-results-post-type-options',
+					'wpCli',
+				);
+
+				await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress');
+				const apiResponsePromise = loggedInPage.waitForResponse(
+					'**/wp-json/elasticpress/v1/features*',
+				);
+
+				await loggedInPage.getByRole('button', { name: 'Live Search' }).click();
+				await loggedInPage.getByRole('button', { name: 'Instant Results' }).click();
+				await addInstantResultFilter(loggedInPage, 'post type');
+				await loggedInPage.getByRole('button', { name: 'Save changes' }).click();
+
+				await apiResponsePromise;
+
+				const responsePromise = instantResultRequestPromise(loggedInPage, 'search=new');
+				await loggedInPage.goto('/');
+				await searchFor(loggedInPage, 'new');
+				await responsePromise;
+
+				const postTypeFacet = loggedInPage.locator('.ep-search-panel').filter({
+					has: loggedInPage
+						.locator('.ep-search-panel__button')
+						.filter({ hasText: 'Type' }),
+				});
+				await expect(postTypeFacet).toContainText('(filtered)');
+			});
+
+			test('Can filter price range options', async ({ loggedInPage }) => {
+				await maybeEnableFeature('instant-results');
+				await maybeEnableFeature('woocommerce');
+				await activatePlugin(loggedInPage, 'filter-instant-results-price-range', 'wpCli');
+				await wpCli('wp elasticpress sync');
+
+				await goToAdminPage(loggedInPage, 'admin.php?page=elasticpress');
+				const apiResponsePromise = loggedInPage.waitForResponse(
+					'**/wp-json/elasticpress/v1/features*',
+				);
+
+				await loggedInPage.getByRole('button', { name: 'Live Search' }).click();
+				await loggedInPage.getByRole('button', { name: 'Instant Results' }).click();
+				await addInstantResultFilter(loggedInPage, 'price');
+				await loggedInPage.getByRole('button', { name: 'Save changes' }).click();
+
+				await apiResponsePromise;
+
+				const responsePromise = instantResultRequestPromise(
+					loggedInPage,
+					'search=ergonomic',
+				);
+				await loggedInPage.goto('/');
+				await searchFor(loggedInPage, 'ergonomic');
+				await responsePromise;
+
+				const priceValues = await loggedInPage
+					.locator('.ep-search-price-facet__values')
+					.textContent();
+				expect(priceValues).toContain('$0');
+				expect(priceValues).toContain('$999');
+			});
+
+			test('Can filter components (did-you-mean and sort)', async ({ loggedInPage }) => {
+				await maybeEnableFeature('instant-results');
+				await maybeEnableFeature('did-you-mean');
+				await activatePlugin(loggedInPage, 'filter-instant-results-components', 'wpCli');
+
+				await wpCli('wp elasticpress sync --setup --yes');
+
+				const responsePromise = instantResultRequestPromise(
+					loggedInPage,
+					'search=wordpless',
+				);
+				await loggedInPage.goto('/');
+				await searchFor(loggedInPage, 'wordpless');
+				await expect(loggedInPage.locator('.ep-search-modal')).toBeVisible();
+				await responsePromise;
+
+				await expect(loggedInPage.locator('.my-custom-did-you-mean')).toBeVisible();
+				await expect(loggedInPage.locator('.my-custom-sort')).toBeVisible();
+			});
+
+			test('Can filter the search response', async ({ loggedInPage }) => {
+				await maybeEnableFeature('instant-results');
+				await activatePlugin(loggedInPage, 'filter-instant-results-response', 'wpCli');
+
+				const responsePromise = instantResultRequestPromise(loggedInPage, 'search=new');
+				await loggedInPage.goto('/');
+				await searchFor(loggedInPage, 'new');
+				await expect(loggedInPage.locator('.ep-search-modal')).toBeVisible();
+				await responsePromise;
+
+				await expect(loggedInPage.locator('.ep-search-result')).not.toBeVisible();
+				await expect(loggedInPage.locator('.ep-search-results__title')).toContainText('0');
+			});
+
+			test('Can filter the front-end config', async ({ loggedInPage }) => {
+				await maybeEnableFeature('instant-results');
+				await activatePlugin(loggedInPage, 'filter-instant-results-config', 'wpCli');
+
+				await loggedInPage.goto('/');
+
+				const config = await loggedInPage.evaluate(() => {
+					return (window as any).epInstantResults;
+				});
+
+				expect(config.highlightTag).toBe('mark');
+				expect(config.epTestFilteredConfig).toBe(true);
 			});
 		});
 

--- a/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-components.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-components.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Components
+ * Description: Filters the Instant Results sort and did-you-mean components for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_action(
+	'wp_footer',
+	function (): void {
+		?>
+		<script>
+			document.addEventListener('DOMContentLoaded', function() {
+				const el = wp.element.createElement;
+
+				const filterSort = (sort) => {
+					return el('div', { className: 'my-custom-sort' }, sort);
+				};
+
+				const filterDidYouMean = (didYouMean) => {
+					return el('div', { className: 'my-custom-did-you-mean' }, didYouMean);
+				};
+
+				wp.hooks.addFilter('ep.InstantResults.component.sort', 'ep-test', filterSort);
+				wp.hooks.addFilter('ep.InstantResults.component.didYouMean', 'ep-test', filterDidYouMean);
+			});
+		</script>
+		<?php
+	}
+);

--- a/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-config.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-config.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Config
+ * Description: Filters the Instant Results front-end configuration for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_filter(
+	'ep_instant_results_config',
+	function ( $config ) {
+		$config['highlightTag']         = 'mark';
+		$config['epTestFilteredConfig'] = true;
+		return $config;
+	}
+);

--- a/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-label.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-label.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Facet Labels
+ * Description: Filters the Instant Results facet labels for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_action(
+	'wp_footer',
+	function (): void {
+		?>
+		<script>
+			document.addEventListener('DOMContentLoaded', function() {
+				const filterFacetLabel = (label, name, type, postTypes) => {
+					if (type === 'post_type') {
+						return 'Filtered Type Label';
+					}
+					return label;
+				};
+
+				wp.hooks.addFilter('ep.InstantResults.filter.label', 'ep-test', filterFacetLabel);
+			});
+		</script>
+		<?php
+	}
+);

--- a/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-post-type-options.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-post-type-options.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Post Type Options
+ * Description: Filters the Instant Results post type options for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_action(
+	'wp_footer',
+	function (): void {
+		?>
+		<script>
+			document.addEventListener('DOMContentLoaded', function() {
+				const filterPostTypeOptions = (options) => {
+					return options.map(function(option) {
+						return Object.assign({}, option, {
+							label: option.label + ' (filtered)',
+						});
+					});
+				};
+
+				wp.hooks.addFilter('ep.InstantResults.filter.postType.options', 'ep-test', filterPostTypeOptions);
+			});
+		</script>
+		<?php
+	}
+);

--- a/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-price-range.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-price-range.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Price Range
+ * Description: Filters the Instant Results price range bounds for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_action(
+	'wp_footer',
+	function (): void {
+		?>
+		<script>
+			document.addEventListener('DOMContentLoaded', function() {
+				const filterPriceRange = (range) => {
+					return { min: 0, max: 999 };
+				};
+
+				wp.hooks.addFilter('ep.InstantResults.filter.priceRange.options', 'ep-test', filterPriceRange);
+			});
+		</script>
+		<?php
+	}
+);

--- a/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-response.php
+++ b/tests/e2e/src/wordpress-files/test-plugins/filter-instant-results-response.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Filter Instant Results Response
+ * Description: Filters the Instant Results search response for test purposes.
+ * Version:     1.0.0
+ * Author:      10up Inc.
+ * License:     GPLv2 or later
+ *
+ * @package ElasticPress_Tests_E2e
+ */
+
+add_action(
+	'wp_footer',
+	function (): void {
+		?>
+		<script>
+			document.addEventListener('DOMContentLoaded', function() {
+				const filterResponse = (response) => {
+					if (response && response.hits) {
+						response.hits.hits = [];
+						response.hits.total = typeof response.hits.total === 'number' ? 0 : { value: 0 };
+					}
+					return response;
+				};
+
+				wp.hooks.addFilter('ep.InstantResults.response', 'ep-test', filterResponse);
+			});
+		</script>
+		<?php
+	}
+);


### PR DESCRIPTION
## Summary

This PR adds more filters to the Instant Results feature so developers can customize facet labels, facet options, individual components, and the front-end configuration object. It addresses the customization gaps described in #3975.

Fixes #3975

## Changes

### assets/js/api-search/index.js

**Before:**
```js
setResults(response);
```

**After:**
```js
const filteredResponse = applyFilters('ep.InstantResults.response', response);

setResults(filteredResponse || response);
```

**Why:** allows third-party code to modify the search results response before it is passed to the React state, with a fallback in case a filter returns a falsy value.

### assets/js/instant-results/components/facets/facet.js

**Before:** facets received the `label` prop directly.

**After:** the label is passed through `ep.InstantResults.filter.label` with the facet name, type, and post types so all facet labels can be customized from one filter.

**Why:** gives developers a single hook for changing facet labels without editing component internals.

### assets/js/instant-results/components/facets/post-type-facet.js

**Before:**
```js
const options = useMemo(() => buckets.reduce(reduceOptions, []), [buckets, reduceOptions]);
```

**After:** reduced options are passed through `ep.InstantResults.filter.postType.options` before being rendered.

**Why:** lets developers reorder, remove, or relabel post type options.

### assets/js/instant-results/components/facets/price-range-facet.js

**Before:** the slider min/max were taken directly from aggregations.

**After:** the min/max values are passed through `ep.InstantResults.filter.priceRange.options` as `{ min, max }`.

**Why:** allows the price range bounds to be adjusted by third-party code.

### assets/js/instant-results/components/results/did-you-mean.js and assets/js/instant-results/components/tools/sort.js

**Before:** components were returned directly.

**After:** components are assigned to a variable and returned through `ep.InstantResults.component.didYouMean` and `ep.InstantResults.component.sort` respectively.

**Why:** follows the same pattern already used for `ep.InstantResults.Result` and `ep.InstantResults.Pagination` so components can be wrapped or replaced.

### includes/classes/Feature/InstantResults/InstantResults.php

**Before:** the localized `epInstantResults` config was passed directly to `wp_localize_script`.

**After:** the config is built into a variable, filtered through `ep_instant_results_config`, and then passed to `wp_localize_script`.

**Why:** provides a PHP-side hook for the entire front-end configuration object.

## Testing

**Test 1: Facet label filter**
1. Add a JS filter on `ep.InstantResults.filter.label` to rename a taxonomy facet.
2. Open Instant Results and view the sidebar.

Result: the facet label is updated.

**Test 2: Post type options filter**
1. Add a JS filter on `ep.InstantResults.filter.postType.options` to transform option labels.
2. Open Instant Results and expand the post type facet.

Result: the option labels reflect the filter output.

**Test 3: PHP config filter**
1. Add a PHP filter on `ep_instant_results_config` to change a value.
2. Load the page and inspect `window.epInstantResults`.

Result: the modified value is present in the front-end config.

## Notes

- `npm run lint-js` passes for the changed JS files.
- `composer run lint` reports only pre-existing failures in other test files; `InstantResults.php` is clean.
- `vendor/bin/phpunit --filter TestInstantResults` passes except for an unrelated pre-existing quote mismatch in `test_requirements_status`.
- CodeRabbit review passed with no actionable findings.