### PR TITLE
Store meta and taxonomy as json

### DIFF
--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -655,13 +655,12 @@ class SearchOrdering extends Feature {
 			$to_inject = array();
 
 			foreach ( $posts as $key => &$post ) {
-				if ( isset( $post->terms ) && isset( $post->terms[ self::TAXONOMY_NAME ] ) ) {
-					foreach ( $post->terms[ self::TAXONOMY_NAME ] as $current_term ) {
+				$terms = json_decode( wp_specialchars_decode( $post->terms, ENT_QUOTES ), true );
+				if ( isset( $terms[ self::TAXONOMY_NAME ] ) ) {
+					foreach ( $terms[ self::TAXONOMY_NAME ] as $current_term ) {
 						if ( strtolower( $current_term['name'] ) === $search_query ) {
 							$to_inject[ $current_term['term_order'] ] = $post;
-
 							unset( $posts[ $key ] );
-
 							break;
 						}
 					}

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -477,7 +477,11 @@ class QueryIntegration {
 				if ( 'post_author' === $key ) {
 					$post->$key = $post_array[ $key ]['id'];
 				} elseif ( isset( $post_array[ $key ] ) ) {
-					$post->$key = $post_array[ $key ];
+					if ( in_array( $key, [ 'terms', 'meta', 'post_meta' ], true ) && is_array( $post_array[ $key ] ) ) {
+						$post->$key = wp_json_encode( $post_array[ $key ] );
+					} else {
+						$post->$key = $post_array[ $key ];
+					}
 				}
 			}
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -476,7 +476,7 @@ class TestPost extends BaseTestCase {
 		$this->assertNotNull( $query->posts[0]->terms );
 		$post = $query->posts[0];
 
-		$terms = $post->terms;
+		$terms = json_decode( $post->terms, true );
 		$this->assertTrue( isset( $terms[ $tax_name ] ) );
 		$this->assertTrue( count( $terms[ $tax_name ] ) === 1 );
 		$indexed_terms  = $terms[ $tax_name ];
@@ -1686,7 +1686,8 @@ class TestPost extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 		$this->assertEquals( 1, $query->post_count );
 
-		$this->assertEquals( 1, count( $query->posts[0]->meta['test_key'] ) );
+		$meta = json_decode( $query->posts[0]->meta, true );
+		$this->assertEquals( 1, count( $meta['test_key'] ) );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -10617,4 +10617,40 @@ class TestPost extends BaseTestCase {
 		$this->assertSame( 2, $query->found_posts );
 		$this->assertSame( 0, $query->max_num_pages );
 	}
+
+	/**
+	 * Test that post term and meta are stored as JSON.
+	 *
+	 * @since 5.3.4
+	 * @group post
+	 */
+	public function test_post_term_and_meta_are_stored_as_json() {
+		$category_id = $this->ep_factory->category->create();
+		$post_id     = $this->ep_factory->post->create(
+			[
+				'meta_input' => [
+					'test_key' => 'test_value',
+				],
+				'tax_input'  => [
+					'category' => [ $category_id ],
+				],
+			]
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query(
+			[
+				'ep_integrate' => true,
+				'post__in'     => [ $post_id ],
+			]
+		);
+
+		$this->assertTrue( $query->elasticsearch_success );
+
+		$post = get_post( $query->posts[0], OBJECT, 'edit' );
+
+		$this->assertJson( wp_specialchars_decode( $post->terms, ENT_QUOTES ), true );
+		$this->assertJson( wp_specialchars_decode( $post->meta, ENT_QUOTES ), true );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR encodes terms and meta values as JSON when formatting ES hits as posts, so persistent object caches no longer store PHP arrays on `WP_Post` objects


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4339 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - EP corrupts the WP_Post obect when its cached. 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @marc-kohde


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
