### PR TITLE
upkeep/4315: React 18 => 19 (WordPress 7.1) Upgrade Issues

### DIFF
--- a/assets/js/sites-admin.js
+++ b/assets/js/sites-admin.js
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { ToggleControl } from '@wordpress/components';
 import domReady from '@wordpress/dom-ready';
-import { render, useState, WPElement } from '@wordpress/element';
+import { createRoot, render, useState, WPElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -71,13 +71,20 @@ const init = () => {
 	const toggles = document.getElementsByClassName('index-toggle');
 
 	for (const toggle of toggles) {
-		render(
+		const element = (
 			<ElasticPressToggleControl
 				blogId={toggle.dataset.blogId}
 				isDefaultChecked={toggle.checked}
-			/>,
-			toggle.parentElement,
+			/>
 		);
+
+		if (typeof createRoot === 'function') {
+			const root = createRoot(toggle.parentElement);
+
+			root.render(element);
+		} else {
+			render(element, toggle.parentElement);
+		}
 	}
 };
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4315 

- `ReactDOM.render()` is conditionally handled
- `react-slider` is not a concern at the moment. It does not explicitly declare support for react 19, and hasn't been updated in 2 years. It still works with react-19. Not urgent, but we can consider migrating to actively maintained sliders such as https://www.npmjs.com/package/@radix-ui/react-slider
- usage of `forwardRef`: This can't be conditionally handled, but it is not a concern at the moment. I did not see deprecation warnings in the console either.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Add compatibility fixes for React 19

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ZacharyRener @Sidsector9 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
