### PR TITLE
fix(readme): bump Tested up to 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === ElasticPress ===
 Contributors: 10up, tlovett1, vhauri, tott, felipeelia, oscarssanchez, cmmarslender
 Tags:         performance, search, elasticsearch, fuzzy, related posts
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag:   5.3.3
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
Bump WordPress "Tested up to" version from 7.0 to 7.1 for WordPress 7.1 compatibility.
Fixes #4344

## Changes
### readme.txt
**Before:** `Tested up to: 7.0`
**After:** `Tested up to: 7.1`
**Why:** WordPress 7.1 is now stable. Plugin metadata must reflect tested compatibility.

## Testing
**Test 1: Verify version in readme**
1. Check `readme.txt` line 4 shows `Tested up to: 7.1`
2. WordPress plugin page displays "Tested up to WordPress 7.1"