### PR TITLE
fix(search): add keyword boost support for post search

### DIFF
--- a/includes/classes/Feature/Search/Search.php
+++ b/includes/classes/Feature/Search/Search.php
@@ -62,6 +62,7 @@ class Search extends Feature {
 			'highlight_enabled'    => '0',
 			'highlight_excerpt'    => '0',
 			'highlight_tag'        => 'mark',
+			'keyword_boosts'       => '',
 		];
 
 		$this->available_during_installation = true;
@@ -117,6 +118,7 @@ class Search extends Feature {
 	public function search_setup() {
 		add_filter( 'ep_elasticpress_enabled', [ $this, 'integrate_search_queries' ], 10, 2 );
 		add_filter( 'ep_formatted_args', [ $this, 'weight_recent' ], 11, 2 );
+		add_filter( 'ep_formatted_args', [ $this, 'apply_keyword_boosts' ], 25, 2 );
 		add_filter( 'ep_query_post_type', [ $this, 'filter_query_post_type_for_search' ], 10, 2 );
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
@@ -731,6 +733,177 @@ class Search extends Feature {
 	}
 
 	/**
+	 * Sanitize settings before saving.
+	 *
+	 * @since 5.3.4
+	 * @param array $settings Submitted settings for the feature.
+	 * @return array
+	 */
+	public function sanitize_settings_callback( $settings ) {
+		if ( isset( $settings['keyword_boosts'] ) ) {
+			$settings['keyword_boosts'] = $this->normalize_keyword_boosts( $settings['keyword_boosts'] );
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Parse and normalize keyword:boost pairs.
+	 *
+	 * @since 5.3.4
+	 * @param string $raw Raw textarea value.
+	 * @return string Normalized line-separated keyword:boost pairs.
+	 */
+	protected function normalize_keyword_boosts( $raw ) {
+		$boosts = $this->parse_keyword_boosts( $raw );
+		$lines  = array();
+
+		foreach ( $boosts as $keyword => $boost ) {
+			$lines[] = $keyword . ':' . $boost;
+		}
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Parse keyword:boost pairs from a string.
+	 *
+	 * @since 5.3.4
+	 * @param string $raw Raw textarea value.
+	 * @return array Associative array of keyword => boost.
+	 */
+	protected function parse_keyword_boosts( $raw ) {
+		$parsed = array();
+
+		if ( empty( $raw ) ) {
+			return $parsed;
+		}
+
+		$lines = preg_split( '/\r\n|\r|\n/', $raw );
+
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+
+			if ( empty( $line ) || false === strpos( $line, ':' ) ) {
+				continue;
+			}
+
+			$parts   = explode( ':', $line, 2 );
+			$keyword = sanitize_text_field( trim( $parts[0] ) );
+			$boost   = trim( $parts[1] );
+
+			if ( '' === $keyword || '' === $boost ) {
+				continue;
+			}
+
+			$boost = floatval( $boost );
+
+			if ( $boost <= 0 || $boost > 100 ) {
+				continue;
+			}
+
+			$parsed[ $keyword ] = $boost;
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Get keyword boosts for the current search query.
+	 *
+	 * @since 5.3.4
+	 * @return array Associative array of keyword => boost.
+	 */
+	protected function get_keyword_boosts() {
+		$settings = $this->get_settings();
+		$raw      = isset( $settings['keyword_boosts'] ) ? $settings['keyword_boosts'] : '';
+		$boosts   = $this->parse_keyword_boosts( $raw );
+
+		/**
+		 * Filter keyword boosts.
+		 *
+		 * @since 5.3.4
+		 * @hook ep_search_keyword_boosts
+		 * @param array $boosts Keyword => boost pairs.
+		 * @return array
+		 */
+		return apply_filters( 'ep_search_keyword_boosts', $boosts );
+	}
+
+	/**
+	 * Apply keyword boosts to the Elasticsearch query.
+	 *
+	 * @since 5.3.4
+	 * @param array $formatted_args Formatted ES args.
+	 * @param array $args           WP_Query args.
+	 * @return array
+	 */
+	public function apply_keyword_boosts( $formatted_args, $args ) {
+		if ( empty( $args['s'] ) ) {
+			return $formatted_args;
+		}
+
+		$boosts = $this->get_keyword_boosts();
+
+		if ( empty( $boosts ) ) {
+			return $formatted_args;
+		}
+
+		$default_search_fields = array(
+			'post_title',
+			'post_excerpt',
+			'post_content',
+		);
+
+		/**
+		 * Filter default post search fields
+		 *
+		 * @hook ep_search_fields
+		 * @param array $fields Default search fields
+		 * @param array $args   WP Query args
+		 * @return array
+		 */
+		$search_fields = apply_filters( 'ep_search_fields', $default_search_fields, $args );
+
+		if ( empty( $search_fields ) ) {
+			return $formatted_args;
+		}
+
+		if ( ! isset( $formatted_args['query'] ) ) {
+			return $formatted_args;
+		}
+
+		$query = &$formatted_args['query'];
+
+		if ( isset( $query['function_score']['query'] ) ) {
+			$query = &$query['function_score']['query'];
+		}
+
+		if ( ! isset( $query['bool']['should'] ) ) {
+			$existing_query = $query;
+			$query          = array(
+				'bool' => array(
+					'must'   => array( $existing_query ),
+					'should' => array(),
+				),
+			);
+		}
+
+		foreach ( $boosts as $keyword => $boost ) {
+			$query['bool']['should'][] = array(
+				'multi_match' => array(
+					'query'  => $keyword,
+					'type'   => 'phrase',
+					'fields' => $search_fields,
+					'boost'  => (float) $boost,
+				),
+			);
+		}
+
+		return $formatted_args;
+	}
+
+	/**
 	 * Saves exclude from search meta.
 	 *
 	 * @param int $post_id The post ID.
@@ -870,6 +1043,13 @@ class Search extends Feature {
 				'default' => 'simple',
 				'key'     => 'synonyms_editor_mode',
 				'type'    => 'hidden',
+			],
+			[
+				'default' => '',
+				'help'    => __( 'Boost specific keywords in search results. Enter one keyword per line, followed by a colon and a boost number, e.g. <code>premium:5</code>. Boosts must be between 0.01 and 100.', 'elasticpress' ),
+				'key'     => 'keyword_boosts',
+				'label'   => __( 'Keyword boosts', 'elasticpress' ),
+				'type'    => 'textarea',
 			],
 		];
 

--- a/tests/php/features/TestSearch.php
+++ b/tests/php/features/TestSearch.php
@@ -45,6 +45,13 @@ class TestSearch extends BaseTestCase {
 		parent::tear_down();
 
 		$this->fired_actions = array();
+
+		ElasticPress\Features::factory()->update_feature(
+			'search',
+			array(
+				'keyword_boosts' => '',
+			)
+		);
 	}
 
 	/**
@@ -346,11 +353,221 @@ class TestSearch extends BaseTestCase {
 
 		$settings_keys = wp_list_pluck( $settings_schema, 'key' );
 
-		$expected = [ 'active', 'decaying_enabled', 'highlight_enabled', 'highlight_excerpt', 'highlight_tag', 'synonyms_editor_mode' ];
+		$expected = [ 'active', 'decaying_enabled', 'highlight_enabled', 'highlight_excerpt', 'highlight_tag', 'synonyms_editor_mode', 'keyword_boosts' ];
 		if ( ! is_multisite() ) {
 			$expected[] = 'additional_links';
 		}
 
 		$this->assertSame( $expected, $settings_keys );
+	}
+
+	/**
+	 * Test keyword boosts are injected into the ES query when date decay is enabled.
+	 *
+	 * @since 5.3.4
+	 * @group search
+	 */
+	public function testKeywordBoostsInjectedWithDecay() {
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+		ElasticPress\Features::factory()->setup_features();
+		ElasticPress\Features::factory()->get_registered_feature( 'search' )->search_setup();
+
+		ElasticPress\Features::factory()->update_feature(
+			'search',
+			array(
+				'active'         => true,
+				'keyword_boosts' => "premium:5\nsale:3.5\n",
+			)
+		);
+
+		add_filter( 'ep_formatted_args', array( $this, 'catch_ep_formatted_args' ), 25 );
+
+		$query = new \WP_Query(
+			array(
+				's' => 'test',
+			)
+		);
+
+		$this->assertTrue( isset( $this->fired_actions['ep_formatted_args'] ) );
+
+		$es_query = $this->fired_actions['ep_formatted_args']['query'];
+		$this->assertTrue( isset( $es_query['function_score']['query']['bool']['should'] ) );
+
+		$shoulds = $es_query['function_score']['query']['bool']['should'];
+		$found   = 0;
+
+		foreach ( $shoulds as $should ) {
+			if ( ! isset( $should['multi_match']['query'] ) ) {
+				continue;
+			}
+
+			if ( 'premium' === $should['multi_match']['query'] && 5.0 === $should['multi_match']['boost'] ) {
+				++$found;
+			}
+
+			if ( 'sale' === $should['multi_match']['query'] && 3.5 === $should['multi_match']['boost'] ) {
+				++$found;
+			}
+		}
+
+		$this->assertSame( 2, $found );
+	}
+
+	/**
+	 * Test keyword boosts are injected into the ES query when date decay is disabled.
+	 *
+	 * @since 5.3.4
+	 * @group search
+	 */
+	public function testKeywordBoostsInjectedWithoutDecay() {
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+		ElasticPress\Features::factory()->setup_features();
+		ElasticPress\Features::factory()->get_registered_feature( 'search' )->search_setup();
+
+		ElasticPress\Features::factory()->update_feature(
+			'search',
+			array(
+				'active'           => true,
+				'decaying_enabled' => false,
+				'keyword_boosts'   => "premium:5\n",
+			)
+		);
+
+		add_filter( 'ep_formatted_args', array( $this, 'catch_ep_formatted_args' ), 25 );
+
+		$query = new \WP_Query(
+			array(
+				's' => 'test',
+			)
+		);
+
+		$this->assertTrue( isset( $this->fired_actions['ep_formatted_args'] ) );
+
+		$es_query = $this->fired_actions['ep_formatted_args']['query'];
+		$this->assertTrue( isset( $es_query['bool']['should'] ) );
+		$this->assertFalse( isset( $es_query['function_score'] ) );
+
+		$found = false;
+		foreach ( $es_query['bool']['should'] as $should ) {
+			if ( isset( $should['multi_match']['query'] ) && 'premium' === $should['multi_match']['query'] && 5.0 === $should['multi_match']['boost'] ) {
+				$found = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $found );
+	}
+
+	/**
+	 * Test keyword boosts are not injected when empty.
+	 *
+	 * @since 5.3.4
+	 * @group search
+	 */
+	public function testKeywordBoostsNotInjectedWhenEmpty() {
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+		ElasticPress\Features::factory()->setup_features();
+		ElasticPress\Features::factory()->get_registered_feature( 'search' )->search_setup();
+
+		ElasticPress\Features::factory()->update_feature(
+			'search',
+			array(
+				'active'           => true,
+				'decaying_enabled' => false,
+				'keyword_boosts'   => '',
+			)
+		);
+
+		add_filter( 'ep_formatted_args', array( $this, 'catch_ep_formatted_args' ), 25 );
+
+		$query = new \WP_Query(
+			array(
+				's' => 'test',
+			)
+		);
+
+		$this->assertTrue( isset( $this->fired_actions['ep_formatted_args'] ) );
+
+		$es_query      = $this->fired_actions['ep_formatted_args']['query'];
+		$boost_clauses = 0;
+		$other_clauses = 0;
+
+		foreach ( $es_query['bool']['should'] as $should ) {
+			if ( isset( $should['multi_match']['query'] ) ) {
+				++$boost_clauses;
+			} else {
+				++$other_clauses;
+			}
+		}
+
+		$this->assertSame( 0, $boost_clauses );
+		$this->assertGreaterThan( 0, $other_clauses );
+	}
+
+	/**
+	 * Test keyword boost parsing and sanitization.
+	 *
+	 * @since 5.3.4
+	 * @group search
+	 */
+	public function testKeywordBoostsSanitization() {
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+		ElasticPress\Features::factory()->setup_features();
+		$search = ElasticPress\Features::factory()->get_registered_feature( 'search' );
+
+		$normalized = $search->sanitize_settings_callback(
+			array(
+				'keyword_boosts' => "premium:5\nno-colon\n  sale:0 \n  valid:2.5  \nbig:101\nnegative:-3\n",
+			)
+		);
+
+		$this->assertSame( "premium:5\nvalid:2.5", $normalized['keyword_boosts'] );
+	}
+
+	/**
+	 * Test keyword boosts filter allows programmatic override.
+	 *
+	 * @since 5.3.4
+	 * @group search
+	 */
+	public function testKeywordBoostsFilter() {
+		ElasticPress\Features::factory()->activate_feature( 'search' );
+		ElasticPress\Features::factory()->setup_features();
+		ElasticPress\Features::factory()->get_registered_feature( 'search' )->search_setup();
+
+		ElasticPress\Features::factory()->update_feature(
+			'search',
+			array(
+				'active'         => true,
+				'keyword_boosts' => '',
+			)
+		);
+
+		add_filter(
+			'ep_search_keyword_boosts',
+			function () {
+				return array( 'filterterm' => 7 );
+			}
+		);
+
+		add_filter( 'ep_formatted_args', array( $this, 'catch_ep_formatted_args' ), 25 );
+
+		$query = new \WP_Query(
+			array(
+				's' => 'test',
+			)
+		);
+
+		$es_query = $this->fired_actions['ep_formatted_args']['query'];
+		$shoulds  = isset( $es_query['function_score']['query']['bool']['should'] ) ? $es_query['function_score']['query']['bool']['should'] : $es_query['bool']['should'];
+		$found    = false;
+		foreach ( $shoulds as $should ) {
+			if ( isset( $should['multi_match']['query'] ) && 'filterterm' === $should['multi_match']['query'] && 7.0 === $should['multi_match']['boost'] ) {
+				$found = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $found );
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds the ability to boost specific keywords in post search results. Admins can configure keyword:boost pairs in the Post Search feature settings, and the plugin injects additional `multi_match` `should` clauses into the Elasticsearch query, increasing the relevance score for documents that contain those keywords. No reindex is required because the change only affects the query DSL at search time.

Fixes #3534

## Changes

### Search feature settings (`includes/classes/Feature/Search/Search.php`)

**Before:**

There was no UI or mechanism to assign a boost factor to specific keywords.

**After:**

A new `keyword_boosts` textarea is exposed in the Post Search feature schema. The dashboard renders it automatically, and submitted values are sanitized into normalized `keyword:boost` lines.

```php
[
    \x27default\x27 => \x27\x27,
    \x27help\x27    => __( \x27Boost specific keywords in search results. Enter one keyword per line, followed by a colon and a boost number, e.g. <code>premium:5</code>. Boosts must be between 0.01 and 100.\x27, \x27elasticpress\x27 ),
    \x27key\x27     => \x27keyword_boosts\x27,
    \x27label\x27   => __( \x27Keyword boosts\x27, \x27elasticpress\x27 ),
    \x27type\x27    => \x27textarea\x27,
],
```

**Why:** The React dashboard is schema-driven, so adding a `textarea` entry to the feature settings schema is enough to expose the option without touching any JavaScript.

### Query injection (`includes/classes/Feature/Search/Search.php`)

**After:**

A new `apply_keyword_boosts()` method hooks into `ep_formatted_args` at priority 25, after date decay (11) and weighting (20). It appends one `multi_match` phrase clause per configured keyword to the existing `bool.should` array, reusing the same search fields so field weights remain effective.

```php
foreach ( $boosts as $keyword => $boost ) {
    $query[\x27bool\x27][\x27should\x27][] = array(
        \x27multi_match\x27 => array(
            \x27query\x27  => $keyword,
            \x27type\x27   => \x27phrase\x27,
            \x27fields\x27 => $search_fields,
            \x27boost\x27  => (float) $boost,
        ),
    );
}
```

**Why:** The additional `should` clauses are added inside the `function_score` query, so they work together with date decay and per-field weighting. Wrapping the original query in `must` for the edge case where `bool.should` is missing keeps the original query required while the keyword clauses remain optional scoring signals.

### Filter hook

**After:**

```php
return apply_filters( \x27ep_search_keyword_boosts\x27, $boosts );
```

**Why:** Developers can programmatically override or extend the keyword list without editing the admin setting.

### Tests (`tests/php/features/TestSearch.php`)

**After:**

Five new tests verify the feature:

- `testKeywordBoostsInjectedWithDecay` — confirms two keyword clauses are injected when date decay is enabled.
- `testKeywordBoostsInjectedWithoutDecay` — confirms injection when date decay is disabled.
- `testKeywordBoostsNotInjectedWhenEmpty` — confirms no extra clauses when the setting is empty.
- `testKeywordBoostsSanitization` — confirms malformed lines and out-of-range boosts are dropped.
- `testKeywordBoostsFilter` — confirms the `ep_search_keyword_boosts` filter works.

**Why:** The tests assert the exact ES query shape and the sanitize behavior, which matches the existing Search/Weighting test patterns in the repo.

## Testing

**Test 1: Keyword boost affects ranking**
1. Enable Post Search and save `keyword_boosts` with `premium:5`.
2. Create two posts containing the term "product"; one titled "Premium product" and one titled "Regular product".
3. Search for "product" on the frontend.
Result: "Premium product" ranks higher than "Regular product".

**Test 2: Sanitization**
1. Enter `premium:5`, `sale:0`, `big:101`, `negative:-3`, and `no-colon` on separate lines.
2. Save the settings.
Result: Only `premium:5` is stored; invalid lines are dropped.

**Test 3: Empty setting**
1. Leave the Keyword boosts textarea empty and save.
2. Search for any term.
Result: The Elasticsearch query shape is unchanged from the default behavior.

**Test 4: Filter override**
1. Add a filter on `ep_search_keyword_boosts` returning `array( \x27filterterm\x27 => 7 )`.
2. Run a search.
Result: The query contains a `multi_match` clause for `filterterm` with `boost: 7`.

## Automated tests

```bash
vendor/bin/phpunit --filter testKeywordBoosts -c single-site.xml.dist
```

All five new keyword-boost tests pass. The full `TestSearch` suite has one pre-existing failure (`testSearchOn`) that also fails on the upstream `develop` branch in this environment and is unrelated to this change.
