### PR TITLE
Fix: Notice design issue on WordPress 7.1

### DIFF
--- a/assets/js/features/style.css
+++ b/assets/js/features/style.css
@@ -1,6 +1,8 @@
 #ep-dashboard {
 
 	& .components-notice {
+		align-items: center;
+		display: flex;
 		margin: 16px 0;
 	}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the notice on the Features page doesn't look good on WordPress 7.1 

**Before** 
<img width="1744" height="504" alt="Screenshot 2026-08-24 at 11-20-22" src="https://github.com/user-attachments/assets/4b4d428e-4045-4958-9c1b-4ae512e1ec19" />

**After**
<img width="1772" height="478" alt="Screenshot 2026-08-24 at 11-21-22" src="https://github.com/user-attachments/assets/4c50c0ee-3dae-4557-8d47-b3ad5718f4ef" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Notice design on Features page

### Credits
<!-- Please list @burhandodhy d all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burha

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- x ] All new and existing tests pass.
