### PR TITLE
Tests: add unit test coverage for ElasticPressIo and ElasticPressIoTemplateManager

### DIFF
--- a/tests/php/TestElasticPressIo.php
+++ b/tests/php/TestElasticPressIo.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Test the ElasticPressIo class methods.
+ *
+ * @since 5.3.6
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress\ElasticPressIo;
+
+/**
+ * TestElasticPressIo test class
+ */
+class TestElasticPressIo extends BaseTestCase {
+
+	/**
+	 * Setup the test environment
+	 */
+	public function set_up(): void {
+		delete_transient( ElasticPressIo::STATUS_TRANSIENT_NAME );
+		parent::set_up();
+	}
+
+	/**
+	 * Tear down the test environment
+	 */
+	public function tear_down(): void {
+		delete_transient( ElasticPressIo::STATUS_TRANSIENT_NAME );
+		putenv( 'IS_EPIO_ENVIRONMENT' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that methods return empty structures when not on an ElasticPress.io environment.
+	 *
+	 * @since 5.3.6
+	 * @group epio
+	 */
+	public function test_non_epio_environment_returns_empty() {
+		putenv( 'IS_EPIO_ENVIRONMENT=0' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+		update_option( 'ep_host', 'http://127.0.0.1:9200' );
+
+		$epio = new ElasticPressIo();
+
+		$this->assertSame( [], $epio->get_endpoint_status() );
+		$this->assertSame( [], $epio->get_endpoint_messages() );
+		$this->assertSame( [], $epio->get_endpoint_available_services() );
+		$this->assertFalse( $epio->is_service_available( 'synonyms' ) );
+	}
+
+	/**
+	 * Test retrieving endpoint status, messages, and services from cached transient.
+	 *
+	 * @since 5.3.6
+	 * @group epio
+	 */
+	public function test_get_endpoint_status_from_transient() {
+		putenv( 'IS_EPIO_ENVIRONMENT=1' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+
+		$expected_status = [
+			'messages'         => [
+				'System operational',
+				'Maintenance complete',
+			],
+			'avaiableServices' => [
+				'synonyms'     => true,
+				'autosuggest'  => true,
+				'disabled_svc' => false,
+				'empty_svc'    => '',
+			],
+		];
+
+		set_transient( ElasticPressIo::STATUS_TRANSIENT_NAME, $expected_status );
+
+		$epio = new ElasticPressIo();
+
+		$status = $epio->get_endpoint_status();
+		$this->assertSame( $expected_status, $status );
+
+		$messages = $epio->get_endpoint_messages();
+		$this->assertSame( $expected_status['messages'], $messages );
+
+		$services = $epio->get_endpoint_available_services();
+		$this->assertSame( $expected_status['avaiableServices'], $services );
+
+		$this->assertTrue( $epio->is_service_available( 'synonyms' ) );
+		$this->assertTrue( $epio->is_service_available( 'autosuggest' ) );
+		$this->assertFalse( $epio->is_service_available( 'disabled_svc' ) );
+		$this->assertFalse( $epio->is_service_available( 'empty_svc' ) );
+		$this->assertFalse( $epio->is_service_available( 'non_existent_service' ) );
+	}
+}

--- a/tests/php/TestElasticPressIoTemplateManager.php
+++ b/tests/php/TestElasticPressIoTemplateManager.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Test the ElasticPressIoTemplateManager trait.
+ *
+ * @since 5.3.6
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress\ElasticPressIoTemplateManager;
+
+/**
+ * ElasticPressIoTemplateManager test class.
+ */
+class TestElasticPressIoTemplateManager extends BaseTestCase {
+
+	/**
+	 * Helper to get a mock instance using the trait.
+	 *
+	 * @param string $slug Feature slug.
+	 * @return object
+	 */
+	protected function get_mock_manager( $slug = 'test-feature-slug' ) {
+		return new class( $slug ) {
+			use ElasticPressIoTemplateManager;
+
+			/**
+			 * Template endpoint.
+			 *
+			 * @var string
+			 */
+			public $endpoint = '_scripts/test-template';
+
+			/**
+			 * Template source.
+			 *
+			 * @var string
+			 */
+			public $template = '{"script":{"lang":"mustache","source":"{}"}}';
+
+			/**
+			 * Feature slug.
+			 *
+			 * @var string
+			 */
+			public $slug;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string $slug Feature slug.
+			 */
+			public function __construct( $slug ) {
+				$this->slug = $slug;
+			}
+
+			/**
+			 * Get template endpoint.
+			 *
+			 * @return string
+			 */
+			public function get_template_endpoint(): string {
+				return $this->endpoint;
+			}
+
+			/**
+			 * Get search template.
+			 *
+			 * @return string
+			 */
+			public function get_search_template(): string {
+				return $this->template;
+			}
+
+			/**
+			 * Get feature slug.
+			 *
+			 * @return string
+			 */
+			public function get_feature_slug(): string {
+				return $this->slug;
+			}
+		};
+	}
+
+	/**
+	 * Test get_hook_prefix replaces hyphens with underscores.
+	 */
+	public function test_get_hook_prefix() {
+		$manager = $this->get_mock_manager( 'test-feature-slug' );
+		$this->assertSame( 'ep_test_feature_slug', $manager->get_hook_prefix() );
+
+		$manager2 = $this->get_mock_manager( 'woocommerce-orders-autosuggest' );
+		$this->assertSame( 'ep_woocommerce_orders_autosuggest', $manager2->get_hook_prefix() );
+	}
+
+	/**
+	 * Test epio_save_search_template fires action with correct template argument.
+	 */
+	public function test_epio_save_search_template() {
+		$manager = $this->get_mock_manager();
+
+		$fired           = false;
+		$action_template = '';
+
+		add_action(
+			'ep_test_feature_slug_template_saved',
+			function ( $template ) use ( &$fired, &$action_template ) {
+				$fired           = true;
+				$action_template = $template;
+			},
+			10,
+			1
+		);
+
+		$manager->epio_save_search_template();
+
+		$this->assertTrue( $fired );
+		$this->assertSame( '{"script":{"lang":"mustache","source":"{}"}}', $action_template );
+	}
+
+	/**
+	 * Test epio_delete_search_template fires action.
+	 */
+	public function test_epio_delete_search_template() {
+		$manager = $this->get_mock_manager();
+
+		$fired = false;
+
+		add_action(
+			'ep_test_feature_slug_template_deleted',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$manager->epio_delete_search_template();
+
+		$this->assertTrue( $fired );
+	}
+
+	/**
+	 * Test epio_get_search_template returns error or template body.
+	 */
+	public function test_epio_get_search_template() {
+		$manager = $this->get_mock_manager();
+
+		// Case 1: Remote error returns WP_Error.
+		add_filter( 'ep_intercept_remote_request', '__return_true' );
+		add_filter(
+			'ep_do_intercept_request',
+			function () {
+				return new \WP_Error( 404, 'Template not found' );
+			}
+		);
+
+		$result = $manager->epio_get_search_template();
+		$this->assertWPError( $result );
+
+		remove_all_filters( 'ep_do_intercept_request' );
+
+		// Case 2: Success response.
+		$template_body = '{"template":"body"}';
+		add_filter(
+			'ep_do_intercept_request',
+			function () use ( $template_body ) {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => $template_body,
+				];
+			}
+		);
+
+		$result_success = $manager->epio_get_search_template();
+		$this->assertSame( $template_body, $result_success );
+
+		remove_all_filters( 'ep_do_intercept_request' );
+		remove_filter( 'ep_intercept_remote_request', '__return_true' );
+	}
+
+	/**
+	 * Test after_update_feature triggers save on activation and delete on deactivation.
+	 */
+	public function test_after_update_feature() {
+		$manager = $this->get_mock_manager();
+
+		$saved_fired   = false;
+		$deleted_fired = false;
+
+		add_action(
+			'ep_test_feature_slug_template_saved',
+			function () use ( &$saved_fired ) {
+				$saved_fired = true;
+			}
+		);
+
+		add_action(
+			'ep_test_feature_slug_template_deleted',
+			function () use ( &$deleted_fired ) {
+				$deleted_fired = true;
+			}
+		);
+
+		// Different feature slug: should not trigger.
+		$manager->after_update_feature( 'different-feature', [], [ 'active' => true ] );
+		$this->assertFalse( $saved_fired );
+		$this->assertFalse( $deleted_fired );
+
+		// Matched slug, activated.
+		$manager->after_update_feature( 'test-feature-slug', [], [ 'active' => true ] );
+		$this->assertTrue( $saved_fired );
+		$this->assertFalse( $deleted_fired );
+
+		// Reset flags.
+		$saved_fired = false;
+
+		// Matched slug, deactivated.
+		$manager->after_update_feature( 'test-feature-slug', [], [ 'active' => false ] );
+		$this->assertFalse( $saved_fired );
+		$this->assertTrue( $deleted_fired );
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces comprehensive automated unit test coverage for `ElasticPressIo` and the `ElasticPressIoTemplateManager` trait in `10up/ElasticPress`.

These components manage the lifecycle of ElasticPress.io search template registration, remote template synchronization, service availability checks, and caching. Prior to this PR, neither component had dedicated unit tests in `tests/php/`.

This PR is **100% test-only** and introduces **zero production code changes**, ensuring zero risk of regressions while significantly strengthening the test harness.

## Changes

### 1. `tests/php/TestElasticPressIo.php` (New File)
Dedicated unit test suite for `ElasticPress\ElasticPressIo`:
- **`test_non_epio_environment_returns_empty()`**:
  - Sets `IS_EPIO_ENVIRONMENT=0` to simulate a non-ElasticPress.io environment.
  - Verifies that `get_endpoint_status()`, `get_endpoint_messages()`, and `get_endpoint_available_services()` safely return empty arrays (`[]`).
  - Verifies that `is_service_available('synonyms')` returns `false` without making any unexpected HTTP requests.
- **`test_get_endpoint_status_from_transient()`**:
  - Sets `IS_EPIO_ENVIRONMENT=1` and seeds `set_transient( ElasticPressIo::STATUS_TRANSIENT_NAME, ... )` with structured endpoint responses (operational messages, available services with boolean and string flags).
  - Verifies that status, messages, and available services are accurately deserialized from transient cache.
  - Verifies `is_service_available()` logic across multiple scenarios: active services return `true`, explicitly disabled services return `false`, empty string flags return `false`, and non-existent services return `false`.

### 2. `tests/php/TestElasticPressIoTemplateManager.php` (New File)
Dedicated unit test suite for the `ElasticPress\ElasticPressIoTemplateManager` trait using an anonymous class test double:
- **`test_get_hook_prefix()`**:
  - Verifies that `get_hook_prefix()` correctly converts hyphenated feature slugs into underscore-delimited WordPress hook prefixes (e.g. `test-feature-slug` -> `ep_test_feature_slug`, `woocommerce-orders-autosuggest` -> `ep_woocommerce_orders_autosuggest`).
- **`test_epio_save_search_template()`**:
  - Verifies that `epio_save_search_template()` triggers the `{hook_prefix}_template_saved` action hook and passes the exact search template JSON body.
- **`test_epio_delete_search_template()`**:
  - Verifies that `epio_delete_search_template()` triggers the `{hook_prefix}_template_deleted` action hook upon template deletion.
- **`test_epio_get_search_template()`**:
  - Case 1 (Remote Error): Intercepts the request using `ep_intercept_remote_request` / `ep_do_intercept_request` to simulate a `WP_Error` and verifies that `epio_get_search_template()` safely bubbles up the `WP_Error`.
  - Case 2 (Success): Simulates an HTTP 200 response with a JSON payload and verifies that the retrieved template body is returned intact.
- **`test_after_update_feature()`**:
  - Verifies feature slug isolation: feature update events for mismatched slugs do not trigger any save or delete actions.
  - Verifies that activating the feature (`['active' => true]`) calls `epio_save_search_template()` and fires the save hook.
  - Verifies that deactivating the feature (`['active' => false]`) calls `epio_delete_search_template()` and fires the delete hook.

## Testing

**1. PHPUnit Execution**
```bash
./vendor/bin/phpunit tests/php/TestElasticPressIo.php
./vendor/bin/phpunit tests/php/TestElasticPressIoTemplateManager.php
```
Result: All 7 tests and 25 assertions pass (`OK (7 tests, 25 assertions)` in < 0.15s).

**2. Coding Standards (10up PHPCS Standard)**
```bash
./vendor/bin/phpcs tests/php/TestElasticPressIo.php tests/php/TestElasticPressIoTemplateManager.php
```
Result: `0 errors, 0 warnings` (100% compliant with 10up PHPCS standards).
