### PR TITLE
feat(autosuggest): enable autosuggest in the WordPress admin

### DIFF
--- a/includes/classes/Feature/Autosuggest/Autosuggest.php
+++ b/includes/classes/Feature/Autosuggest/Autosuggest.php
@@ -45,9 +45,10 @@ class Autosuggest extends Feature {
 		$this->requires_install_reindex = true;
 
 		$this->default_settings = [
-			'endpoint_url'         => '',
-			'autosuggest_selector' => '',
-			'trigger_ga_event'     => '0',
+			'endpoint_url'             => '',
+			'autosuggest_selector'     => '',
+			'trigger_ga_event'         => '0',
+			'enable_admin_autosuggest' => '0',
 		];
 
 		$this->available_during_installation = true;
@@ -80,6 +81,7 @@ class Autosuggest extends Feature {
 	 */
 	public function setup() {
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 		add_filter( 'ep_post_mapping', [ $this, 'mapping' ] );
 		add_filter( 'ep_post_sync_args', [ $this, 'filter_term_suggest' ], 10 );
 		add_filter( 'ep_post_fuzziness_arg', [ $this, 'set_fuzziness' ], 10, 3 );
@@ -293,21 +295,74 @@ class Autosuggest extends Feature {
 			return;
 		}
 
-		$host     = Utils\get_host();
-		$settings = $this->get_settings();
-
-		if ( defined( 'EP_AUTOSUGGEST_ENDPOINT' ) && EP_AUTOSUGGEST_ENDPOINT ) {
-			$endpoint_url = EP_AUTOSUGGEST_ENDPOINT;
-		} elseif ( Utils\is_epio() ) {
-				$endpoint_url = trailingslashit( $host ) . Indexables::factory()->get( 'post' )->get_index_name() . '/autosuggest';
-		} else {
-			$endpoint_url = $settings['endpoint_url'];
-		}
+		$settings     = $this->get_settings();
+		$endpoint_url = $this->get_autosuggest_endpoint_url();
 
 		if ( empty( $endpoint_url ) ) {
 			return;
 		}
 
+		$this->enqueue_autosuggest_assets();
+
+		$query = $this->generate_search_query();
+
+		wp_localize_script(
+			'elasticpress-autosuggest',
+			'epas',
+			apply_filters(
+				'ep_autosuggest_options',
+				$this->get_epas_options( $query, $endpoint_url, $settings )
+			)
+		);
+	}
+
+	/**
+	 * Enqueue autosuggest assets for the WordPress admin.
+	 *
+	 * @since 5.4.0
+	 */
+	public function enqueue_admin_scripts() {
+		if ( Utils\is_indexing() ) {
+			return;
+		}
+
+		$settings = $this->get_settings();
+
+		if ( empty( $settings['enable_admin_autosuggest'] ) ) {
+			return;
+		}
+
+		$capability = apply_filters( 'ep_admin_autosuggest_capability', 'edit_posts' );
+		if ( ! current_user_can( $capability ) ) {
+			return;
+		}
+
+		$endpoint_url = $this->get_autosuggest_endpoint_url();
+
+		if ( empty( $endpoint_url ) ) {
+			return;
+		}
+
+		$this->enqueue_autosuggest_assets();
+
+		$query = $this->generate_admin_search_query();
+
+		wp_localize_script(
+			'elasticpress-autosuggest',
+			'epas',
+			apply_filters(
+				'ep_autosuggest_options',
+				$this->get_epas_options( $query, $endpoint_url, $settings )
+			)
+		);
+	}
+
+	/**
+	 * Enqueue the shared autosuggest script and stylesheet.
+	 *
+	 * @since 5.4.0
+	 */
+	protected function enqueue_autosuggest_assets() {
 		wp_enqueue_script(
 			'elasticpress-autosuggest',
 			EP_URL . 'dist/js/autosuggest-script.js',
@@ -324,14 +379,42 @@ class Autosuggest extends Feature {
 			Utils\get_asset_info( 'autosuggest-styles', 'dependencies' ),
 			Utils\get_asset_info( 'autosuggest-styles', 'version' )
 		);
+	}
 
+	/**
+	 * Get the configured autosuggest endpoint URL.
+	 *
+	 * @since 5.4.0
+	 * @return string
+	 */
+	protected function get_autosuggest_endpoint_url() {
+		if ( defined( 'EP_AUTOSUGGEST_ENDPOINT' ) && EP_AUTOSUGGEST_ENDPOINT ) {
+			return EP_AUTOSUGGEST_ENDPOINT;
+		}
+
+		if ( Utils\is_epio() ) {
+			return trailingslashit( Utils\get_host() ) . Indexables::factory()->get( 'post' )->get_index_name() . '/autosuggest';
+		}
+
+		$settings = $this->get_settings();
+		return $settings['endpoint_url'];
+	}
+
+	/**
+	 * Build the autosuggest options array to localize to JavaScript.
+	 *
+	 * @since 5.4.0
+	 * @param array  $query        Generated query array.
+	 * @param string $endpoint_url Endpoint URL.
+	 * @param array  $settings     Feature settings.
+	 * @return array
+	 */
+	protected function get_epas_options( $query, $endpoint_url, $settings ) {
 		/** Features Class @var Features $features */
 		$features = Features::factory();
 
 		/** Search Feature @var Feature\Search\Search $search */
 		$search = $features->get_registered_feature( 'search' );
-
-		$query = $this->generate_search_query();
 
 		$epas_options = [
 			'query'               => $query['body'],
@@ -380,37 +463,17 @@ class Autosuggest extends Feature {
 			$epas_options['highlightingClass']   = apply_filters( 'ep_highlighting_class', 'ep-highlight' );
 		}
 
-		/**
-		 * Output variables to use in Javascript
-		 * index: the Elasticsearch index name
-		 * endpointUrl:  the Elasticsearch autosuggest endpoint url
-		 * postType: which post types to use for suggestions
-		 * action: the action to take when selecting an item. Possible values are "search" and "navigate".
-		 */
-		wp_localize_script(
-			'elasticpress-autosuggest',
-			'epas',
-			/**
-			 * Filter autosuggest JavaScript options
-			 *
-			 * @hook ep_autosuggest_options
-			 * @param  {array} $options Autosuggest options to be localized
-			 * @return  {array} New options
-			 */
-			apply_filters(
-				'ep_autosuggest_options',
-				$epas_options
-			)
-		);
+		return $epas_options;
 	}
 
 	/**
 	 * Build a default search request to pass to the autosuggest javascript.
 	 * The request will include a placeholder that can then be replaced.
 	 *
+	 * @param bool $is_admin Whether the query is being generated for the admin.
 	 * @return array Generated ElasticSearch request array( 'placeholder'=> placeholderstring, 'body' => request body )
 	 */
-	public function generate_search_query() {
+	public function generate_search_query( $is_admin = false ) {
 
 		/**
 		 * Filter autosuggest query placeholder
@@ -435,12 +498,16 @@ class Autosuggest extends Feature {
 		 */
 		$post_type = apply_filters( 'ep_term_suggest_post_type', array_values( $post_type ) );
 
-		$post_status = get_post_stati(
-			[
-				'public'              => true,
-				'exclude_from_search' => false,
-			]
-		);
+		if ( $is_admin ) {
+			$post_status = Indexables::factory()->get( 'post' )->get_indexable_post_status();
+		} else {
+			$post_status = get_post_stati(
+				[
+					'public'              => true,
+					'exclude_from_search' => false,
+				]
+			);
+		}
 
 		/**
 		 * Filter post statuses available to autosuggest
@@ -501,6 +568,52 @@ class Autosuggest extends Feature {
 			'placeholder' => $placeholder,
 			'query_vars'  => $args,
 		];
+	}
+
+	/**
+	 * Generate an autosuggest query template for the WordPress admin.
+	 *
+	 * Forces ElasticPress integration for the duration of the query so the
+	 * template can be captured from an admin context.
+	 *
+	 * @since 5.4.0
+	 * @return array Generated query array.
+	 */
+	public function generate_admin_search_query() {
+		$original_user_id = get_current_user_id();
+		wp_set_current_user( 0 );
+
+		add_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request_for_admin_template' ], 10, 2 );
+
+		$query = $this->generate_search_query( true );
+
+		remove_filter( 'ep_is_integrated_request', [ $this, 'is_integrated_request_for_admin_template' ], 10 );
+
+		wp_set_current_user( $original_user_id );
+
+		return $query;
+	}
+
+	/**
+	 * Enable ElasticPress integration for the admin query template.
+	 *
+	 * Applied as a filter on Utils\is_integrated_request() so the query used to
+	 * generate the admin autosuggest template is integrated regardless of the
+	 * request type.
+	 *
+	 * @since 5.4.0
+	 * @param bool   $is_integrated Whether queries for the request will be integrated.
+	 * @param string $context       Context for the original check.
+	 * @return bool
+	 */
+	public function is_integrated_request_for_admin_template( $is_integrated, $context ) {
+		$supported_contexts = [ 'search', 'autosuggest' ];
+
+		if ( in_array( $context, $supported_contexts, true ) ) {
+			return true;
+		}
+
+		return $is_integrated;
 	}
 
 	/**
@@ -878,6 +991,13 @@ class Autosuggest extends Feature {
 				'key'     => 'trigger_ga_event',
 				'help'    => __( 'Enable to fire a gtag tracking event when an autosuggest result is clicked.', 'elasticpress' ),
 				'label'   => __( 'Trigger Google Analytics events', 'elasticpress' ),
+				'type'    => 'checkbox',
+			],
+			[
+				'default' => '0',
+				'key'     => 'enable_admin_autosuggest',
+				'help'    => __( 'Adds autosuggest to admin search fields such as the post list table. Requires a publicly accessible autosuggest endpoint or ElasticPress.io.', 'elasticpress' ),
+				'label'   => __( 'Enable autosuggest in the WordPress admin', 'elasticpress' ),
 				'type'    => 'checkbox',
 			],
 		];

--- a/tests/php/features/TestAutosuggest.php
+++ b/tests/php/features/TestAutosuggest.php
@@ -284,9 +284,26 @@ class TestAutosuggest extends BaseTestCase {
 		$settings_keys = wp_list_pluck( $settings_schema, 'key' );
 
 		$this->assertSame(
-			[ 'active', 'autosuggest_selector', 'trigger_ga_event', 'endpoint_url' ],
+			[ 'active', 'autosuggest_selector', 'trigger_ga_event', 'enable_admin_autosuggest', 'endpoint_url' ],
 			$settings_keys
 		);
+	}
+
+	/**
+	 * Test admin autosuggest setting schema
+	 *
+	 * @since 5.4.0
+	 * @group autosuggest
+	 */
+	public function test_admin_autosuggest_setting_schema() {
+		$settings_schema = $this->get_feature()->get_settings_schema();
+
+		$admin_setting = wp_list_filter( $settings_schema, [ 'key' => 'enable_admin_autosuggest' ] );
+		$admin_setting = array_values( $admin_setting );
+
+		$this->assertNotEmpty( $admin_setting );
+		$this->assertSame( 'checkbox', $admin_setting[0]['type'] );
+		$this->assertSame( '0', $admin_setting[0]['default'] );
 	}
 
 	/**
@@ -494,5 +511,147 @@ class TestAutosuggest extends BaseTestCase {
 	 */
 	public function test_intercept_remote_request_method_throws_warning() {
 		$this->assertTrue( $this->get_feature()->intercept_remote_request() );
+	}
+
+	/**
+	 * Reset autosuggest script/style registrations between enqueue tests.
+	 */
+	protected function reset_autosuggest_assets() {
+		wp_dequeue_script( 'elasticpress-autosuggest' );
+		wp_deregister_script( 'elasticpress-autosuggest' );
+		wp_dequeue_style( 'elasticpress-autosuggest' );
+		wp_deregister_style( 'elasticpress-autosuggest' );
+	}
+
+	/**
+	 * Test admin autosuggest is not enqueued by default.
+	 *
+	 * @since 5.4.0
+	 * @group autosuggest
+	 */
+	public function test_admin_autosuggest_default_off() {
+		set_current_screen( 'edit.php' );
+		$this->reset_autosuggest_assets();
+
+		$this->get_feature()->enqueue_admin_scripts();
+
+		$this->assertFalse( wp_script_is( 'elasticpress-autosuggest' ) );
+		$this->assertFalse( wp_style_is( 'elasticpress-autosuggest' ) );
+	}
+
+	/**
+	 * Test admin autosuggest enqueue respects the setting and endpoint.
+	 *
+	 * @since 5.4.0
+	 * @group autosuggest
+	 */
+	public function test_admin_autosuggest_enqueue_respects_setting() {
+		set_current_screen( 'edit.php' );
+		$this->reset_autosuggest_assets();
+
+		$filter = function () {
+			return [
+				'autosuggest' => [
+					'endpoint_url'             => 'http://example.com',
+					'enable_admin_autosuggest' => '1',
+				],
+			];
+		};
+
+		add_filter( 'pre_site_option_ep_feature_settings', $filter );
+		add_filter( 'pre_option_ep_feature_settings', $filter );
+
+		$this->get_feature()->enqueue_admin_scripts();
+
+		$this->assertTrue( wp_script_is( 'elasticpress-autosuggest' ) );
+		$this->assertTrue( wp_style_is( 'elasticpress-autosuggest' ) );
+	}
+
+	/**
+	 * Test admin autosuggest enqueue without endpoint does not load assets.
+	 *
+	 * @since 5.4.0
+	 * @group autosuggest
+	 */
+	public function test_admin_autosuggest_enqueue_without_endpoint() {
+		set_current_screen( 'edit.php' );
+		$this->reset_autosuggest_assets();
+
+		$filter = function () {
+			return [
+				'autosuggest' => [
+					'enable_admin_autosuggest' => '1',
+				],
+			];
+		};
+
+		add_filter( 'pre_site_option_ep_feature_settings', $filter );
+		add_filter( 'pre_option_ep_feature_settings', $filter );
+
+		$this->get_feature()->enqueue_admin_scripts();
+
+		$this->assertFalse( wp_script_is( 'elasticpress-autosuggest' ) );
+		$this->assertFalse( wp_style_is( 'elasticpress-autosuggest' ) );
+	}
+
+	/**
+	 * Test admin autosuggest enqueue respects capability.
+	 *
+	 * @since 5.4.0
+	 * @group autosuggest
+	 */
+	public function test_admin_autosuggest_enqueue_respects_capability() {
+		set_current_screen( 'edit.php' );
+		$this->reset_autosuggest_assets();
+
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$filter = function () {
+			return [
+				'autosuggest' => [
+					'endpoint_url'             => 'http://example.com',
+					'enable_admin_autosuggest' => '1',
+				],
+			];
+		};
+
+		add_filter( 'pre_site_option_ep_feature_settings', $filter );
+		add_filter( 'pre_option_ep_feature_settings', $filter );
+
+		$this->get_feature()->enqueue_admin_scripts();
+
+		$this->assertFalse( wp_script_is( 'elasticpress-autosuggest' ) );
+		$this->assertFalse( wp_style_is( 'elasticpress-autosuggest' ) );
+	}
+
+	/**
+	 * Test the admin query template integration override.
+	 *
+	 * @since 5.4.0
+	 * @group autosuggest
+	 */
+	public function test_is_integrated_request_for_admin_template() {
+		$feature = $this->get_feature();
+
+		$this->assertTrue( $feature->is_integrated_request_for_admin_template( false, 'search' ) );
+		$this->assertTrue( $feature->is_integrated_request_for_admin_template( false, 'autosuggest' ) );
+		$this->assertFalse( $feature->is_integrated_request_for_admin_template( false, 'some_other_context' ) );
+		$this->assertTrue( $feature->is_integrated_request_for_admin_template( true, 'some_other_context' ) );
+	}
+
+	/**
+	 * Test the admin search query template.
+	 *
+	 * @since 5.4.0
+	 * @group autosuggest
+	 */
+	public function test_generate_admin_search_query() {
+		$feature = $this->get_feature();
+		$query   = $feature->generate_admin_search_query();
+
+		$this->assertArrayHasKey( 'body', $query );
+		$this->assertArrayHasKey( 'placeholder', $query );
+		$this->assertContains( 'ep_autosuggest_placeholder', $query );
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds an opt-in setting to extend the Autosuggest feature to the WordPress admin area, such as the post list table search box. The frontend autosuggest code and assets are reused; the only backend change is an admin-specific query template that uses the post statuses actually stored in the index.

Fixes #3886

## Changes

### `includes/classes/Feature/Autosuggest/Autosuggest.php`

**Before:**
The feature only hooked `wp_enqueue_scripts` and generated a query template based on public, searchable post statuses. Admin requests were never integrated, so the template could not be built from an admin context.

**After:**
- A new `enable_admin_autosuggest` checkbox setting is added to the feature settings schema.
- `admin_enqueue_scripts` is hooked to `enqueue_admin_scripts()`, which loads the same `elasticpress-autosuggest` script/style when the setting is enabled and the current user has the `edit_posts` capability (filterable via `ep_admin_autosuggest_capability`).
- Shared enqueue and option-building logic is extracted into `enqueue_autosuggest_assets()`, `get_autosuggest_endpoint_url()`, and `get_epas_options()` so both frontend and admin use the same localization structure.
- `generate_search_query()` now accepts an optional `$is_admin` flag. When true, it uses `Indexables::factory()->get( 'post' )->get_indexable_post_status()` so the template matches what is actually indexed (including drafts/private/future when Protected Content is active).
- `generate_admin_search_query()` temporarily filters `ep_is_integrated_request` to return `true` for the `search` and `autosuggest` contexts, mirroring the pattern used by Instant Results and WooCommerce Orders Autosuggest. The filter is removed immediately after the template is captured, so regular admin queries are unaffected.

### `tests/php/features/TestAutosuggest.php`

**After:**
Seven new tests cover the setting schema, default-off behavior, enqueue gating when the setting is enabled, endpoint requirement, capability check, the `ep_is_integrated_request` override callback, and the admin query template generation.

## Testing

**Test 1: Enable admin autosuggest and see suggestions on the post list**
1. Go to ElasticPress > Features > Autosuggest and check Enable autosuggest in the WordPress admin.
2. Navigate to Posts > All Posts.
3. Type in the search box (`#post-search-input`).
Result: matching suggestions appear in a dropdown and clicking one navigates to the post.

**Test 2: Capability check**
1. Log in as a user without `edit_posts` (e.g., Subscriber).
2. Visit any admin screen.
Result: the autosuggest script is not loaded.

**Test 3: Frontend unchanged**
1. Visit a frontend search form.
2. Type in the search field.
Result: autosuggest continues to work exactly as before.

**Test 4: PHPUnit**
1. Run `composer run test -- --filter TestAutosuggest`.
Result: 24 tests, 67 assertions, all pass.