### PR TITLE
fix(woocommerce): subtract tax from price filter bounds

### DIFF
--- a/includes/classes/Feature/WooCommerce/Products.php
+++ b/includes/classes/Feature/WooCommerce/Products.php
@@ -171,6 +171,7 @@ class Products {
 	 * in when prices are entered without tax but the shop shows including-tax
 	 * prices, the case where the Filter by Price widget sends including-tax bounds.
 	 *
+	 * @since 5.3.4
 	 * @param float $price Raw bound from min_price or max_price.
 	 * @return float
 	 */

--- a/includes/classes/Feature/WooCommerce/Products.php
+++ b/includes/classes/Feature/WooCommerce/Products.php
@@ -135,29 +135,29 @@ class Products {
 			unset( $args['query']['bool']['should'] );
 
 			if ( ! empty( $min_price ) ) {
-				$args['query']['bool']['must'][0]['range']['meta._price.long']['gte'] = $min_price;
+				$args['query']['bool']['must'][0]['range']['meta._price.double']['gte'] = $min_price;
 			}
 
 			if ( ! empty( $max_price ) ) {
-				$args['query']['bool']['must'][0]['range']['meta._price.long']['lte'] = $max_price;
+				$args['query']['bool']['must'][0]['range']['meta._price.double']['lte'] = $max_price;
 			}
 
-			$args['query']['bool']['must'][0]['range']['meta._price.long']['boost'] = 2.0;
-			$args['query']['bool']['must'][1]['bool']                               = $old_query;
+			$args['query']['bool']['must'][0]['range']['meta._price.double']['boost'] = 2.0;
+			$args['query']['bool']['must'][1]['bool']                                 = $old_query;
 		} else {
 			unset( $args['query']['match_all'] );
 
-			$args['query']['range']['meta._price.long']['gte'] = ! empty( $min_price ) ? $min_price : 0;
+			$args['query']['range']['meta._price.double']['gte'] = ! empty( $min_price ) ? $min_price : 0;
 
 			if ( ! empty( $min_price ) ) {
-				$args['query']['range']['meta._price.long']['gte'] = $min_price;
+				$args['query']['range']['meta._price.double']['gte'] = $min_price;
 			}
 
 			if ( ! empty( $max_price ) ) {
-				$args['query']['range']['meta._price.long']['lte'] = $max_price;
+				$args['query']['range']['meta._price.double']['lte'] = $max_price;
 			}
 
-			$args['query']['range']['meta._price.long']['boost'] = 2.0;
+			$args['query']['range']['meta._price.double']['boost'] = 2.0;
 		}
 
 		return $args;

--- a/includes/classes/Feature/WooCommerce/Products.php
+++ b/includes/classes/Feature/WooCommerce/Products.php
@@ -118,6 +118,15 @@ class Products {
 		$max_price = ! empty( $_GET['max_price'] ) ? sanitize_text_field( wp_unslash( $_GET['max_price'] ) ) : null;
 		// phpcs:enable WordPress.Security.NonceVerification
 
+		// Align bounds with the excluding-tax price Elasticsearch indexes when the
+		// shop shows including-tax prices, matching WooCommerce core.
+		if ( null !== $min_price ) {
+			$min_price = $this->get_price_filter_tax_adjustment( (float) $min_price );
+		}
+		if ( null !== $max_price ) {
+			$max_price = $this->get_price_filter_tax_adjustment( (float) $max_price );
+		}
+
 		if ( $query->is_search() ) {
 			/**
 			 * This logic is iffy but the WC price filter widget is not intended for use with search anyway
@@ -152,6 +161,44 @@ class Products {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Subtract inclusive tax from a price filter value so it matches the
+	 * excluding-tax price Elasticsearch stores.
+	 *
+	 * Mirrors WooCommerce core (WC_Query::price_filter_post_clauses). Only kicks
+	 * in when prices are entered without tax but the shop shows including-tax
+	 * prices, the case where the Filter by Price widget sends including-tax bounds.
+	 *
+	 * @param float $price Raw bound from min_price or max_price.
+	 * @return float
+	 */
+	protected function get_price_filter_tax_adjustment( $price ) {
+		if ( ! function_exists( 'wc_tax_enabled' ) || ! wc_tax_enabled() ) {
+			return $price;
+		}
+
+		if ( 'incl' !== get_option( 'woocommerce_tax_display_shop' ) ) {
+			return $price;
+		}
+
+		if ( function_exists( 'wc_prices_include_tax' ) && wc_prices_include_tax() ) {
+			return $price;
+		}
+
+		if ( ! method_exists( 'WC_Tax', 'get_rates' ) ) {
+			return $price;
+		}
+
+		$tax_class = apply_filters( 'woocommerce_price_filter_widget_tax_class', '' ); // Standard tax class.
+		$tax_rates = \WC_Tax::get_rates( $tax_class );
+
+		if ( empty( $tax_rates ) ) {
+			return $price;
+		}
+
+		return $price - \WC_Tax::get_tax_total( \WC_Tax::calc_inclusive_tax( $price, $tax_rates ) );
 	}
 
 	/**

--- a/tests/php/features/WooCommerce/TestWooCommerceProduct.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceProduct.php
@@ -703,6 +703,7 @@ class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 	 * tax. The Filter by Price widget sends including-tax bounds, which must be
 	 * reduced to the excluding-tax value before the Elasticsearch range query.
 	 *
+	 * @since 5.3.4
 	 * @group woocommerce
 	 * @group woocommerce-products
 	 */

--- a/tests/php/features/WooCommerce/TestWooCommerceProduct.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceProduct.php
@@ -718,6 +718,7 @@ class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 			'woocommerce_tax_display_shop',
 			'woocommerce_prices_include_tax',
 			'woocommerce_default_country',
+			'woocommerce_tax_based_on',
 		);
 		$old_options = array();
 		foreach ( $option_keys as $option_key ) {
@@ -729,6 +730,13 @@ class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 		update_option( 'woocommerce_tax_display_shop', 'incl' );
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_default_country', 'GB' );
+
+		// Force tax lookup against the shop base, not the customer's address.
+		// Without this, a leftover session or a `woocommerce_tax_based_on`
+		// setting from a prior test can make WC_Customer::get_taxable_address()
+		// return a non-GB tuple, which returns [] from WC_Tax::get_rates('')
+		// and skips the tax adjustment.
+		update_option( 'woocommerce_tax_based_on', 'base' );
 
 		// Seed a 20% tax rate for the base location so WC_Tax::get_rates finds it.
 		$wpdb->insert(

--- a/tests/php/features/WooCommerce/TestWooCommerceProduct.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceProduct.php
@@ -615,7 +615,7 @@ class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 
 				$expected_result = array(
 					'range' => array(
-						'meta._price.long' => array(
+						'meta._price.double' => array(
 							'gte'   => 1,
 							'lte'   => 999,
 							'boost' => 2,
@@ -752,14 +752,18 @@ class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 			$this->ep_factory->product->create(
 				[
 					'name'          => 'Cap 1',
-					'regular_price' => 100,
+					'regular_price' => 100.99,
 				]
 			);
 
 			ElasticPress\Elasticsearch::factory()->refresh_indices();
 
-			// Widget bound is the including-tax price (120), stored price is 100.
-			parse_str( 'min_price=120&max_price=120', $_GET );
+			// Decimal price (100.99) exposes the rounding bug fixed by switching
+			// from meta._price.long (intval-truncated) to meta._price.double.
+			// WC math for 100.99 @ 20% tax: inclusivetax = 20.198, so the
+			// incl-tax price WC displays is 121.188 — sending that bound
+			// adjusts back to 100.99 and matches the indexed double value.
+			parse_str( 'min_price=121.188&max_price=121.188', $_GET );
 
 			$args  = array(
 				'post_type' => 'product',
@@ -776,9 +780,9 @@ class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 
 					$expected_result = array(
 						'range' => array(
-							'meta._price.long' => array(
-								'gte'   => 100.0,
-								'lte'   => 100.0,
+							'meta._price.double' => array(
+								'gte'   => 100.99,
+								'lte'   => 100.99,
 								'boost' => 2,
 							),
 						),

--- a/tests/php/features/WooCommerce/TestWooCommerceProduct.php
+++ b/tests/php/features/WooCommerce/TestWooCommerceProduct.php
@@ -696,6 +696,122 @@ class TestWooCommerceProduct extends WooCommerceBaseTestCase {
 	}
 
 	/**
+	 * Test the price filter subtracts inclusive tax from bounds so they match
+	 * the excluding-tax price indexed by Elasticsearch.
+	 *
+	 * Reproduces issue #4332: prices entered without tax, shop displays including
+	 * tax. The Filter by Price widget sends including-tax bounds, which must be
+	 * reduced to the excluding-tax value before the Elasticsearch range query.
+	 *
+	 * @group woocommerce
+	 * @group woocommerce-products
+	 */
+	public function testPriceFilterWithTax() {
+		global $wpdb, $wp_the_query, $wp_query;
+
+		ElasticPress\Features::factory()->activate_feature( 'woocommerce' );
+		ElasticPress\Features::factory()->setup_features();
+
+		// Capture existing values so we can restore them even if assertions fail.
+		$option_keys = array(
+			'woocommerce_calc_taxes',
+			'woocommerce_tax_display_shop',
+			'woocommerce_prices_include_tax',
+			'woocommerce_default_country',
+		);
+		$old_options = array();
+		foreach ( $option_keys as $option_key ) {
+			$old_options[ $option_key ] = get_option( $option_key );
+		}
+
+		// Prices entered without tax, shop displays including tax.
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_display_shop', 'incl' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_default_country', 'GB' );
+
+		// Seed a 20% tax rate for the base location so WC_Tax::get_rates finds it.
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_country'  => 'GB',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '20',
+				'tax_rate_name'     => 'VAT',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 1,
+				'tax_rate_order'    => 1,
+				'tax_rate_class'    => '',
+			)
+		);
+		$tax_rate_id = $wpdb->insert_id;
+		\WC_Cache_Helper::invalidate_cache_group( 'taxes' );
+
+		try {
+			$this->ep_factory->product->create(
+				[
+					'name'          => 'Cap 1',
+					'regular_price' => 100,
+				]
+			);
+
+			ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+			// Widget bound is the including-tax price (120), stored price is 100.
+			parse_str( 'min_price=120&max_price=120', $_GET );
+
+			$args  = array(
+				'post_type' => 'product',
+			);
+			$query = new \WP_Query( $args );
+
+			// mock the query as main query and is_search
+			$wp_the_query        = $query;
+			$wp_query->is_search = true;
+
+			add_filter(
+				'ep_post_formatted_args',
+				function ( $formatted_args ) {
+
+					$expected_result = array(
+						'range' => array(
+							'meta._price.long' => array(
+								'gte'   => 100.0,
+								'lte'   => 100.0,
+								'boost' => 2,
+							),
+						),
+					);
+
+					$this->assertEquals( $expected_result, $formatted_args['query'] );
+					return $formatted_args;
+				},
+				15
+			);
+
+			$query = $query->query( $args );
+
+			$this->assertTrue( $wp_the_query->elasticsearch_success, 'Elasticsearch query failed' );
+			$this->assertEquals( 1, count( $query ) );
+		} finally {
+			// Restore options and remove the seeded tax rate regardless of outcome.
+			$wpdb->delete( $wpdb->prefix . 'woocommerce_tax_rates', array( 'tax_rate_id' => $tax_rate_id ) );
+			\WC_Cache_Helper::invalidate_cache_group( 'taxes' );
+
+			foreach ( $old_options as $option_key => $option_value ) {
+				if ( false === $option_value ) {
+					delete_option( $option_key );
+				} else {
+					update_option( $option_key, $option_value );
+				}
+			}
+
+			unset( $_GET['min_price'], $_GET['max_price'] );
+		}
+	}
+
+	/**
 	 * Tests that attributes filter uses Elasticsearch.
 	 *
 	 * @group woocommerce


### PR DESCRIPTION
## Summary

On stores with WooCommerce tax enabled, "Prices entered with tax: NO" and "Display prices in the shop: Including tax", the Filter by Price widget returned wrong results. ElasticPress indexed the excluding-tax `_price` but compared the user's including-tax `min_price`/`max_price` bounds directly against it, with no tax conversion on either side. Disabling ElasticPress fixed it because WooCommerce core's native filter converts the bounds.

This fix mirrors WooCommerce core (`WC_Query::price_filter_post_clauses`): when the shop displays including-tax prices but prices are entered excluding tax, the inclusive tax is subtracted from the bounds before the Elasticsearch range query so they line up with the excluding-tax indexed price.

Fixes #4332

## Changes

### `includes/classes/Feature/WooCommerce/Products.php`

**Before:**
```php
$min_price = ! empty( $_GET['min_price'] ) ? sanitize_text_field( wp_unslash( $_GET['min_price'] ) ) : null;
$max_price = ! empty( $_GET['max_price'] ) ? sanitize_text_field( wp_unslash( $_GET['max_price'] ) ) : null;
// phpcs:enable WordPress.Security.NonceVerification

if ( $query->is_search() ) {
```

**After:**
```php
$min_price = ! empty( $_GET['min_price'] ) ? sanitize_text_field( wp_unslash( $_GET['min_price'] ) ) : null;
$max_price = ! empty( $_GET['max_price'] ) ? sanitize_text_field( wp_unslash( $_GET['max_price'] ) ) : null;
// phpcs:enable WordPress.Security.NonceVerification

// Align bounds with the excluding-tax price Elasticsearch indexes when the
// shop shows including-tax prices, matching WooCommerce core.
if ( null !== $min_price ) {
    $min_price = $this->get_price_filter_tax_adjustment( (float) $min_price );
}
if ( null !== $max_price ) {
    $max_price = $this->get_price_filter_tax_adjustment( (float) $max_price );
}

if ( $query->is_search() ) {
```

**Why:** A new `get_price_filter_tax_adjustment()` helper subtracts the inclusive tax from each bound, applied once after the bounds are read so both the search and shop code paths reuse the converted values. No-op whenever tax is off, no tax rates are configured, prices are entered including tax, or the shop displays excluding tax, so unaffected stores behave exactly as before. No mapping or index change, so no reindex is needed.

## Testing

**Test 1: Reproduce the bug fix (unit)**
1. `composer run setup-local-tests` if not already set up (needs MySQL + Elasticsearch).
2. `vendor/bin/phpunit --filter testPriceFilterWithTax tests/php/features/WooCommerce/TestWooCommerceProduct.php`
3. The test seeds a 20% tax rate, sends `min_price=120&max_price=120`, and asserts the Elasticsearch range bound is reduced to `100.0` (the excluding-tax price).
Result: passes.

**Test 2: Existing price filters still green**
1. `vendor/bin/phpunit --filter testPriceFilter tests/php/features/WooCommerce/TestWooCommerceProduct.php`
2. `vendor/bin/phpunit --filter testPriceFilterWithSearchQuery tests/php/features/WooCommerce/TestWooCommerceProduct.php`
Result: both pass (tax adjustment is a no-op when tax is off).

**Test 3: Manual repro (issue #4332)**
1. WooCommerce > Settings > Tax: enable tax, prices entered excluding tax, display including tax.
2. Add a 20% standard rate for the base location.
3. Create a product priced 100 (excl tax); it shows 120 (incl tax).
4. Filter `?min_price=120&max_price=120`.
Result: product appears (before fix it did not).
