### PR TITLE
Fix: Disable post cache for cross-site queries

### DIFF
--- a/includes/classes/ElementorUtils.php
+++ b/includes/classes/ElementorUtils.php
@@ -108,7 +108,7 @@ class ElementorUtils {
 			if ( ! is_array( $template_content ) ) {
 				continue;
 			}
-			$all_widgets      = array_merge(
+			$all_widgets = array_merge(
 				$all_widgets,
 				$this->recursively_get_inner_widgets( $template_content )
 			);

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -318,7 +318,9 @@ class QueryIntegration {
 			}
 
 			/**
-			 * Queries scoped to other sites need the posts cache disabled. That cache is blog-specific, so priming it with posts from another site would make later calls to get_post() return foreign content for an ID that also exists here.
+			 * Disable the post cache for cross-site results. The `posts` cache group is
+			 * per-blog and keyed by ID only, so caching another site's post can poison
+			 * later get_post() calls for the same ID on the current site.
 			 */
 			if ( 'all' === $scope || ! empty( $site__in ) || ! empty( $site__not_in ) ) {
 				$query->set( 'cache_results', false );

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -98,7 +98,7 @@ class QueryIntegration {
 	}
 
 	/**
-	 * Disables cache_results, adds header.
+	 * Adds header.
 	 *
 	 * @param WP_Query $query WP_Query instance
 	 * @since 0.9
@@ -211,8 +211,6 @@ class QueryIntegration {
 	 * @return string
 	 */
 	public function get_es_posts( $posts, $query ) {
-		global $wpdb;
-
 		/**
 		 * Filter to skip WP Query integration
 		 *
@@ -317,6 +315,13 @@ class QueryIntegration {
 				// @codeCoverageIgnoreStart
 				$scope = 'current';
 				// @codeCoverageIgnoreEnd
+			}
+
+			/**
+			 * Queries scoped to other sites need the posts cache disabled. That cache is blog-specific, so priming it with posts from another site would make later calls to get_post() return foreign content for an ID that also exists here.
+			 */
+			if ( 'all' === $scope || ! empty( $site__in ) || ! empty( $site__not_in ) ) {
+				$query->set( 'cache_results', false );
 			}
 
 			$index = null;

--- a/tests/php/indexables/TestPostMultisite.php
+++ b/tests/php/indexables/TestPostMultisite.php
@@ -2108,4 +2108,83 @@ class TestPostMultisite extends BaseTestCase {
 		$this->assertEquals( 4, $query->post_count );
 		$this->assertEquals( 4, $query->found_posts );
 	}
+
+	/**
+	 * Tests cache_results is disabled when the `site__in` parameter is used.
+	 *
+	 * @since 5.3.4
+	 * @group testMultipleTests
+	 */
+	public function test_cache_results_set_to_false_when_site__in_argument() {
+
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		$args = [
+			'ep_integrate' => true,
+			'site__in'     => 'all',
+		];
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertFalse( $query->get( 'cache_results' ) );
+	}
+
+	/**
+	 * Tests cache_results is disabled when the `site__not_in` parameter is used.
+	 *
+	 * @since 5.3.4
+	 * @group testMultipleTests
+	 */
+	public function test_cache_results_set_to_false_when_site__not_in_argument() {
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		$args = [
+			'ep_integrate' => true,
+			'site__not_in' => [ $sites[1]['blog_id'] ],
+		];
+
+		$query = new \WP_Query( $args );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertFalse( $query->get( 'cache_results' ) );
+	}
+
+	/**
+	 * Tests cache_results is disabled when the scope is set to all.
+	 *
+	 * @since 5.3.4
+	 * @group testMultipleTests
+	 */
+	public function test_cache_results_set_to_false_when_scope_is_all() {
+		$sites = ElasticPress\Utils\get_sites();
+
+		if ( ! is_multisite() ) {
+			$this->assertEmpty( $sites );
+			return;
+		}
+
+		$scope = function () {
+			return 'all';
+		};
+
+		add_filter( 'ep_search_scope', $scope );
+
+		$query = new \WP_Query( [ 'ep_integrate' => true ] );
+
+		remove_filter( 'ep_search_scope', $scope );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertFalse( $query->get( 'cache_results' ) );
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

On multisite, cross-site Elasticsearch queries (`site__in`, `site__not_in`, or `ep_search_scope` → `all`) could prime the blog-specific posts cache with posts from other sites. Because that cache is keyed by post ID only, a later `get_post()` for a local ID could return another site's content.

This change disables `cache_results` for those cross-site query scopes in `get_es_posts()`, after the final scope is resolved.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4352 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Set cache_results to false if the query args contain site__in or site__not_in, or if ep_search_scope is set to all.
 
### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @dannyreaktiv

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
