### PR TITLE
Fix: Respect ep_is_facetable false to disable faceting on queries

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -270,8 +270,9 @@ class Facets extends Feature {
 			return true;
 		}
 
-		if ( ! empty( $query->get( 'ep_is_facetable' ) ) ) {
-			return true;
+		$ep_is_facetable = $query->get( 'ep_is_facetable', null );
+		if ( null !== $ep_is_facetable ) {
+			return (bool) $ep_is_facetable;
 		}
 
 		if ( is_admin() || is_feed() ) {

--- a/tests/php/features/TestFacet.php
+++ b/tests/php/features/TestFacet.php
@@ -608,6 +608,32 @@ class TestFacet extends BaseTestCase {
 	}
 
 	/**
+	 * Test is_facetable returns false when ep_is_facetable is explicitly false.
+	 *
+	 * @since 5.3.4
+	 * @group facets
+	 */
+	public function test_is_facetable_respects_explicit_false() {
+		global $wp_the_query, $wp_query;
+
+		$facet_feature = Features::factory()->get_registered_feature( 'facets' );
+
+		$query = new \WP_Query(
+			[
+				's'               => 'test',
+				'ep_integrate'    => true,
+				'ep_is_facetable' => false,
+			]
+		);
+
+		// mock the query as main query.
+		$wp_the_query = $query;
+		$wp_query     = $query;
+
+		$this->assertFalse( $facet_feature->is_facetable( $query ) );
+	}
+
+	/**
 	 * Utility function for the testGetSelected test.
 	 *
 	 * Private as it is super specific and not likely to be extended.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
The `ep_is_facetable` query argument was only handled as a positive override. When set to `false`, it was ignored and `is_facetable()` continued through the standard checks, so faceting could still be enabled on queries such as the main search query.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4335

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable the Filters feature.
2. Add the code and ensure that Es response doesn't have aggregation
```
add_action( 'pre_get_posts', function ( $query ) {
	if ( ! is_admin() && $query->is_main_query() && $query->is_search() ) {
		$query->set( 'ep_is_facetable', false );
	}
} );
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Respect `ep_is_facetable` false to disable faceting on queries

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @dmitrijCraq

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
