### PR TITLE
Fix TypeError in json_decode when template content is an array

### DIFF
--- a/includes/classes/ElementorUtils.php
+++ b/includes/classes/ElementorUtils.php
@@ -102,7 +102,12 @@ class ElementorUtils {
 			if ( ! $template_content ) {
 				continue;
 			}
-			$template_content = json_decode( $template_content, true );
+			if ( is_string( $template_content ) ) {
+				$template_content = json_decode( $template_content, true );
+			}
+			if ( ! is_array( $template_content ) ) {
+				continue;
+			}
 			$all_widgets      = array_merge(
 				$all_widgets,
 				$this->recursively_get_inner_widgets( $template_content )


### PR DESCRIPTION
### Summary
This PR prevents a fatal PHP `TypeError` in `ElementorUtils::get_all_widgets_in_all_templates()` when the post meta `_elementor_data` is retrieved as an array rather than a JSON-encoded string.

### The Problem
Under certain environments, database setups, or migrations, `_elementor_data` post meta may be stored as a serialized PHP array in the database instead of a JSON string. When retrieved via `get_post_meta($id, '_elementor_data', true)`, WordPress automatically unserializes it and returns a PHP `array`.

In PHP 8.0+, passing an array directly to `json_decode()` throws a fatal type error:
`TypeError: json_decode(): Argument #1 ($json) must be of type string, array given`

Additionally, if the metadata is corrupt or missing, passing the resulting non-array to `recursively_get_inner_widgets()` (which expects an `array` parameter) causes another fatal `TypeError`.

### The Solution
1. Added a check `is_string( $template_content )` before calling `json_decode( $template_content, true )`.
2. Added a check `is_array( $template_content )` before merging widgets to ensure we do not pass invalid types to `recursively_get_inner_widgets()`.
3. Skipped corrupt or empty templates cleanly via `continue`.
