### PR TITLE
Fix: max_num_pages becomes negative when posts_per_page is -1

### DIFF
--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -362,7 +362,7 @@ class QueryIntegration {
 			$found_documents              = is_array( $ep_query['found_documents'] ) ? $ep_query['found_documents']['value'] : $ep_query['found_documents']; // 7.0+ have this as an array rather than int
 			$query->found_posts           = $found_documents;
 			$query->num_posts             = $query->found_posts;
-			$query->max_num_pages         = ceil( $found_documents / $query->get( 'posts_per_page' ) );
+			$query->max_num_pages         = -1 === $query->get( 'posts_per_page' ) ? 0 : ceil( $found_documents / $query->get( 'posts_per_page' ) );
 			$query->suggested_terms       = $this->maybe_sanitize_suggestion( $ep_query );
 			$query->elasticsearch_success = true;
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -10592,4 +10592,28 @@ class TestPost extends BaseTestCase {
 		$queries_after = $wpdb->num_queries;
 		$this->assertGreaterThan( $queries_before, $queries_after );
 	}
+
+	/**
+	 * Test max_num_pages when posts_per_page is -1.
+	 *
+	 * @since 5.3.4
+	 * @group post
+	 */
+	public function test_max_num_pages_with_posts_per_page_negative_one() {
+		$this->ep_factory->post->create();
+		$this->ep_factory->post->create();
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate'   => true,
+				'posts_per_page' => -1,
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertSame( 2, $query->found_posts );
+		$this->assertSame( 0, $query->max_num_pages );
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -10608,7 +10608,7 @@ class TestPost extends BaseTestCase {
 		$query = new \WP_Query(
 			[
 				'ep_integrate'   => true,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPress.WP.PostsPerPageNoUnlimited.posts_per_page_posts_per_page
 			]
 		);
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
When running a `WP_Query` `posts_per_page => -1`, ElasticPress was calculating `max_num_pages` as `ceil( found_posts / -1 )`, producing a negative value (for example, `-17` when 17 posts were found). WordPress core treats `posts_per_page => -1` as "return all posts" and leaves `max_num_pages` at `0` because pagination does not apply.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4334 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - `max_num_pages` becomes negative when posts_per_page is -1

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @dmitrijCraq

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
