### PR TITLE
fix(post): guard the post_author read in format_hits_as_posts

### DIFF
--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -475,7 +475,9 @@ class QueryIntegration {
 
 			foreach ( $post_return_args as $key ) {
 				if ( 'post_author' === $key ) {
-					$post->$key = $post_array[ $key ]['id'];
+					if ( isset( $post_array[ $key ]['id'] ) ) {
+						$post->$key = $post_array[ $key ]['id'];
+					}
 				} elseif ( isset( $post_array[ $key ] ) ) {
 					if ( in_array( $key, [ 'terms', 'meta', 'post_meta' ], true ) && is_array( $post_array[ $key ] ) ) {
 						$post->$key = wp_json_encode( $post_array[ $key ] );

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -1691,6 +1691,136 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test that a narrowed `_source` does not emit PHP warnings.
+	 *
+	 * A query can narrow `_source` via `ep_formatted_args` while leaving `fields`
+	 * at its default, which routes hits to `format_hits_as_posts()`. Every property
+	 * that method copies must tolerate being absent from the document. Any warning
+	 * raised while building the post objects fails this test, as the suite converts
+	 * warnings and notices to exceptions.
+	 *
+	 * @since 5.3.4
+	 * @group post
+	 */
+	public function testFormatHitsAsPostsWithNarrowedSource() {
+		$post_id = $this->ep_factory->post->create( array( 'post_content' => 'findme narrowed source' ) );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$filter_executed = false;
+
+		$narrow_source = function ( $formatted_args ) use ( &$filter_executed ) {
+			$filter_executed = true;
+
+			$formatted_args['_source'] = array( 'post_id' );
+
+			return $formatted_args;
+		};
+
+		add_filter( 'ep_formatted_args', $narrow_source );
+		$query = new \WP_Query( array( 'ep_integrate' => true ) );
+		remove_filter( 'ep_formatted_args', $narrow_source );
+
+		$this->assertTrue( $filter_executed );
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( $post_id, $query->posts[0]->ID );
+		$this->assertSame( '0', $query->posts[0]->post_author );
+	}
+
+	/**
+	 * Data provider for the testFormatHitsAsPostsWithPostAuthorShape method.
+	 *
+	 * `post_author` is indexed as an object and read through a nested `['id']`
+	 * subscript, so shapes other than the complete one have to be tolerated too.
+	 * A scalar string is fatal when the subscript is unguarded.
+	 *
+	 * Shapes carrying no usable id leave the property unset, exactly as the other
+	 * properties in the same loop do, so `WP_Post` supplies its own default of '0'.
+	 *
+	 * @since 5.3.4
+	 * @return array
+	 */
+	public function postAuthorShapeProvider() {
+		return [
+			[
+				[
+					'login' => 'author_login',
+					'id'    => 5,
+				],
+				5,
+			],
+			[ [ 'id' => 0 ], 0 ],
+			[ [ 'id' => '' ], '' ],
+			[ [ 'id' => null ], '0' ],
+			[ [ 'login' => 'author_login' ], '0' ],
+			[ 1, '0' ],
+			[ '', '0' ],
+		];
+	}
+
+	/**
+	 * Test that post_author is read without error whatever shape it arrives in.
+	 *
+	 * @param mixed $post_author Value to place in the document.
+	 * @param mixed $expected    Expected value on the returned post.
+	 * @since 5.3.4
+	 * @dataProvider postAuthorShapeProvider
+	 * @group post
+	 */
+	public function testFormatHitsAsPostsWithPostAuthorShape( $post_author, $expected ) {
+		$this->ep_factory->post->create( array( 'post_content' => 'findme author shape' ) );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$filter_executed = false;
+
+		$set_author = function ( $document ) use ( $post_author, &$filter_executed ) {
+			$filter_executed = true;
+
+			$document['post_author'] = $post_author;
+
+			return $document;
+		};
+
+		add_filter( 'ep_retrieve_the_post', $set_author );
+		$query = new \WP_Query( array( 'ep_integrate' => true ) );
+		remove_filter( 'ep_retrieve_the_post', $set_author );
+
+		$this->assertTrue( $filter_executed );
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertSame( $expected, $query->posts[0]->post_author );
+	}
+
+	/**
+	 * Test that post_author is still populated when it is present in the document.
+	 *
+	 * Companion to testFormatHitsAsPostsWithNarrowedSource: guarding the read must
+	 * not stop the property being set for ordinary queries.
+	 *
+	 * @since 5.3.4
+	 * @group post
+	 */
+	public function testFormatHitsAsPostsSetsPostAuthor() {
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+
+		$this->ep_factory->post->create(
+			array(
+				'post_content' => 'findme with author',
+				'post_author'  => $user_id,
+			)
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$query = new \WP_Query( array( 'ep_integrate' => true ) );
+
+		$this->assertTrue( $query->elasticsearch_success );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( $user_id, $query->posts[0]->post_author );
+	}
+
+	/**
 	 * Test a query that fuzzy searches meta
 	 *
 	 * @since 1.0


### PR DESCRIPTION
### Description of the Change

`QueryIntegration::format_hits_as_posts()` copies a fixed list of properties from each Elasticsearch hit onto the post object it returns. Every property is read behind an `isset()` check except `post_author`, which is special-cased and read unconditionally through a nested `['id']` subscript:

https://github.com/10up/ElasticPress/blob/90018165947a084223e5994b3d23760820064fa6/includes/classes/Indexable/Post/QueryIntegration.php#L476-L486

Because the subscript is unguarded, what happens depends entirely on the shape of the value in the document:

| `post_author` in the document | Before this PR |
|---|---|
| `[... 'id' => 5 ]` | `5` |
| `[ 'id' => 0 ]` | `0` |
| `[ 'id' => '' ]` (indexed for a deleted user, `Post.php:444-449`) | `''` |
| `[ 'id' => null ]` | `null`, no warning |
| key present, `id` missing | `null` + `Undefined array key "id"` |
| absent entirely | `null` + 2 warnings |
| a scalar integer | `null` + `Trying to access array offset on value of type int` |
| **a string** | **uncaught `TypeError: Cannot access offset of type string on string`** |

The common route to the middle rows is a query that narrows `_source` through `ep_formatted_args` while leaving `fields` at its default, which routes hits to this formatter. That produces two warnings for every hit, on every such query.

ElasticPress never trips this itself, which is why it has survived so long. The plugin's own `_source` narrowing (`Post::maybe_set_fields()`, for `fields => 'ids'` and `'id=>parent'`) always pairs with `format_hits_as_ids()` / `format_hits_as_id_parents()`, formatters that expect a narrow document. Only third-party code reaches the combination of a narrowed `_source` and the default formatter.

**The change.** Give `post_author` the same guard its 20 siblings already have:

```php
if ( 'post_author' === $key ) {
	if ( isset( $post_array[ $key ]['id'] ) ) {
		$post->$key = $post_array[ $key ]['id'];
	}
} elseif ( isset( $post_array[ $key ] ) ) {
```

A valid id is still copied, including `0` and the empty string indexed for a deleted user, since `isset()` is true for both. Anything unusable leaves the property unset, exactly as the sibling properties already do, so `WP_Post` supplies its own default.

**Benefits.** Removes the log noise, and removes a fatal error path. Sites narrowing `_source` for performance no longer have to choose between the optimisation and a clean log.

**History suggests this was an oversight rather than a decision.** `d96e67588` (2015-06-03) introduced the copy loop and the `post_author` special case together, with nothing guarded. A month later `9bd776390` (2015-07-02) changed `} else {` to `} elseif ( isset( $post_array[ $key ] ) ) {` — commit subject *"isset and unit test using ep_search_post_return_args filter to test. Fixes #306"*, a deliberate fix for a key in the return-args list being missing from the document. That is the same failure mode `post_author` still has; the fix simply did not extend into the branch above it. Everything since is cosmetic: `ba55e0fe87` moved the loop, `aaf3a97d9e` was PHPCS whitespace, `45a6d34df2` applied Yoda conditions.

**Alternative considered, and a question for maintainers.** The other candidate fix is `$post->$key = $post_array[ $key ]['id'] ?? null;`. Both silence the warnings and the `TypeError`; they differ only in what a caller sees when there is no usable id:

| | `?? null` | `isset()` guard (this PR) |
|---|---|---|
| Value | `null` | `'0'` (WP_Post default) |
| `isset( $post->post_author )` | `false` | `true` |
| Matches the other 20 properties | no | yes |
| Matches dropping `post_author` via `ep_search_post_return_args` | no (`null` vs `'0'`) | yes |
| Preserves the exact current return value | yes | no |

I went with the guard because it makes all the "no author data" paths agree and yields a value of the type `WP_Post` declares, but `?? null` is the smaller behavioural delta and is a defensible preference. It is a one-line swap plus test expectations — happy to switch if you would rather preserve `null`.

**Not addressed here:** a `post_author` arriving as an object still fatals (`Cannot use object of type stdClass as array`), before and after this change. It seemed out of scope for a guard on the documented shape, but say the word if you would like it covered.

Closes #

### How to test the Change

Automated:

```bash
composer run setup-local-tests   # if not already set up (needs MySQL + Elasticsearch)
EP_HOST=http://127.0.0.1:8890/ composer run test-single-site -- --filter testFormatHitsAsPosts
```

Nine cases pass. Reverting just the `includes/classes/Indexable/Post/QueryIntegration.php` hunk and re-running fails five of them — four as errors raised by the suite's `convertWarningsToExceptions`, one on the value.

Manually, on any indexed site with `WP_DEBUG` on:

1. Add a filter that narrows `_source` on a marked query:
   ```php
   add_filter(
       'ep_formatted_args',
       function ( $formatted_args, $args ) {
           if ( ! empty( $args['my_id_only_query'] ) ) {
               $formatted_args['_source'] = array( 'post_id' );
           }
           return $formatted_args;
       },
       10,
       2
   );
   ```
2. Run `new WP_Query( array( 'ep_integrate' => true, 'my_id_only_query' => true, 'posts_per_page' => 100 ) );`
3. Before this change the debug log fills with `Undefined array key "post_author"` and `Trying to access array offset on ...`, two per hit. After, the log is clean and the posts come back unchanged.

To see the fatal, return a string from `ep_retrieve_the_post` for `post_author` and run any `ep_integrate` query.

### Changelog Entry

> Fixed - PHP warnings, and a fatal error on some document shapes, when `post_author` is missing or malformed in an Elasticsearch hit — for example when a query narrows `_source` via `ep_formatted_args`.

### Credits

Props @freibergergarcia

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly. <!-- No documentation surface: internal read guard, no API, hook or behaviour that the docs describe. -->
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass. <!-- Full single-site suite run locally on PHP 8.2.30 / WordPress 7.0.3 / Elasticsearch 8.12.2: 954 tests, 3572 assertions, 953 passing. The one failure, TestWooCommerceProduct::testPriceFilterWithTax, is a float-precision comparison (100.99 vs 100.99000000000001) that reproduces identically on an unmodified develop checkout, so it is unrelated to this PR. CI additionally covers ES 7.10.1 and 9.1.5 and multisite, which I have not run locally. -->