### PR TITLE
fix(did-you-mean): suppress suggestions for valid queries and matching terms

### DIFF
--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -127,8 +127,19 @@ class DidYouMean extends Feature {
 			return false;
 		}
 
+		/**
+		 * Filter whether to suppress the suggestion when the current query already returned results.
+		 *
+		 * @since 5.4.0
+		 * @hook ep_suggestion_suppress_when_results_exist
+		 * @param {bool}     $suppress Whether to suppress the suggestion. Default true.
+		 * @param {WP_Query} $query    The WP_Query object.
+		 * @return {bool} New value
+		 */
+		$suppress_when_results_exist = apply_filters( 'ep_suggestion_suppress_when_results_exist', true, $query );
+
 		// No need to suggest alternatives if the current query already returned results.
-		if ( $query->found_posts > 0 ) {
+		if ( $suppress_when_results_exist && $query->found_posts > 0 ) {
 			return false;
 		}
 

--- a/includes/classes/Feature/DidYouMean/DidYouMean.php
+++ b/includes/classes/Feature/DidYouMean/DidYouMean.php
@@ -127,8 +127,19 @@ class DidYouMean extends Feature {
 			return false;
 		}
 
+		// No need to suggest alternatives if the current query already returned results.
+		if ( $query->found_posts > 0 ) {
+			return false;
+		}
+
 		$term = $this->get_suggested_term( $query );
 		if ( empty( $term ) ) {
+			return false;
+		}
+
+		// No need to suggest the same term the user already typed.
+		$search_term = $query->query_vars['s'] ?? '';
+		if ( strtolower( $term ) === strtolower( $search_term ) ) {
 			return false;
 		}
 
@@ -293,6 +304,12 @@ class DidYouMean extends Feature {
 
 		$term = $this->get_suggested_term( $wp_query );
 		if ( empty( $term ) ) {
+			return;
+		}
+
+		// Do not redirect to the same term the user already searched for.
+		$search_term = $wp_query->query_vars['s'] ?? '';
+		if ( strtolower( $term ) === strtolower( $search_term ) ) {
 			return;
 		}
 

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -495,6 +495,35 @@ class TestDidYouMean extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that `ep_suggestion_suppress_when_results_exist` filter can restore the suggestion when results exist.
+	 */
+	public function testGetSuggestionSuppressWhenResultsExistFilter() {
+		$query                        = new \WP_Query(
+			[
+				's' => 'shirt',
+			]
+		);
+		$query->found_posts           = 1;
+		$query->suggested_terms       = [
+			'options' => [
+				[
+					'text' => 'shift',
+				],
+			],
+		];
+		$query->query_vars['s']       = 'shirt';
+		$query->elasticsearch_success = true;
+
+		// Default behavior: suppressed because the query already has results.
+		$this->assertFalse( ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
+
+		add_filter( 'ep_suggestion_suppress_when_results_exist', '__return_false' );
+
+		$expected = sprintf( '<span class="ep-spell-suggestion">Did you mean: <a href="%s">shift</a>?</span>', get_search_link( 'shift' ) );
+		$this->assertEquals( $expected, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
+	}
+
+	/**
 	 * Tests that get_suggestion returns false when the top suggestion matches the original term.
 	 */
 	public function testGetSuggestionNotShownWhenTopSuggestionMatchesOriginalTerm() {

--- a/tests/php/features/TestDidYouMean.php
+++ b/tests/php/features/TestDidYouMean.php
@@ -116,6 +116,9 @@ class TestDidYouMean extends BaseTestCase {
 
 		$this->assertTrue( $query->elasticsearch_success );
 
+		// Force no results so the suggestion is displayed.
+		$query->found_posts = 0;
+
 		$expected = sprintf( '<span class="ep-spell-suggestion">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
 		$this->assertEquals( $expected, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
 	}
@@ -142,6 +145,9 @@ class TestDidYouMean extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 
 		$query = $query->query( $args );
+
+		// Force no results so the suggestion is displayed.
+		$wp_query->found_posts = 0;
 
 		$expected = sprintf( '<span class="ep-spell-suggestion">Did you mean: <a href="%s">test</a>?</span>', get_search_link( 'test' ) );
 		$this->assertEquals( $expected, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion() );
@@ -180,6 +186,10 @@ class TestDidYouMean extends BaseTestCase {
 				's' => 'teet',
 			]
 		);
+
+		// Force no results so the suggestion is displayed.
+		$query->found_posts = 0;
+
 		$this->assertEquals( $expected_result, ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
 	}
 
@@ -338,6 +348,9 @@ class TestDidYouMean extends BaseTestCase {
 		$wp_the_query = $query;
 		$wp_query     = $query;
 
+		// Force no results so the suggestion is displayed.
+		$query->found_posts = 0;
+
 		ob_start();
 		do_action( 'ep_suggestions' );
 		$output = ob_get_clean();
@@ -370,6 +383,9 @@ class TestDidYouMean extends BaseTestCase {
 		);
 
 		parse_str( 'ep_suggestion_original_term=Original Term', $_GET );
+
+		// Force no results so the suggestion is displayed.
+		$query->found_posts = 0;
 
 		ob_start();
 		do_action( 'ep_suggestions', $query );
@@ -456,5 +472,71 @@ class TestDidYouMean extends BaseTestCase {
 			[ 'active', 'search_behavior' ],
 			$settings_keys
 		);
+	}
+
+	/**
+	 * Tests that get_suggestion returns false when the current search term already has results.
+	 */
+	public function testGetSuggestionNotShownWhenResultsExist() {
+		$this->ep_factory->post->create( [ 'post_content' => 'Shirt product' ] );
+		$this->ep_factory->post->create( [ 'post_content' => 'Shift product' ] );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				's' => 'shirt',
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertGreaterThan( 0, $query->found_posts );
+		$this->assertFalse( ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
+	}
+
+	/**
+	 * Tests that get_suggestion returns false when the top suggestion matches the original term.
+	 */
+	public function testGetSuggestionNotShownWhenTopSuggestionMatchesOriginalTerm() {
+		$query                        = new \WP_Query(
+			[
+				's' => 'shirt',
+			]
+		);
+		$query->found_posts           = 0;
+		$query->suggested_terms       = [
+			'options' => [
+				[
+					'text' => 'shirt',
+				],
+			],
+		];
+		$query->query_vars['s']       = 'shirt';
+		$query->elasticsearch_success = true;
+
+		$this->assertFalse( ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
+	}
+
+	/**
+	 * Tests that get_suggestion returns false when the top suggestion matches the original term with different casing.
+	 */
+	public function testGetSuggestionNotShownWhenTopSuggestionMatchesOriginalTermCaseInsensitive() {
+		$query                        = new \WP_Query(
+			[
+				's' => 'shirt',
+			]
+		);
+		$query->found_posts           = 0;
+		$query->suggested_terms       = [
+			'options' => [
+				[
+					'text' => 'Shirt',
+				],
+			],
+		];
+		$query->query_vars['s']       = 'shirt';
+		$query->elasticsearch_success = true;
+
+		$this->assertFalse( ElasticPress\Features::factory()->get_registered_feature( 'did-you-mean' )->get_suggestion( $query ) );
 	}
 }


### PR DESCRIPTION
## Summary

"Did You Mean" currently shows the top suggestion even when the current search term already returns results. This leads to confusing suggestions like "Did you mean: shift?" when searching for "shirt" with valid results. This fix suppresses the suggestion when the query has results, or when the suggestion matches the original term. It also applies the same guard to the redirect behavior to prevent a redirect loop.

Closes #3602

## Changes

### `includes/classes/Feature/DidYouMean/DidYouMean.php`

**`get_suggestion()`** now returns `false` early in two cases:

**Before:**
```php
$term = $this->get_suggested_term( $query );
if ( empty( $term ) ) {
    return false;
}

$html = sprintf( '<span class="ep-spell-suggestion">%s: <a href="%s">%s</a>?</span>', ... );
```

**After:**
```php
$suppress_when_results_exist = apply_filters( 'ep_suggestion_suppress_when_results_exist', true, $query );

if ( $suppress_when_results_exist && $query->found_posts > 0 ) {
    return false;
}

$term = $this->get_suggested_term( $query );
if ( empty( $term ) ) {
    return false;
}

$search_term = $query->query_vars['s'] ?? '';
if ( strtolower( $term ) === strtolower( $search_term ) ) {
    return false;
}

$html = sprintf( '<span class="ep-spell-suggestion">%s: <a href="%s">%s</a>?</span>', ... );
```

**Why:** This matches the existing behavior of `get_alternatives_terms()`, which already hides the alternative list when the query has results. The case-insensitive match guard prevents the feature from suggesting the same term the user already typed.

A new `ep_suggestion_suppress_when_results_exist` filter (default `true`) was added per review feedback, so sites that want the suggestion to still show up alongside results can opt back in with one line, instead of the fix being all-or-nothing.

**`automatically_redirect_user()`** also skips redirecting if the suggested term equals the current search term:

**After:**
```php
$term = $this->get_suggested_term( $wp_query );
if ( empty( $term ) ) {
    return;
}

$search_term = $wp_query->query_vars['s'] ?? '';
if ( strtolower( $term ) === strtolower( $search_term ) ) {
    return;
}
```

**Why:** Prevents an infinite redirect loop when the phrase suggester returns the same term as the original query.

## How to test the Change

**Test 1: Valid query with results**
1. Create posts containing "shirt" and "shift".
2. Sync the index.
3. Search for "shirt".
Result: results load and no "Did you mean: shift?" message appears.

**Test 2: Typo with no results**
1. Search for "shirf".
Result: "Did you mean: shirt?" appears because the query has no results.

**Test 3: Same-term suggestion**
1. Mock or trigger a query where the top suggestion equals the original term (e.g., "shirt" → "shirt" or "Shirt").
Result: no suggestion is displayed.

**Test 4: Restore suggestion via filter**
1. Add `add_filter( 'ep_suggestion_suppress_when_results_exist', '__return_false' );` to a must-use plugin.
2. Repeat Test 1.
Result: "Did you mean: shift?" now shows again alongside the "shirt" results.

## Unit tests

Tests added/updated in `tests/php/features/TestDidYouMean.php`:

- `testGetSuggestionNotShownWhenResultsExist`
- `testGetSuggestionNotShownWhenTopSuggestionMatchesOriginalTerm`
- `testGetSuggestionNotShownWhenTopSuggestionMatchesOriginalTermCaseInsensitive`
- `testGetSuggestionSuppressWhenResultsExistFilter`

Run with:

```bash
vendor/bin/phpunit --filter TestDidYouMean
```

All 21 tests pass. Full `composer run test-single-site` suite also run (944 tests) with no regressions (1 pre-existing unrelated failure in `TestInstantResults` on WP 7.0, not touched by this PR).

### Changelog Entry

> Fixed - "Did You Mean" no longer suggests a term when the current search already has results or when the suggestion matches the original term (case-insensitive), preventing confusing suggestions and redirect loops. A new `ep_suggestion_suppress_when_results_exist` filter allows restoring the previous behavior.

### Credits

Props @faisalahammad

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
